### PR TITLE
Use endorsement.Set to log all the endorsements

### DIFF
--- a/consensus/scheme/rolldpos/fsm_test.go
+++ b/consensus/scheme/rolldpos/fsm_test.go
@@ -226,8 +226,7 @@ func TestStartRoundEvt(t *testing.T) {
 		require.Equal(t, sInitPropose, s)
 		assert.Equal(t, uint64(0), cfsm.ctx.epoch.subEpochNum)
 		assert.NotNil(t, cfsm.ctx.round.proposer, delegates[2])
-		assert.NotNil(t, cfsm.ctx.round.proposalEndorses, s)
-		assert.NotNil(t, cfsm.ctx.round.lockEndorses, s)
+		assert.NotNil(t, cfsm.ctx.round.endorsementSets, s)
 		assert.Equal(t, eInitBlock, (<-cfsm.evtq).Type())
 	})
 	t.Run("is-not-proposer", func(t *testing.T) {
@@ -250,8 +249,7 @@ func TestStartRoundEvt(t *testing.T) {
 		require.Equal(t, sAcceptPropose, s)
 		assert.Equal(t, uint64(0), cfsm.ctx.epoch.subEpochNum)
 		assert.NotNil(t, cfsm.ctx.round.proposer, delegates[2])
-		assert.NotNil(t, cfsm.ctx.round.proposalEndorses, s)
-		assert.NotNil(t, cfsm.ctx.round.lockEndorses, s)
+		assert.NotNil(t, cfsm.ctx.round.endorsementSets, s)
 		assert.Equal(t, eProposeBlockTimeout, (<-cfsm.evtq).Type())
 	})
 }
