### PR TITLE
reset the boundary of 'no' decision

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -189,7 +189,7 @@ func (ctx *rollDPoSCtx) calcDurationSinceLastBlock() (time.Duration, error) {
 	return ctx.clock.Now().Sub(blk.Header.Timestamp()), nil
 }
 
-// calcQuorum calculates if more than 2/3 vote yes or no
+// calcQuorum calculates if more than 2/3 vote yes or no including self's vote
 func (ctx *rollDPoSCtx) calcQuorum(decisions map[string]bool) (bool, bool) {
 	yes := 0
 	no := 0
@@ -201,7 +201,7 @@ func (ctx *rollDPoSCtx) calcQuorum(decisions map[string]bool) (bool, bool) {
 		}
 	}
 	numDelegates := len(ctx.epoch.delegates)
-	return yes >= numDelegates*2/3+1, no >= numDelegates*2/3+1
+	return yes >= numDelegates*2/3+1, no >= numDelegates*1/3
 }
 
 // isEpochFinished checks the epoch is finished or not

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -131,7 +131,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		candidates[3]: false,
 	})
 	assert.False(t, yes)
-	assert.False(t, no)
+	assert.True(t, no)
 }
 
 func TestIsEpochFinished(t *testing.T) {


### PR DESCRIPTION
Say "no" number of "no" is more than 1/3 of delegates.

We could remove self notification, and jump from Prepare to eFinishEpoch if Prepare's decision is "no", which I will do in a follow up PR