### PR TITLE
Unify the initPropose step for proposer and non-proposer

### DIFF
--- a/consensus/scheme/rolldpos/fsm.go
+++ b/consensus/scheme/rolldpos/fsm.go
@@ -26,9 +26,7 @@ import (
 )
 
 /**
- * TODO:
- *  1. Store endorse decisions of follow up status
- *  2. For the nodes received correct proposal, add proposer's proposal endorse without signature, which could be replaced with real signature
+ * TODO: For the nodes received correct proposal, add proposer's proposal endorse without signature, which could be replaced with real signature
  */
 
 var (

--- a/consensus/scheme/rolldpos/fsm.go
+++ b/consensus/scheme/rolldpos/fsm.go
@@ -112,9 +112,10 @@ func newConsensusFSM(ctx *rollDPoSCtx) (*cFSM, error) {
 		AddStates(sDKGGeneration, sRoundStart, sInitPropose, sAcceptPropose, sAcceptProposalEndorse, sAcceptLockEndorse).
 		AddTransition(sEpochStart, eRollDelegates, cm.handleRollDelegatesEvt, []fsm.State{sEpochStart, sDKGGeneration}).
 		AddTransition(sDKGGeneration, eGenerateDKG, cm.handleGenerateDKGEvt, []fsm.State{sRoundStart}).
-		AddTransition(sRoundStart, eStartRound, cm.handleStartRoundEvt, []fsm.State{sInitPropose, sAcceptPropose}).
+		AddTransition(sRoundStart, eStartRound, cm.handleStartRoundEvt, []fsm.State{sInitPropose}).
 		AddTransition(sRoundStart, eFinishEpoch, cm.handleFinishEpochEvt, []fsm.State{sEpochStart, sRoundStart}).
 		AddTransition(sInitPropose, eInitBlock, cm.handleInitBlockEvt, []fsm.State{sAcceptPropose}).
+		AddTransition(sInitPropose, eProposeBlockTimeout, cm.handleProposeBlockTimeout, []fsm.State{sAcceptProposalEndorse}).
 		AddTransition(
 			sAcceptPropose,
 			eProposeBlock,
@@ -344,33 +345,36 @@ func (m *cFSM) handleStartRoundEvt(_ fsm.Event) (fsm.State, error) {
 		m.ctx.round = roundCtx{
 			height:          height,
 			number:          0,
-			timestamp:       m.ctx.clock.Now(),
 			endorsementSets: make(map[hash.Hash32B]*endorsement.Set),
-			proposer:        proposer,
 		}
 	}
-	if proposer == m.ctx.addr.RawAddress {
-		logger.Info().
-			Str("proposer", proposer).
-			Uint64("height", height).
-			Msg("current node is the proposer")
-		m.produce(m.newCEvt(eInitBlock), 0)
-		// TODO: we may need timeout event for block producer too
-		return sInitPropose, nil
-	}
-	logger.Info().
-		Str("proposer", proposer).
-		Uint64("height", height).
-		Msg("current node is not the proposer")
+	m.ctx.round.proposer = proposer
+	m.ctx.round.timestamp = m.ctx.clock.Now()
+
 	// Setup timeout for waiting for proposed block
+	m.produce(m.newCEvt(eInitBlock), 0)
 	m.produce(m.newTimeoutEvt(eProposeBlockTimeout), m.ctx.cfg.AcceptProposeTTL)
-	return sAcceptPropose, nil
+
+	return sInitPropose, nil
 }
 
 func (m *cFSM) handleInitBlockEvt(evt fsm.Event) (fsm.State, error) {
-	blk, err := m.ctx.mintBlock()
-	if err != nil {
-		return sEpochStart, errors.Wrap(err, "error when minting a block")
+	log := logger.Info().
+		Str("proposer", m.ctx.round.proposer).
+		Uint64("height", m.ctx.round.height).
+		Uint32("round", m.ctx.round.number)
+	if m.ctx.round.proposer != m.ctx.addr.RawAddress {
+		log.Msg("current node is not the proposer")
+		return sAcceptPropose, nil
+	}
+	log.Msg("current node is the proposer")
+	blk := m.ctx.round.block
+	if blk == nil {
+		var err error
+		blk, err = m.ctx.mintBlock()
+		if err != nil {
+			return sEpochStart, errors.Wrap(err, "error when minting a block")
+		}
 	}
 	proposeBlkEvt := m.newProposeBlkEvt(blk)
 	proposeBlkEvtProto := proposeBlkEvt.toProtoMsg()
@@ -477,6 +481,7 @@ func (m *cFSM) handleProposeBlockTimeout(evt fsm.Event) (fsm.State, error) {
 	logger.Warn().
 		Str("proposer", m.ctx.round.proposer).
 		Uint64("height", m.ctx.round.height).
+		Uint32("round", m.ctx.round.number).
 		Msg("didn't receive the proposed block before timeout")
 
 	return m.moveToAcceptProposalEndorse()

--- a/consensus/scheme/rolldpos/fsm_test.go
+++ b/consensus/scheme/rolldpos/fsm_test.go
@@ -246,11 +246,20 @@ func TestStartRoundEvt(t *testing.T) {
 		}
 		s, err := cfsm.handleStartRoundEvt(cfsm.newCEvt(eStartRound))
 		require.NoError(t, err)
-		require.Equal(t, sAcceptPropose, s)
+		require.Equal(t, sInitPropose, s)
 		assert.Equal(t, uint64(0), cfsm.ctx.epoch.subEpochNum)
 		assert.NotNil(t, cfsm.ctx.round.proposer, delegates[2])
 		assert.NotNil(t, cfsm.ctx.round.endorsementSets, s)
-		assert.Equal(t, eProposeBlockTimeout, (<-cfsm.evtq).Type())
+		evt := <-cfsm.evtq
+		assert.Equal(t, eInitBlock, evt.Type())
+		s, err = cfsm.handleInitBlockEvt(evt)
+		assert.Equal(t, sAcceptPropose, s)
+		assert.NoError(t, err)
+		evt = <-cfsm.evtq
+		assert.Equal(t, eProposeBlockTimeout, evt.Type())
+		s, err = cfsm.handleProposeBlockTimeout(evt)
+		assert.Equal(t, sAcceptProposalEndorse, s)
+		assert.NoError(t, err)
 	})
 }
 

--- a/proto/blockchain.pb.go
+++ b/proto/blockchain.pb.go
@@ -791,51 +791,6 @@ func (m *ActionPb) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_ActionPb proto.InternalMessageInfo
 
-type isActionPb_Action interface {
-	isActionPb_Action()
-}
-
-type ActionPb_Transfer struct {
-	Transfer *TransferPb `protobuf:"bytes,10,opt,name=transfer,proto3,oneof"`
-}
-type ActionPb_Vote struct {
-	Vote *VotePb `protobuf:"bytes,11,opt,name=vote,proto3,oneof"`
-}
-type ActionPb_Execution struct {
-	Execution *ExecutionPb `protobuf:"bytes,12,opt,name=execution,proto3,oneof"`
-}
-type ActionPb_SecretProposal struct {
-	SecretProposal *SecretProposalPb `protobuf:"bytes,13,opt,name=secretProposal,proto3,oneof"`
-}
-type ActionPb_SecretWitness struct {
-	SecretWitness *SecretWitnessPb `protobuf:"bytes,14,opt,name=secretWitness,proto3,oneof"`
-}
-type ActionPb_StartSubChain struct {
-	StartSubChain *StartSubChainPb `protobuf:"bytes,15,opt,name=startSubChain,proto3,oneof"`
-}
-type ActionPb_StopSubChain struct {
-	StopSubChain *StopSubChainPb `protobuf:"bytes,16,opt,name=stopSubChain,proto3,oneof"`
-}
-type ActionPb_PutBlock struct {
-	PutBlock *PutBlockPb `protobuf:"bytes,17,opt,name=putBlock,proto3,oneof"`
-}
-
-func (*ActionPb_Transfer) isActionPb_Action()       {}
-func (*ActionPb_Vote) isActionPb_Action()           {}
-func (*ActionPb_Execution) isActionPb_Action()      {}
-func (*ActionPb_SecretProposal) isActionPb_Action() {}
-func (*ActionPb_SecretWitness) isActionPb_Action()  {}
-func (*ActionPb_StartSubChain) isActionPb_Action()  {}
-func (*ActionPb_StopSubChain) isActionPb_Action()   {}
-func (*ActionPb_PutBlock) isActionPb_Action()       {}
-
-func (m *ActionPb) GetAction() isActionPb_Action {
-	if m != nil {
-		return m.Action
-	}
-	return nil
-}
-
 func (m *ActionPb) GetVersion() uint32 {
 	if m != nil {
 		return m.Version
@@ -867,6 +822,65 @@ func (m *ActionPb) GetGasPrice() []byte {
 func (m *ActionPb) GetSignature() []byte {
 	if m != nil {
 		return m.Signature
+	}
+	return nil
+}
+
+type isActionPb_Action interface {
+	isActionPb_Action()
+}
+
+type ActionPb_Transfer struct {
+	Transfer *TransferPb `protobuf:"bytes,10,opt,name=transfer,proto3,oneof"`
+}
+
+type ActionPb_Vote struct {
+	Vote *VotePb `protobuf:"bytes,11,opt,name=vote,proto3,oneof"`
+}
+
+type ActionPb_Execution struct {
+	Execution *ExecutionPb `protobuf:"bytes,12,opt,name=execution,proto3,oneof"`
+}
+
+type ActionPb_SecretProposal struct {
+	SecretProposal *SecretProposalPb `protobuf:"bytes,13,opt,name=secretProposal,proto3,oneof"`
+}
+
+type ActionPb_SecretWitness struct {
+	SecretWitness *SecretWitnessPb `protobuf:"bytes,14,opt,name=secretWitness,proto3,oneof"`
+}
+
+type ActionPb_StartSubChain struct {
+	StartSubChain *StartSubChainPb `protobuf:"bytes,15,opt,name=startSubChain,proto3,oneof"`
+}
+
+type ActionPb_StopSubChain struct {
+	StopSubChain *StopSubChainPb `protobuf:"bytes,16,opt,name=stopSubChain,proto3,oneof"`
+}
+
+type ActionPb_PutBlock struct {
+	PutBlock *PutBlockPb `protobuf:"bytes,17,opt,name=putBlock,proto3,oneof"`
+}
+
+func (*ActionPb_Transfer) isActionPb_Action() {}
+
+func (*ActionPb_Vote) isActionPb_Action() {}
+
+func (*ActionPb_Execution) isActionPb_Action() {}
+
+func (*ActionPb_SecretProposal) isActionPb_Action() {}
+
+func (*ActionPb_SecretWitness) isActionPb_Action() {}
+
+func (*ActionPb_StartSubChain) isActionPb_Action() {}
+
+func (*ActionPb_StopSubChain) isActionPb_Action() {}
+
+func (*ActionPb_PutBlock) isActionPb_Action() {}
+
+func (m *ActionPb) GetAction() isActionPb_Action {
+	if m != nil {
+		return m.Action
 	}
 	return nil
 }


### PR DESCRIPTION
In initPropose:
non-proposers jump directly to the AcceptPropose;
proposer proposes a block and then jump to the AcceptPropose step.

Which helps simplify the logic.