### PR TITLE
IOTEX-38 Move consensus and blocksync start to server start

### DIFF
--- a/dispatch/dispatch.go
+++ b/dispatch/dispatch.go
@@ -100,16 +100,7 @@ func (d *IotxDispatcher) Start(ctx context.Context) error {
 	if atomic.AddInt32(&d.started, 1) != 1 {
 		return errors.New("Dispatcher already started")
 	}
-
 	logger.Info().Msg("Starting dispatcher")
-	if err := d.cs.Start(ctx); err != nil {
-		return errors.Wrap(err, "error when starting consensus")
-	}
-
-	if err := d.bs.Start(ctx); err != nil {
-		return errors.Wrap(err, "error when starting blocksync")
-	}
-
 	d.wg.Add(1)
 	go d.newsHandler()
 	return nil
@@ -121,16 +112,7 @@ func (d *IotxDispatcher) Stop(ctx context.Context) error {
 		logger.Warn().Msg("Dispatcher already in the process of shutting down")
 		return nil
 	}
-
 	logger.Info().Msg("Dispatcher is shutting down")
-	if err := d.cs.Stop(ctx); err != nil {
-		return err
-	}
-
-	if err := d.bs.Stop(ctx); err != nil {
-		return err
-	}
-
 	close(d.quit)
 	d.wg.Wait()
 	return nil

--- a/dispatch/dispatch_test.go
+++ b/dispatch/dispatch_test.go
@@ -26,11 +26,9 @@ func TestNewDispatcher(t *testing.T) {
 	defer ctrl.Finish()
 
 	ctx := context.Background()
-	d, bs := createDispatcher(ctrl)
+	d, _ := createDispatcher(ctrl)
 	assert.NotNil(t, d)
 
-	bs.EXPECT().Start(gomock.Any()).Times(1)
-	bs.EXPECT().Stop(gomock.Any()).Times(1)
 	err := d.Start(ctx)
 	assert.NoError(t, err)
 	defer func() {
@@ -47,8 +45,6 @@ func TestDispatchBlockMsg(t *testing.T) {
 	d, bs := createDispatcher(ctrl)
 	assert.NotNil(t, d)
 
-	bs.EXPECT().Start(gomock.Any()).Times(1)
-	bs.EXPECT().Stop(gomock.Any()).Times(1)
 	err := d.Start(ctx)
 	assert.NoError(t, err)
 	defer func() {
@@ -74,8 +70,6 @@ func TestDispatchBlockSyncReq(t *testing.T) {
 	d, bs := createDispatcher(ctrl)
 	assert.NotNil(t, d)
 
-	bs.EXPECT().Start(gomock.Any()).Times(1)
-	bs.EXPECT().Stop(gomock.Any()).Times(1)
 	err := d.Start(ctx)
 	assert.NoError(t, err)
 	defer func() {
@@ -101,8 +95,6 @@ func TestDispatchBlockSyncData(t *testing.T) {
 	d, bs := createDispatcher(ctrl)
 	assert.NotNil(t, d)
 
-	bs.EXPECT().Start(gomock.Any()).Times(1)
-	bs.EXPECT().Stop(gomock.Any()).Times(1)
 	err := d.Start(ctx)
 	assert.NoError(t, err)
 	defer func() {
@@ -129,8 +121,6 @@ func createDispatcher(
 	}
 	bs := mock_blocksync.NewMockBlockSync(ctrl)
 	cs := mock_consensus.NewMockConsensus(ctrl)
-	cs.EXPECT().Start(gomock.Any()).Times(1)
-	cs.EXPECT().Stop(gomock.Any()).Times(1)
 	dp, _ := NewDispatcher(cfg, nil, bs, cs)
 
 	return dp, bs

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -20,16 +20,18 @@ import (
 	"github.com/iotexproject/iotex-core/explorer"
 	"github.com/iotexproject/iotex-core/logger"
 	"github.com/iotexproject/iotex-core/network"
+	"github.com/pkg/errors"
 )
 
 // Server is the iotex server instance containing all components.
 type Server struct {
+	cfg        *config.Config
 	chain      blockchain.Blockchain
 	actPool    actpool.ActPool
 	p2p        network.Overlay
-	dispatcher dispatcher.Dispatcher
-	cfg        *config.Config
 	consensus  consensus.Consensus
+	blocksync  blocksync.BlockSync
+	dispatcher dispatcher.Dispatcher
 	explorer   *explorer.Server
 }
 
@@ -62,20 +64,22 @@ func NewInMemTestServer(cfg *config.Config) *Server {
 // Start starts the server
 func (s *Server) Start(ctx context.Context) error {
 	if err := s.chain.Start(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when starting blockchain")
-		return nil
+		return errors.Wrap(err, "error when starting blockchain")
 	}
 	if err := s.dispatcher.Start(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when starting dispatcher")
-		return nil
+		return errors.Wrap(err, "error when starting dispatcher")
+	}
+	if err := s.consensus.Start(ctx); err != nil {
+		return errors.Wrap(err, "error when starting consensus")
+	}
+	if err := s.blocksync.Start(ctx); err != nil {
+		return errors.Wrap(err, "error when starting blocksync")
 	}
 	if err := s.p2p.Start(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when starting P2P networks")
-		return nil
+		return errors.Wrap(err, "error when starting P2P networks")
 	}
 	if err := s.explorer.Start(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when starting explorer")
-		return nil
+		return errors.Wrap(err, "error when starting explorer")
 	}
 	return nil
 }
@@ -83,20 +87,22 @@ func (s *Server) Start(ctx context.Context) error {
 // Stop stops the server
 func (s *Server) Stop(ctx context.Context) error {
 	if err := s.explorer.Stop(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when stopping explorer")
-		return nil
+		return errors.Wrap(err, "error when stopping explorer")
 	}
 	if err := s.p2p.Stop(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when stopping P2P networks")
-		return nil
+		return errors.Wrap(err, "error when stopping P2P networks")
+	}
+	if err := s.consensus.Stop(ctx); err != nil {
+		return errors.Wrap(err, "error when stopping consensus")
+	}
+	if err := s.blocksync.Stop(ctx); err != nil {
+		return errors.Wrap(err, "error when stopping blocksync")
 	}
 	if err := s.dispatcher.Stop(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when stopping dispatcher")
-		return nil
+		return errors.Wrap(err, "error when stopping dispatcher")
 	}
 	if err := s.chain.Stop(ctx); err != nil {
-		logger.Panic().Err(err).Msg("error when stopping blockchain")
-		return nil
+		return errors.Wrap(err, "error when stopping blockchain")
 	}
 	return nil
 }
@@ -126,6 +132,10 @@ func (s *Server) Consensus() consensus.Consensus {
 	return s.consensus
 }
 
+func (s *Server) BlockSync() blocksync.BlockSync {
+	return s.blocksync
+}
+
 // Explorer returns the explorer instance
 func (s *Server) Explorer() *explorer.Server {
 	return s.explorer
@@ -147,14 +157,12 @@ func newServer(cfg *config.Config, chain blockchain.Blockchain) *Server {
 	if consensus == nil {
 		logger.Fatal().Msg("Failed to create Consensus")
 	}
-
 	// create dispatcher instance
 	dispatcher, err := dispatch.NewDispatcher(cfg, actPool, bs, consensus)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Fail to create dispatcher")
 	}
 	p2p.AttachDispatcher(dispatcher)
-
 	var exp *explorer.Server
 	if cfg.Explorer.IsTest || os.Getenv("APP_ENV") == "development" {
 		logger.Warn().Msg("Using test server with fake data...")
@@ -168,8 +176,9 @@ func newServer(cfg *config.Config, chain blockchain.Blockchain) *Server {
 		chain:      chain,
 		actPool:    actPool,
 		p2p:        p2p,
-		dispatcher: dispatcher,
 		consensus:  consensus,
+		blocksync:  bs,
+		dispatcher: dispatcher,
 		explorer:   exp,
 	}
 }

--- a/server/main.go
+++ b/server/main.go
@@ -46,7 +46,7 @@ func init() {
 func main() {
 	cfg, err := config.New()
 	if err != nil {
-		logger.Fatal().Err(err).Msg("Failed to new config.")
+		logger.Panic().Err(err).Msg("Failed to new config.")
 		return
 	}
 
@@ -57,24 +57,23 @@ func main() {
 	ctx := context.Background()
 	ctxWithValue := context.WithValue(ctx, blockchain.RecoveryHeightKey, uint64(recoveryHeight))
 	if err := svr.Start(ctxWithValue); err != nil {
-		logger.Fatal().Err(err).Msg("Fail to start server.")
+		logger.Fatal().Err(err).Msg("Failed to start server.")
 		return
 	}
 	defer func() {
-		err := svr.Stop(ctx)
-		if err != nil {
-			logger.Error().Err(err)
+		if err := svr.Stop(ctx); err != nil {
+			logger.Panic().Err(err).Msg("Failed to stop server.")
 		}
 	}()
 
 	if cfg.System.HeartbeatInterval > 0 {
 		task := routine.NewRecurringTask(itx.NewHeartbeatHandler(svr).Log, cfg.System.HeartbeatInterval)
 		if err := task.Start(ctx); err != nil {
-			logger.Panic().Err(err)
+			logger.Panic().Err(err).Msg("Failed to start heartbeat routine.")
 		}
 		defer func() {
 			if err := task.Stop(ctx); err != nil {
-				logger.Panic().Err(err)
+				logger.Panic().Err(err).Msg("Failed to stop heartbeat routine.")
 			}
 		}()
 	}


### PR DESCRIPTION
They are the top level components, which shouldn't be started in dispatcher