@@ -282,9 +280,8 @@ func TestHandleInitBlockEvt(t *testing.T) {
 	)
 	cfsm.ctx.epoch.numSubEpochs = uint(2)
 	cfsm.ctx.round = roundCtx{
-		proposalEndorses: make(map[hash.Hash32B]map[string]bool),
-		lockEndorses:     make(map[hash.Hash32B]map[string]bool),
-		proposer:         delegates[2],
+		endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
+		proposer:        delegates[2],
 	}
 
 	t.Run("secret-block", func(t *testing.T) {
@@ -333,11 +330,10 @@ func TestHandleProposeBlockEvt(t *testing.T) {
 		numSubEpochs: uint(1),
 	}
 	round := roundCtx{
-		height:           2,
-		number:           0,
-		proposalEndorses: make(map[hash.Hash32B]map[string]bool),
-		lockEndorses:     make(map[hash.Hash32B]map[string]bool),
-		proposer:         delegates[2],
+		height:          2,
+		number:          0,
+		endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
+		proposer:        delegates[2],
 	}
 
 	t.Run("pass-validation", func(t *testing.T) {
@@ -562,9 +558,8 @@ func TestHandleProposalEndorseEvt(t *testing.T) {
 		numSubEpochs: uint(1),
 	}
 	round := roundCtx{
-		proposalEndorses: make(map[hash.Hash32B]map[string]bool),
-		lockEndorses:     make(map[hash.Hash32B]map[string]bool),
-		proposer:         delegates[2],
+		endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
+		proposer:        delegates[2],
 	}
 
 	t.Run("gather-endorses", func(t *testing.T) {
@@ -659,9 +654,8 @@ func TestHandleCommitEndorseEvt(t *testing.T) {
 	}
 
 	round := roundCtx{
-		proposalEndorses: make(map[hash.Hash32B]map[string]bool),
-		lockEndorses:     make(map[hash.Hash32B]map[string]bool),
-		proposer:         delegates[2],
+		endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
+		proposer:        delegates[2],
 	}
 
 	t.Run("gather-commits-secret-block", func(t *testing.T) {
@@ -829,9 +823,8 @@ func TestHandleFinishEpochEvt(t *testing.T) {
 		numSubEpochs: uint(2),
 	}
 	round := roundCtx{
-		proposalEndorses: make(map[hash.Hash32B]map[string]bool),
-		lockEndorses:     make(map[hash.Hash32B]map[string]bool),
-		proposer:         delegates[2],
+		endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
+		proposer:        delegates[2],
 	}
 	t.Run("dkg-not-finished", func(t *testing.T) {
 		cfsm := newTestCFSM(

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -388,14 +388,13 @@ type epochCtx struct {
 
 // roundCtx keeps the context data for the current round and block.
 type roundCtx struct {
-	height           uint64
-	number           uint32
-	proofOfLock      *endorsement.Set
-	timestamp        time.Time
-	block            *blockchain.Block
-	proposalEndorses map[hash.Hash32B]map[string]bool
-	lockEndorses     map[hash.Hash32B]map[string]bool
-	proposer         string
+	height          uint64
+	number          uint32
+	proofOfLock     *endorsement.Set
+	timestamp       time.Time
+	block           *blockchain.Block
+	endorsementSets map[hash.Hash32B]*endorsement.Set
+	proposer        string
 }
 
 // RollDPoS is Roll-DPoS consensus main entrance

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -475,7 +475,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 
 	// Test proposal endorse msg
 	blkHash := blk.HashBlock()
-	en, err := endorsement.NewEndorsement(
+	en := endorsement.NewEndorsement(
 		endorsement.NewConsensusVote(
 			blkHash,
 			blk.Height(),
@@ -484,7 +484,6 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 		),
 		addr,
 	)
-	assert.NoError(t, err)
 	msg := en.ToProtoMsg()
 
 	eEvt, err := r.cfsm.newEndorseEvtWithEndorsePb(msg)
@@ -492,7 +491,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 	assert.NotNil(t, eEvt)
 
 	// Test commit endorse msg
-	en, err = endorsement.NewEndorsement(
+	en = endorsement.NewEndorsement(
 		endorsement.NewConsensusVote(
 			blkHash,
 			blk.Height(),
@@ -501,7 +500,6 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 		),
 		addr,
 	)
-	assert.NoError(t, err)
 	msg = en.ToProtoMsg()
 	eEvt, err = r.cfsm.newEndorseEvtWithEndorsePb(msg)
 	assert.NoError(t, err)

--- a/endorsement/endorsement.go
+++ b/endorsement/endorsement.go
@@ -68,17 +68,14 @@ type Endorsement struct {
 }
 
 // NewEndorsement creates an Endorsement for an consensus vote
-func NewEndorsement(object *ConsensusVote, endorser *iotxaddress.Address) (*Endorsement, error) {
-	if endorser.PrivateKey == keypair.ZeroPrivateKey {
-		return nil, errors.New("The endorser's private key is empty")
-	}
+func NewEndorsement(object *ConsensusVote, endorser *iotxaddress.Address) *Endorsement {
 	hash := object.Hash()
 	return &Endorsement{
 		object:         object,
 		endorser:       endorser.RawAddress,
 		endorserPubkey: endorser.PublicKey,
 		signature:      crypto.EC283.Sign(endorser.PrivateKey, hash[:]),
-	}, nil
+	}
 }
 
 // ConsensusVote returns the Object of the endorse for signature

--- a/endorsement/endorsementset.go
+++ b/endorsement/endorsementset.go
@@ -11,15 +11,21 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/iotxaddress"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
 // Set is a collection of endorsements for block
 type Set struct {
 	blkHash      hash.Hash32B
 	endorsements []*Endorsement
+}
+
+// NewSet creates an endorsement set
+func NewSet(blkHash hash.Hash32B) *Set {
+	return &Set{
+		blkHash:      blkHash,
+		endorsements: []*Endorsement{},
+	}
 }
 
 // AddEndorsement adds an endorsement with the right block hash and signature
@@ -35,25 +41,23 @@ func (s *Set) AddEndorsement(en *Endorsement) error {
 	return nil
 }
 
-func (s *Set) blockHash() hash.Hash32B {
+// BlockHash returns the hash of the endorsed block
+func (s *Set) BlockHash() hash.Hash32B {
 	return s.blkHash
 }
 
-func (s *Set) numOfValidEndorsements(topics []ConsensusVoteTopic, endorsers []*iotxaddress.Address) uint16 {
-	topicSet := map[ConsensusVoteTopic]bool{}
-	for _, topic := range topics {
-		topicSet[topic] = true
-	}
-	endorserSet := map[keypair.PublicKey]bool{}
+// NumOfValidEndorsements returns the number of endorsements of the given topics and the endorsers
+func (s *Set) NumOfValidEndorsements(topics map[ConsensusVoteTopic]bool, endorsers []string) int {
+	endorserSet := map[string]bool{}
 	for _, endorser := range endorsers {
-		endorserSet[endorser.PublicKey] = true
+		endorserSet[endorser] = true
 	}
-	cnt := uint16(0)
+	cnt := 0
 	for _, endorsement := range s.endorsements {
-		if _, ok := topicSet[endorsement.ConsensusVote().Topic]; !ok {
+		if _, ok := topics[endorsement.ConsensusVote().Topic]; !ok {
 			continue
 		}
-		if _, ok := endorserSet[endorsement.endorserPubkey]; !ok {
+		if _, ok := endorserSet[endorsement.endorser]; !ok {
 			continue
 		}
 		cnt++


### PR DESCRIPTION
Previously, we use maps to count the number of endorsements for block proposal and block commit. With endorsementSet, we replace these maps with an endorsement set