### PR TITLE
Check endorse block hash

### DIFF
--- a/action/const.go
+++ b/action/const.go
@@ -8,11 +8,6 @@ package action
 
 import "github.com/pkg/errors"
 
-const (
-	// GasLimit is the total gas limit to be consumed in a block
-	GasLimit = uint64(1000000000)
-)
-
 var (
 	// ErrHitGasLimit is the error when hit gas limit
 	ErrHitGasLimit = errors.New("Hit Gas Limit")

--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -356,7 +356,7 @@ func (ap *actPool) validateTsf(tsf *action.Transfer) error {
 		return errors.Wrapf(ErrActPool, "oversized data")
 	}
 	// Reject over-gassed transfer
-	if tsf.GasLimit() > action.GasLimit {
+	if tsf.GasLimit() > blockchain.GasLimit {
 		logger.Error().Msg("Error when validating transfer's gas limit")
 		return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 	}
@@ -409,7 +409,7 @@ func (ap *actPool) validateExecution(exec *action.Execution) error {
 		return errors.Wrapf(ErrActPool, "oversized data")
 	}
 	// Reject over-gassed execution
-	if exec.GasLimit() > action.GasLimit {
+	if exec.GasLimit() > blockchain.GasLimit {
 		logger.Error().Msg("Error when validating execution's gas limit")
 		return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 	}
@@ -465,7 +465,7 @@ func (ap *actPool) validateVote(vote *action.Vote) error {
 		return errors.Wrapf(ErrActPool, "oversized data")
 	}
 	// Reject over-gassed transfer
-	if vote.GasLimit() > action.GasLimit {
+	if vote.GasLimit() > blockchain.GasLimit {
 		logger.Error().Msg("Error when validating vote's gas limit")
 		return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 	}

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -78,7 +78,7 @@ func TestActPool_validateTsf(t *testing.T) {
 	err = ap.validateTsf(tsf)
 	require.Equal(ErrActPool, errors.Cause(err))
 	// Case III: Over-gassed transfer
-	tsf, err = action.NewTransfer(uint64(1), big.NewInt(1), "1", "2", nil, action.GasLimit+1, big.NewInt(0))
+	tsf, err = action.NewTransfer(uint64(1), big.NewInt(1), "1", "2", nil, blockchain.GasLimit+1, big.NewInt(0))
 	require.NoError(err)
 	err = ap.validateTsf(tsf)
 	require.Equal(ErrGasHigherThanLimit, errors.Cause(err))
@@ -145,7 +145,7 @@ func TestActPool_validateVote(t *testing.T) {
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
 	// Case I: Over-gassed vote
-	vote, err := action.NewVote(1, "123", "456", action.GasLimit+1, big.NewInt(0))
+	vote, err := action.NewVote(1, "123", "456", blockchain.GasLimit+1, big.NewInt(0))
 	require.NoError(err)
 	err = ap.validateVote(vote)
 	require.Equal(ErrGasHigherThanLimit, errors.Cause(err))
@@ -317,7 +317,7 @@ func TestActPool_AddActs(t *testing.T) {
 	err = ap.AddTsf(overBalTsf)
 	require.Equal(ErrBalance, errors.Cause(err))
 	// Case VI: over gas limit
-	creationExecution, err := action.NewExecution(addr1.RawAddress, action.EmptyAddress, uint64(5), big.NewInt(int64(0)), action.GasLimit+100, big.NewInt(10), []byte{})
+	creationExecution, err := action.NewExecution(addr1.RawAddress, action.EmptyAddress, uint64(5), big.NewInt(int64(0)), blockchain.GasLimit+100, big.NewInt(10), []byte{})
 	require.NoError(err)
 	err = ap.AddExecution(creationExecution)
 	require.Equal(ErrGasHigherThanLimit, errors.Cause(err))

--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -25,6 +25,9 @@ import (
 	"github.com/iotexproject/iotex-core/state"
 )
 
+// GasLimit is the total gas limit to be consumed in a block
+const GasLimit = uint64(1000000000)
+
 // Payee defines the struct of payee
 type Payee struct {
 	Address string

--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -25,7 +25,7 @@ import (
 	"github.com/iotexproject/iotex-core/state"
 )
 
-// GasLimit is the total gas limit to be consumed in a block
+// GasLimit is the total gas limit could be consumed in a block
 const GasLimit = uint64(1000000000)
 
 // Payee defines the struct of payee

--- a/blockchain/blockvalidator.go
+++ b/blockchain/blockvalidator.go
@@ -96,7 +96,7 @@ func (v *validator) verifyActions(blk *Block, containCoinbase bool) error {
 
 		if blk.Header.height > 0 && !tsf.IsCoinbase() {
 			// Reject over-gassed transfer
-			if tsf.GasLimit() > action.GasLimit {
+			if tsf.GasLimit() > GasLimit {
 				return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 			}
 			intrinsicGas, err := tsf.IntrinsicGas()
@@ -150,7 +150,7 @@ func (v *validator) verifyActions(blk *Block, containCoinbase bool) error {
 
 		if blk.Header.height > 0 {
 			// Reject over-gassed vote
-			if vote.GasLimit() > action.GasLimit {
+			if vote.GasLimit() > GasLimit {
 				return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 			}
 			intrinsicGas, err := vote.IntrinsicGas()
@@ -219,7 +219,7 @@ func (v *validator) verifyActions(blk *Block, containCoinbase bool) error {
 		}(execution, &correctAction)
 
 		// Reject over-gassed execution
-		if execution.GasLimit() > action.GasLimit {
+		if execution.GasLimit() > GasLimit {
 			return errors.Wrapf(ErrGasHigherThanLimit, "gas is higher than gas limit")
 		}
 		intrinsicGas, err := execution.IntrinsicGas()

--- a/blockchain/evm.go
+++ b/blockchain/evm.go
@@ -92,7 +92,7 @@ func NewEVMParams(blk *Block, execution *action.Execution, stateDB *EVMStateDBAd
 		BlockNumber: new(big.Int).SetUint64(blk.Height()),
 		Time:        new(big.Int).SetInt64(blk.Header.Timestamp().Unix()),
 		Difficulty:  new(big.Int).SetUint64(uint64(50)),
-		GasLimit:    action.GasLimit,
+		GasLimit:    GasLimit,
 		GasPrice:    execution.GasPrice(),
 	}
 
@@ -139,7 +139,7 @@ func securityDeposit(ps *EVMParams, stateDB vm.StateDB, gasLimit *uint64) error 
 
 // ExecuteContracts process the contracts in a block
 func ExecuteContracts(blk *Block, ws state.WorkingSet, bc Blockchain) {
-	gasLimit := action.GasLimit
+	gasLimit := GasLimit
 	blk.receipts = make(map[hash.Hash32B]*Receipt)
 	for idx, execution := range blk.Executions {
 		// TODO (zhi) log receipt to stateDB


### PR DESCRIPTION
If the received endorse is of different block, reject these endorses. This will prevent two blocks reach consensus at the same time. 