### PR TITLE
IOTEX-109 Define state interface and make working set expose generic state manipulation methods

### DIFF
--- a/action/subchain/protocol.go
+++ b/action/subchain/protocol.go
@@ -100,12 +100,12 @@ func (p *Protocol) validateStartSubChain(start *action.StartSubChain, ws state.W
 	if _, ok := p.subChains[start.ChainID()]; ok {
 		return fmt.Errorf("%d is used by another sub-chain", start.ChainID())
 	}
-	var state *state.AccountState
+	var account *state.Account
 	var err error
 	if ws == nil {
-		state, err = p.sf.LoadOrCreateAccountState(start.OwnerAddress(), 0)
+		account, err = p.sf.LoadOrCreateAccountState(start.OwnerAddress(), 0)
 	} else {
-		state, err = ws.LoadOrCreateAccountState(start.OwnerAddress(), 0)
+		account, err = ws.LoadOrCreateAccountState(start.OwnerAddress(), 0)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "error when getting the state of address %s", start.OwnerAddress())
@@ -113,10 +113,10 @@ func (p *Protocol) validateStartSubChain(start *action.StartSubChain, ws state.W
 	if start.SecurityDeposit().Cmp(MinSecurityDeposit) < 0 {
 		return fmt.Errorf("security deposit is smaller than the minimal requirement %d", MinSecurityDeposit)
 	}
-	if state.Balance.Cmp(start.SecurityDeposit()) < 0 {
+	if account.Balance.Cmp(start.SecurityDeposit()) < 0 {
 		return errors.New("sub-chain owner doesn't have enough balance for security deposit")
 	}
-	if state.Balance.Cmp(big.NewInt(0).Add(start.SecurityDeposit(), start.OperationDeposit())) < 0 {
+	if account.Balance.Cmp(big.NewInt(0).Add(start.SecurityDeposit(), start.OperationDeposit())) < 0 {
 		return errors.New("sub-chain owner doesn't have enough balance for operation deposit")
 	}
 	if start.StartHeight() < p.chain.TipHeight()+MinStartHeightDelay {

--- a/action/subchain/protocol.go
+++ b/action/subchain/protocol.go
@@ -100,12 +100,12 @@ func (p *Protocol) validateStartSubChain(start *action.StartSubChain, ws state.W
 	if _, ok := p.subChains[start.ChainID()]; ok {
 		return fmt.Errorf("%d is used by another sub-chain", start.ChainID())
 	}
-	var state *state.State
+	var state *state.AccountState
 	var err error
 	if ws == nil {
-		state, err = p.sf.LoadOrCreateState(start.OwnerAddress(), 0)
+		state, err = p.sf.LoadOrCreateAccountState(start.OwnerAddress(), 0)
 	} else {
-		state, err = ws.LoadOrCreateState(start.OwnerAddress(), 0)
+		state, err = ws.LoadOrCreateAccountState(start.OwnerAddress(), 0)
 	}
 	if err != nil {
 		return errors.Wrapf(err, "error when getting the state of address %s", start.OwnerAddress())

--- a/action/subchain/protocol_test.go
+++ b/action/subchain/protocol_test.go
@@ -29,13 +29,13 @@ func TestProtocolValidateSubChainStart(t *testing.T) {
 	chain := mock_blockchain.NewMockBlockchain(ctrl)
 	chain.EXPECT().TipHeight().Return(uint64(100)).AnyTimes()
 	factory := mock_state.NewMockFactory(ctrl)
-	factory.EXPECT().LoadOrCreateState(gomock.Any(), gomock.Any()).Return(
-		&state.State{Balance: big.NewInt(2000000000)},
+	factory.EXPECT().LoadOrCreateAccountState(gomock.Any(), gomock.Any()).Return(
+		&state.AccountState{Balance: big.NewInt(2000000000)},
 		nil,
 	).AnyTimes()
 	ws := mock_state.NewMockWorkingSet(ctrl)
-	ws.EXPECT().LoadOrCreateState(gomock.Any(), gomock.Any()).Return(
-		&state.State{Balance: big.NewInt(1500000000)},
+	ws.EXPECT().LoadOrCreateAccountState(gomock.Any(), gomock.Any()).Return(
+		&state.AccountState{Balance: big.NewInt(1500000000)},
 		nil,
 	).AnyTimes()
 

--- a/action/subchain/protocol_test.go
+++ b/action/subchain/protocol_test.go
@@ -30,12 +30,12 @@ func TestProtocolValidateSubChainStart(t *testing.T) {
 	chain.EXPECT().TipHeight().Return(uint64(100)).AnyTimes()
 	factory := mock_state.NewMockFactory(ctrl)
 	factory.EXPECT().LoadOrCreateAccountState(gomock.Any(), gomock.Any()).Return(
-		&state.AccountState{Balance: big.NewInt(2000000000)},
+		&state.Account{Balance: big.NewInt(2000000000)},
 		nil,
 	).AnyTimes()
 	ws := mock_state.NewMockWorkingSet(ctrl)
 	ws.EXPECT().LoadOrCreateAccountState(gomock.Any(), gomock.Any()).Return(
-		&state.AccountState{Balance: big.NewInt(1500000000)},
+		&state.Account{Balance: big.NewInt(1500000000)},
 		nil,
 	).AnyTimes()
 

--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -361,7 +361,7 @@ func (b *Block) HashBlock() hash.Hash32B {
 // VerifyStateRoot verifies the state root in header
 func (b *Block) VerifyStateRoot(root hash.Hash32B) error {
 	if b.Header.stateRoot != root {
-		return errors.New("State root hash does not match")
+		return errors.New("AccountState root hash does not match")
 	}
 	return nil
 }

--- a/blockchain/block.go
+++ b/blockchain/block.go
@@ -361,7 +361,7 @@ func (b *Block) HashBlock() hash.Hash32B {
 // VerifyStateRoot verifies the state root in header
 func (b *Block) VerifyStateRoot(root hash.Hash32B) error {
 	if b.Header.stateRoot != root {
-		return errors.New("AccountState root hash does not match")
+		return errors.New("state root hash does not match")
 	}
 	return nil
 }

--- a/blockchain/block_test.go
+++ b/blockchain/block_test.go
@@ -241,7 +241,7 @@ func TestWrongNonce(t *testing.T) {
 	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.NoError(err)
 	val := validator{sf, ""}
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
@@ -353,7 +353,7 @@ func TestWrongCoinbaseTsf(t *testing.T) {
 	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.Nil(err)
 	val := validator{sf, ""}
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
@@ -462,7 +462,7 @@ func TestValidateSecretBlock(t *testing.T) {
 	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.Nil(err)
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.Nil(err)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -36,7 +36,7 @@ type Blockchain interface {
 	Balance(addr string) (*big.Int, error)
 	// Nonce returns the nonce if the account exists
 	Nonce(addr string) (uint64, error)
-	// CreateState adds a new AccountState with initial balance to the factory
+	// CreateState adds a new account state with initial balance to the factory
 	CreateState(addr string, init uint64) (*state.AccountState, error)
 	// CandidatesByHeight returns the candidate list by a given height
 	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
@@ -81,7 +81,7 @@ type Blockchain interface {
 	GetBlockHashByExecutionHash(h hash.Hash32B) (hash.Hash32B, error)
 	// GetReceiptByExecutionHash returns the receipt by execution hash
 	GetReceiptByExecutionHash(h hash.Hash32B) (*Receipt, error)
-	// GetFactory returns the AccountState Factory
+	// GetFactory returns the state factory
 	GetFactory() state.Factory
 	// GetChainID returns the chain ID
 	ChainID() uint32
@@ -89,7 +89,7 @@ type Blockchain interface {
 	TipHash() hash.Hash32B
 	// TipHeight returns tip block's height
 	TipHeight() uint64
-	// StateByAddr returns state of a given address
+	// StateByAddr returns account state of a given address
 	StateByAddr(address string) (*state.AccountState, error)
 
 	// For block operations
@@ -407,7 +407,7 @@ func (bc *blockchain) Nonce(addr string) (uint64, error) {
 	return bc.sf.Nonce(addr)
 }
 
-// CreateState adds a new AccountState with initial balance to the factory
+// CreateState adds a new account state with initial balance to the factory
 func (bc *blockchain) CreateState(addr string, init uint64) (*state.AccountState, error) {
 	return bc.sf.LoadOrCreateAccountState(addr, init)
 }
@@ -608,7 +608,7 @@ func (bc *blockchain) GetReceiptByExecutionHash(h hash.Hash32B) (*Receipt, error
 	return bc.dao.getReceiptByExecutionHash(h)
 }
 
-// GetFactory returns the AccountState Factory
+// GetFactory returns the state factory
 func (bc *blockchain) GetFactory() state.Factory {
 	return bc.sf
 }
@@ -737,7 +737,7 @@ func (bc *blockchain) CommitBlock(blk *Block) error {
 	return bc.commitBlock(blk)
 }
 
-// StateByAddr returns the state of an address
+// StateByAddr returns the account state of an address
 func (bc *blockchain) StateByAddr(address string) (*state.AccountState, error) {
 	if bc.sf != nil {
 		s, err := bc.sf.AccountState(address)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -36,8 +36,8 @@ type Blockchain interface {
 	Balance(addr string) (*big.Int, error)
 	// Nonce returns the nonce if the account exists
 	Nonce(addr string) (uint64, error)
-	// CreateState adds a new account state with initial balance to the factory
-	CreateState(addr string, init uint64) (*state.AccountState, error)
+	// CreateState adds a new account with initial balance to the factory
+	CreateState(addr string, init uint64) (*state.Account, error)
 	// CandidatesByHeight returns the candidate list by a given height
 	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
 	// For exposing blockchain states
@@ -89,8 +89,8 @@ type Blockchain interface {
 	TipHash() hash.Hash32B
 	// TipHeight returns tip block's height
 	TipHeight() uint64
-	// StateByAddr returns account state of a given address
-	StateByAddr(address string) (*state.AccountState, error)
+	// StateByAddr returns account of a given address
+	StateByAddr(address string) (*state.Account, error)
 
 	// For block operations
 	// MintNewBlock creates a new block with given actions and dkg keys
@@ -407,8 +407,8 @@ func (bc *blockchain) Nonce(addr string) (uint64, error) {
 	return bc.sf.Nonce(addr)
 }
 
-// CreateState adds a new account state with initial balance to the factory
-func (bc *blockchain) CreateState(addr string, init uint64) (*state.AccountState, error) {
+// CreateState adds a new account with initial balance to the factory
+func (bc *blockchain) CreateState(addr string, init uint64) (*state.Account, error) {
 	return bc.sf.LoadOrCreateAccountState(addr, init)
 }
 
@@ -737,8 +737,8 @@ func (bc *blockchain) CommitBlock(blk *Block) error {
 	return bc.commitBlock(blk)
 }
 
-// StateByAddr returns the account state of an address
-func (bc *blockchain) StateByAddr(address string) (*state.AccountState, error) {
+// StateByAddr returns the account of an address
+func (bc *blockchain) StateByAddr(address string) (*state.Account, error) {
 	if bc.sf != nil {
 		s, err := bc.sf.AccountState(address)
 		if err != nil {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -36,8 +36,8 @@ type Blockchain interface {
 	Balance(addr string) (*big.Int, error)
 	// Nonce returns the nonce if the account exists
 	Nonce(addr string) (uint64, error)
-	// CreateState adds a new State with initial balance to the factory
-	CreateState(addr string, init uint64) (*state.State, error)
+	// CreateState adds a new AccountState with initial balance to the factory
+	CreateState(addr string, init uint64) (*state.AccountState, error)
 	// CandidatesByHeight returns the candidate list by a given height
 	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
 	// For exposing blockchain states
@@ -81,7 +81,7 @@ type Blockchain interface {
 	GetBlockHashByExecutionHash(h hash.Hash32B) (hash.Hash32B, error)
 	// GetReceiptByExecutionHash returns the receipt by execution hash
 	GetReceiptByExecutionHash(h hash.Hash32B) (*Receipt, error)
-	// GetFactory returns the State Factory
+	// GetFactory returns the AccountState Factory
 	GetFactory() state.Factory
 	// GetChainID returns the chain ID
 	ChainID() uint32
@@ -90,7 +90,7 @@ type Blockchain interface {
 	// TipHeight returns tip block's height
 	TipHeight() uint64
 	// StateByAddr returns state of a given address
-	StateByAddr(address string) (*state.State, error)
+	StateByAddr(address string) (*state.AccountState, error)
 
 	// For block operations
 	// MintNewBlock creates a new block with given actions and dkg keys
@@ -310,7 +310,7 @@ func (bc *blockchain) startEmptyBlockchain() error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to obtain working set from state factory")
 	}
-	if _, err := ws.LoadOrCreateState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply); err != nil {
+	if _, err := ws.LoadOrCreateAccountState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply); err != nil {
 		return errors.Wrap(err, "failed to create Creator into StateFactory")
 	}
 	if _, err := ws.RunActions(0, nil, nil, nil, nil); err != nil {
@@ -353,7 +353,7 @@ func (bc *blockchain) startExistingBlockchain(recoveryHeight uint64) error {
 	}
 	// If restarting factory from fresh db, first create creator's state
 	if startHeight == 0 {
-		if _, err := ws.LoadOrCreateState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply); err != nil {
+		if _, err := ws.LoadOrCreateAccountState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply); err != nil {
 			return err
 		}
 		if _, err := ws.RunActions(0, nil, nil, nil, nil); err != nil {
@@ -407,9 +407,9 @@ func (bc *blockchain) Nonce(addr string) (uint64, error) {
 	return bc.sf.Nonce(addr)
 }
 
-// CreateState adds a new State with initial balance to the factory
-func (bc *blockchain) CreateState(addr string, init uint64) (*state.State, error) {
-	return bc.sf.LoadOrCreateState(addr, init)
+// CreateState adds a new AccountState with initial balance to the factory
+func (bc *blockchain) CreateState(addr string, init uint64) (*state.AccountState, error) {
+	return bc.sf.LoadOrCreateAccountState(addr, init)
 }
 
 // CandidatesByHeight returns the candidate list by a given height
@@ -608,7 +608,7 @@ func (bc *blockchain) GetReceiptByExecutionHash(h hash.Hash32B) (*Receipt, error
 	return bc.dao.getReceiptByExecutionHash(h)
 }
 
-// GetFactory returns the State Factory
+// GetFactory returns the AccountState Factory
 func (bc *blockchain) GetFactory() state.Factory {
 	return bc.sf
 }
@@ -738,9 +738,9 @@ func (bc *blockchain) CommitBlock(blk *Block) error {
 }
 
 // StateByAddr returns the state of an address
-func (bc *blockchain) StateByAddr(address string) (*state.State, error) {
+func (bc *blockchain) StateByAddr(address string) (*state.AccountState, error) {
 	if bc.sf != nil {
-		s, err := bc.sf.State(address)
+		s, err := bc.sf.AccountState(address)
 		if err != nil {
 			logger.Warn().Err(err).Str("Address", address)
 			return nil, errors.New("account does not exist")

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -215,11 +215,11 @@ func TestCreateBlockchain(t *testing.T) {
 
 	hash := genesis.HashBlock()
 	require.Equal(hash, deserialize.HashBlock())
-	fmt.Printf("SerializeCandidateList/DeserializeCandidateList Block hash = %x match\n", hash)
+	fmt.Printf("Serialize/Deserialize Block hash = %x match\n", hash)
 
 	hash = genesis.TxRoot()
 	require.Equal(hash, deserialize.TxRoot())
-	fmt.Printf("SerializeCandidateList/DeserializeCandidateList Block merkle = %x match\n", hash)
+	fmt.Printf("Serialize/Deserialize Block merkle = %x match\n", hash)
 
 	// add 4 sample blocks
 	require.Nil(addTestingTsfBlocks(bc))

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -215,11 +215,11 @@ func TestCreateBlockchain(t *testing.T) {
 
 	hash := genesis.HashBlock()
 	require.Equal(hash, deserialize.HashBlock())
-	fmt.Printf("Serialize/Deserialize Block hash = %x match\n", hash)
+	fmt.Printf("SerializeCandidateList/DeserializeCandidateList Block hash = %x match\n", hash)
 
 	hash = genesis.TxRoot()
 	require.Equal(hash, deserialize.TxRoot())
-	fmt.Printf("Serialize/Deserialize Block merkle = %x match\n", hash)
+	fmt.Printf("SerializeCandidateList/DeserializeCandidateList Block merkle = %x match\n", hash)
 
 	// add 4 sample blocks
 	require.Nil(addTestingTsfBlocks(bc))
@@ -247,7 +247,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.NoError(err)
 
 	// Create a blockchain from scratch
@@ -465,7 +465,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.NoError(err)
 	// Create a blockchain from scratch
 	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
@@ -724,7 +724,7 @@ func TestCoinbaseTransfer(t *testing.T) {
 	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 	require.NoError(err)
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.NoError(err)
@@ -795,15 +795,15 @@ func TestBlocks(t *testing.T) {
 
 	sf, _ := state.NewFactory(&cfg, state.InMemTrieOption())
 	require.NoError(sf.Start(context.Background()))
-	sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 
 	// Create a blockchain from scratch
 	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	a := ta.Addrinfo["alfa"]
 	c := ta.Addrinfo["bravo"]
-	sf.LoadOrCreateState(a.RawAddress, uint64(100000))
-	sf.LoadOrCreateState(c.RawAddress, uint64(100000))
+	sf.LoadOrCreateAccountState(a.RawAddress, uint64(100000))
+	sf.LoadOrCreateAccountState(c.RawAddress, uint64(100000))
 
 	for i := 0; i < 10; i++ {
 		tsfs := []*action.Transfer{}
@@ -836,15 +836,15 @@ func TestActions(t *testing.T) {
 
 	sf, _ := state.NewFactory(&cfg, state.InMemTrieOption())
 	require.NoError(sf.Start(context.Background()))
-	sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 
 	// Create a blockchain from scratch
 	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	a := ta.Addrinfo["alfa"]
 	c := ta.Addrinfo["bravo"]
-	sf.LoadOrCreateState(a.RawAddress, uint64(100000))
-	sf.LoadOrCreateState(c.RawAddress, uint64(100000))
+	sf.LoadOrCreateAccountState(a.RawAddress, uint64(100000))
+	sf.LoadOrCreateAccountState(c.RawAddress, uint64(100000))
 
 	val := validator{sf, ""}
 	tsfs := []*action.Transfer{}
@@ -879,7 +879,7 @@ func TestDummyReplacement(t *testing.T) {
 
 	sf, _ := state.NewFactory(&cfg, state.InMemTrieOption())
 	require.NoError(sf.Start(context.Background()))
-	sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
+	sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, Gen.TotalSupply)
 
 	// Create a blockchain from scratch
 	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())

--- a/blockchain/evmstatedbadapter.go
+++ b/blockchain/evmstatedbadapter.go
@@ -58,7 +58,7 @@ func (stateDB *EVMStateDBAdapter) Error() error {
 // CreateAccount creates an account in iotx blockchain
 func (stateDB *EVMStateDBAdapter) CreateAccount(evmAddr common.Address) {
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
-	_, err := stateDB.ws.LoadOrCreateState(addr.IotxAddress(), 0)
+	_, err := stateDB.ws.LoadOrCreateAccountState(addr.IotxAddress(), 0)
 	if err != nil {
 		logger.Error().Err(err).Msg("CreateAccount")
 		// stateDB.logError(err)
@@ -75,7 +75,7 @@ func (stateDB *EVMStateDBAdapter) SubBalance(evmAddr common.Address, amount *big
 	// stateDB.GetBalance(evmAddr)
 	logger.Debug().Msgf("SubBalance %v from %s", amount, evmAddr.Hex())
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
-	state, err := stateDB.ws.CachedState(addr.IotxAddress())
+	state, err := stateDB.ws.CachedAccountState(addr.IotxAddress())
 	if err != nil {
 		logger.Error().Err(err).Msg("SubBalance")
 		stateDB.logError(err)
@@ -94,7 +94,7 @@ func (stateDB *EVMStateDBAdapter) AddBalance(evmAddr common.Address, amount *big
 	logger.Debug().Msgf("AddBalance %v to %s", amount, evmAddr.Hex())
 
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
-	state, err := stateDB.ws.CachedState(addr.IotxAddress())
+	state, err := stateDB.ws.CachedAccountState(addr.IotxAddress())
 	if err != nil {
 		logger.Error().Err(err).Hex("addrHash", evmAddr[:]).Msg("AddBalance")
 		stateDB.logError(err)
@@ -107,7 +107,7 @@ func (stateDB *EVMStateDBAdapter) AddBalance(evmAddr common.Address, amount *big
 // GetBalance gets the balance of account
 func (stateDB *EVMStateDBAdapter) GetBalance(evmAddr common.Address) *big.Int {
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
-	state, err := stateDB.ws.CachedState(addr.IotxAddress())
+	state, err := stateDB.ws.CachedAccountState(addr.IotxAddress())
 	if err != nil {
 		logger.Error().Err(err).Msg("GetBalance")
 		return nil
@@ -229,7 +229,7 @@ func (stateDB *EVMStateDBAdapter) HasSuicided(common.Address) bool {
 func (stateDB *EVMStateDBAdapter) Exist(evmAddr common.Address) bool {
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
 	logger.Debug().Msgf("Check existence of %s", addr.IotxAddress())
-	if state, err := stateDB.ws.CachedState(addr.IotxAddress()); err != nil || state == nil {
+	if state, err := stateDB.ws.CachedAccountState(addr.IotxAddress()); err != nil || state == nil {
 		logger.Debug().Msgf("Account %s does not exist", addr.IotxAddress())
 		return false
 	}

--- a/blockchain/evmstatedbadapter.go
+++ b/blockchain/evmstatedbadapter.go
@@ -230,7 +230,7 @@ func (stateDB *EVMStateDBAdapter) Exist(evmAddr common.Address) bool {
 	addr := address.New(stateDB.bc.ChainID(), evmAddr.Bytes())
 	logger.Debug().Msgf("Check existence of %s", addr.IotxAddress())
 	if state, err := stateDB.ws.CachedAccountState(addr.IotxAddress()); err != nil || state == nil {
-		logger.Debug().Msgf("Account %s does not exist", addr.IotxAddress())
+		logger.Debug().Msgf("account %s does not exist", addr.IotxAddress())
 		return false
 	}
 	return true

--- a/blocksync/slidingwindow.go
+++ b/blocksync/slidingwindow.go
@@ -97,7 +97,7 @@ func (sw *SlidingWindow) updateState() {
 		Msg("blocksync window")
 	logger.Debug().
 		Int("prevState", sw.prevState).
-		Int("State", sw.State).
+		Int("AccountState", sw.State).
 		Msg("blocksync state")
 }
 
@@ -117,14 +117,14 @@ func (sw *SlidingWindow) Update(value uint64) {
 	sw.mu.Unlock()
 }
 
-// TurnClose returns true if State transitions Open --> Closing/Closed
+// TurnClose returns true if AccountState transitions Open --> Closing/Closed
 func (sw *SlidingWindow) TurnClose() bool {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	return sw.prevState == Open && sw.State == Closing
 }
 
-// TurnOpen returns true if State transitions Closing/Closed --> Open
+// TurnOpen returns true if AccountState transitions Closing/Closed --> Open
 func (sw *SlidingWindow) TurnOpen() bool {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()

--- a/blocksync/slidingwindow.go
+++ b/blocksync/slidingwindow.go
@@ -97,7 +97,7 @@ func (sw *SlidingWindow) updateState() {
 		Msg("blocksync window")
 	logger.Debug().
 		Int("prevState", sw.prevState).
-		Int("AccountState", sw.State).
+		Int("state", sw.State).
 		Msg("blocksync state")
 }
 
@@ -117,14 +117,14 @@ func (sw *SlidingWindow) Update(value uint64) {
 	sw.mu.Unlock()
 }
 
-// TurnClose returns true if AccountState transitions Open --> Closing/Closed
+// TurnClose returns true if state transitions Open --> Closing/Closed
 func (sw *SlidingWindow) TurnClose() bool {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()
 	return sw.prevState == Open && sw.State == Closing
 }
 
-// TurnOpen returns true if AccountState transitions Closing/Closed --> Open
+// TurnOpen returns true if state transitions Closing/Closed --> Open
 func (sw *SlidingWindow) TurnOpen() bool {
 	sw.mu.Lock()
 	defer sw.mu.Unlock()

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -715,7 +715,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 			sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
 			require.NoError(t, err)
 			for j := 0; j < numNodes; j++ {
-				_, err := sf.LoadOrCreateState(chainRawAddrs[j], uint64(0))
+				_, err := sf.LoadOrCreateAccountState(chainRawAddrs[j], uint64(0))
 				require.NoError(t, err)
 				_, err = sf.RunActions(0, nil, nil, nil, nil)
 				require.NoError(t, err)

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -159,7 +159,7 @@ func TestExplorerApi(t *testing.T) {
 	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, blockchain.Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, blockchain.Gen.TotalSupply)
 	require.NoError(err)
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.NoError(err)
@@ -442,7 +442,7 @@ func TestService_StateByAddr(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	s := state.State{
+	s := state.AccountState{
 		Balance:      big.NewInt(46),
 		Nonce:        uint64(0),
 		IsCandidate:  false,
@@ -713,7 +713,7 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
-	_, err = sf.LoadOrCreateState(ta.Addrinfo["producer"].RawAddress, blockchain.Gen.TotalSupply)
+	_, err = sf.LoadOrCreateAccountState(ta.Addrinfo["producer"].RawAddress, blockchain.Gen.TotalSupply)
 	require.NoError(err)
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.NoError(err)

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -442,7 +442,7 @@ func TestService_StateByAddr(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	s := state.AccountState{
+	s := state.Account{
 		Balance:      big.NewInt(46),
 		Nonce:        uint64(0),
 		IsCandidate:  false,

--- a/misc/scripts/mockgen.sh
+++ b/misc/scripts/mockgen.sh
@@ -35,6 +35,13 @@ mockgen -destination=./test/mock/mock_state/mock_state.go  \
         -package=mock_state \
         Factory
 
+mkdir -p ./test/mock/mock_state
+mockgen -destination=./test/mock/mock_state/mock_workingset.go  \
+        -source=./state/workingset.go \
+        -imports =github.com/iotexproject/iotex-core/state \
+        -package=mock_state \
+        WorkingSet
+
 mkdir -p ./test/mock/mock_consensus
 mockgen -destination=./test/mock/mock_consensus/mock_consensus.go  \
         -source=./consensus/consensus.go \

--- a/state/account.go
+++ b/state/account.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2018 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package state
+
+import (
+	"bytes"
+	"encoding/gob"
+	"math/big"
+
+	"github.com/iotexproject/iotex-core/pkg/hash"
+)
+
+// Account is the canonical representation of an account.
+type Account struct {
+	// 0 is reserved from actions in genesis block and coinbase transfers nonces
+	// other actions' nonces start from 1
+	Nonce        uint64
+	Balance      *big.Int
+	Root         hash.Hash32B // storage trie root for contract account
+	CodeHash     []byte       // hash of the smart contract byte-code for contract account
+	IsCandidate  bool
+	VotingWeight *big.Int
+	Votee        string
+	Voters       map[string]*big.Int
+}
+
+// Serialize serializes account state into bytes
+func (st *Account) Serialize() ([]byte, error) {
+	var ss bytes.Buffer
+	e := gob.NewEncoder(&ss)
+	if err := e.Encode(st); err != nil {
+		return nil, ErrFailedToMarshalState
+	}
+	return ss.Bytes(), nil
+}
+
+// Deserialize deserializes bytes into account state
+func (st *Account) Deserialize(ss []byte) error {
+	e := gob.NewDecoder(bytes.NewBuffer(ss))
+	if err := e.Decode(st); err != nil {
+		return ErrFailedToUnmarshalState
+	}
+	return nil
+}
+
+// AddBalance adds balance for account state
+func (st *Account) AddBalance(amount *big.Int) error {
+	st.Balance.Add(st.Balance, amount)
+	return nil
+}
+
+// SubBalance subtracts balance for account state
+func (st *Account) SubBalance(amount *big.Int) error {
+	// make sure there's enough fund to spend
+	if amount.Cmp(st.Balance) == 1 {
+		return ErrNotEnoughBalance
+	}
+	st.Balance.Sub(st.Balance, amount)
+	return nil
+}
+
+// clone clones the account state
+func (st *Account) clone() *Account {
+	s := *st
+	s.Balance = nil
+	s.Balance = new(big.Int).Set(st.Balance)
+	s.VotingWeight = nil
+	s.VotingWeight = new(big.Int).Set(st.VotingWeight)
+	if st.CodeHash != nil {
+		s.CodeHash = nil
+		s.CodeHash = make([]byte, len(st.CodeHash))
+		copy(s.CodeHash, st.CodeHash)
+	}
+	// Voters won't be used, set to nil for simplicity
+	s.Voters = nil
+	return &s
+}

--- a/state/candidate.go
+++ b/state/candidate.go
@@ -84,8 +84,8 @@ func pbToCandidate(candPb *iproto.Candidate) (*Candidate, error) {
 	return candidate, nil
 }
 
-// Serialize serializes a list of Candidates to bytes
-func Serialize(candidates CandidateList) ([]byte, error) {
+// SerializeCandidateList serializes a list of Candidates to bytes
+func SerializeCandidateList(candidates CandidateList) ([]byte, error) {
 	candidatesPb := make([]*iproto.Candidate, 0, len(candidates))
 	for _, cand := range candidates {
 		candPb, err := candidateToPb(cand)
@@ -97,8 +97,8 @@ func Serialize(candidates CandidateList) ([]byte, error) {
 	return proto.Marshal(&iproto.CandidateList{Candidates: candidatesPb})
 }
 
-// Deserialize deserializes bytes to list of Candidates
-func Deserialize(buf []byte) (CandidateList, error) {
+// DeserializeCandidateList deserializes bytes to list of Candidates
+func DeserializeCandidateList(buf []byte) (CandidateList, error) {
 	candList := &iproto.CandidateList{}
 	if err := proto.Unmarshal(buf, candList); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal candidate list")

--- a/state/candidate.go
+++ b/state/candidate.go
@@ -9,9 +9,9 @@ package state
 import (
 	"math/big"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
+	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/iotex-core/iotxaddress"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
@@ -49,6 +49,36 @@ func (l CandidateList) Less(i, j int) bool {
 	return res == 1
 }
 
+// Serialize serializes a list of Candidates to bytes
+func (l CandidateList) Serialize() ([]byte, error) {
+	candidatesPb := make([]*iproto.Candidate, 0, len(l))
+	for _, cand := range l {
+		candPb, err := candidateToPb(cand)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert candidate to protobuf's candidate message")
+		}
+		candidatesPb = append(candidatesPb, candPb)
+	}
+	return proto.Marshal(&iproto.CandidateList{Candidates: candidatesPb})
+}
+
+// Deserialize deserializes bytes to list of Candidates
+func (l CandidateList) Deserialize(buf []byte) (CandidateList, error) {
+	candList := &iproto.CandidateList{}
+	if err := proto.Unmarshal(buf, candList); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal candidate list")
+	}
+	candidatesPb := candList.Candidates
+	for _, candPb := range candidatesPb {
+		cand, err := pbToCandidate(candPb)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert protobuf's candidate message to candidate")
+		}
+		l = append(l, cand)
+	}
+	return l, nil
+}
+
 // candidateToPb converts a candidate to protobuf's candidate message
 func candidateToPb(cand *Candidate) (*iproto.Candidate, error) {
 	if cand == nil {
@@ -82,37 +112,6 @@ func pbToCandidate(candPb *iproto.Candidate) (*Candidate, error) {
 		LastUpdateHeight: candPb.LastUpdateHeight,
 	}
 	return candidate, nil
-}
-
-// SerializeCandidateList serializes a list of Candidates to bytes
-func SerializeCandidateList(candidates CandidateList) ([]byte, error) {
-	candidatesPb := make([]*iproto.Candidate, 0, len(candidates))
-	for _, cand := range candidates {
-		candPb, err := candidateToPb(cand)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to convert candidate to protobuf's candidate message")
-		}
-		candidatesPb = append(candidatesPb, candPb)
-	}
-	return proto.Marshal(&iproto.CandidateList{Candidates: candidatesPb})
-}
-
-// DeserializeCandidateList deserializes bytes to list of Candidates
-func DeserializeCandidateList(buf []byte) (CandidateList, error) {
-	candList := &iproto.CandidateList{}
-	if err := proto.Unmarshal(buf, candList); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal candidate list")
-	}
-	candidatesPb := candList.Candidates
-	candidates := make(CandidateList, 0, len(candidatesPb))
-	for _, candPb := range candidatesPb {
-		cand, err := pbToCandidate(candPb)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to convert protobuf's candidate message to candidate")
-		}
-		candidates = append(candidates, cand)
-	}
-	return candidates, nil
 }
 
 // MapToCandidates converts a map of cachedCandidates to candidate list

--- a/state/candidate_test.go
+++ b/state/candidate_test.go
@@ -60,9 +60,9 @@ func TestCandidate(t *testing.T) {
 	require.Equal("io1qyqsyqcyl7ge4df3g94rzxvd2acldsfvdtq22kvf2ws722", candidateList[1].Address)
 	require.Equal("io1qyqsyqcy0av2reec8lrrth063uj8xkuugmmtu3tm2pahu9", candidateList[2].Address)
 
-	candidatesBytes, err := SerializeCandidateList(candidateList)
+	candidatesBytes, err := candidateList.Serialize()
 	require.NoError(err)
-	candidates, err := DeserializeCandidateList(candidatesBytes)
+	candidates, err := CandidateList{}.Deserialize(candidatesBytes)
 	require.NoError(err)
 	require.Equal(3, len(candidates))
 	require.Equal("io1qyqsyqcyf64rhvaj2y70q66yzkrpkhl52428vm5v88gqah", candidates[0].Address)

--- a/state/candidate_test.go
+++ b/state/candidate_test.go
@@ -60,9 +60,9 @@ func TestCandidate(t *testing.T) {
 	require.Equal("io1qyqsyqcyl7ge4df3g94rzxvd2acldsfvdtq22kvf2ws722", candidateList[1].Address)
 	require.Equal("io1qyqsyqcy0av2reec8lrrth063uj8xkuugmmtu3tm2pahu9", candidateList[2].Address)
 
-	candidatesBytes, err := Serialize(candidateList)
+	candidatesBytes, err := SerializeCandidateList(candidateList)
 	require.NoError(err)
-	candidates, err := Deserialize(candidatesBytes)
+	candidates, err := DeserializeCandidateList(candidatesBytes)
 	require.NoError(err)
 	require.Equal(3, len(candidates))
 	require.Equal("io1qyqsyqcyf64rhvaj2y70q66yzkrpkhl52428vm5v88gqah", candidates[0].Address)

--- a/state/contract.go
+++ b/state/contract.go
@@ -30,7 +30,7 @@ type (
 	contract struct {
 		*AccountState
 		dirtyCode  bool      // contract's code has been set
-		dirtyState bool      // contract's AccountState has changed
+		dirtyState bool      // contract's account state has changed
 		code       []byte    // contract byte-code
 		trie       trie.Trie // storage trie of the contract
 	}

--- a/state/contract_test.go
+++ b/state/contract_test.go
@@ -38,7 +38,7 @@ func TestCreateContract(t *testing.T) {
 
 	code := []byte("test contract creation")
 	addr := testaddress.Addrinfo["alfa"]
-	_, err = sf.LoadOrCreateState(addr.RawAddress, 0)
+	_, err = sf.LoadOrCreateAccountState(addr.RawAddress, 0)
 	require.Nil(err)
 	contractHash, _ := iotxaddress.GetPubkeyHash(addr.RawAddress)
 	contract := byteutil.BytesTo20B(contractHash)
@@ -59,7 +59,7 @@ func TestCreateContract(t *testing.T) {
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.Nil(err)
 	// reload same contract
-	contract1, err := sf.LoadOrCreateState(addr.RawAddress, 0)
+	contract1, err := sf.LoadOrCreateAccountState(addr.RawAddress, 0)
 	require.Nil(err)
 	require.Equal(contract1.CodeHash, codeHash[:])
 	require.Nil(sf.Commit(nil))
@@ -69,7 +69,7 @@ func TestCreateContract(t *testing.T) {
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 	// reload same contract
-	contract1, err = sf.LoadOrCreateState(addr.RawAddress, 0)
+	contract1, err = sf.LoadOrCreateAccountState(addr.RawAddress, 0)
 	require.Nil(err)
 	require.Equal(contract1.CodeHash, codeHash[:])
 	// contract already exist
@@ -94,7 +94,7 @@ func TestLoadStoreContract(t *testing.T) {
 
 	code := []byte("test contract creation")
 	addr := testaddress.Addrinfo["alfa"]
-	_, err = sf.LoadOrCreateState(addr.RawAddress, 0)
+	_, err = sf.LoadOrCreateAccountState(addr.RawAddress, 0)
 	require.Nil(err)
 	contractHash, _ := iotxaddress.GetPubkeyHash(addr.RawAddress)
 	contract := byteutil.BytesTo20B(contractHash)
@@ -114,7 +114,7 @@ func TestLoadStoreContract(t *testing.T) {
 
 	code1 := []byte("2nd contract creation")
 	addr1 := testaddress.Addrinfo["bravo"]
-	_, err = sf.LoadOrCreateState(addr1.RawAddress, 0)
+	_, err = sf.LoadOrCreateAccountState(addr1.RawAddress, 0)
 	require.Nil(err)
 	contractHash, err = iotxaddress.GetPubkeyHash(addr1.RawAddress)
 	require.Nil(err)

--- a/state/factory.go
+++ b/state/factory.go
@@ -54,11 +54,11 @@ type (
 	Factory interface {
 		lifecycle.StartStopper
 		// Accounts
-		LoadOrCreateAccountState(string, uint64) (*AccountState, error)
+		LoadOrCreateAccountState(string, uint64) (*Account, error)
 		Balance(string) (*big.Int, error)
 		Nonce(string) (uint64, error) // Note that Nonce starts with 1.
-		AccountState(string) (*AccountState, error)
-		CachedAccountState(string) (*AccountState, error)
+		AccountState(string) (*Account, error)
+		CachedAccountState(string) (*Account, error)
 		RootHash() hash.Hash32B
 		Height() (uint64, error)
 		NewWorkingSet() (WorkingSet, error)
@@ -196,11 +196,11 @@ func (sf *factory) Start(ctx context.Context) error { return sf.lifecycle.OnStar
 func (sf *factory) Stop(ctx context.Context) error { return sf.lifecycle.OnStop(ctx) }
 
 //======================================
-// AccountState functions
+// account functions
 //======================================
 // LoadOrCreateAccountState loads existing or adds a new account with initial balance to the factory
 // addr should be a bech32 properly-encoded string
-func (sf *factory) LoadOrCreateAccountState(addr string, init uint64) (*AccountState, error) {
+func (sf *factory) LoadOrCreateAccountState(addr string, init uint64) (*Account, error) {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
 	return sf.activeWs.LoadOrCreateAccountState(addr, init)
@@ -220,15 +220,15 @@ func (sf *factory) Nonce(addr string) (uint64, error) {
 	return sf.activeWs.Nonce(addr)
 }
 
-// AccountState returns the confirmed account state on the chain
-func (sf *factory) AccountState(addr string) (*AccountState, error) {
+// account returns the confirmed account state on the chain
+func (sf *factory) AccountState(addr string) (*Account, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.activeWs.AccountState(addr)
 }
 
 // CachedAccountState returns the cached account state if the address exists in local cache
-func (sf *factory) CachedAccountState(addr string) (*AccountState, error) {
+func (sf *factory) CachedAccountState(addr string) (*Account, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.activeWs.CachedAccountState(addr)

--- a/state/factory.go
+++ b/state/factory.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	// ErrNotEnoughBalance is the error that the balance is not enough
-	ErrNotEnoughBalance = errors.New("not enough balance")
+	// ErrNotEnoughBalance is the error that the Balance is not enough
+	ErrNotEnoughBalance = errors.New("not enough Balance")
 
 	// ErrAccountNotExist is the error that the account does not exist
 	ErrAccountNotExist = errors.New("account does not exist")
@@ -35,15 +35,15 @@ var (
 	// ErrAccountCollision is the error that the account already exists
 	ErrAccountCollision = errors.New("account already exists")
 
-	// ErrFailedToMarshalState is the error that the state marshaling is failed
-	ErrFailedToMarshalState = errors.New("failed to marshal state")
+	// ErrFailedToMarshalState is the error that the AccountState marshaling is failed
+	ErrFailedToMarshalState = errors.New("failed to marshal AccountState")
 
-	// ErrFailedToUnmarshalState is the error that the state un-marshaling is failed
-	ErrFailedToUnmarshalState = errors.New("failed to unmarshal state")
+	// ErrFailedToUnmarshalState is the error that the AccountState un-marshaling is failed
+	ErrFailedToUnmarshalState = errors.New("failed to unmarshal AccountState")
 )
 
 const (
-	// CurrentHeightKey indicates the key of current factory height in underlying DB
+	// CurrentHeightKey indicates the key of current factory Height in underlying DB
 	CurrentHeightKey = "currentHeight"
 	// AccountTrieRootKey indicates the key of accountTrie root hash in underlying DB
 	AccountTrieRootKey = "accountTrieRoot"
@@ -54,11 +54,11 @@ type (
 	Factory interface {
 		lifecycle.StartStopper
 		// Accounts
-		LoadOrCreateState(string, uint64) (*State, error)
+		LoadOrCreateAccountState(string, uint64) (*AccountState, error)
 		Balance(string) (*big.Int, error)
 		Nonce(string) (uint64, error) // Note that Nonce starts with 1.
-		State(string) (*State, error)
-		CachedState(string) (*State, error)
+		AccountState(string) (*AccountState, error)
+		CachedAccountState(string) (*AccountState, error)
 		RootHash() hash.Hash32B
 		Height() (uint64, error)
 		NewWorkingSet() (WorkingSet, error)
@@ -98,7 +98,7 @@ type (
 // FactoryOption sets Factory construction parameter
 type FactoryOption func(*factory, *config.Config) error
 
-// PrecreatedTrieDBOption uses pre-created trie DB for state factory
+// PrecreatedTrieDBOption uses pre-created trie DB for AccountState factory
 func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		if kv == nil {
@@ -108,7 +108,7 @@ func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = kv
-		// get state trie root
+		// get AccountState trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -118,7 +118,7 @@ func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 	}
 }
 
-// DefaultTrieOption creates trie from config for state factory
+// DefaultTrieOption creates trie from config for AccountState factory
 func DefaultTrieOption() FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		dbPath := cfg.Chain.TrieDBPath
@@ -130,7 +130,7 @@ func DefaultTrieOption() FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = trieDB
-		// get state trie root
+		// get AccountState trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -140,7 +140,7 @@ func DefaultTrieOption() FactoryOption {
 	}
 }
 
-// InMemTrieOption creates in memory trie for state factory
+// InMemTrieOption creates in memory trie for AccountState factory
 func InMemTrieOption() FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		trieDB := db.NewMemKVStore()
@@ -148,7 +148,7 @@ func InMemTrieOption() FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = trieDB
-		// get state trie root
+		// get AccountState trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -158,7 +158,7 @@ func InMemTrieOption() FactoryOption {
 	}
 }
 
-// ActionHandlerOption sets the action handlers for state factory
+// ActionHandlerOption sets the action handlers for AccountState factory
 func ActionHandlerOption(actionHandlers ...ActionHandler) FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		sf.actionHandlers = actionHandlers
@@ -166,7 +166,7 @@ func ActionHandlerOption(actionHandlers ...ActionHandler) FactoryOption {
 	}
 }
 
-// NewFactory creates a new state factory
+// NewFactory creates a new AccountState factory
 func NewFactory(cfg *config.Config, opts ...FactoryOption) (Factory, error) {
 	sf := &factory{
 		currentChainHeight: 0,
@@ -175,7 +175,7 @@ func NewFactory(cfg *config.Config, opts ...FactoryOption) (Factory, error) {
 
 	for _, opt := range opts {
 		if err := opt(sf, cfg); err != nil {
-			logger.Error().Err(err).Msgf("Failed to execute state factory creation option %p", opt)
+			logger.Error().Err(err).Msgf("Failed to execute AccountState factory creation option %p", opt)
 			return nil, err
 		}
 	}
@@ -196,21 +196,21 @@ func (sf *factory) Start(ctx context.Context) error { return sf.lifecycle.OnStar
 func (sf *factory) Stop(ctx context.Context) error { return sf.lifecycle.OnStop(ctx) }
 
 //======================================
-// State/Account functions
+// AccountState/Account functions
 //======================================
-// LoadOrCreateState loads existing or adds a new State with initial balance to the factory
+// LoadOrCreateAccountState loads existing or adds a new AccountState with initial Balance to the factory
 // addr should be a bech32 properly-encoded string
-func (sf *factory) LoadOrCreateState(addr string, init uint64) (*State, error) {
+func (sf *factory) LoadOrCreateAccountState(addr string, init uint64) (*AccountState, error) {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
-	return sf.activeWs.LoadOrCreateState(addr, init)
+	return sf.activeWs.LoadOrCreateAccountState(addr, init)
 }
 
-// Balance returns balance
+// Balance returns Balance
 func (sf *factory) Balance(addr string) (*big.Int, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
-	return sf.activeWs.balance(addr)
+	return sf.activeWs.Balance(addr)
 }
 
 // Nonce returns the Nonce if the account exists
@@ -220,34 +220,34 @@ func (sf *factory) Nonce(addr string) (uint64, error) {
 	return sf.activeWs.Nonce(addr)
 }
 
-// State returns the confirmed state on the chain
-func (sf *factory) State(addr string) (*State, error) {
+// AccountState returns the confirmed AccountState on the chain
+func (sf *factory) AccountState(addr string) (*AccountState, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
-	return sf.activeWs.state(addr)
+	return sf.activeWs.AccountState(addr)
 }
 
-// CachedState returns the cached state if the address exists in local cache
-func (sf *factory) CachedState(addr string) (*State, error) {
+// CachedAccountState returns the cached AccountState if the address exists in local cache
+func (sf *factory) CachedAccountState(addr string) (*AccountState, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
-	return sf.activeWs.CachedState(addr)
+	return sf.activeWs.CachedAccountState(addr)
 }
 
-// RootHash returns the hash of the root node of the state trie
+// RootHash returns the hash of the root node of the AccountState trie
 func (sf *factory) RootHash() hash.Hash32B {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.rootHash
 }
 
-// Height returns factory's height
+// Height returns factory's Height
 func (sf *factory) Height() (uint64, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	height, err := sf.dao.Get(trie.AccountKVNameSpace, []byte(CurrentHeightKey))
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get factory's height from underlying DB")
+		return 0, errors.Wrap(err, "failed to get factory's Height from underlying DB")
 	}
 	return byteutil.BytesToUint64(height), nil
 }
@@ -280,19 +280,19 @@ func (sf *factory) Commit(ws WorkingSet) error {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
 	if ws != nil {
-		if sf.currentChainHeight != ws.version() {
-			// another working set with correct version already committed, do nothing
+		if sf.currentChainHeight != ws.Version() {
+			// another working set with correct Version already committed, do nothing
 			return nil
 		}
 		sf.activeWs = nil
 		sf.activeWs = ws
 	}
-	if err := sf.activeWs.commit(); err != nil {
-		return errors.Wrap(err, "failed to commit working set")
+	if err := sf.activeWs.Commit(); err != nil {
+		return errors.Wrap(err, "failed to Commit working set")
 	}
-	// Update chain height and root
-	sf.currentChainHeight = sf.activeWs.height()
-	sf.rootHash = sf.activeWs.rootHash()
+	// Update chain Height and root
+	sf.currentChainHeight = sf.activeWs.Height()
+	sf.rootHash = sf.activeWs.RootHash()
 	return nil
 }
 
@@ -341,7 +341,7 @@ func (sf *factory) SetContractState(addr hash.PKHash, key, value hash.Hash32B) e
 func (sf *factory) Candidates() (uint64, []*Candidate) {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
-	candidates, err := MapToCandidates(sf.activeWs.workingCandidates())
+	candidates, err := MapToCandidates(sf.activeWs.WorkingCandidates())
 	if err != nil {
 		return sf.currentChainHeight, nil
 	}
@@ -352,14 +352,14 @@ func (sf *factory) Candidates() (uint64, []*Candidate) {
 	return sf.currentChainHeight, candidates[:sf.numCandidates]
 }
 
-// CandidatesByHeight returns array of Candidates in candidate pool of a given height
+// CandidatesByHeight returns array of Candidates in candidate pool of a given Height
 func (sf *factory) CandidatesByHeight(height uint64) ([]*Candidate, error) {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
-	// Load Candidates on the given height from underlying db
-	candidates, err := sf.activeWs.getCandidates(height)
+	// Load Candidates on the given Height from underlying db
+	candidates, err := sf.activeWs.GetCandidates(height)
 	if err != nil {
-		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on height %d", height)
+		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on Height %d", height)
 	}
 	if len(candidates) > int(sf.numCandidates) {
 		candidates = candidates[:sf.numCandidates]

--- a/state/factory.go
+++ b/state/factory.go
@@ -26,8 +26,8 @@ import (
 )
 
 var (
-	// ErrNotEnoughBalance is the error that the Balance is not enough
-	ErrNotEnoughBalance = errors.New("not enough Balance")
+	// ErrNotEnoughBalance is the error that the balance is not enough
+	ErrNotEnoughBalance = errors.New("not enough balance")
 
 	// ErrAccountNotExist is the error that the account does not exist
 	ErrAccountNotExist = errors.New("account does not exist")
@@ -35,15 +35,15 @@ var (
 	// ErrAccountCollision is the error that the account already exists
 	ErrAccountCollision = errors.New("account already exists")
 
-	// ErrFailedToMarshalState is the error that the AccountState marshaling is failed
-	ErrFailedToMarshalState = errors.New("failed to marshal AccountState")
+	// ErrFailedToMarshalState is the error that the state marshaling is failed
+	ErrFailedToMarshalState = errors.New("failed to marshal state")
 
-	// ErrFailedToUnmarshalState is the error that the AccountState un-marshaling is failed
-	ErrFailedToUnmarshalState = errors.New("failed to unmarshal AccountState")
+	// ErrFailedToUnmarshalState is the error that the state un-marshaling is failed
+	ErrFailedToUnmarshalState = errors.New("failed to unmarshal state")
 )
 
 const (
-	// CurrentHeightKey indicates the key of current factory Height in underlying DB
+	// CurrentHeightKey indicates the key of current factory height in underlying DB
 	CurrentHeightKey = "currentHeight"
 	// AccountTrieRootKey indicates the key of accountTrie root hash in underlying DB
 	AccountTrieRootKey = "accountTrieRoot"
@@ -98,7 +98,7 @@ type (
 // FactoryOption sets Factory construction parameter
 type FactoryOption func(*factory, *config.Config) error
 
-// PrecreatedTrieDBOption uses pre-created trie DB for AccountState factory
+// PrecreatedTrieDBOption uses pre-created trie DB for state factory
 func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		if kv == nil {
@@ -108,7 +108,7 @@ func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = kv
-		// get AccountState trie root
+		// get state trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -118,7 +118,7 @@ func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 	}
 }
 
-// DefaultTrieOption creates trie from config for AccountState factory
+// DefaultTrieOption creates trie from config for state factory
 func DefaultTrieOption() FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		dbPath := cfg.Chain.TrieDBPath
@@ -130,7 +130,7 @@ func DefaultTrieOption() FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = trieDB
-		// get AccountState trie root
+		// get state trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -140,7 +140,7 @@ func DefaultTrieOption() FactoryOption {
 	}
 }
 
-// InMemTrieOption creates in memory trie for AccountState factory
+// InMemTrieOption creates in memory trie for state factory
 func InMemTrieOption() FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		trieDB := db.NewMemKVStore()
@@ -148,7 +148,7 @@ func InMemTrieOption() FactoryOption {
 			return errors.Wrap(err, "failed to start trie db")
 		}
 		sf.dao = trieDB
-		// get AccountState trie root
+		// get state trie root
 		root, err := sf.getRoot(trie.AccountKVNameSpace, AccountTrieRootKey)
 		if err != nil {
 			return errors.Wrap(err, "failed to get accountTrie's root hash from underlying DB")
@@ -158,7 +158,7 @@ func InMemTrieOption() FactoryOption {
 	}
 }
 
-// ActionHandlerOption sets the action handlers for AccountState factory
+// ActionHandlerOption sets the action handlers for state factory
 func ActionHandlerOption(actionHandlers ...ActionHandler) FactoryOption {
 	return func(sf *factory, cfg *config.Config) error {
 		sf.actionHandlers = actionHandlers
@@ -166,7 +166,7 @@ func ActionHandlerOption(actionHandlers ...ActionHandler) FactoryOption {
 	}
 }
 
-// NewFactory creates a new AccountState factory
+// NewFactory creates a new state factory
 func NewFactory(cfg *config.Config, opts ...FactoryOption) (Factory, error) {
 	sf := &factory{
 		currentChainHeight: 0,
@@ -175,7 +175,7 @@ func NewFactory(cfg *config.Config, opts ...FactoryOption) (Factory, error) {
 
 	for _, opt := range opts {
 		if err := opt(sf, cfg); err != nil {
-			logger.Error().Err(err).Msgf("Failed to execute AccountState factory creation option %p", opt)
+			logger.Error().Err(err).Msgf("Failed to execute state factory creation option %p", opt)
 			return nil, err
 		}
 	}
@@ -196,9 +196,9 @@ func (sf *factory) Start(ctx context.Context) error { return sf.lifecycle.OnStar
 func (sf *factory) Stop(ctx context.Context) error { return sf.lifecycle.OnStop(ctx) }
 
 //======================================
-// AccountState/Account functions
+// AccountState functions
 //======================================
-// LoadOrCreateAccountState loads existing or adds a new AccountState with initial Balance to the factory
+// LoadOrCreateAccountState loads existing or adds a new account with initial balance to the factory
 // addr should be a bech32 properly-encoded string
 func (sf *factory) LoadOrCreateAccountState(addr string, init uint64) (*AccountState, error) {
 	sf.mutex.Lock()
@@ -206,7 +206,7 @@ func (sf *factory) LoadOrCreateAccountState(addr string, init uint64) (*AccountS
 	return sf.activeWs.LoadOrCreateAccountState(addr, init)
 }
 
-// Balance returns Balance
+// Balance returns balance
 func (sf *factory) Balance(addr string) (*big.Int, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
@@ -220,34 +220,34 @@ func (sf *factory) Nonce(addr string) (uint64, error) {
 	return sf.activeWs.Nonce(addr)
 }
 
-// AccountState returns the confirmed AccountState on the chain
+// AccountState returns the confirmed account state on the chain
 func (sf *factory) AccountState(addr string) (*AccountState, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.activeWs.AccountState(addr)
 }
 
-// CachedAccountState returns the cached AccountState if the address exists in local cache
+// CachedAccountState returns the cached account state if the address exists in local cache
 func (sf *factory) CachedAccountState(addr string) (*AccountState, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.activeWs.CachedAccountState(addr)
 }
 
-// RootHash returns the hash of the root node of the AccountState trie
+// RootHash returns the hash of the root node of the state trie
 func (sf *factory) RootHash() hash.Hash32B {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.rootHash
 }
 
-// Height returns factory's Height
+// Height returns factory's height
 func (sf *factory) Height() (uint64, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	height, err := sf.dao.Get(trie.AccountKVNameSpace, []byte(CurrentHeightKey))
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get factory's Height from underlying DB")
+		return 0, errors.Wrap(err, "failed to get factory's height from underlying DB")
 	}
 	return byteutil.BytesToUint64(height), nil
 }
@@ -281,16 +281,16 @@ func (sf *factory) Commit(ws WorkingSet) error {
 	defer sf.mutex.Unlock()
 	if ws != nil {
 		if sf.currentChainHeight != ws.Version() {
-			// another working set with correct Version already committed, do nothing
+			// another working set with correct version already committed, do nothing
 			return nil
 		}
 		sf.activeWs = nil
 		sf.activeWs = ws
 	}
 	if err := sf.activeWs.Commit(); err != nil {
-		return errors.Wrap(err, "failed to Commit working set")
+		return errors.Wrap(err, "failed to commit working set")
 	}
-	// Update chain Height and root
+	// Update chain height and root
 	sf.currentChainHeight = sf.activeWs.Height()
 	sf.rootHash = sf.activeWs.RootHash()
 	return nil
@@ -352,14 +352,14 @@ func (sf *factory) Candidates() (uint64, []*Candidate) {
 	return sf.currentChainHeight, candidates[:sf.numCandidates]
 }
 
-// CandidatesByHeight returns array of Candidates in candidate pool of a given Height
+// CandidatesByHeight returns array of Candidates in candidate pool of a given height
 func (sf *factory) CandidatesByHeight(height uint64) ([]*Candidate, error) {
 	sf.mutex.Lock()
 	defer sf.mutex.Unlock()
-	// Load Candidates on the given Height from underlying db
+	// Load Candidates on the given height from underlying db
 	candidates, err := sf.activeWs.GetCandidates(height)
 	if err != nil {
-		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on Height %d", height)
+		return []*Candidate{}, errors.Wrapf(err, "failed to get candidates on height %d", height)
 	}
 	if len(candidates) > int(sf.numCandidates) {
 		candidates = candidates[:sf.numCandidates]

--- a/state/factory_test.go
+++ b/state/factory_test.go
@@ -103,7 +103,7 @@ func TestBalance(t *testing.T) {
 	defer ctrl.Finish()
 
 	state := &AccountState{Balance: big.NewInt(20)}
-	// Add 10 to the Balance
+	// Add 10 to the balance
 	err := state.AddBalance(big.NewInt(10))
 	require.Nil(err)
 	// Balance should == 30 now

--- a/state/factory_test.go
+++ b/state/factory_test.go
@@ -35,45 +35,46 @@ const testTriePath = "trie.test"
 
 func TestEncodeDecode(t *testing.T) {
 	require := require.New(t)
-	ss, err := stateToBytes(
-		&State{
-			Nonce:        0x10,
-			Balance:      big.NewInt(20000000),
-			VotingWeight: big.NewInt(1000000000),
-		})
-	require.Nil(err)
+	s1 := AccountState{
+		Nonce:        0x10,
+		Balance:      big.NewInt(20000000),
+		VotingWeight: big.NewInt(1000000000),
+	}
+	ss, err := s1.Serialize()
+	require.NoError(err)
 	require.NotEmpty(ss)
 
-	state, _ := bytesToState(ss)
-	require.Equal(big.NewInt(20000000), state.Balance)
-	require.Equal(uint64(0x10), state.Nonce)
-	require.Equal(hash.ZeroHash32B, state.Root)
-	require.Equal([]byte(nil), state.CodeHash)
-	require.Equal(big.NewInt(1000000000), state.VotingWeight)
+	s2 := AccountState{}
+	require.NoError(s2.Deserialize(ss))
+	require.Equal(big.NewInt(20000000), s2.Balance)
+	require.Equal(uint64(0x10), s2.Nonce)
+	require.Equal(hash.ZeroHash32B, s2.Root)
+	require.Equal([]byte(nil), s2.CodeHash)
+	require.Equal(big.NewInt(1000000000), s2.VotingWeight)
 }
 
 func TestGob(t *testing.T) {
 	require := require.New(t)
 	ss, _ := hex.DecodeString("79ff8103010105537461746501ff8200010801054e6f6e6365010600010742616c616e636501ff84000104526f6f7401ff86000108436f646548617368010a00010b497343616e646964617465010200010c566f74696e6757656967687401ff84000105566f746565010c000106566f7465727301ff880000000aff83050102ff8a00000017ff85010101074861736833324201ff860001060140000024ff87040101136d61705b737472696e675d2a6269672e496e7401ff8800010c01ff8400002cff820202022d0120000000000000000000000000000000000000000000000000000000000000000003010200")
-	state, err := bytesToState(ss)
-	require.Nil(err)
+	s1 := AccountState{}
+	require.NoError(s1.Deserialize(ss))
 
 	// another serialized byte
 	st, _ := hex.DecodeString("79ff8503010105537461746501ff8600010801054e6f6e6365010600010742616c616e636501ff88000104526f6f7401ff8a000108436f646548617368010a00010b497343616e646964617465010200010c566f74696e6757656967687401ff88000105566f746565010c000106566f7465727301ff8c0000000aff87050102ff8e00000017ff89010101074861736833324201ff8a0001060140000024ff8b040101136d61705b737472696e675d2a6269672e496e7401ff8c00010c01ff8800002cff860202022d0120000000000000000000000000000000000000000000000000000000000000000003010200")
 	require.NotEqual(ss, st)
 
 	// same struct after deserialization
-	tate, err := bytesToState(st)
-	require.Nil(err)
-	require.Equal(state.Nonce, tate.Nonce)
-	require.Equal(state.Balance, tate.Balance)
-	require.Equal(state.Root, tate.Root)
-	require.Equal(state.CodeHash, tate.CodeHash)
-	require.Equal(state.IsCandidate, tate.IsCandidate)
-	require.Equal(state.VotingWeight, tate.VotingWeight)
-	require.Equal(state.Votee, tate.Votee)
-	require.Equal(state.Voters, map[string]*big.Int(nil))
-	require.Equal(tate.Voters, map[string]*big.Int(nil))
+	s2 := AccountState{}
+	require.NoError(s2.Deserialize(st))
+	require.Equal(s1.Nonce, s2.Nonce)
+	require.Equal(s1.Balance, s2.Balance)
+	require.Equal(s1.Root, s2.Root)
+	require.Equal(s1.CodeHash, s2.CodeHash)
+	require.Equal(s1.IsCandidate, s2.IsCandidate)
+	require.Equal(s1.VotingWeight, s2.VotingWeight)
+	require.Equal(s1.Votee, s2.Votee)
+	require.Equal(s1.Voters, map[string]*big.Int(nil))
+	require.Equal(s2.Voters, map[string]*big.Int(nil))
 }
 
 func TestCreateState(t *testing.T) {
@@ -85,12 +86,12 @@ func TestCreateState(t *testing.T) {
 	require.Equal(trie.EmptyRoot, sf.RootHash())
 	addr, err := iotxaddress.NewAddress(true, []byte{0xa4, 0x00, 0x00, 0x00})
 	require.Nil(err)
-	state, _ := sf.LoadOrCreateState(addr.RawAddress, 5)
+	state, _ := sf.LoadOrCreateAccountState(addr.RawAddress, 5)
 	_, err = sf.RunActions(0, nil, nil, nil, nil)
 	require.Nil(err)
 	require.Equal(uint64(0x0), state.Nonce)
 	require.Equal(big.NewInt(5), state.Balance)
-	ss, err := sf.State(addr.RawAddress)
+	ss, err := sf.AccountState(addr.RawAddress)
 	require.Nil(err)
 	require.Equal(uint64(0x0), ss.Nonce)
 	require.Equal(big.NewInt(5), ss.Balance)
@@ -101,31 +102,33 @@ func TestBalance(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	state := &State{Balance: big.NewInt(20)}
-	// Add 10 to the balance
+	state := &AccountState{Balance: big.NewInt(20)}
+	// Add 10 to the Balance
 	err := state.AddBalance(big.NewInt(10))
 	require.Nil(err)
-	// balance should == 30 now
+	// Balance should == 30 now
 	require.Equal(0, state.Balance.Cmp(big.NewInt(30)))
 }
 
 func TestClone(t *testing.T) {
 	require := require.New(t)
-	ss := &State{
+	ss := &AccountState{
 		Nonce:        0x10,
 		Balance:      big.NewInt(200),
 		VotingWeight: big.NewInt(1000),
 	}
-	st := ss.clone()
-	require.Equal(big.NewInt(200), st.Balance)
-	require.Equal(big.NewInt(1000), st.VotingWeight)
+	st := ss.Clone()
+	ast, ok := st.(*AccountState)
+	require.True(ok)
+	require.Equal(big.NewInt(200), ast.Balance)
+	require.Equal(big.NewInt(1000), ast.VotingWeight)
 
-	require.Nil(st.AddBalance(big.NewInt(100)))
-	st.VotingWeight.Sub(st.VotingWeight, big.NewInt(300))
+	require.Nil(ast.AddBalance(big.NewInt(100)))
+	ast.VotingWeight.Sub(ast.VotingWeight, big.NewInt(300))
 	require.Equal(big.NewInt(200), ss.Balance)
 	require.Equal(big.NewInt(1000), ss.VotingWeight)
-	require.Equal(big.NewInt(200+100), st.Balance)
-	require.Equal(big.NewInt(1000-300), st.VotingWeight)
+	require.Equal(big.NewInt(200+100), ast.Balance)
+	require.Equal(big.NewInt(1000-300), ast.VotingWeight)
 }
 
 func voteForm(height uint64, cs []*Candidate) []string {
@@ -253,17 +256,17 @@ func TestCandidates(t *testing.T) {
 	cfg.Chain.NumCandidates = 2
 	sf, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, &cfg.DB)))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(a.RawAddress, uint64(100))
+	_, err = sf.LoadOrCreateAccountState(a.RawAddress, uint64(100))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(b.RawAddress, uint64(200))
+	_, err = sf.LoadOrCreateAccountState(b.RawAddress, uint64(200))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(c.RawAddress, uint64(300))
+	_, err = sf.LoadOrCreateAccountState(c.RawAddress, uint64(300))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(d.RawAddress, uint64(100))
+	_, err = sf.LoadOrCreateAccountState(d.RawAddress, uint64(100))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(e.RawAddress, uint64(100))
+	_, err = sf.LoadOrCreateAccountState(e.RawAddress, uint64(100))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(f.RawAddress, uint64(300))
+	_, err = sf.LoadOrCreateAccountState(f.RawAddress, uint64(300))
 	require.NoError(t, err)
 
 	// a:100(0) b:200(0) c:300(0)
@@ -592,7 +595,7 @@ func TestCandidates(t *testing.T) {
 	require.True(t, height == 3)
 	require.True(t, compareStrings(voteForm(sf.Candidates()), []string{e.RawAddress + ":200", b.RawAddress + ":500"}))
 	// a(b):100(0) b(c):200(500) [c(c):100(+200=300)] d(b): 400(100) e(e):200(+0=200) f(d):100(0)
-	cachedStateA, err := sf.CachedState(a.RawAddress)
+	cachedStateA, err := sf.CachedAccountState(a.RawAddress)
 	require.Nil(t, err)
 	require.Equal(t, cachedStateA.Balance, big.NewInt(100))
 }
@@ -624,7 +627,7 @@ func TestCandidatesByHeight(t *testing.T) {
 	candidateList = append(candidateList, cand2)
 	sort.Sort(candidateList)
 
-	candidatesBytes, err := Serialize(candidateList)
+	candidatesBytes, err := SerializeCandidateList(candidateList)
 	require.NoError(t, err)
 
 	require.Nil(t, sf.dao.Put(trie.CandidateKVNameSpace, byteutil.Uint64ToBytes(0), candidatesBytes))
@@ -639,7 +642,7 @@ func TestCandidatesByHeight(t *testing.T) {
 
 	candidateList = append(candidateList, cand3)
 	sort.Sort(candidateList)
-	candidatesBytes, err = Serialize(candidateList)
+	candidatesBytes, err = SerializeCandidateList(candidateList)
 	require.NoError(t, err)
 
 	require.Nil(t, sf.dao.Put(trie.CandidateKVNameSpace, byteutil.Uint64ToBytes(1), candidatesBytes))
@@ -667,9 +670,9 @@ func TestUnvote(t *testing.T) {
 	sf, ok := f.(*factory)
 	require.True(t, ok)
 
-	_, err = sf.LoadOrCreateState(a.RawAddress, uint64(100))
+	_, err = sf.LoadOrCreateAccountState(a.RawAddress, uint64(100))
 	require.NoError(t, err)
-	_, err = sf.LoadOrCreateState(b.RawAddress, uint64(200))
+	_, err = sf.LoadOrCreateAccountState(b.RawAddress, uint64(200))
 	require.NoError(t, err)
 
 	vote1, err := action.NewVote(0, a.RawAddress, "", uint64(100000), big.NewInt(10))

--- a/state/factory_test.go
+++ b/state/factory_test.go
@@ -35,7 +35,7 @@ const testTriePath = "trie.test"
 
 func TestEncodeDecode(t *testing.T) {
 	require := require.New(t)
-	s1 := AccountState{
+	s1 := Account{
 		Nonce:        0x10,
 		Balance:      big.NewInt(20000000),
 		VotingWeight: big.NewInt(1000000000),
@@ -44,7 +44,7 @@ func TestEncodeDecode(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(ss)
 
-	s2 := AccountState{}
+	s2 := Account{}
 	require.NoError(s2.Deserialize(ss))
 	require.Equal(big.NewInt(20000000), s2.Balance)
 	require.Equal(uint64(0x10), s2.Nonce)
@@ -56,7 +56,7 @@ func TestEncodeDecode(t *testing.T) {
 func TestGob(t *testing.T) {
 	require := require.New(t)
 	ss, _ := hex.DecodeString("79ff8103010105537461746501ff8200010801054e6f6e6365010600010742616c616e636501ff84000104526f6f7401ff86000108436f646548617368010a00010b497343616e646964617465010200010c566f74696e6757656967687401ff84000105566f746565010c000106566f7465727301ff880000000aff83050102ff8a00000017ff85010101074861736833324201ff860001060140000024ff87040101136d61705b737472696e675d2a6269672e496e7401ff8800010c01ff8400002cff820202022d0120000000000000000000000000000000000000000000000000000000000000000003010200")
-	s1 := AccountState{}
+	s1 := Account{}
 	require.NoError(s1.Deserialize(ss))
 
 	// another serialized byte
@@ -64,7 +64,7 @@ func TestGob(t *testing.T) {
 	require.NotEqual(ss, st)
 
 	// same struct after deserialization
-	s2 := AccountState{}
+	s2 := Account{}
 	require.NoError(s2.Deserialize(st))
 	require.Equal(s1.Nonce, s2.Nonce)
 	require.Equal(s1.Balance, s2.Balance)
@@ -102,7 +102,7 @@ func TestBalance(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	state := &AccountState{Balance: big.NewInt(20)}
+	state := &Account{Balance: big.NewInt(20)}
 	// Add 10 to the balance
 	err := state.AddBalance(big.NewInt(10))
 	require.Nil(err)
@@ -112,23 +112,21 @@ func TestBalance(t *testing.T) {
 
 func TestClone(t *testing.T) {
 	require := require.New(t)
-	ss := &AccountState{
+	ss := &Account{
 		Nonce:        0x10,
 		Balance:      big.NewInt(200),
 		VotingWeight: big.NewInt(1000),
 	}
-	st := ss.Clone()
-	ast, ok := st.(*AccountState)
-	require.True(ok)
-	require.Equal(big.NewInt(200), ast.Balance)
-	require.Equal(big.NewInt(1000), ast.VotingWeight)
+	account := ss.clone()
+	require.Equal(big.NewInt(200), account.Balance)
+	require.Equal(big.NewInt(1000), account.VotingWeight)
 
-	require.Nil(ast.AddBalance(big.NewInt(100)))
-	ast.VotingWeight.Sub(ast.VotingWeight, big.NewInt(300))
+	require.Nil(account.AddBalance(big.NewInt(100)))
+	account.VotingWeight.Sub(account.VotingWeight, big.NewInt(300))
 	require.Equal(big.NewInt(200), ss.Balance)
 	require.Equal(big.NewInt(1000), ss.VotingWeight)
-	require.Equal(big.NewInt(200+100), ast.Balance)
-	require.Equal(big.NewInt(1000-300), ast.VotingWeight)
+	require.Equal(big.NewInt(200+100), account.Balance)
+	require.Equal(big.NewInt(1000-300), account.VotingWeight)
 }
 
 func voteForm(height uint64, cs []*Candidate) []string {

--- a/state/factory_test.go
+++ b/state/factory_test.go
@@ -625,7 +625,7 @@ func TestCandidatesByHeight(t *testing.T) {
 	candidateList = append(candidateList, cand2)
 	sort.Sort(candidateList)
 
-	candidatesBytes, err := SerializeCandidateList(candidateList)
+	candidatesBytes, err := candidateList.Serialize()
 	require.NoError(t, err)
 
 	require.Nil(t, sf.dao.Put(trie.CandidateKVNameSpace, byteutil.Uint64ToBytes(0), candidatesBytes))
@@ -640,7 +640,7 @@ func TestCandidatesByHeight(t *testing.T) {
 
 	candidateList = append(candidateList, cand3)
 	sort.Sort(candidateList)
-	candidatesBytes, err = SerializeCandidateList(candidateList)
+	candidatesBytes, err = candidateList.Serialize()
 	require.NoError(t, err)
 
 	require.Nil(t, sf.dao.Put(trie.CandidateKVNameSpace, byteutil.Uint64ToBytes(1), candidatesBytes))

--- a/state/state.go
+++ b/state/state.go
@@ -54,13 +54,13 @@ func (st *AccountState) Deserialize(ss []byte) error {
 	return nil
 }
 
-// AddBalance adds Balance for AccountState
+// AddBalance adds balance for account state
 func (st *AccountState) AddBalance(amount *big.Int) error {
 	st.Balance.Add(st.Balance, amount)
 	return nil
 }
 
-// SubBalance subtracts Balance for AccountState
+// SubBalance subtracts balance for account state
 func (st *AccountState) SubBalance(amount *big.Int) error {
 	// make sure there's enough fund to spend
 	if amount.Cmp(st.Balance) == 1 {
@@ -70,6 +70,7 @@ func (st *AccountState) SubBalance(amount *big.Int) error {
 	return nil
 }
 
+// Clone clones the account state
 func (st *AccountState) Clone() State {
 	s := *st
 	s.Balance = nil

--- a/state/state.go
+++ b/state/state.go
@@ -6,83 +6,8 @@
 
 package state
 
-import (
-	"bytes"
-	"encoding/gob"
-	"math/big"
-
-	"github.com/iotexproject/iotex-core/pkg/hash"
-)
-
 // State is the interface, which defines the common methods for state struct to be handled by state factory
 type State interface {
-	Serialize() ([]byte, error)
-	Deserialize([]byte) error
-	Clone() State
-}
-
-// AccountState is the canonical representation of an account.
-type AccountState struct {
-	// 0 is reserved from actions in genesis block and coinbase transfers nonces
-	// other actions' nonces start from 1
-	Nonce        uint64
-	Balance      *big.Int
-	Root         hash.Hash32B // storage trie root for contract account
-	CodeHash     []byte       // hash of the smart contract byte-code for contract account
-	IsCandidate  bool
-	VotingWeight *big.Int
-	Votee        string
-	Voters       map[string]*big.Int
-}
-
-// Serialize serializes account state into bytes
-func (st *AccountState) Serialize() ([]byte, error) {
-	var ss bytes.Buffer
-	e := gob.NewEncoder(&ss)
-	if err := e.Encode(st); err != nil {
-		return nil, ErrFailedToMarshalState
-	}
-	return ss.Bytes(), nil
-}
-
-// Deserialize deserializes bytes into account state
-func (st *AccountState) Deserialize(ss []byte) error {
-	e := gob.NewDecoder(bytes.NewBuffer(ss))
-	if err := e.Decode(st); err != nil {
-		return ErrFailedToUnmarshalState
-	}
-	return nil
-}
-
-// AddBalance adds balance for account state
-func (st *AccountState) AddBalance(amount *big.Int) error {
-	st.Balance.Add(st.Balance, amount)
-	return nil
-}
-
-// SubBalance subtracts balance for account state
-func (st *AccountState) SubBalance(amount *big.Int) error {
-	// make sure there's enough fund to spend
-	if amount.Cmp(st.Balance) == 1 {
-		return ErrNotEnoughBalance
-	}
-	st.Balance.Sub(st.Balance, amount)
-	return nil
-}
-
-// Clone clones the account state
-func (st *AccountState) Clone() State {
-	s := *st
-	s.Balance = nil
-	s.Balance = new(big.Int).Set(st.Balance)
-	s.VotingWeight = nil
-	s.VotingWeight = new(big.Int).Set(st.VotingWeight)
-	if st.CodeHash != nil {
-		s.CodeHash = nil
-		s.CodeHash = make([]byte, len(st.CodeHash))
-		copy(s.CodeHash, st.CodeHash)
-	}
-	// Voters won't be used, set to nil for simplicity
-	s.Voters = nil
-	return &s
+	Serialize() (data []byte, err error)
+	Deserialize(data []byte) error
 }

--- a/state/workingset.go
+++ b/state/workingset.go
@@ -8,7 +8,9 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"math/big"
+	"reflect"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -25,25 +27,29 @@ type (
 	// WorkingSet defines an interface for working set of states changes
 	WorkingSet interface {
 		// states and actions
-		LoadOrCreateState(string, uint64) (*State, error)
+		LoadOrCreateAccountState(string, uint64) (*AccountState, error)
 		Nonce(string) (uint64, error) // Note that Nonce starts with 1.
-		CachedState(string) (*State, error)
+		CachedAccountState(string) (*AccountState, error)
 		RunActions(uint64, []*action.Transfer, []*action.Vote, []*action.Execution, []action.Action) (hash.Hash32B, error)
-		commit() error
+		Commit() error
 		// contracts
 		GetCodeHash(hash.PKHash) (hash.Hash32B, error)
 		GetCode(hash.PKHash) ([]byte, error)
 		SetCode(hash.PKHash, []byte) error
 		GetContractState(hash.PKHash, hash.Hash32B) (hash.Hash32B, error)
 		SetContractState(hash.PKHash, hash.Hash32B, hash.Hash32B) error
-		// private func
-		balance(string) (*big.Int, error)
-		state(string) (*State, error)
-		rootHash() hash.Hash32B
-		version() uint64
-		height() uint64
-		workingCandidates() map[hash.PKHash]*Candidate
-		getCandidates(height uint64) (CandidateList, error)
+		// Accounts
+		Balance(string) (*big.Int, error)
+		AccountState(string) (*AccountState, error)
+		RootHash() hash.Hash32B
+		Version() uint64
+		Height() uint64
+		WorkingCandidates() map[hash.PKHash]*Candidate
+		GetCandidates(height uint64) (CandidateList, error)
+
+		State(hash.PKHash, State) (State, error)
+		CachedState(hash.PKHash, State) (State, error)
+		PutState(hash.PKHash, State) error
 	}
 
 	// workingSet implements Workingset interface, tracks pending changes to account/contract in local cache
@@ -51,10 +57,10 @@ type (
 		ver              uint64
 		blkHeight        uint64
 		cachedCandidates map[hash.PKHash]*Candidate
-		savedAccount     map[string]*State        // save account state before being modified in this block
-		cachedAccount    map[hash.PKHash]*State   // accounts being modified in this block
+		savedStates      map[hash.PKHash]State    // saved states before being modified in this block
+		cachedStates     map[hash.PKHash]State    // states being modified in this block
 		cachedContract   map[hash.PKHash]Contract // contracts being modified in this block
-		accountTrie      trie.Trie                // global state trie
+		accountTrie      trie.Trie                // global AccountState trie
 		cb               db.CachedBatch           // cached batch for pending writes
 		dao              db.KVStore               // the underlying DB for account/contract storage
 		actionHandlers   []ActionHandler
@@ -71,8 +77,8 @@ func NewWorkingSet(
 	ws := &workingSet{
 		ver:              version,
 		cachedCandidates: make(map[hash.PKHash]*Candidate),
-		savedAccount:     make(map[string]*State),
-		cachedAccount:    make(map[hash.PKHash]*State),
+		savedStates:      make(map[hash.PKHash]State),
+		cachedStates:     make(map[hash.PKHash]State),
 		cachedContract:   make(map[hash.PKHash]Contract),
 		cb:               db.NewCachedBatch(),
 		dao:              kv,
@@ -80,101 +86,120 @@ func NewWorkingSet(
 	}
 	tr, err := trie.NewTrieSharedBatch(ws.dao, ws.cb, trie.AccountKVNameSpace, root)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate state trie from config")
+		return nil, errors.Wrap(err, "failed to generate AccountState trie from config")
 	}
 	ws.accountTrie = tr
 	if err := ws.accountTrie.Start(context.Background()); err != nil {
-		return nil, errors.Wrapf(err, "failed to load state trie from root = %x", root)
+		return nil, errors.Wrapf(err, "failed to load AccountState trie from root = %x", root)
 	}
 	return ws, nil
 }
 
-func (ws *workingSet) workingCandidates() map[hash.PKHash]*Candidate {
+func (ws *workingSet) WorkingCandidates() map[hash.PKHash]*Candidate {
 	return ws.cachedCandidates
 }
 
 //======================================
-// State/Account functions
+// AccountState functions
 //======================================
-// LoadOrCreateState loads existing or adds a new State with initial balance to the factory
+// LoadOrCreateAccountState loads existing or adds a new AccountState with initial Balance to the factory
 // addr should be a bech32 properly-encoded string
-func (ws *workingSet) LoadOrCreateState(addr string, init uint64) (*State, error) {
-	h, err := iotxaddress.GetPubkeyHash(addr)
+func (ws *workingSet) LoadOrCreateAccountState(addr string, init uint64) (*AccountState, error) {
+	addrHash, err := addressToPKHash(addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "error when getting the pubkey hash")
+		return nil, err
 	}
-	addrHash := byteutil.BytesTo20B(h)
-	state, err := ws.cachedState(addrHash)
+	state, err := ws.CachedState(addrHash, &AccountState{})
 	switch {
 	case errors.Cause(err) == ErrAccountNotExist:
 		balance := big.NewInt(0)
 		balance.SetUint64(init)
-		state = &State{
+		accountState := AccountState{
 			Balance:      balance,
 			VotingWeight: big.NewInt(0),
 		}
-		ws.cachedAccount[addrHash] = state
+		ws.cachedStates[addrHash] = &accountState
+		return &accountState, nil
 	case err != nil:
-		return nil, errors.Wrapf(err, "failed to get state of %x from cached state", addrHash)
+		return nil, errors.Wrapf(err, "failed to get AccountState of %x from cached AccountState", addrHash)
 	}
-	return state, nil
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return nil, err
+	}
+	return accountState, nil
 }
 
-// Balance returns balance
-func (ws *workingSet) balance(addr string) (*big.Int, error) {
-	state, err := ws.state(addr)
+// Balance returns Balance
+func (ws *workingSet) Balance(addr string) (*big.Int, error) {
+	state, err := ws.AccountState(addr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get state of %s", addr)
+		return nil, errors.Wrapf(err, "failed to get AccountState of %s", addr)
 	}
 	return state.Balance, nil
 }
 
 // Nonce returns the Nonce if the account exists
 func (ws *workingSet) Nonce(addr string) (uint64, error) {
-	state, err := ws.state(addr)
+	state, err := ws.AccountState(addr)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to get state of %s", addr)
+		return 0, errors.Wrapf(err, "failed to get AccountState of %s", addr)
 	}
 	return state.Nonce, nil
 }
 
-// State returns the confirmed state on the chain
-func (ws *workingSet) state(addr string) (*State, error) {
-	if saved, ok := ws.savedAccount[addr]; ok {
-		return saved, nil
-	}
-	pkHash, err := iotxaddress.GetPubkeyHash(addr)
+// AccountState returns the confirmed AccountState on the chain
+func (ws *workingSet) AccountState(addr string) (*AccountState, error) {
+	addrHash, err := addressToPKHash(addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "error when getting the pubkey hash")
+		return nil, err
 	}
-	return ws.getState(byteutil.BytesTo20B(pkHash))
+	state, ok := ws.savedStates[addrHash]
+	if !ok {
+		state, err = ws.State(addrHash, &AccountState{})
+		if err != nil {
+			return nil, err
+		}
+	}
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return nil, err
+	}
+	return accountState, nil
 }
 
-// CachedState returns the cached state if the address exists in local cache
-func (ws *workingSet) CachedState(addr string) (*State, error) {
-	h, err := iotxaddress.GetPubkeyHash(addr)
+// CachedAccountState returns the cached AccountState if the address exists in local cache
+func (ws *workingSet) CachedAccountState(addr string) (*AccountState, error) {
+	addrHash, err := addressToPKHash(addr)
 	if err != nil {
-		return nil, errors.Wrap(err, "error when getting the pubkey hash")
+		return nil, err
 	}
-	addrHash := byteutil.BytesTo20B(h)
 	if contract, ok := ws.cachedContract[addrHash]; ok {
 		return contract.SelfState(), nil
 	}
-	return ws.cachedState(addrHash)
+	state, err := ws.CachedState(addrHash, &AccountState{})
+	if err != nil {
+		return nil, err
+	}
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return nil, err
+	}
+	return accountState, nil
 }
 
 // RootHash returns the hash of the root node of the accountTrie
-func (ws *workingSet) rootHash() hash.Hash32B {
+func (ws *workingSet) RootHash() hash.Hash32B {
 	return ws.accountTrie.RootHash()
 }
 
-// version returns the version of this working set
-func (ws *workingSet) version() uint64 {
+// Version returns the Version of this working set
+func (ws *workingSet) Version() uint64 {
 	return ws.ver
 }
 
-// Height returns the height of the block being worked on
-func (ws *workingSet) height() uint64 {
+// Height returns the Height of the block being worked on
+func (ws *workingSet) Height() uint64 {
 	return ws.blkHeight
 }
 
@@ -188,9 +213,9 @@ func (ws *workingSet) RunActions(
 	ws.blkHeight = blockHeight
 	// Recover cachedCandidates after restart factory
 	if blockHeight > 0 && len(ws.cachedCandidates) == 0 {
-		candidates, err := ws.getCandidates(blockHeight - 1)
+		candidates, err := ws.GetCandidates(blockHeight - 1)
 		if err != nil {
-			return hash.ZeroHash32B, errors.Wrapf(err, "failed to get previous Candidates on height %d", blockHeight-1)
+			return hash.ZeroHash32B, errors.Wrapf(err, "failed to get previous Candidates on Height %d", blockHeight-1)
 		}
 		if ws.cachedCandidates, err = CandidatesToMap(candidates); err != nil {
 			return hash.ZeroHash32B, errors.Wrap(err, "failed to convert candidate list to map of cached Candidates")
@@ -203,13 +228,17 @@ func (ws *workingSet) RunActions(
 		return hash.ZeroHash32B, errors.Wrap(err, "failed to handle votes")
 	}
 
-	// update pending state changes to trie
-	for addr, state := range ws.cachedAccount {
-		if err := ws.putState(addr[:], state); err != nil {
-			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending state changes to trie")
+	// update pending AccountState changes to trie
+	for addr, state := range ws.cachedStates {
+		if err := ws.PutState(addr, state); err != nil {
+			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending AccountState changes to trie")
+		}
+		accountState, err := stateToAccountState(state)
+		if err != nil {
+			return hash.ZeroHash32B, err
 		}
 		// Perform vote update operation on candidate and delegate pools
-		if !state.IsCandidate {
+		if !accountState.IsCandidate {
 			// remove the candidate if the person is not a candidate anymore
 			if _, ok := ws.cachedCandidates[addr]; ok {
 				delete(ws.cachedCandidates, addr)
@@ -217,10 +246,13 @@ func (ws *workingSet) RunActions(
 			continue
 		}
 		totalWeight := big.NewInt(0)
-		totalWeight.Add(totalWeight, state.VotingWeight)
-		voteeAddr, _ := iotxaddress.GetPubkeyHash(state.Votee)
-		if addr == byteutil.BytesTo20B(voteeAddr) {
-			totalWeight.Add(totalWeight, state.Balance)
+		totalWeight.Add(totalWeight, accountState.VotingWeight)
+		voteePKHash, err := addressToPKHash(accountState.Votee)
+		if err != nil {
+			return hash.ZeroHash32B, err
+		}
+		if addr == voteePKHash {
+			totalWeight.Add(totalWeight, accountState.Balance)
 		}
 		ws.updateCandidate(addr, totalWeight, blockHeight)
 	}
@@ -230,25 +262,32 @@ func (ws *workingSet) RunActions(
 			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending contract changes")
 		}
 		state := contract.SelfState()
-		// store the account (with new storage trie root) into state trie
-		if err := ws.putState(addr[:], state); err != nil {
-			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending contract state changes to trie")
+		// store the account (with new storage trie root) into AccountState trie
+		if err := ws.PutState(addr, state); err != nil {
+			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending contract AccountState changes to trie")
 		}
 	}
 	// increase Executor's Nonce for every execution in this block
 	for _, e := range executions {
-		addr, _ := iotxaddress.GetPubkeyHash(e.Executor())
-		state, err := ws.cachedState(byteutil.BytesTo20B(addr))
+		executorPKHash, err := addressToPKHash(e.Executor())
+		if err != nil {
+			return hash.ZeroHash32B, err
+		}
+		state, err := ws.CachedState(executorPKHash, &AccountState{})
 		if err != nil {
 			return hash.ZeroHash32B, errors.Wrap(err, "executor does not exist")
 		}
-		// save state before modifying
-		ws.saveState(e.Executor(), state)
-		if e.Nonce() > state.Nonce {
-			state.Nonce = e.Nonce()
+		accountState, err := stateToAccountState(state)
+		if err != nil {
+			return hash.ZeroHash32B, err
 		}
-		if err := ws.putState(addr, state); err != nil {
-			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending state changes to trie")
+		// save AccountState before modifying
+		ws.saveState(executorPKHash, state)
+		if e.Nonce() > accountState.Nonce {
+			accountState.Nonce = e.Nonce()
+		}
+		if err := ws.PutState(executorPKHash, state); err != nil {
+			return hash.ZeroHash32B, errors.Wrap(err, "failed to update pending AccountState changes to trie")
 		}
 	}
 
@@ -271,26 +310,26 @@ func (ws *workingSet) RunActions(
 		return hash.ZeroHash32B, errors.Wrap(err, "failed to convert map of cached Candidates to candidate list")
 	}
 	sort.Sort(candidates)
-	candidatesBytes, err := Serialize(candidates)
+	candidatesBytes, err := SerializeCandidateList(candidates)
 	if err != nil {
 		return hash.ZeroHash32B, errors.Wrap(err, "failed to serialize Candidates")
 	}
 	h := byteutil.Uint64ToBytes(blockHeight)
 	if err := ws.dao.Put(trie.CandidateKVNameSpace, h, candidatesBytes); err != nil {
-		return hash.ZeroHash32B, errors.Wrapf(err, "failed to store Candidates on height %d", blockHeight)
+		return hash.ZeroHash32B, errors.Wrapf(err, "failed to store Candidates on Height %d", blockHeight)
 	}
-	// Persist current chain height
+	// Persist current chain Height
 	if err := ws.dao.Put(trie.AccountKVNameSpace, []byte(CurrentHeightKey), h); err != nil {
-		return hash.ZeroHash32B, errors.Wrap(err, "failed to store accountTrie's current height")
+		return hash.ZeroHash32B, errors.Wrap(err, "failed to store accountTrie's current Height")
 	}
-	return ws.rootHash(), nil
+	return ws.RootHash(), nil
 }
 
 // Commit persists all changes in RunActions() into the DB
-func (ws *workingSet) commit() error {
-	// commit all changes in a batch
+func (ws *workingSet) Commit() error {
+	// Commit all changes in a batch
 	if err := ws.accountTrie.Commit(); err != nil {
-		return errors.Wrap(err, "failed to commit all changes to underlying DB in a batch")
+		return errors.Wrap(err, "failed to Commit all changes to underlying DB in a batch")
 	}
 	ws.clearCache()
 	return nil
@@ -304,11 +343,15 @@ func (ws *workingSet) GetCodeHash(addr hash.PKHash) (hash.Hash32B, error) {
 	if contract, ok := ws.cachedContract[addr]; ok {
 		return byteutil.BytesTo32B(contract.SelfState().CodeHash), nil
 	}
-	state, err := ws.cachedState(addr)
+	state, err := ws.CachedState(addr, &AccountState{})
 	if err != nil {
 		return hash.ZeroHash32B, errors.Wrapf(err, "failed to GetCodeHash for contract %x", addr)
 	}
-	return byteutil.BytesTo32B(state.CodeHash), nil
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return hash.ZeroHash32B, err
+	}
+	return byteutil.BytesTo32B(accountState.CodeHash), nil
 }
 
 // GetCode returns contract's code
@@ -316,11 +359,15 @@ func (ws *workingSet) GetCode(addr hash.PKHash) ([]byte, error) {
 	if contract, ok := ws.cachedContract[addr]; ok {
 		return contract.GetCode()
 	}
-	state, err := ws.cachedState(addr)
+	state, err := ws.CachedState(addr, &AccountState{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to GetCode for contract %x", addr)
 	}
-	return ws.dao.Get(trie.CodeKVNameSpace, state.CodeHash[:])
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return nil, err
+	}
+	return ws.dao.Get(trie.CodeKVNameSpace, accountState.CodeHash[:])
 }
 
 // SetCode sets contract's code
@@ -363,74 +410,79 @@ func (ws *workingSet) SetContractState(addr hash.PKHash, key, value hash.Hash32B
 	return contract.SetState(key, value[:])
 }
 
-//======================================
-// private state/account functions
-//======================================
-// getState pulls a State from DB
-func (ws *workingSet) getState(hash hash.PKHash) (*State, error) {
+// State pulls a state from DB
+func (ws *workingSet) State(hash hash.PKHash, s State) (State, error) {
 	mstate, err := ws.accountTrie.Get(hash[:])
 	if errors.Cause(err) == trie.ErrNotExist {
 		return nil, errors.Wrapf(ErrAccountNotExist, "addrHash = %x", hash[:])
 	}
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get state of %x", hash)
+		return nil, errors.Wrapf(err, "failed to get AccountState of %x", hash)
 	}
-	return bytesToState(mstate)
+	if err := s.Deserialize(mstate); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
-func (ws *workingSet) cachedState(hash hash.PKHash) (*State, error) {
-	if state, ok := ws.cachedAccount[hash]; ok {
+// CachedState pulls a state from cache first. If missing, it will hit DB
+func (ws *workingSet) CachedState(hash hash.PKHash, s State) (State, error) {
+	if state, ok := ws.cachedStates[hash]; ok {
 		return state, nil
 	}
 	// add to local cache
-	state, err := ws.getState(hash)
+	state, err := ws.State(hash, s)
 	if state != nil {
-		ws.cachedAccount[hash] = state
+		ws.cachedStates[hash] = state
 	}
 	return state, err
 }
 
-// getState stores a State to DB
-func (ws *workingSet) putState(addr []byte, state *State) error {
-	ss, err := stateToBytes(state)
+// PutState put a state into DB
+func (ws *workingSet) PutState(pkHash hash.PKHash, state State) error {
+	ss, err := state.Serialize()
 	if err != nil {
-		return errors.Wrapf(err, "failed to convert state %v to bytes", state)
+		return errors.Wrapf(err, "failed to convert AccountState %v to bytes", state)
 	}
-	return ws.accountTrie.Upsert(addr, ss)
+	return ws.accountTrie.Upsert(pkHash[:], ss)
 }
 
-func (ws *workingSet) saveState(addr string, state *State) {
-	if _, ok := ws.savedAccount[addr]; !ok {
-		ws.savedAccount[addr] = state.clone()
+//======================================
+// private AccountState/account functions
+//======================================
+
+func (ws *workingSet) saveState(hash hash.PKHash, state State) {
+	if _, ok := ws.savedStates[hash]; !ok {
+		ws.savedStates[hash] = state.Clone()
 	}
 }
 
 func (ws *workingSet) getContract(addr hash.PKHash) (Contract, error) {
-	state, err := ws.cachedState(addr)
+	state, err := ws.CachedState(addr, &AccountState{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get the cached state of %x", addr)
+		return nil, errors.Wrapf(err, "failed to get the cached AccountState of %x", addr)
 	}
-	delete(ws.cachedAccount, addr)
-	if state.Root == hash.ZeroHash32B {
-		state.Root = trie.EmptyRoot
+	accountState, err := stateToAccountState(state)
+	if err != nil {
+		return nil, err
 	}
-	tr, err := trie.NewTrieSharedBatch(ws.dao, ws.cb, trie.ContractKVNameSpace, state.Root)
+	tr, err := trie.NewTrieSharedDB(ws.dao, trie.ContractKVNameSpace, state.Root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create storage trie for new contract %x", addr)
 	}
 	// add to contract cache
-	contract := newContract(state, tr)
+	contract := newContract(accountState, tr)
 	ws.cachedContract[addr] = contract
 	return contract, nil
 }
 
 // clearCache removes all local changes after committing to trie
 func (ws *workingSet) clearCache() {
-	ws.savedAccount = nil
-	ws.cachedAccount = nil
+	ws.savedStates = nil
+	ws.cachedStates = nil
 	ws.cachedContract = nil
-	ws.savedAccount = make(map[string]*State)
-	ws.cachedAccount = make(map[hash.PKHash]*State)
+	ws.savedStates = make(map[hash.PKHash]State)
+	ws.cachedStates = make(map[hash.PKHash]State)
 	ws.cachedContract = make(map[hash.PKHash]Contract)
 }
 
@@ -444,12 +496,12 @@ func (ws *workingSet) updateCandidate(pkHash hash.PKHash, totalWeight *big.Int, 
 	candidate.LastUpdateHeight = blockHeight
 }
 
-func (ws *workingSet) getCandidates(height uint64) (CandidateList, error) {
+func (ws *workingSet) GetCandidates(height uint64) (CandidateList, error) {
 	candidatesBytes, err := ws.dao.Get(trie.CandidateKVNameSpace, byteutil.Uint64ToBytes(height))
 	if err != nil {
-		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on height %d", height)
+		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on Height %d", height)
 	}
-	return Deserialize(candidatesBytes)
+	return DeserializeCandidateList(candidatesBytes)
 }
 
 //======================================
@@ -462,18 +514,22 @@ func (ws *workingSet) handleTsf(tsf []*action.Transfer) error {
 		}
 		if !tx.IsCoinbase() {
 			// check sender
-			sender, err := ws.LoadOrCreateState(tx.Sender(), 0)
+			sender, err := ws.LoadOrCreateAccountState(tx.Sender(), 0)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load or create the state of sender %s", tx.Sender())
+				return errors.Wrapf(err, "failed to load or create the AccountState of sender %s", tx.Sender())
 			}
-			// save state before modifying
-			ws.saveState(tx.Sender(), sender)
+			// save AccountState before modifying
+			senderPKHash, err := addressToPKHash(tx.Sender())
+			if err != nil {
+				return err
+			}
+			ws.saveState(senderPKHash, sender)
 			if tx.Amount().Cmp(sender.Balance) == 1 {
-				return errors.Wrapf(ErrNotEnoughBalance, "failed to verify the balance of sender %s", tx.Sender())
+				return errors.Wrapf(ErrNotEnoughBalance, "failed to verify the Balance of sender %s", tx.Sender())
 			}
-			// update sender balance
+			// update sender Balance
 			if err := sender.SubBalance(tx.Amount()); err != nil {
-				return errors.Wrapf(err, "failed to update the balance of sender %s", tx.Sender())
+				return errors.Wrapf(err, "failed to update the Balance of sender %s", tx.Sender())
 			}
 			// update sender Nonce
 			if tx.Nonce() > sender.Nonce {
@@ -482,35 +538,47 @@ func (ws *workingSet) handleTsf(tsf []*action.Transfer) error {
 			// Update sender votes
 			if len(sender.Votee) > 0 && sender.Votee != tx.Sender() {
 				// sender already voted to a different person
-				voteeOfSender, err := ws.LoadOrCreateState(sender.Votee, 0)
+				voteeOfSender, err := ws.LoadOrCreateAccountState(sender.Votee, 0)
 				if err != nil {
-					return errors.Wrapf(err, "failed to load or create the state of sender's votee %s", sender.Votee)
+					return errors.Wrapf(err, "failed to load or create the AccountState of sender's votee %s", sender.Votee)
 				}
-				// save state before modifying
-				ws.saveState(sender.Votee, voteeOfSender)
+				// save AccountState before modifying
+				voteePKHash, err := addressToPKHash(sender.Votee)
+				if err != nil {
+					return err
+				}
+				ws.saveState(voteePKHash, voteeOfSender)
 				voteeOfSender.VotingWeight.Sub(voteeOfSender.VotingWeight, tx.Amount())
 			}
 		}
 		// check recipient
-		recipient, err := ws.LoadOrCreateState(tx.Recipient(), 0)
+		recipient, err := ws.LoadOrCreateAccountState(tx.Recipient(), 0)
 		if err != nil {
-			return errors.Wrapf(err, "failed to laod or create the state of recipient %s", tx.Recipient())
+			return errors.Wrapf(err, "failed to laod or create the AccountState of recipient %s", tx.Recipient())
 		}
-		// save state before modifying
-		ws.saveState(tx.Recipient(), recipient)
-		// update recipient balance
+		// save AccountState before modifying
+		recipientPKHash, err := addressToPKHash(tx.Recipient())
+		if err != nil {
+			return err
+		}
+		ws.saveState(recipientPKHash, recipient)
+		// update recipient Balance
 		if err := recipient.AddBalance(tx.Amount()); err != nil {
-			return errors.Wrapf(err, "failed to update the balance of recipient %s", tx.Recipient())
+			return errors.Wrapf(err, "failed to update the Balance of recipient %s", tx.Recipient())
 		}
 		// Update recipient votes
 		if len(recipient.Votee) > 0 && recipient.Votee != tx.Recipient() {
 			// recipient already voted to a different person
-			voteeOfRecipient, err := ws.LoadOrCreateState(recipient.Votee, 0)
+			voteeOfRecipient, err := ws.LoadOrCreateAccountState(recipient.Votee, 0)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load or create the state of recipient's votee %s", recipient.Votee)
+				return errors.Wrapf(err, "failed to load or create the AccountState of recipient's votee %s", recipient.Votee)
 			}
-			// save state before modifying
-			ws.saveState(recipient.Votee, voteeOfRecipient)
+			// save AccountState before modifying
+			voteePKHash, err := addressToPKHash(recipient.Votee)
+			if err != nil {
+				return err
+			}
+			ws.saveState(voteePKHash, voteeOfRecipient)
 			voteeOfRecipient.VotingWeight.Add(voteeOfRecipient.VotingWeight, tx.Amount())
 		}
 	}
@@ -519,12 +587,16 @@ func (ws *workingSet) handleTsf(tsf []*action.Transfer) error {
 
 func (ws *workingSet) handleVote(blockHeight uint64, vote []*action.Vote) error {
 	for _, v := range vote {
-		voteFrom, err := ws.LoadOrCreateState(v.Voter(), 0)
+		voteFrom, err := ws.LoadOrCreateAccountState(v.Voter(), 0)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load or create the state of voter %s", v.Voter())
+			return errors.Wrapf(err, "failed to load or create the AccountState of voter %s", v.Voter())
 		}
-		// save state before modifying
-		ws.saveState(v.Voter(), voteFrom)
+		// save AccountState before modifying
+		voterPKHash, err := addressToPKHash(v.Voter())
+		if err != nil {
+			return err
+		}
+		ws.saveState(voterPKHash, voteFrom)
 		// update voteFrom Nonce
 		if v.Nonce() > voteFrom.Nonce {
 			voteFrom.Nonce = v.Nonce()
@@ -532,12 +604,16 @@ func (ws *workingSet) handleVote(blockHeight uint64, vote []*action.Vote) error 
 		// Update old votee's weight
 		if len(voteFrom.Votee) > 0 && voteFrom.Votee != v.Voter() {
 			// voter already voted
-			oldVotee, err := ws.LoadOrCreateState(voteFrom.Votee, 0)
+			oldVotee, err := ws.LoadOrCreateAccountState(voteFrom.Votee, 0)
 			if err != nil {
-				return errors.Wrapf(err, "failed to load or create the state of voter's old votee %s", voteFrom.Votee)
+				return errors.Wrapf(err, "failed to load or create the AccountState of voter's old votee %s", voteFrom.Votee)
 			}
-			// save state before modifying
-			ws.saveState(voteFrom.Votee, oldVotee)
+			// save AccountState before modifying
+			voteePKHash, err := addressToPKHash(voteFrom.Votee)
+			if err != nil {
+				return err
+			}
+			ws.saveState(voteePKHash, oldVotee)
 			oldVotee.VotingWeight.Sub(oldVotee.VotingWeight, voteFrom.Balance)
 			voteFrom.Votee = ""
 		}
@@ -548,12 +624,16 @@ func (ws *workingSet) handleVote(blockHeight uint64, vote []*action.Vote) error 
 			continue
 		}
 
-		voteTo, err := ws.LoadOrCreateState(v.Votee(), 0)
+		voteTo, err := ws.LoadOrCreateAccountState(v.Votee(), 0)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load or create the state of votee %s", v.Votee())
+			return errors.Wrapf(err, "failed to load or create the AccountState of votee %s", v.Votee())
 		}
-		// save state before modifying
-		ws.saveState(v.Votee(), voteTo)
+		// save AccountState before modifying
+		voteePKHash, err := addressToPKHash(v.Votee())
+		if err != nil {
+			return err
+		}
+		ws.saveState(voteePKHash, voteTo)
 		if v.Voter() != v.Votee() {
 			// Voter votes to a different person
 			voteTo.VotingWeight.Add(voteTo.VotingWeight, voteFrom.Balance)
@@ -562,14 +642,9 @@ func (ws *workingSet) handleVote(blockHeight uint64, vote []*action.Vote) error 
 			// Vote to self: self-nomination or cancel the previous vote case
 			voteFrom.Votee = v.Voter()
 			voteFrom.IsCandidate = true
-			pkHash, err := iotxaddress.GetPubkeyHash(v.Voter())
-			if err != nil {
-				return errors.Wrap(err, "cannot get the hash of the address")
-			}
-			pkHashAddress := byteutil.BytesTo20B(pkHash)
 			votePubkey := v.VoterPublicKey()
-			if _, ok := ws.cachedCandidates[pkHashAddress]; !ok {
-				ws.cachedCandidates[pkHashAddress] = &Candidate{
+			if _, ok := ws.cachedCandidates[voterPKHash]; !ok {
+				ws.cachedCandidates[voterPKHash] = &Candidate{
 					Address:        v.Voter(),
 					PublicKey:      votePubkey,
 					CreationHeight: blockHeight,
@@ -578,4 +653,21 @@ func (ws *workingSet) handleVote(blockHeight uint64, vote []*action.Vote) error 
 		}
 	}
 	return nil
+}
+
+func addressToPKHash(addr string) (hash.PKHash, error) {
+	var pkHash hash.PKHash
+	senderPKHashBytes, err := iotxaddress.GetPubkeyHash(addr)
+	if err != nil {
+		return pkHash, errors.Wrap(err, "cannot get the hash of the address")
+	}
+	return byteutil.BytesTo20B(senderPKHashBytes), nil
+}
+
+func stateToAccountState(state State) (*AccountState, error) {
+	accountState, ok := state.(*AccountState)
+	if !ok {
+		return nil, fmt.Errorf("error when casting state of %s into account state", reflect.TypeOf(state).String())
+	}
+	return accountState, nil
 }

--- a/state/workingset.go
+++ b/state/workingset.go
@@ -466,7 +466,11 @@ func (ws *workingSet) getContract(addr hash.PKHash) (Contract, error) {
 	if err != nil {
 		return nil, err
 	}
-	tr, err := trie.NewTrieSharedDB(ws.dao, trie.ContractKVNameSpace, account.Root)
+	delete(ws.cachedStates, addr)
+	if account.Root == hash.ZeroHash32B {
+		account.Root = trie.EmptyRoot
+	}
+	tr, err := trie.NewTrieSharedBatch(ws.dao, ws.cb, trie.ContractKVNameSpace, account.Root)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create storage trie for new contract %x", addr)
 	}

--- a/state/workingset.go
+++ b/state/workingset.go
@@ -60,7 +60,7 @@ type (
 		savedStates      map[hash.PKHash]State    // saved states before being modified in this block
 		cachedStates     map[hash.PKHash]State    // states being modified in this block
 		cachedContract   map[hash.PKHash]Contract // contracts being modified in this block
-		accountTrie      trie.Trie                // global AccountState trie
+		accountTrie      trie.Trie                // global account state trie
 		cb               db.CachedBatch           // cached batch for pending writes
 		dao              db.KVStore               // the underlying DB for account/contract storage
 		actionHandlers   []ActionHandler
@@ -86,11 +86,11 @@ func NewWorkingSet(
 	}
 	tr, err := trie.NewTrieSharedBatch(ws.dao, ws.cb, trie.AccountKVNameSpace, root)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate AccountState trie from config")
+		return nil, errors.Wrap(err, "failed to generate state trie from config")
 	}
 	ws.accountTrie = tr
 	if err := ws.accountTrie.Start(context.Background()); err != nil {
-		return nil, errors.Wrapf(err, "failed to load AccountState trie from root = %x", root)
+		return nil, errors.Wrapf(err, "failed to load state trie from root = %x", root)
 	}
 	return ws, nil
 }
@@ -102,7 +102,7 @@ func (ws *workingSet) WorkingCandidates() map[hash.PKHash]*Candidate {
 //======================================
 // AccountState functions
 //======================================
-// LoadOrCreateAccountState loads existing or adds a new AccountState with initial Balance to the factory
+// LoadOrCreateAccountState loads existing or adds a new account state with initial balance to the factory
 // addr should be a bech32 properly-encoded string
 func (ws *workingSet) LoadOrCreateAccountState(addr string, init uint64) (*AccountState, error) {
 	addrHash, err := addressToPKHash(addr)
@@ -130,11 +130,11 @@ func (ws *workingSet) LoadOrCreateAccountState(addr string, init uint64) (*Accou
 	return accountState, nil
 }
 
-// Balance returns Balance
+// Balance returns balance
 func (ws *workingSet) Balance(addr string) (*big.Int, error) {
 	state, err := ws.AccountState(addr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get AccountState of %s", addr)
+		return nil, errors.Wrapf(err, "failed to get account state of %s", addr)
 	}
 	return state.Balance, nil
 }
@@ -143,12 +143,12 @@ func (ws *workingSet) Balance(addr string) (*big.Int, error) {
 func (ws *workingSet) Nonce(addr string) (uint64, error) {
 	state, err := ws.AccountState(addr)
 	if err != nil {
-		return 0, errors.Wrapf(err, "failed to get AccountState of %s", addr)
+		return 0, errors.Wrapf(err, "failed to get account state of %s", addr)
 	}
 	return state.Nonce, nil
 }
 
-// AccountState returns the confirmed AccountState on the chain
+// AccountState returns the confirmed account state on the chain
 func (ws *workingSet) AccountState(addr string) (*AccountState, error) {
 	addrHash, err := addressToPKHash(addr)
 	if err != nil {
@@ -168,7 +168,7 @@ func (ws *workingSet) AccountState(addr string) (*AccountState, error) {
 	return accountState, nil
 }
 
-// CachedAccountState returns the cached AccountState if the address exists in local cache
+// CachedAccountState returns the cached account state if the address exists in local cache
 func (ws *workingSet) CachedAccountState(addr string) (*AccountState, error) {
 	addrHash, err := addressToPKHash(addr)
 	if err != nil {

--- a/state/workingset.go
+++ b/state/workingset.go
@@ -310,7 +310,7 @@ func (ws *workingSet) RunActions(
 		return hash.ZeroHash32B, errors.Wrap(err, "failed to convert map of cached Candidates to candidate list")
 	}
 	sort.Sort(candidates)
-	candidatesBytes, err := SerializeCandidateList(candidates)
+	candidatesBytes, err := candidates.Serialize()
 	if err != nil {
 		return hash.ZeroHash32B, errors.Wrap(err, "failed to serialize Candidates")
 	}
@@ -505,7 +505,7 @@ func (ws *workingSet) GetCandidates(height uint64) (CandidateList, error) {
 	if err != nil {
 		return []*Candidate{}, errors.Wrapf(err, "failed to get Candidates on Height %d", height)
 	}
-	return DeserializeCandidateList(candidatesBytes)
+	return CandidateList{}.Deserialize(candidatesBytes)
 }
 
 //======================================

--- a/test/mock/mock_actpool/mock_actpool.go
+++ b/test/mock/mock_actpool/mock_actpool.go
@@ -5,11 +5,10 @@
 package mock_actpool
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	action "github.com/iotexproject/iotex-core/action"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
+	reflect "reflect"
 )
 
 // MockActPool is a mock of ActPool interface

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -90,9 +90,9 @@ func (mr *MockBlockchainMockRecorder) Nonce(addr interface{}) *gomock.Call {
 }
 
 // CreateState mocks base method
-func (m *MockBlockchain) CreateState(addr string, init uint64) (*state.AccountState, error) {
+func (m *MockBlockchain) CreateState(addr string, init uint64) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "CreateState", addr, init)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -424,9 +424,9 @@ func (mr *MockBlockchainMockRecorder) TipHeight() *gomock.Call {
 }
 
 // StateByAddr mocks base method
-func (m *MockBlockchain) StateByAddr(address string) (*state.AccountState, error) {
+func (m *MockBlockchain) StateByAddr(address string) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "StateByAddr", address)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -6,15 +6,14 @@ package mock_blockchain
 
 import (
 	context "context"
-	big "math/big"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	action "github.com/iotexproject/iotex-core/action"
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	iotxaddress "github.com/iotexproject/iotex-core/iotxaddress"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
 	state "github.com/iotexproject/iotex-core/state"
+	big "math/big"
+	reflect "reflect"
 )
 
 // MockBlockchain is a mock of Blockchain interface
@@ -91,9 +90,9 @@ func (mr *MockBlockchainMockRecorder) Nonce(addr interface{}) *gomock.Call {
 }
 
 // CreateState mocks base method
-func (m *MockBlockchain) CreateState(addr string, init uint64) (*state.State, error) {
+func (m *MockBlockchain) CreateState(addr string, init uint64) (*state.AccountState, error) {
 	ret := m.ctrl.Call(m, "CreateState", addr, init)
-	ret0, _ := ret[0].(*state.State)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -425,9 +424,9 @@ func (mr *MockBlockchainMockRecorder) TipHeight() *gomock.Call {
 }
 
 // StateByAddr mocks base method
-func (m *MockBlockchain) StateByAddr(address string) (*state.State, error) {
+func (m *MockBlockchain) StateByAddr(address string) (*state.AccountState, error) {
 	ret := m.ctrl.Call(m, "StateByAddr", address)
-	ret0, _ := ret[0].(*state.State)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/mock/mock_state/mock_state.go
+++ b/test/mock/mock_state/mock_state.go
@@ -62,9 +62,9 @@ func (mr *MockFactoryMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 }
 
 // LoadOrCreateAccountState mocks base method
-func (m *MockFactory) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.AccountState, error) {
+func (m *MockFactory) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "LoadOrCreateAccountState", arg0, arg1)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -101,9 +101,9 @@ func (mr *MockFactoryMockRecorder) Nonce(arg0 interface{}) *gomock.Call {
 }
 
 // AccountState mocks base method
-func (m *MockFactory) AccountState(arg0 string) (*state.AccountState, error) {
+func (m *MockFactory) AccountState(arg0 string) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "AccountState", arg0)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -114,9 +114,9 @@ func (mr *MockFactoryMockRecorder) AccountState(arg0 interface{}) *gomock.Call {
 }
 
 // CachedAccountState mocks base method
-func (m *MockFactory) CachedAccountState(arg0 string) (*state.AccountState, error) {
+func (m *MockFactory) CachedAccountState(arg0 string) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "CachedAccountState", arg0)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/mock/mock_state/mock_state.go
+++ b/test/mock/mock_state/mock_state.go
@@ -6,13 +6,12 @@ package mock_state
 
 import (
 	context "context"
-	big "math/big"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	action "github.com/iotexproject/iotex-core/action"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
 	state "github.com/iotexproject/iotex-core/state"
+	big "math/big"
+	reflect "reflect"
 )
 
 // MockFactory is a mock of Factory interface
@@ -62,17 +61,17 @@ func (mr *MockFactoryMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockFactory)(nil).Stop), arg0)
 }
 
-// LoadOrCreateState mocks base method
-func (m *MockFactory) LoadOrCreateState(arg0 string, arg1 uint64) (*state.State, error) {
-	ret := m.ctrl.Call(m, "LoadOrCreateState", arg0, arg1)
-	ret0, _ := ret[0].(*state.State)
+// LoadOrCreateAccountState mocks base method
+func (m *MockFactory) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "LoadOrCreateAccountState", arg0, arg1)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadOrCreateState indicates an expected call of LoadOrCreateState
-func (mr *MockFactoryMockRecorder) LoadOrCreateState(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadOrCreateState", reflect.TypeOf((*MockFactory)(nil).LoadOrCreateState), arg0, arg1)
+// LoadOrCreateAccountState indicates an expected call of LoadOrCreateAccountState
+func (mr *MockFactoryMockRecorder) LoadOrCreateAccountState(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadOrCreateAccountState", reflect.TypeOf((*MockFactory)(nil).LoadOrCreateAccountState), arg0, arg1)
 }
 
 // Balance mocks base method
@@ -101,30 +100,30 @@ func (mr *MockFactoryMockRecorder) Nonce(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockFactory)(nil).Nonce), arg0)
 }
 
-// State mocks base method
-func (m *MockFactory) State(arg0 string) (*state.State, error) {
-	ret := m.ctrl.Call(m, "State", arg0)
-	ret0, _ := ret[0].(*state.State)
+// AccountState mocks base method
+func (m *MockFactory) AccountState(arg0 string) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "AccountState", arg0)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// State indicates an expected call of State
-func (mr *MockFactoryMockRecorder) State(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockFactory)(nil).State), arg0)
+// AccountState indicates an expected call of AccountState
+func (mr *MockFactoryMockRecorder) AccountState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountState", reflect.TypeOf((*MockFactory)(nil).AccountState), arg0)
 }
 
-// CachedState mocks base method
-func (m *MockFactory) CachedState(arg0 string) (*state.State, error) {
-	ret := m.ctrl.Call(m, "CachedState", arg0)
-	ret0, _ := ret[0].(*state.State)
+// CachedAccountState mocks base method
+func (m *MockFactory) CachedAccountState(arg0 string) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "CachedAccountState", arg0)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CachedState indicates an expected call of CachedState
-func (mr *MockFactoryMockRecorder) CachedState(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedState", reflect.TypeOf((*MockFactory)(nil).CachedState), arg0)
+// CachedAccountState indicates an expected call of CachedAccountState
+func (mr *MockFactoryMockRecorder) CachedAccountState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedAccountState", reflect.TypeOf((*MockFactory)(nil).CachedAccountState), arg0)
 }
 
 // RootHash mocks base method

--- a/test/mock/mock_state/mock_workingset.go
+++ b/test/mock/mock_state/mock_workingset.go
@@ -9,6 +9,7 @@ import (
 	action "github.com/iotexproject/iotex-core/action"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
 	state "github.com/iotexproject/iotex-core/state"
+	big "math/big"
 	reflect "reflect"
 )
 
@@ -35,17 +36,17 @@ func (m *MockWorkingSet) EXPECT() *MockWorkingSetMockRecorder {
 	return m.recorder
 }
 
-// LoadOrCreateState mocks base method
-func (m *MockWorkingSet) LoadOrCreateState(arg0 string, arg1 uint64) (*state.State, error) {
-	ret := m.ctrl.Call(m, "LoadOrCreateState", arg0, arg1)
-	ret0, _ := ret[0].(*state.State)
+// LoadOrCreateAccountState mocks base method
+func (m *MockWorkingSet) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "LoadOrCreateAccountState", arg0, arg1)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// LoadOrCreateState indicates an expected call of LoadOrCreateState
-func (mr *MockWorkingSetMockRecorder) LoadOrCreateState(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadOrCreateState", reflect.TypeOf((*MockWorkingSet)(nil).LoadOrCreateState), arg0, arg1)
+// LoadOrCreateAccountState indicates an expected call of LoadOrCreateAccountState
+func (mr *MockWorkingSetMockRecorder) LoadOrCreateAccountState(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadOrCreateAccountState", reflect.TypeOf((*MockWorkingSet)(nil).LoadOrCreateAccountState), arg0, arg1)
 }
 
 // Nonce mocks base method
@@ -61,17 +62,17 @@ func (mr *MockWorkingSetMockRecorder) Nonce(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockWorkingSet)(nil).Nonce), arg0)
 }
 
-// CachedState mocks base method
-func (m *MockWorkingSet) CachedState(arg0 string) (*state.State, error) {
-	ret := m.ctrl.Call(m, "CachedState", arg0)
-	ret0, _ := ret[0].(*state.State)
+// CachedAccountState mocks base method
+func (m *MockWorkingSet) CachedAccountState(arg0 string) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "CachedAccountState", arg0)
+	ret0, _ := ret[0].(*state.AccountState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// CachedState indicates an expected call of CachedState
-func (mr *MockWorkingSetMockRecorder) CachedState(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedState", reflect.TypeOf((*MockWorkingSet)(nil).CachedState), arg0)
+// CachedAccountState indicates an expected call of CachedAccountState
+func (mr *MockWorkingSetMockRecorder) CachedAccountState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedAccountState", reflect.TypeOf((*MockWorkingSet)(nil).CachedAccountState), arg0)
 }
 
 // RunActions mocks base method
@@ -87,16 +88,16 @@ func (mr *MockWorkingSetMockRecorder) RunActions(arg0, arg1, arg2, arg3, arg4 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunActions", reflect.TypeOf((*MockWorkingSet)(nil).RunActions), arg0, arg1, arg2, arg3, arg4)
 }
 
-// commit mocks base method
-func (m *MockWorkingSet) commit() error {
-	ret := m.ctrl.Call(m, "commit")
+// Commit mocks base method
+func (m *MockWorkingSet) Commit() error {
+	ret := m.ctrl.Call(m, "Commit")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// commit indicates an expected call of commit
-func (mr *MockWorkingSetMockRecorder) commit() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "commit", reflect.TypeOf((*MockWorkingSet)(nil).commit))
+// Commit indicates an expected call of Commit
+func (mr *MockWorkingSetMockRecorder) Commit() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockWorkingSet)(nil).Commit))
 }
 
 // GetCodeHash mocks base method
@@ -160,4 +161,129 @@ func (m *MockWorkingSet) SetContractState(arg0 hash.PKHash, arg1, arg2 hash.Hash
 // SetContractState indicates an expected call of SetContractState
 func (mr *MockWorkingSetMockRecorder) SetContractState(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetContractState", reflect.TypeOf((*MockWorkingSet)(nil).SetContractState), arg0, arg1, arg2)
+}
+
+// Balance mocks base method
+func (m *MockWorkingSet) Balance(arg0 string) (*big.Int, error) {
+	ret := m.ctrl.Call(m, "Balance", arg0)
+	ret0, _ := ret[0].(*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Balance indicates an expected call of Balance
+func (mr *MockWorkingSetMockRecorder) Balance(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Balance", reflect.TypeOf((*MockWorkingSet)(nil).Balance), arg0)
+}
+
+// AccountState mocks base method
+func (m *MockWorkingSet) AccountState(arg0 string) (*state.AccountState, error) {
+	ret := m.ctrl.Call(m, "AccountState", arg0)
+	ret0, _ := ret[0].(*state.AccountState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AccountState indicates an expected call of AccountState
+func (mr *MockWorkingSetMockRecorder) AccountState(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountState", reflect.TypeOf((*MockWorkingSet)(nil).AccountState), arg0)
+}
+
+// RootHash mocks base method
+func (m *MockWorkingSet) RootHash() hash.Hash32B {
+	ret := m.ctrl.Call(m, "RootHash")
+	ret0, _ := ret[0].(hash.Hash32B)
+	return ret0
+}
+
+// RootHash indicates an expected call of RootHash
+func (mr *MockWorkingSetMockRecorder) RootHash() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockWorkingSet)(nil).RootHash))
+}
+
+// Version mocks base method
+func (m *MockWorkingSet) Version() uint64 {
+	ret := m.ctrl.Call(m, "Version")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// Version indicates an expected call of Version
+func (mr *MockWorkingSetMockRecorder) Version() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockWorkingSet)(nil).Version))
+}
+
+// Height mocks base method
+func (m *MockWorkingSet) Height() uint64 {
+	ret := m.ctrl.Call(m, "Height")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// Height indicates an expected call of Height
+func (mr *MockWorkingSetMockRecorder) Height() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockWorkingSet)(nil).Height))
+}
+
+// WorkingCandidates mocks base method
+func (m *MockWorkingSet) WorkingCandidates() map[hash.PKHash]*state.Candidate {
+	ret := m.ctrl.Call(m, "WorkingCandidates")
+	ret0, _ := ret[0].(map[hash.PKHash]*state.Candidate)
+	return ret0
+}
+
+// WorkingCandidates indicates an expected call of WorkingCandidates
+func (mr *MockWorkingSetMockRecorder) WorkingCandidates() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkingCandidates", reflect.TypeOf((*MockWorkingSet)(nil).WorkingCandidates))
+}
+
+// GetCandidates mocks base method
+func (m *MockWorkingSet) GetCandidates(height uint64) (state.CandidateList, error) {
+	ret := m.ctrl.Call(m, "GetCandidates", height)
+	ret0, _ := ret[0].(state.CandidateList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCandidates indicates an expected call of GetCandidates
+func (mr *MockWorkingSetMockRecorder) GetCandidates(height interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCandidates", reflect.TypeOf((*MockWorkingSet)(nil).GetCandidates), height)
+}
+
+// State mocks base method
+func (m *MockWorkingSet) State(arg0 hash.PKHash, arg1 state.State) (state.State, error) {
+	ret := m.ctrl.Call(m, "State", arg0, arg1)
+	ret0, _ := ret[0].(state.State)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// State indicates an expected call of State
+func (mr *MockWorkingSetMockRecorder) State(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockWorkingSet)(nil).State), arg0, arg1)
+}
+
+// CachedState mocks base method
+func (m *MockWorkingSet) CachedState(arg0 hash.PKHash, arg1 state.State) (state.State, error) {
+	ret := m.ctrl.Call(m, "CachedState", arg0, arg1)
+	ret0, _ := ret[0].(state.State)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CachedState indicates an expected call of CachedState
+func (mr *MockWorkingSetMockRecorder) CachedState(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CachedState", reflect.TypeOf((*MockWorkingSet)(nil).CachedState), arg0, arg1)
+}
+
+// PutState mocks base method
+func (m *MockWorkingSet) PutState(arg0 hash.PKHash, arg1 state.State) error {
+	ret := m.ctrl.Call(m, "PutState", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutState indicates an expected call of PutState
+func (mr *MockWorkingSetMockRecorder) PutState(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutState", reflect.TypeOf((*MockWorkingSet)(nil).PutState), arg0, arg1)
 }

--- a/test/mock/mock_state/mock_workingset.go
+++ b/test/mock/mock_state/mock_workingset.go
@@ -37,9 +37,9 @@ func (m *MockWorkingSet) EXPECT() *MockWorkingSetMockRecorder {
 }
 
 // LoadOrCreateAccountState mocks base method
-func (m *MockWorkingSet) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.AccountState, error) {
+func (m *MockWorkingSet) LoadOrCreateAccountState(arg0 string, arg1 uint64) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "LoadOrCreateAccountState", arg0, arg1)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -63,9 +63,9 @@ func (mr *MockWorkingSetMockRecorder) Nonce(arg0 interface{}) *gomock.Call {
 }
 
 // CachedAccountState mocks base method
-func (m *MockWorkingSet) CachedAccountState(arg0 string) (*state.AccountState, error) {
+func (m *MockWorkingSet) CachedAccountState(arg0 string) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "CachedAccountState", arg0)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,9 +177,9 @@ func (mr *MockWorkingSetMockRecorder) Balance(arg0 interface{}) *gomock.Call {
 }
 
 // AccountState mocks base method
-func (m *MockWorkingSet) AccountState(arg0 string) (*state.AccountState, error) {
+func (m *MockWorkingSet) AccountState(arg0 string) (*state.Account, error) {
 	ret := m.ctrl.Call(m, "AccountState", arg0)
-	ret0, _ := ret[0].(*state.AccountState)
+	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
1. Define the state interface with common methods that state factory only needs to understand
2. Expose generic state manipulation methods from WorkingSet
3. Relocating original State struct to AccountState