### PR TITLE
Fix the 2-chain e2e test failure in console

### DIFF
--- a/e2etest/multichain_test.go
+++ b/e2etest/multichain_test.go
@@ -64,6 +64,8 @@ func TestTwoChains(t *testing.T) {
 		require.NoError(t, svr.Stop(ctx))
 	}()
 
+	time.Sleep(time.Second)
+
 	mainChainClient := exp.NewExplorerProxy(
 		fmt.Sprintf("http://127.0.0.1:%d", svr.ChainService(cfg.Chain.ID).Explorer().Port()),
 	)

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -223,6 +224,8 @@ func StartServer(svr *Server, cfg *config.Config) {
 
 	if cfg.System.HTTPProfilingPort > 0 {
 		go func() {
+			runtime.SetMutexProfileFraction(1)
+			runtime.SetBlockProfileRate(1)
 			if err := http.ListenAndServe(
 				fmt.Sprintf(":%d", cfg.System.HTTPProfilingPort),
 				nil,


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1c0 pc=0x43b320d]

goroutine 30 [running]:
github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt.(*DB).beginRWTx(0x0, 0x0, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt/db.go:506 +0x3d
github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt.(*DB).Begin(0x0, 0x47a7a01, 0xc4202d7be8, 0x402c469, 0xc42024a030)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt/db.go:461 +0x38
github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt.(*DB).Update(0x0, 0xc4202d7c28, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/vendor/github.com/boltdb/bolt/db.go:584 +0x3c
github.com/iotexproject/iotex-core/db.(*boltDB).Commit(0xc4201ae200, 0x598d2f8, 0xc42024a0a0, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/db/db.go:304 +0x139
github.com/iotexproject/iotex-core/state.(*workingSet).Commit(0xc4201a4150, 0x0, 0xc4200e59b8)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/state/workingset.go:311 +0x82
github.com/iotexproject/iotex-core/state.(*factory).Commit(0xc4200e59a0, 0x49136e0, 0xc4201a4150, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/state/factory.go:255 +0x95
github.com/iotexproject/iotex-core/blockchain.(*blockchain).commitBlock(0xc4201600c0, 0xc4202e4000, 0xc4201600c0, 0xc4202e4000)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/blockchain/blockchain.go:857 +0x21e
github.com/iotexproject/iotex-core/blockchain.(*blockchain).CommitBlock(0xc4201600c0, 0xc4202e4000, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/blockchain/blockchain.go:763 +0x77
github.com/iotexproject/iotex-core/consensus.NewConsensus.func2(0xc4202e4000, 0x0, 0x0)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/consensus/consensus.go:102 +0x4f
github.com/iotexproject/iotex-core/consensus/scheme.(*standaloneHandler).Run(0xc4201a2b40)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/consensus/scheme/standalone.go:43 +0xb3
github.com/iotexproject/iotex-core/consensus/scheme.(*standaloneHandler).Run-fm()
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/consensus/scheme/standalone.go:59 +0x2a
github.com/iotexproject/iotex-core/pkg/routine.(*RecurringTask).Start.func1(0xc4200a4660, 0xc4201a2b70)
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/pkg/routine/recurringtask.go:60 +0x52
created by github.com/iotexproject/iotex-core/pkg/routine.(*RecurringTask).Start
	/Users/zjshen/Projects/go/src/github.com/iotexproject/iotex-core/pkg/routine/recurringtask.go:52 +0xa2
exit status 2

```

Actually I don't know the root cause, but feel bolt/db.go L506 should have nil ptr concern. Sleeping 1 second before doing anything seems to be able to mitigate the racing