### PR TITLE
IOTEX-121 Persist the sub-chain address together with the used Chain IDs

### DIFF
--- a/action/subchain/datamodel.go
+++ b/action/subchain/datamodel.go
@@ -7,12 +7,17 @@
 package subchain
 
 import (
+	"encoding/gob"
 	"math/big"
 
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/state"
 )
+
+func init() {
+	gob.Register(InOperation{})
+}
 
 // SubChain represents the state of a sub-chain in the state factory
 type SubChain struct {
@@ -52,7 +57,22 @@ func (bp *BlockProof) Serialize() ([]byte, error) { return state.GobBasedSeriali
 // Deserialize deserialize bytes into block proof state
 func (bp *BlockProof) Deserialize(data []byte) error { return state.GobBasedDeserialize(bp, data) }
 
-// CompareChainID compare two chain IDs
-func CompareChainID(x interface{}, y interface{}) int {
-	return int(int64(x.(uint32)) - int64(y.(uint32)))
+// InOperation represents a record of a sub-chain in operation
+type InOperation struct {
+	ID   uint32
+	Addr []byte
+}
+
+// SortInOperation compare two ChainInUse records by their chain IDs. If one of the input's type is not
+// InOperation, it will not be comparable and 0 will be returned.
+func SortInOperation(x interface{}, y interface{}) int {
+	cio1, ok := x.(InOperation)
+	if !ok {
+		return 0
+	}
+	cio2, ok := y.(InOperation)
+	if !ok {
+		return 0
+	}
+	return int(int64(cio1.ID) - int64(cio2.ID))
 }

--- a/action/subchain/protocol.go
+++ b/action/subchain/protocol.go
@@ -31,8 +31,8 @@ const (
 var (
 	// MinSecurityDeposit represents the security deposit minimal required for start a sub-chain, which is 1M iotx
 	MinSecurityDeposit = big.NewInt(0).Mul(big.NewInt(1000000000), big.NewInt(blockchain.Iotx))
-	// usedChainIDsKey is to find the used chain IDs in the state factory
-	usedChainIDsKey = byteutil.BytesTo20B(hash.Hash160b([]byte("usedChainIDs")))
+	// subChainsInOperationKey is to find the used chain IDs in the state factory
+	subChainsInOperationKey = byteutil.BytesTo20B(hash.Hash160b([]byte("subChainsInOperation")))
 )
 
 // Protocol defines the protocol of handling sub-chain actions

--- a/state/state.go
+++ b/state/state.go
@@ -33,7 +33,7 @@ func GobBasedSerialize(state State) ([]byte, error) {
 	var buf bytes.Buffer
 	e := gob.NewEncoder(&buf)
 	if err := e.Encode(state); err != nil {
-		return nil, errors.Wrapf(ErrStateSerialization, "error when serializing %T state", state)
+		return nil, errors.Wrapf(err, "error when serializing %T state", state)
 	}
 	return buf.Bytes(), nil
 }
@@ -43,7 +43,7 @@ func GobBasedDeserialize(state State, data []byte) error {
 	buf := bytes.NewBuffer(data)
 	e := gob.NewDecoder(buf)
 	if err := e.Decode(state); err != nil {
-		return errors.Wrapf(ErrStateDeserialization, "error when deserializing %T state", state)
+		return errors.Wrapf(err, "error when deserializing %T state", state)
 	}
 	return nil
 }
@@ -76,7 +76,7 @@ func (slice SortedSlice) Exist(e interface{}, f func(interface{}, interface{}) i
 	idx := sort.Search(len(slice), func(i int) bool {
 		return f(slice[i], e) >= 0
 	})
-	return idx < len(slice) && slice[idx] == e
+	return idx < len(slice) && f(slice[idx], e) == 0
 }
 
 // Append appends a state into the state slice

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package state
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSortedSlice(t *testing.T) {
+	t.Parallel()
+
+	compare := func(x interface{}, y interface{}) int {
+		return int(int64(x.(uint32)) - int64(y.(uint32)))
+	}
+
+	input := make([]uint32, 15)
+	for i := range input {
+		input[i] = uint32(i + 1)
+	}
+	for i := range input {
+		j := rand.Intn(i + 1)
+		input[i], input[j] = input[j], input[i]
+	}
+
+	var slice1 SortedSlice
+	for _, e := range input {
+		slice1 = slice1.Append(e, compare)
+	}
+	for _, e := range input {
+		assert.True(t, slice1.Exist(e, compare))
+	}
+	assert.False(t, slice1.Exist(uint32(0), compare))
+	assert.False(t, slice1.Exist(uint32(16), compare))
+
+	data, err := slice1.Serialize()
+	require.NoError(t, err)
+	var slice2 SortedSlice
+	require.NoError(t, slice2.Deserialize(data))
+	assert.Equal(t, slice1, slice2)
+}


### PR DESCRIPTION
The reason of doing this is to get all sub chain in operation account at restart, and start the services for them.