### PR TITLE
add genesis block when we start service

### DIFF
--- a/indexservice/server.go
+++ b/indexservice/server.go
@@ -62,6 +62,13 @@ func (s *Server) Start(ctx context.Context) error {
 		return errors.Wrap(err, "error when subscribe to block")
 	}
 
+	// sync genesis block
+	genesisBlk, err := s.bc.GetBlockByHeight(0)
+	if err != nil {
+		return errors.Wrap(err, "error when get genesis block")
+	}
+	s.idx.BuildIndex(genesisBlk)
+
 	go func() {
 		for {
 			select {


### PR DESCRIPTION
we need to sync genesis block in index service. Because indexservice is start after block start. so indexservice will miss the first block