### PR TITLE
More endorse verification

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -412,10 +412,12 @@ func TestRollDPoSConsensus(t *testing.T) {
 	newConsensusComponents := func(numNodes int) ([]*RollDPoS, []*directOverlay, []blockchain.Blockchain) {
 		cfg := config.Default
 		cfg.Consensus.RollDPoS.Delay = 300 * time.Millisecond
-		cfg.Consensus.RollDPoS.ProposerInterval = time.Second
+		cfg.Consensus.RollDPoS.ProposerInterval = 1 * time.Second
 		cfg.Consensus.RollDPoS.AcceptProposeTTL = 100 * time.Millisecond
 		cfg.Consensus.RollDPoS.AcceptProposalEndorseTTL = 100 * time.Millisecond
 		cfg.Consensus.RollDPoS.AcceptCommitEndorseTTL = 100 * time.Millisecond
+		cfg.Consensus.RollDPoS.UnmatchedEventTTL = 300 * time.Millisecond
+		cfg.Consensus.RollDPoS.UnmatchedEventInterval = 20 * time.Millisecond
 		cfg.Consensus.RollDPoS.NumDelegates = uint(numNodes)
 
 		chainAddrs := make([]*iotxaddress.Address, 0, numNodes)
@@ -439,7 +441,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		candidatesByHeightFunc := func(_ uint64) ([]*state.Candidate, error) {
 			candidates := make([]*state.Candidate, 0, numNodes)
 			for _, addr := range chainAddrs {
-				candidates = append(candidates, &state.Candidate{Address: addr.RawAddress})
+				candidates = append(candidates, &state.Candidate{Address: addr.RawAddress, PubKey: addr.PublicKey[:]})
 			}
 			return candidates, nil
 		}

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/iotexproject/iotex-core/config"

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/iotexproject/iotex-core/config"


### PR DESCRIPTION
1. Add endorser signature verification
2. Add height to each consensus message, and use it to determine when to use or dump an event
3. Move timeout events to Round Start
4. Unify candidates generation in rolldpos
5. Fix unit tests