### PR TITLE
Adjust codecov patch coverage target to auto

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,6 +8,6 @@ coverage:
     patch:
       default:
         enabled: yes
-        target: 70%
+        target: auto
     ignore:
       - "txvm"


### PR DESCRIPTION
70% may not always make sense. For example, the original code coverage is low. We should use auto instead, which enforces the coverage doesn't go down after patch.