### PR TITLE
IOTEX-143 Make sub-chain start from an empty genesis block

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -293,46 +293,39 @@ func (bc *blockchain) Start(ctx context.Context) (err error) {
 }
 
 func (bc *blockchain) startEmptyBlockchain() error {
-	ctx := context.Background()
-	genesis := NewGenesisBlock(bc.config)
-	if genesis == nil {
-		return errors.New("cannot create genesis block")
-	}
-	// Genesis block has height 0
-	if genesis.Header.height != 0 {
-		return errors.New(fmt.Sprintf("genesis block has height %d but expects 0", genesis.Height()))
-	}
-	if bc.sf == nil {
-		return errors.New("statefactory cannot be nil")
-	}
-	// add producer into Trie
 	ws, err := bc.sf.NewWorkingSet()
 	if err != nil {
 		return errors.Wrap(err, "Failed to obtain working set from state factory")
 	}
-	if _, err := ws.LoadOrCreateAccountState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply); err != nil {
-		return errors.Wrap(err, "failed to create Creator into StateFactory")
+	var genesis *Block
+	if bc.config.Chain.GenesisActionsPath != "" || !bc.config.Chain.EmptyGenesis {
+		genesis = NewGenesisBlock(bc.config)
+		if genesis == nil {
+			return errors.New("cannot create genesis block")
+		}
+		// Genesis block has height 0
+		if genesis.Header.height != 0 {
+			return errors.New(fmt.Sprintf("genesis block has height %d but expects 0", genesis.Height()))
+		}
+		if bc.sf == nil {
+			return errors.New("statefactory cannot be nil")
+		}
+		// add creator into Trie
+		if err := bc.addCreatorIntoAccounts(ws); err != nil {
+			return err
+		}
+		// run execution and update state trie root hash
+		root, err := bc.runActions(genesis, ws, false)
+		if err != nil {
+			return errors.Wrap(err, "failed to update state changes in Genesis block")
+		}
+		genesis.Header.stateRoot = root
+		genesis.workingSet = ws
+		// add Genesis block as very first block
+	} else {
+		genesis = NewBlock(bc.ChainID(), 0, hash.ZeroHash32B, bc.now(), keypair.ZeroPublicKey, nil)
+		genesis.workingSet = ws
 	}
-	gasLimit := GasLimit
-	ctx = state.WithRunActionsCtx(ctx, state.RunActionsCtx{
-		ProducerAddr:    genesis.ProducerAddress(),
-		GasLimit:        &gasLimit,
-		EnableGasCharge: bc.config.Chain.EnableGasCharge,
-	})
-	if _, _, err := ws.RunActions(ctx, 0, nil); err != nil {
-		return errors.Wrap(err, "failed to create Creator into StateFactory")
-	}
-	if err := bc.sf.Commit(ws); err != nil {
-		return errors.Wrap(err, "failed to add Creator into StateFactory")
-	}
-	// run execution and update state trie root hash
-	root, err := bc.runActions(genesis, ws, false)
-	if err != nil {
-		return errors.Wrap(err, "failed to update state changes in Genesis block")
-	}
-	genesis.Header.stateRoot = root
-	genesis.workingSet = ws
-	// add Genesis block as very first block
 	if err := bc.commitBlock(genesis); err != nil {
 		return errors.Wrap(err, "failed to commit Genesis block")
 	}
@@ -932,3 +925,17 @@ func (bc *blockchain) EmitToSubscribers(blk *Block) error {
 }
 
 func (bc *blockchain) now() uint64 { return uint64(bc.clk.Now().Unix()) }
+
+func (bc *blockchain) addCreatorIntoAccounts(ws state.WorkingSet) error {
+	account, err := ws.LoadOrCreateAccountState(Gen.CreatorAddr(bc.ChainID()), Gen.TotalSupply)
+	if err != nil {
+		return errors.Wrap(err, "failed to create Creator state into StateFactory")
+	}
+	if err := ws.PutState(Gen.CreatorPKHash(), account); err != nil {
+		return errors.Wrap(err, "failed to put Creator state into StateFactory")
+	}
+	if err := bc.sf.Commit(ws); err != nil {
+		return errors.Wrap(err, "failed to commit Creator state into StateFactory")
+	}
+	return nil
+}

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -85,6 +85,12 @@ func (g *Genesis) CreatorAddr(chainID uint32) string {
 	return generateAddr(chainID, pk)
 }
 
+// CreatorPKHash returns the creator public key hash
+func (g *Genesis) CreatorPKHash() hash.PKHash {
+	pk, _ := decodeKey(g.CreatorPubKey, "")
+	return keypair.HashPubKey(pk)
+}
+
 // NewGenesisBlock creates a new genesis block
 func NewGenesisBlock(cfg *config.Config) *Block {
 	var filePath string

--- a/config/config.go
+++ b/config/config.go
@@ -95,6 +95,7 @@ var (
 			ProducerPrivKey:              keypair.EncodePrivateKey(keypair.ZeroPrivateKey),
 			InMemTest:                    false,
 			GenesisActionsPath:           "",
+			EmptyGenesis:                 false,
 			NumCandidates:                101,
 			EnableFallBackToFreshDB:      false,
 			EnableSubChainStartInGenesis: false,
@@ -217,6 +218,7 @@ type (
 		// InMemTest creates in-memory DB file for local testing
 		InMemTest                    bool   `yaml:"inMemTest"`
 		GenesisActionsPath           string `yaml:"genesisActionsPath"`
+		EmptyGenesis                 bool   `yaml:"emptyGenesis"`
 		NumCandidates                uint   `yaml:"numCandidates"`
 		EnableFallBackToFreshDB      bool   `yaml:"enableFallbackToFreshDb"`
 		EnableSubChainStartInGenesis bool   `yaml:"enableSubChainStartInGenesis"`

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -88,7 +88,7 @@ func NewConsensus(
 		blk, err := bc.MintNewBlock(acts, GetAddr(cfg), nil,
 			nil, "")
 		if err != nil {
-			logger.Error().Msg("Failed to mint a block")
+			logger.Error().Err(err).Msg("Failed to mint a block")
 			return nil, err
 		}
 		logger.Info().

--- a/server/itx/subchain.go
+++ b/server/itx/subchain.go
@@ -79,7 +79,9 @@ func (s *Server) startSubChainService(addr string, sc *mainchain.SubChain) error
 				cfg.Chain.Address = addr
 				cfg.Chain.ChainDBPath = getSubChainDBPath(sc.ChainID, cfg.Chain.ChainDBPath)
 				cfg.Chain.TrieDBPath = getSubChainDBPath(sc.ChainID, cfg.Chain.TrieDBPath)
+				cfg.Chain.GenesisActionsPath = ""
 				cfg.Chain.EnableSubChainStartInGenesis = false
+				cfg.Chain.EmptyGenesis = true
 				cfg.Explorer.Port = cfg.Explorer.Port - int(s.rootChainService.ChainID()) + int(sc.ChainID)
 				if err := s.NewChainService(&cfg); err != nil {
 					logger.Error().Err(err).Msgf("error when constructing the sub-chain %d", sc.ChainID)

--- a/state/candidate.go
+++ b/state/candidate.go
@@ -118,9 +118,6 @@ func pbToCandidate(candPb *iproto.Candidate) (*Candidate, error) {
 
 // MapToCandidates converts a map of cachedCandidates to candidate list
 func MapToCandidates(candidateMap map[hash.PKHash]*Candidate) (CandidateList, error) {
-	if candidateMap == nil {
-		return nil, errors.Wrap(ErrCandidateMap, "candidate map cannot be nil")
-	}
 	candidates := make(CandidateList, 0, len(candidateMap))
 	for _, cand := range candidateMap {
 		candidates = append(candidates, cand)
@@ -130,9 +127,6 @@ func MapToCandidates(candidateMap map[hash.PKHash]*Candidate) (CandidateList, er
 
 // CandidatesToMap converts a candidate list to map of cachedCandidates
 func CandidatesToMap(candidates CandidateList) (map[hash.PKHash]*Candidate, error) {
-	if candidates == nil {
-		return nil, errors.Wrap(ErrCandidateList, "candidate list cannot be nil")
-	}
 	candidateMap := make(map[hash.PKHash]*Candidate)
 	for _, candidate := range candidates {
 		if candidate == nil {

--- a/state/workingset.go
+++ b/state/workingset.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/iotxaddress"
+	"github.com/iotexproject/iotex-core/logger"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/trie"
@@ -174,8 +175,8 @@ func (ws *workingSet) RunActions(
 	if blockHeight > 0 && len(ws.cachedCandidates) == 0 {
 		candidates, err := ws.getCandidates(blockHeight - 1)
 		if err != nil {
-			return hash.ZeroHash32B, nil,
-				errors.Wrapf(err, "failed to get previous Candidates on Height %d", blockHeight-1)
+			logger.Info().Err(err).Msgf("No previous Candidates on Height %d", blockHeight-1)
+			candidates = CandidateList{}
 		}
 		if ws.cachedCandidates, err = CandidatesToMap(candidates); err != nil {
 			return hash.ZeroHash32B, nil,


### PR DESCRIPTION
1. Clean up the code of handling genesis block state mutation
2. Relax the assumption that candidates always exist
3. The code to check if we should use empty genesis block is not refined. There requires a future code refactor work to make genesis block creation more coherent