### PR TITLE
Fix network-partition-time-rotation sporadic test failure

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -541,7 +541,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 	})
 
 	checkChains := func(chains []blockchain.Blockchain, height uint64) {
-		assert.NoError(t, testutil.WaitUntil(100*time.Millisecond, 5*time.Second, func() (bool, error) {
+		assert.NoError(t, testutil.WaitUntil(100*time.Millisecond, 10*time.Second, func() (bool, error) {
 			for _, chain := range chains {
 				blk, err := chain.GetBlockByHeight(height)
 				if blk == nil || err != nil {

--- a/logger/README.md
+++ b/logger/README.md
@@ -7,7 +7,6 @@ easily parsed and analyzed from all servers.
 
 ```
 import "logger"
-logger.Print("your message")
 logger.Debug().Str("StrKey", "StrValue").Float("FloatKey", float_number).Msg("Your msg");
 ```
 


### PR DESCRIPTION
According to the log: https://circleci.com/gh/iotexproject/iotex-core/414, the test failed as simple as time limit too short. After 5 secs, it only committed block 1. I enlarge the wait period to 10 secs.