### PR TITLE
Pass config struct instead of pointer

### DIFF
--- a/action/protocols/account/protocol_test.go
+++ b/action/protocols/account/protocol_test.go
@@ -27,7 +27,7 @@ func TestProtocol_Handle(t *testing.T) {
 
 	cfg := config.Default
 	ctx := context.Background()
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(ctx))
 	defer func() {

--- a/action/protocols/multichain/mainchain/createdeposit_test.go
+++ b/action/protocols/multichain/mainchain/createdeposit_test.go
@@ -31,7 +31,7 @@ func TestValidateDeposit(t *testing.T) {
 
 	cfg := config.Default
 	ctx := context.Background()
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(t, err)
 	require.NoError(t, sf.Start(ctx))
 	ctrl := gomock.NewController(t)
@@ -103,7 +103,7 @@ func TestMutateDeposit(t *testing.T) {
 
 	cfg := config.Default
 	ctx := context.Background()
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(t, err)
 	require.NoError(t, sf.Start(ctx))
 	ctrl := gomock.NewController(t)

--- a/action/protocols/multichain/mainchain/protocol_test.go
+++ b/action/protocols/multichain/mainchain/protocol_test.go
@@ -28,7 +28,7 @@ func TestAddSubChainActions(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := config.Default
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(t, bc.Start(ctx))
 	_, err := bc.CreateState(
 		testaddress.Addrinfo["producer"].RawAddress,

--- a/action/protocols/multichain/mainchain/putblock_test.go
+++ b/action/protocols/multichain/mainchain/putblock_test.go
@@ -32,7 +32,7 @@ func TestHandlePutBlock(t *testing.T) {
 	cfg := config.Default
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(t, err)
 	require.NoError(t, sf.Start(ctx))
 	chain := mock_blockchain.NewMockBlockchain(ctrl)

--- a/action/protocols/multichain/mainchain/startsubchain_test.go
+++ b/action/protocols/multichain/mainchain/startsubchain_test.go
@@ -213,7 +213,7 @@ func TestHandleStartSubChain(t *testing.T) {
 
 	cfg := config.Default
 	ctx := context.Background()
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(t, err)
 	require.NoError(t, sf.Start(ctx))
 	ctrl := gomock.NewController(t)
@@ -294,7 +294,7 @@ func TestNoStartSubChainInGenesis(t *testing.T) {
 	cfg := config.Default
 
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&cfg, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(cfg, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	p := NewProtocol(bc)
 	bc.GetFactory().AddActionHandlers(p)
 	require.NoError(t, bc.Start(ctx))
@@ -310,7 +310,7 @@ func TestStartSubChainInGenesis(t *testing.T) {
 	cfg.Chain.EnableSubChainStartInGenesis = true
 
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&cfg, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(cfg, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	p := NewProtocol(bc)
 	bc.GetFactory().AddActionHandlers(p)
 	require.NoError(t, bc.Start(ctx))

--- a/action/protocols/multichain/subchain/protocol_test.go
+++ b/action/protocols/multichain/subchain/protocol_test.go
@@ -30,7 +30,7 @@ func TestValidateDeposit(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(t, bc.Start(ctx))
 	exp := mock_explorer.NewMockExplorer(ctrl)
 
@@ -93,7 +93,7 @@ func TestMutateDeposit(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(t, bc.Start(ctx))
 	exp := mock_explorer.NewMockExplorer(ctrl)
 

--- a/action/protocols/vote/protocol_test.go
+++ b/action/protocols/vote/protocol_test.go
@@ -33,7 +33,7 @@ func TestProtocol_Handle(t *testing.T) {
 
 	cfg := config.Default
 	ctx := context.Background()
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(ctx))
 	defer func() {
@@ -129,7 +129,7 @@ func TestProtocol_Handle(t *testing.T) {
 
 func TestProtocol_Validate(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(
 		testaddress.Addrinfo["producer"].RawAddress,

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -58,7 +58,7 @@ var (
 
 func TestActPool_validateGenericAction(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -116,7 +116,7 @@ func TestActPool_AddActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -260,7 +260,7 @@ func TestActPool_AddActs(t *testing.T) {
 func TestActPool_PickActs(t *testing.T) {
 	createActPool := func(cfg config.ActPool) (*actPool, []*action.Transfer, []*action.Vote, []*action.Execution) {
 		require := require.New(t)
-		bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+		bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 		require.NoError(bc.Start(context.Background()))
 		_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 		require.NoError(err)
@@ -349,7 +349,7 @@ func TestActPool_PickActs(t *testing.T) {
 
 func TestActPool_removeConfirmedActs(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -406,7 +406,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 func TestActPool_Reset(t *testing.T) {
 	require := require.New(t)
 
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -795,7 +795,7 @@ func TestActPool_Reset(t *testing.T) {
 
 func TestActPool_removeInvalidActs(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -840,7 +840,7 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 
 func TestActPool_GetPendingNonce(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -881,7 +881,7 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 
 func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -920,7 +920,7 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 
 func TestActPool_GetActionByHash(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)
@@ -957,7 +957,7 @@ func TestActPool_GetActionByHash(t *testing.T) {
 
 func TestActPool_GetCapacity(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	// Create actpool
 	apConfig := getActPoolCfg()
 	Ap, err := NewActPool(bc, apConfig)
@@ -969,7 +969,7 @@ func TestActPool_GetCapacity(t *testing.T) {
 
 func TestActPool_GetSize(t *testing.T) {
 	require := require.New(t)
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1.RawAddress, big.NewInt(100))
 	require.NoError(err)

--- a/blockchain/block_test.go
+++ b/blockchain/block_test.go
@@ -233,7 +233,7 @@ func TestSignBlock(t *testing.T) {
 }
 
 func TestWrongNonce(t *testing.T) {
-	cfg := &config.Default
+	cfg := config.Default
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	defer testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
@@ -399,7 +399,7 @@ func TestWrongNonce(t *testing.T) {
 }
 
 func TestWrongCoinbaseTsf(t *testing.T) {
-	cfg := &config.Default
+	cfg := config.Default
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	defer testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
@@ -521,7 +521,7 @@ func TestCoinbaseTransferValidation(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.Default
 	cfg.Chain.ID = 1
-	chain := NewBlockchain(&cfg, InMemStateFactoryOption(), InMemDaoOption())
+	chain := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
 	require.NotNil(t, chain)
 	require.NoError(t, chain.Start(ctx))
 	defer require.NoError(t, chain.Stop(ctx))
@@ -547,7 +547,7 @@ func TestCoinbaseTransferValidation(t *testing.T) {
 }
 
 func TestValidateSecretBlock(t *testing.T) {
-	cfg := &config.Default
+	cfg := config.Default
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	defer testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -177,7 +177,7 @@ func TestCreateBlockchain(t *testing.T) {
 	Gen.BlockReward = big.NewInt(0)
 
 	// create chain
-	bc := NewBlockchain(&cfg, InMemStateFactoryOption(), InMemDaoOption())
+	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	height := bc.TipHeight()
@@ -239,13 +239,13 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Explorer.Enabled = true
 
-	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
+	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
 
 	// Create a blockchain from scratch
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 
@@ -272,7 +272,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	require.Equal(27, transfers)
 
 	// Load a blockchain from DB
-	bc = NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	defer func() {
 		err := bc.Stop(ctx)
@@ -465,12 +465,12 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
-	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
+	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
 	// Create a blockchain from scratch
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 
@@ -499,7 +499,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.Equal(0, transfers)
 
 	// Load a blockchain from DB
-	bc = NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	defer func() {
 		err := bc.Stop(ctx)
@@ -642,7 +642,7 @@ func TestBlockchain_Validator(t *testing.T) {
 	cfg.Chain.TrieDBPath = ""
 
 	ctx := context.Background()
-	bc := NewBlockchain(&cfg, InMemDaoOption(), InMemStateFactoryOption())
+	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption())
 	require.NoError(t, bc.Start(ctx))
 	defer func() {
 		err := bc.Stop(ctx)
@@ -671,10 +671,10 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 	// Disable block reward to make bookkeeping easier
 	Gen.BlockReward = big.NewInt(0)
 
-	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
+	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
 	// TODO: change the value when Candidates size is changed
@@ -698,13 +698,13 @@ func TestCoinbaseTransfer(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 
-	sf, err := state.NewFactory(&cfg, state.DefaultTrieOption())
+	sf, err := state.NewFactory(cfg, state.DefaultTrieOption())
 	require.Nil(err)
 	require.NoError(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
 
 	Gen.BlockReward = big.NewInt(0)
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
 	height := bc.TipHeight()
@@ -736,7 +736,7 @@ func TestBlockchain_StateByAddr(t *testing.T) {
 	cfg := config.Default
 	// disable account-based testing
 	// create chain
-	bc := NewBlockchain(&cfg, InMemDaoOption(), InMemStateFactoryOption())
+	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption())
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
 
@@ -766,12 +766,12 @@ func TestBlocks(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 
-	sf, _ := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, _ := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
 
 	// Create a blockchain from scratch
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	a := ta.Addrinfo["alfa"]
 	c := ta.Addrinfo["bravo"]
@@ -820,12 +820,12 @@ func TestActions(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 
-	sf, _ := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, _ := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
 
 	// Create a blockchain from scratch
-	bc := NewBlockchain(&cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	a := ta.Addrinfo["alfa"]
 	c := ta.Addrinfo["bravo"]
@@ -869,7 +869,7 @@ func TestMintDKGBlock(t *testing.T) {
 	lastSeed, _ := hex.DecodeString("9de6306b08158c423330f7a27243a1a5cbe39bfd764f07818437882d21241567")
 	cfg := config.Default
 	clk := clock.NewMock()
-	chain := NewBlockchain(&cfg, InMemDaoOption(), InMemStateFactoryOption(), ClockOption(clk))
+	chain := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption(), ClockOption(clk))
 	require.NoError(chain.Start(context.Background()))
 
 	var err error

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -90,8 +90,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testBlockDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		cfg := config.Default
-		dao := newBlockDAO(&cfg, kvstore)
+		dao := newBlockDAO(kvstore, config.Default.Explorer.Enabled)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -163,9 +162,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testActionsDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		cfg := config.Default
-		cfg.Explorer.Enabled = true
-		dao := newBlockDAO(&cfg, kvstore)
+		dao := newBlockDAO(kvstore, true)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -377,9 +374,7 @@ func TestBlockDAO(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		cfg := config.Default
-		cfg.Explorer.Enabled = true
-		dao := newBlockDAO(&cfg, kvstore)
+		dao := newBlockDAO(kvstore, true)
 		err := dao.Start(ctx)
 		require.NoError(err)
 		defer func() {
@@ -535,7 +530,7 @@ func TestBlockDAO(t *testing.T) {
 	})
 
 	path := "/tmp/test-kv-store-" + string(rand.Int())
-	cfg := &config.Default.DB
+	cfg := config.Default.DB
 	t.Run("Bolt DB for blocks", func(t *testing.T) {
 		testutil.CleanupPath(t, path)
 		defer testutil.CleanupPath(t, path)

--- a/blockchain/evm_test.go
+++ b/blockchain/evm_test.go
@@ -40,7 +40,7 @@ func TestEVM(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.EnableGasCharge = true
 	cfg.Explorer.Enabled = true
-	bc := NewBlockchain(&cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	defer func() {
@@ -210,7 +210,7 @@ func TestRollDice(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.EnableGasCharge = true
 	cfg.Explorer.Enabled = true
-	bc := NewBlockchain(&cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	defer func() {
@@ -324,7 +324,7 @@ func TestERC20(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Explorer.Enabled = true
-	bc := NewBlockchain(&cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	defer func() {

--- a/blockchain/evmstatedbadapter_test.go
+++ b/blockchain/evmstatedbadapter_test.go
@@ -30,7 +30,7 @@ func TestAddBalance(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Explorer.Enabled = true
-	bc := NewBlockchain(&cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
+	bc := NewBlockchain(cfg, DefaultStateFactoryOption(), BoltDBDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	defer func() {

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -19,7 +19,7 @@ func TestGenesis(t *testing.T) {
 	t.Logf("The TotalSupply is %d", Gen.TotalSupply)
 
 	cfg := config.Default
-	genesisBlk := NewGenesisBlock(&cfg)
+	genesisBlk := NewGenesisBlock(cfg.Chain)
 
 	t.Log("The Genesis Block has the following header:")
 	t.Logf("Version: %d", genesisBlk.Header.version)

--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -44,12 +44,12 @@ type blockSyncer struct {
 
 // NewBlockSyncer returns a new block syncer instance
 func NewBlockSyncer(
-	cfg *config.Config,
+	cfg config.Config,
 	chain blockchain.Blockchain,
 	ap actpool.ActPool,
 	p2p network.Overlay,
 ) (BlockSync, error) {
-	if cfg == nil || chain == nil || ap == nil || p2p == nil {
+	if chain == nil || ap == nil || p2p == nil {
 		return nil, errors.New("cannot create BlockSync: missing param")
 	}
 

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -32,13 +32,13 @@ func TestSyncTaskInterval(t *testing.T) {
 
 	interval := time.Duration(0)
 
-	cfgLightWeight := &config.Config{
+	cfgLightWeight := config.Config{
 		NodeType: config.LightweightType,
 	}
 	lightWeight := syncTaskInterval(cfgLightWeight)
 	assert.Equal(interval, lightWeight)
 
-	cfgDelegate := &config.Config{
+	cfgDelegate := config.Config{
 		NodeType: config.DelegateType,
 		BlockSync: config.BlockSync{
 			Interval: interval,
@@ -47,7 +47,7 @@ func TestSyncTaskInterval(t *testing.T) {
 	delegate := syncTaskInterval(cfgDelegate)
 	assert.Equal(interval, delegate)
 
-	cfgFullNode := &config.Config{
+	cfgFullNode := config.Config{
 		NodeType: config.FullNodeType,
 		BlockSync: config.BlockSync{
 			Interval: interval,
@@ -59,7 +59,7 @@ func TestSyncTaskInterval(t *testing.T) {
 }
 
 func generateP2P() network.Overlay {
-	c := &config.Network{
+	c := config.Network{
 		Host: "127.0.0.1",
 		Port: 10001,
 		MsgLogsCleaningInterval: 2 * time.Second,
@@ -107,7 +107,7 @@ func TestNewBlockSyncer(t *testing.T) {
 	assert.NoError(err)
 
 	// Lightweight
-	cfgLightWeight := &config.Config{
+	cfgLightWeight := config.Config{
 		NodeType: config.LightweightType,
 	}
 
@@ -116,7 +116,7 @@ func TestNewBlockSyncer(t *testing.T) {
 	assert.NotNil(bsLightWeight)
 
 	// Delegate
-	cfgDelegate := &config.Config{
+	cfgDelegate := config.Config{
 		NodeType: config.DelegateType,
 	}
 	cfgDelegate.Network.BootstrapNodes = []string{"123"}
@@ -125,7 +125,7 @@ func TestNewBlockSyncer(t *testing.T) {
 	assert.Nil(err)
 
 	// FullNode
-	cfgFullNode := &config.Config{
+	cfgFullNode := config.Config{
 		NodeType: config.FullNodeType,
 	}
 	cfgFullNode.Network.BootstrapNodes = []string{"123"}
@@ -184,7 +184,7 @@ func TestBlockSyncerProcessSyncRequest(t *testing.T) {
 	assert.NoError(err)
 	p2p := generateP2P()
 
-	cfgFullNode := &config.Config{
+	cfgFullNode := config.Config{
 		NodeType: config.FullNodeType,
 	}
 	cfgFullNode.Network.BootstrapNodes = []string{"123"}
@@ -217,7 +217,7 @@ func TestBlockSyncerProcessSyncRequestError(t *testing.T) {
 	ap, err := actpool.NewActPool(chain, cfg.ActPool)
 	require.NotNil(ap)
 	require.NoError(err)
-	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(&cfg.Network))
+	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 
 	defer func() {
@@ -249,7 +249,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	ap, err := actpool.NewActPool(chain, cfg.ActPool)
 	require.NotNil(ap)
 	require.NoError(err)
-	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(&cfg.Network))
+	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 
 	defer func() {
@@ -294,7 +294,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	ap1, err := actpool.NewActPool(chain1, cfg.ActPool)
 	require.NotNil(ap1)
 	require.NoError(err)
-	bs1, err := NewBlockSyncer(cfg, chain1, ap1, network.NewOverlay(&cfg.Network))
+	bs1, err := NewBlockSyncer(cfg, chain1, ap1, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 	chain2 := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption())
 	require.NoError(chain2.Start(ctx))
@@ -302,7 +302,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	ap2, err := actpool.NewActPool(chain2, cfg.ActPool)
 	require.NotNil(ap2)
 	require.Nil(err)
-	bs2, err := NewBlockSyncer(cfg, chain2, ap2, network.NewOverlay(&cfg.Network))
+	bs2, err := NewBlockSyncer(cfg, chain2, ap2, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 
 	defer func() {
@@ -353,7 +353,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	ap1, err := actpool.NewActPool(chain1, cfg.ActPool)
 	require.NotNil(ap1)
 	require.Nil(err)
-	bs1, err := NewBlockSyncer(cfg, chain1, ap1, network.NewOverlay(&cfg.Network))
+	bs1, err := NewBlockSyncer(cfg, chain1, ap1, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 	chain2 := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption())
 	require.NoError(chain2.Start(ctx))
@@ -361,7 +361,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	ap2, err := actpool.NewActPool(chain2, cfg.ActPool)
 	require.NotNil(ap2)
 	require.Nil(err)
-	bs2, err := NewBlockSyncer(cfg, chain2, ap2, network.NewOverlay(&cfg.Network))
+	bs2, err := NewBlockSyncer(cfg, chain2, ap2, network.NewOverlay(cfg.Network))
 	require.Nil(err)
 
 	defer func() {
@@ -412,7 +412,7 @@ func TestBlockSyncerSync(t *testing.T) {
 	require.NotNil(ap)
 	require.NoError(err)
 
-	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(&cfg.Network))
+	bs, err := NewBlockSyncer(cfg, chain, ap, network.NewOverlay(cfg.Network))
 	require.NotNil(bs)
 	require.NoError(err)
 	require.Nil(bs.Start(ctx))
@@ -439,7 +439,7 @@ func TestBlockSyncerSync(t *testing.T) {
 	time.Sleep(time.Millisecond << 7)
 }
 
-func newTestConfig() (*config.Config, error) {
+func newTestConfig() (config.Config, error) {
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = "trie.test"
 	cfg.Chain.ChainDBPath = "db.test"
@@ -448,5 +448,5 @@ func newTestConfig() (*config.Config, error) {
 	cfg.Network.Host = "127.0.0.1"
 	cfg.Network.Port = 10000
 	cfg.Network.BootstrapNodes = []string{"127.0.0.1:10000", "127.0.0.1:4689"}
-	return &cfg, nil
+	return cfg, nil
 }

--- a/blocksync/util.go
+++ b/blocksync/util.go
@@ -27,7 +27,7 @@ func commitBlock(bc blockchain.Blockchain, ap actpool.ActPool, blk *blockchain.B
 }
 
 // syncTaskInterval returns the recurring sync task interval, or 0 if this config should not need to run sync task
-func syncTaskInterval(cfg *config.Config) time.Duration {
+func syncTaskInterval(cfg config.Config) time.Duration {
 	if cfg.IsLightweight() {
 		return time.Duration(0)
 	}

--- a/blocksync/worker.go
+++ b/blocksync/worker.go
@@ -33,7 +33,7 @@ type syncWorker struct {
 	task         *routine.RecurringTask
 }
 
-func newSyncWorker(chainID uint32, cfg *config.Config, p2p network.Overlay, buf *blockBuffer) *syncWorker {
+func newSyncWorker(chainID uint32, cfg config.Config, p2p network.Overlay, buf *blockBuffer) *syncWorker {
 	w := &syncWorker{
 		chainID:      chainID,
 		p2p:          p2p,

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -63,7 +63,7 @@ func WithTesting() Option {
 }
 
 // New creates a ChainService from config and network.Overlay and dispatcher.Dispatcher.
-func New(cfg *config.Config, p2p network.Overlay, dispatcher dispatcher.Dispatcher, opts ...Option) (*ChainService, error) {
+func New(cfg config.Config, p2p network.Overlay, dispatcher dispatcher.Dispatcher, opts ...Option) (*ChainService, error) {
 	var ops optionParams
 	for _, opt := range opts {
 		if err := opt(&ops); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,7 @@ func TestNewDefaultConfig(t *testing.T) {
 	// Default config doesn't have block producer addr setup
 	cfg, err := New()
 	require.NotNil(t, err)
-	require.Nil(t, cfg)
+	require.Equal(t, Config{}, cfg)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 }
 
@@ -35,7 +35,7 @@ func TestNewConfigWithoutValidation(t *testing.T) {
 	cfg, err := New(DoNotValidate)
 	require.Nil(t, err)
 	require.NotNil(t, cfg)
-	require.Equal(t, Default, *cfg)
+	require.Equal(t, Default, cfg)
 }
 
 func TestNewConfigWithWrongConfigPath(t *testing.T) {
@@ -44,7 +44,7 @@ func TestNewConfigWithWrongConfigPath(t *testing.T) {
 
 	cfg, err := New()
 	require.NotNil(t, err)
-	require.Nil(t, cfg)
+	require.Equal(t, Config{}, cfg)
 	require.Contains(t, err.Error(), "open wrong_path: no such file or directory")
 }
 
@@ -177,7 +177,7 @@ func TestValidateKeyPair(t *testing.T) {
 	cfg := Default
 	cfg.Chain.ProducerPubKey = "hello world"
 	cfg.Chain.ProducerPrivKey = "world hello"
-	err := ValidateKeyPair(&cfg)
+	err := ValidateKeyPair(cfg)
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "encoding/hex:"), err.Error())
 
@@ -187,7 +187,7 @@ func TestValidateKeyPair(t *testing.T) {
 	require.Nil(t, err)
 	cfg.Chain.ProducerPubKey = keypair.EncodePublicKey(pk)
 	cfg.Chain.ProducerPrivKey = keypair.EncodePrivateKey(sk)
-	err = ValidateKeyPair(&cfg)
+	err = ValidateKeyPair(cfg)
 	assert.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -200,7 +200,7 @@ func TestValidateExplorer(t *testing.T) {
 	cfg := Default
 	cfg.Explorer.Enabled = true
 	cfg.Explorer.TpsWindow = 0
-	err := ValidateExplorer(&cfg)
+	err := ValidateExplorer(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -213,7 +213,7 @@ func TestValidateChain(t *testing.T) {
 	cfg := Default
 	cfg.Chain.NumCandidates = 0
 
-	err := ValidateChain(&cfg)
+	err := ValidateChain(cfg)
 	require.Error(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -225,7 +225,7 @@ func TestValidateChain(t *testing.T) {
 	cfg.Consensus.Scheme = RollDPoSScheme
 	cfg.Consensus.RollDPoS.NumDelegates = 5
 	cfg.Chain.NumCandidates = 3
-	err = ValidateChain(&cfg)
+	err = ValidateChain(cfg)
 	require.Error(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -238,7 +238,7 @@ func TestValidateConsensusScheme(t *testing.T) {
 	cfg := Default
 	cfg.NodeType = FullNodeType
 	cfg.Consensus.Scheme = RollDPoSScheme
-	err := ValidateConsensusScheme(&cfg)
+	err := ValidateConsensusScheme(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -247,7 +247,7 @@ func TestValidateConsensusScheme(t *testing.T) {
 	)
 
 	cfg.NodeType = LightweightType
-	err = ValidateConsensusScheme(&cfg)
+	err = ValidateConsensusScheme(cfg)
 	assert.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -256,7 +256,7 @@ func TestValidateConsensusScheme(t *testing.T) {
 	)
 
 	cfg.NodeType = "Unknown"
-	err = ValidateConsensusScheme(&cfg)
+	err = ValidateConsensusScheme(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -268,7 +268,7 @@ func TestValidateConsensusScheme(t *testing.T) {
 func TestValidateDispatcher(t *testing.T) {
 	cfg := Default
 	cfg.Dispatcher.EventChanSize = 0
-	err := ValidateDispatcher(&cfg)
+	err := ValidateDispatcher(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -286,7 +286,7 @@ func TestValidateRollDPoS(t *testing.T) {
 	cfg.Consensus.RollDPoS.AcceptProposalEndorseTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.AcceptProposeTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.ProposerInterval = 8 * time.Second
-	err := ValidateRollDPoS(&cfg)
+	err := ValidateRollDPoS(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -295,7 +295,7 @@ func TestValidateRollDPoS(t *testing.T) {
 	)
 
 	cfg.Consensus.RollDPoS.EventChanSize = 0
-	err = ValidateRollDPoS(&cfg)
+	err = ValidateRollDPoS(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -305,7 +305,7 @@ func TestValidateRollDPoS(t *testing.T) {
 
 	cfg.Consensus.RollDPoS.EventChanSize = 1
 	cfg.Consensus.RollDPoS.NumDelegates = 0
-	err = ValidateRollDPoS(&cfg)
+	err = ValidateRollDPoS(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -317,7 +317,7 @@ func TestValidateRollDPoS(t *testing.T) {
 func TestValidateNetwork(t *testing.T) {
 	cfg := Default
 	cfg.Network.PeerDiscovery = false
-	err := ValidateNetwork(&cfg)
+	err := ValidateNetwork(cfg)
 	require.Error(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -329,7 +329,7 @@ func TestValidateNetwork(t *testing.T) {
 func TestValidateActPool(t *testing.T) {
 	cfg := Default
 	cfg.ActPool.MaxNumActsPerAcct = 0
-	err := ValidateActPool(&cfg)
+	err := ValidateActPool(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -342,7 +342,7 @@ func TestValidateActPool(t *testing.T) {
 
 	cfg.ActPool.MaxNumActsPerAcct = 100
 	cfg.ActPool.MaxNumActsPerPool = 0
-	err = ValidateActPool(&cfg)
+	err = ValidateActPool(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
@@ -354,7 +354,7 @@ func TestValidateActPool(t *testing.T) {
 	)
 
 	cfg.ActPool.MaxNumActsPerPool = 99
-	err = ValidateActPool(&cfg)
+	err = ValidateActPool(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -40,7 +40,7 @@ type Consensus interface {
 
 // IotxConsensus implements Consensus
 type IotxConsensus struct {
-	cfg    *config.Consensus
+	cfg    config.Consensus
 	scheme scheme.Scheme
 }
 
@@ -61,7 +61,7 @@ func WithRootChainAPI(exp explorerapi.Explorer) Option {
 
 // NewConsensus creates a IotxConsensus struct.
 func NewConsensus(
-	cfg *config.Config,
+	cfg config.Config,
 	bc blockchain.Blockchain,
 	ap actpool.ActPool,
 	p2p network.Overlay,
@@ -78,7 +78,7 @@ func NewConsensus(
 		}
 	}
 
-	cs := &IotxConsensus{cfg: &cfg.Consensus}
+	cs := &IotxConsensus{cfg: cfg.Consensus}
 	mintBlockCB := func() (*blockchain.Block, error) {
 		acts := ap.PickActs()
 		logger.Debug().
@@ -232,7 +232,7 @@ func (c *IotxConsensus) Scheme() scheme.Scheme {
 }
 
 // GetAddr returns the iotex address
-func GetAddr(cfg *config.Config) *iotxaddress.Address {
+func GetAddr(cfg config.Config) *iotxaddress.Address {
 	addr, err := cfg.BlockchainAddress()
 	if err != nil {
 		logger.Panic().Err(err).Msg("Fail to create new consensus")

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -523,7 +523,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 func TestUpdateSeed(t *testing.T) {
 	require := require.New(t)
 	lastSeed, _ := hex.DecodeString("9de6306b08158c423330f7a27243a1a5cbe39bfd764f07818437882d21241567")
-	chain := blockchain.NewBlockchain(&config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
+	chain := blockchain.NewBlockchain(config.Default, blockchain.InMemStateFactoryOption(), blockchain.InMemDaoOption())
 	require.NoError(chain.Start(context.Background()))
 	ctx := rollDPoSCtx{cfg: config.Default.Consensus.RollDPoS, chain: chain, epoch: epochCtx{seed: lastSeed}}
 	fsm := cFSM{ctx: &ctx}
@@ -726,7 +726,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		p2ps := make([]*directOverlay, 0, numNodes)
 		cs := make([]*RollDPoS, 0, numNodes)
 		for i := 0; i < numNodes; i++ {
-			sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+			sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 			require.NoError(t, err)
 			for j := 0; j < numNodes; j++ {
 				ws, err := sf.NewWorkingSet()
@@ -744,7 +744,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, sf.Commit(ws))
 			}
-			chain := blockchain.NewBlockchain(&cfg, blockchain.InMemDaoOption(), blockchain.PrecreatedStateFactoryOption(sf))
+			chain := blockchain.NewBlockchain(cfg, blockchain.InMemDaoOption(), blockchain.PrecreatedStateFactoryOption(sf))
 			chains = append(chains, chain)
 
 			actPool, err := actpool.NewActPool(chain, cfg.ActPool)

--- a/consensus/sim/consensus_sim.go
+++ b/consensus/sim/consensus_sim.go
@@ -52,7 +52,7 @@ type sim struct {
 
 // NewSim creates a consensus_sim struct
 func NewSim(
-	cfg *config.Config,
+	cfg config.Config,
 	bc blockchain.Blockchain,
 	ap actpool.ActPool,
 	p2p network.Overlay,
@@ -123,7 +123,7 @@ func NewSim(
 
 // NewSimByzantine creates a byzantine consensus_sim struct
 func NewSimByzantine(
-	cfg *config.Config,
+	cfg config.Config,
 	bc blockchain.Blockchain,
 	ap actpool.ActPool,
 	p2p network.Overlay,

--- a/consensus/sim/consensus_sim_server.go
+++ b/consensus/sim/consensus_sim_server.go
@@ -95,7 +95,7 @@ func (s *server) Init(in *pb.InitRequest, stream pb.Simulator_InitServer) error 
 		cfg.Chain.ChainDBPath = "./chain" + strconv.Itoa(i) + ".db"
 		cfg.Chain.TrieDBPath = "./trie" + strconv.Itoa(i) + ".db"
 
-		bc := blockchain.NewBlockchain(&cfg, blockchain.DefaultStateFactoryOption(), blockchain.BoltDBDaoOption())
+		bc := blockchain.NewBlockchain(cfg, blockchain.DefaultStateFactoryOption(), blockchain.BoltDBDaoOption())
 		if err := bc.Start(ctx); err != nil {
 			logger.Panic().Err(err).Msg("error when starting blockchain")
 		}
@@ -106,7 +106,7 @@ func (s *server) Init(in *pb.InitRequest, stream pb.Simulator_InitServer) error 
 			bc.SetValidator(byzVal)
 		}
 
-		overlay := network.NewOverlay(&cfg.Network)
+		overlay := network.NewOverlay(cfg.Network)
 		ap, err := actpool.NewActPool(bc, cfg.ActPool)
 		if err != nil {
 			logger.Fatal().Err(err).Msg("Fail to create actpool")
@@ -114,12 +114,12 @@ func (s *server) Init(in *pb.InitRequest, stream pb.Simulator_InitServer) error 
 
 		var node Sim
 		if i < int(in.NHonest) {
-			node = NewSim(&cfg, bc, ap, overlay)
+			node = NewSim(cfg, bc, ap, overlay)
 		} else if i < int(in.NHonest+in.NFS) {
 			s.nodes = append(s.nodes, nil)
 			continue
 		} else {
-			node = NewSimByzantine(&cfg, bc, ap, overlay)
+			node = NewSimByzantine(cfg, bc, ap, overlay)
 		}
 
 		s.nodes = append(s.nodes, node)

--- a/db/db.go
+++ b/db/db.go
@@ -147,11 +147,11 @@ type boltDB struct {
 	mutex  sync.RWMutex
 	db     *bolt.DB
 	path   string
-	config *config.DB
+	config config.DB
 }
 
 // NewBoltDB instantiates a boltdb based KV store
-func NewBoltDB(path string, cfg *config.DB) KVStore {
+func NewBoltDB(path string, cfg config.DB) KVStore {
 	return &boltDB{db: nil, path: path, config: cfg}
 }
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -28,7 +28,7 @@ var (
 	testV1  = [3][]byte{[]byte("value_1"), []byte("value_2"), []byte("value_3")}
 	testK2  = [3][]byte{[]byte("key_4"), []byte("key_5"), []byte("key_6")}
 	testV2  = [3][]byte{[]byte("value_4"), []byte("value_5"), []byte("value_6")}
-	cfg     = &config.Default.DB
+	cfg     = config.Default.DB
 )
 
 func TestKVStorePutGet(t *testing.T) {

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -108,7 +108,7 @@ type IotxDispatcher struct {
 
 // NewDispatcher creates a new Dispatcher
 func NewDispatcher(
-	cfg *config.Config,
+	cfg config.Config,
 ) (Dispatcher, error) {
 	d := &IotxDispatcher{
 		eventChan:   make(chan interface{}, cfg.Dispatcher.EventChanSize),

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func createDispatcher(t *testing.T, chainID uint32) Dispatcher {
-	cfg := &config.Config{
+	cfg := config.Config{
 		Consensus:  config.Consensus{Scheme: config.NOOPScheme},
 		Dispatcher: config.Dispatcher{EventChanSize: 1024},
 	}

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -58,7 +58,7 @@ func TestLocalActPool(t *testing.T) {
 
 	// create client
 	cfg.Network.BootstrapNodes = []string{svr.P2P().Self().String()}
-	cli := network.NewOverlay(&cfg.Network)
+	cli := network.NewOverlay(cfg.Network)
 	require.NotNil(cli)
 	require.NoError(cli.Start(ctx))
 
@@ -133,7 +133,7 @@ func TestPressureActPool(t *testing.T) {
 
 	// create client
 	cfg.Network.BootstrapNodes = []string{svr.P2P().Self().String()}
-	cli := network.NewOverlay(&cfg.Network)
+	cli := network.NewOverlay(cfg.Network)
 	require.NotNil(cli)
 	require.Nil(cli.Start(ctx))
 
@@ -167,7 +167,7 @@ func TestPressureActPool(t *testing.T) {
 	require.Nil(err)
 }
 
-func newActPoolConfig() (*config.Config, error) {
+func newActPoolConfig() (config.Config, error) {
 	cfg := config.Default
 	cfg.NodeType = config.DelegateType
 	cfg.Chain.TrieDBPath = testTriePath
@@ -180,9 +180,9 @@ func newActPoolConfig() (*config.Config, error) {
 
 	pk, sk, err := crypto.EC283.NewKeyPair()
 	if err != nil {
-		return nil, err
+		return config.Config{}, err
 	}
 	cfg.Chain.ProducerPubKey = keypair.EncodePublicKey(pk)
 	cfg.Chain.ProducerPrivKey = keypair.EncodePrivateKey(sk)
-	return &cfg, nil
+	return cfg, nil
 }

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -58,7 +58,7 @@ func TestLocalCommit(t *testing.T) {
 
 	// create client
 	cfg.Network.BootstrapNodes = []string{svr.P2P().Self().String()}
-	p := network.NewOverlay(&cfg.Network)
+	p := network.NewOverlay(cfg.Network)
 	require.NotNil(p)
 	require.NoError(p.Start(ctx))
 
@@ -440,7 +440,7 @@ func TestVoteLocalCommit(t *testing.T) {
 	require.NotNil(svr.ChainService(chainID).ActionPool())
 
 	cfg.Network.BootstrapNodes = []string{svr.P2P().Self().String()}
-	p := network.NewOverlay(&cfg.Network)
+	p := network.NewOverlay(cfg.Network)
 	require.NotNil(p)
 	require.NoError(p.Start(ctx))
 
@@ -720,7 +720,7 @@ func TestBlockchainRecovery(t *testing.T) {
 	require.Equal(blockchainHeight, factoryHeight)
 }
 
-func newTestConfig() (*config.Config, error) {
+func newTestConfig() (config.Config, error) {
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
@@ -730,9 +730,9 @@ func newTestConfig() (*config.Config, error) {
 
 	pk, sk, err := crypto.EC283.NewKeyPair()
 	if err != nil {
-		return nil, err
+		return config.Config{}, err
 	}
 	cfg.Chain.ProducerPubKey = keypair.EncodePublicKey(pk)
 	cfg.Chain.ProducerPrivKey = keypair.EncodePrivateKey(sk)
-	return &cfg, nil
+	return cfg, nil
 }

--- a/e2etest/multichain_test.go
+++ b/e2etest/multichain_test.go
@@ -54,7 +54,7 @@ func TestTwoChains(t *testing.T) {
 	cfg.Chain.EnableSubChainStartInGenesis = true
 	cfg.Explorer.Enabled = true
 
-	svr, err := itx.NewServer(&cfg)
+	svr, err := itx.NewServer(cfg)
 	require.NoError(t, err)
 
 	ctx := context.Background()

--- a/e2etest/net_test.go
+++ b/e2etest/net_test.go
@@ -43,7 +43,7 @@ func TestNetSync(t *testing.T) {
 
 	// create node
 	ctx := context.Background()
-	svr, err := itx.NewServer(&cfg)
+	svr, err := itx.NewServer(cfg)
 	require.Nil(t, err)
 	require.NotNil(t, svr)
 	assert.Nil(t, svr.Start(ctx))

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -157,7 +157,7 @@ func TestExplorerApi(t *testing.T) {
 	testutil.CleanupPath(t, testDBPath)
 	defer testutil.CleanupPath(t, testDBPath)
 
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
@@ -166,7 +166,7 @@ func TestExplorerApi(t *testing.T) {
 
 	// create chain
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&cfg, blockchain.PrecreatedStateFactoryOption(sf), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(cfg, blockchain.PrecreatedStateFactoryOption(sf), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	ap, err := actpool.NewActPool(bc, cfg.ActPool)
@@ -793,7 +793,7 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 	testutil.CleanupPath(t, testDBPath)
 	defer testutil.CleanupPath(t, testDBPath)
 
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 	require.NoError(addCreatorToFactory(sf))
@@ -802,7 +802,7 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 
 	// create chain
 	ctx := context.Background()
-	bc := blockchain.NewBlockchain(&cfg, blockchain.PrecreatedStateFactoryOption(sf), blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(cfg, blockchain.PrecreatedStateFactoryOption(sf), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(ctx))
 	require.NotNil(bc)
 	require.Nil(err)
@@ -946,7 +946,7 @@ func TestService_GetDeposits(t *testing.T) {
 	cfg := config.Default
 	ctx := context.Background()
 	bc := mock_blockchain.NewMockBlockchain(ctrl)
-	sf, err := state.NewFactory(&cfg, state.InMemTrieOption())
+	sf, err := state.NewFactory(cfg, state.InMemTrieOption())
 	require.NoError(err)
 	require.NoError(sf.Start(ctx))
 	bc.EXPECT().GetFactory().Return(sf).AnyTimes()

--- a/indexservice/server.go
+++ b/indexservice/server.go
@@ -20,7 +20,7 @@ import (
 
 // Server is the container of the index service
 type Server struct {
-	cfg     *config.Config
+	cfg     config.Config
 	idx     *Indexer
 	bc      blockchain.Blockchain
 	blockCh chan *blockchain.Block
@@ -28,7 +28,7 @@ type Server struct {
 
 // NewServer instantiates an index service
 func NewServer(
-	cfg *config.Config,
+	cfg config.Config,
 	bc blockchain.Blockchain,
 ) *Server {
 	blockCh := make(chan *blockchain.Block)

--- a/indexservice/server_test.go
+++ b/indexservice/server_test.go
@@ -19,9 +19,9 @@ func TestServer(t *testing.T) {
 	require := require.New(t)
 
 	// create chain
-	bc := blockchain.NewBlockchain(&config.Default, blockchain.InMemDaoOption())
+	bc := blockchain.NewBlockchain(config.Default, blockchain.InMemDaoOption())
 
-	svr := NewServer(&config.Default, bc)
+	svr := NewServer(config.Default, bc)
 	err := svr.Start(nil)
 	require.Nil(err)
 

--- a/network/overlay.go
+++ b/network/overlay.go
@@ -44,14 +44,14 @@ type IotxOverlay struct {
 	RPC        *RPCServer
 	Gossip     *Gossip
 	Tasks      []*routine.RecurringTask
-	Config     *config.Network
+	Config     config.Network
 	Dispatcher dispatcher.Dispatcher
 
 	lifecycle lifecycle.Lifecycle
 }
 
 // NewOverlay creates an instance of IotxOverlay
-func NewOverlay(config *config.Network) *IotxOverlay {
+func NewOverlay(config config.Network) *IotxOverlay {
 	o := &IotxOverlay{Config: config}
 	o.RPC = NewRPCServer(o)
 	o.PM = NewPeerManager(o, config.NumPeersLowerBound, config.NumPeersUpperBound)

--- a/network/overlay_test.go
+++ b/network/overlay_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
-func LoadTestConfig(addr string, allowMultiConnsPerHost bool) *config.Network {
+func LoadTestConfig(addr string, allowMultiConnsPerHost bool) config.Network {
 	host, portStr, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = "127.0.0.1"
@@ -42,31 +42,27 @@ func LoadTestConfig(addr string, allowMultiConnsPerHost bool) *config.Network {
 	if err != nil {
 		port = 0
 	}
-	config := config.Config{
-		NodeType: config.DelegateType,
-		Network: config.Network{
-			Host: host,
-			Port: port,
-			MsgLogsCleaningInterval: 2 * time.Second,
-			MsgLogRetention:         10 * time.Second,
-			HealthCheckInterval:     time.Second,
-			SilentInterval:          5 * time.Second,
-			PeerMaintainerInterval:  time.Second,
-			NumPeersLowerBound:      5,
-			NumPeersUpperBound:      5,
-			AllowMultiConnsPerHost:  allowMultiConnsPerHost,
-			RateLimitEnabled:        false,
-			PingInterval:            time.Second,
-			BootstrapNodes:          []string{"127.0.0.1:10001", "127.0.0.1:10002"},
-			MaxMsgSize:              1024 * 1024 * 10,
-			PeerDiscovery:           true,
-			TTL:                     3,
-		},
+	return config.Network{
+		Host: host,
+		Port: port,
+		MsgLogsCleaningInterval: 2 * time.Second,
+		MsgLogRetention:         10 * time.Second,
+		HealthCheckInterval:     time.Second,
+		SilentInterval:          5 * time.Second,
+		PeerMaintainerInterval:  time.Second,
+		NumPeersLowerBound:      5,
+		NumPeersUpperBound:      5,
+		AllowMultiConnsPerHost:  allowMultiConnsPerHost,
+		RateLimitEnabled:        false,
+		PingInterval:            time.Second,
+		BootstrapNodes:          []string{"127.0.0.1:10001", "127.0.0.1:10002"},
+		MaxMsgSize:              1024 * 1024 * 10,
+		PeerDiscovery:           true,
+		TTL:                     3,
 	}
-	return &config.Network
 }
 
-func LoadTestConfigWithTLSEnabled(addr string, allowMultiConnsPerHost bool) *config.Network {
+func LoadTestConfigWithTLSEnabled(addr string, allowMultiConnsPerHost bool) config.Network {
 	cfg := LoadTestConfig(addr, allowMultiConnsPerHost)
 	cfg.TLSEnabled = true
 	cfg.CACrtPath = "../test/assets/ssl/iotex.io.crt"
@@ -116,7 +112,7 @@ func TestOverlay(t *testing.T) {
 	for i := 0; i < size; i++ {
 		dp := &MockDispatcher1{}
 		dps = append(dps, dp)
-		var config *config.Network
+		var config config.Network
 		if i == 0 {
 			config = LoadTestConfig("127.0.0.1:10001", true)
 		} else if i == 1 {
@@ -393,7 +389,7 @@ func (d3 *MockDispatcher3) HandleBroadcast(uint32, proto.Message, chan bool) {
 
 func runBenchmarkOp(tell bool, size int, parallel bool, tls bool, b *testing.B) {
 	ctx := context.Background()
-	var cfg1, cfg2 *config.Network
+	var cfg1, cfg2 config.Network
 	if tls {
 		cfg1 = LoadTestConfigWithTLSEnabled("127.0.0.1:10001", true)
 		cfg2 = LoadTestConfigWithTLSEnabled("127.0.0.1:10002", true)

--- a/network/peer.go
+++ b/network/peer.go
@@ -65,7 +65,7 @@ func NewPeer(n string, addr string) *Peer {
 }
 
 // Connect connects the peer
-func (p *Peer) Connect(config *config.Network) error {
+func (p *Peer) Connect(config config.Network) error {
 	// Set up a connection to the peer.
 	var conn *grpc.ClientConn
 	var err error

--- a/network/utils.go
+++ b/network/utils.go
@@ -38,7 +38,7 @@ func stringsAreShuffled(slice []string) {
 	}
 }
 
-func loadCertAndCertPool(config *config.Network) (*tls.Certificate, *x509.CertPool, error) {
+func loadCertAndCertPool(config config.Network) (*tls.Certificate, *x509.CertPool, error) {
 	// Load the certificates from disk
 	cert, err := tls.LoadX509KeyPair(config.PeerCrtPath, config.PeerKeyPath)
 	if err != nil {
@@ -62,7 +62,7 @@ func loadCertAndCertPool(config *config.Network) (*tls.Certificate, *x509.CertPo
 	return &cert, certPool, nil
 }
 
-func generateServerCredentials(config *config.Network) (credentials.TransportCredentials, error) {
+func generateServerCredentials(config config.Network) (credentials.TransportCredentials, error) {
 	cert, certPool, err := loadCertAndCertPool(config)
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func generateServerCredentials(config *config.Network) (credentials.TransportCre
 	}), nil
 }
 
-func generateClientCredentials(config *config.Network) (credentials.TransportCredentials, error) {
+func generateClientCredentials(config config.Network) (credentials.TransportCredentials, error) {
 	cert, certPool, err := loadCertAndCertPool(config)
 	if err != nil {
 		return nil, err

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -31,7 +31,7 @@ import (
 
 // Server is the iotex server instance containing all components.
 type Server struct {
-	cfg                  *config.Config
+	cfg                  config.Config
 	rootChainService     *chainservice.ChainService
 	chainservices        map[uint32]*chainservice.ChainService
 	p2p                  network.Overlay
@@ -42,18 +42,18 @@ type Server struct {
 
 // NewServer creates a new server
 // TODO clean up config, make root config contains network, dispatch and chainservice
-func NewServer(cfg *config.Config) (*Server, error) {
+func NewServer(cfg config.Config) (*Server, error) {
 	return newServer(cfg, false)
 }
 
 // NewInMemTestServer creates a test server in memory
-func NewInMemTestServer(cfg *config.Config) (*Server, error) {
+func NewInMemTestServer(cfg config.Config) (*Server, error) {
 	return newServer(cfg, true)
 }
 
-func newServer(cfg *config.Config, testing bool) (*Server, error) {
+func newServer(cfg config.Config, testing bool) (*Server, error) {
 	// create P2P network and BlockSync
-	p2p := network.NewOverlay(&cfg.Network)
+	p2p := network.NewOverlay(cfg.Network)
 
 	// create dispatcher instance
 	dispatcher, err := dispatcher.NewDispatcher(cfg)
@@ -139,7 +139,7 @@ func (s *Server) Stop(ctx context.Context) error {
 }
 
 // NewChainService creates a new chain service in this server.
-func (s *Server) NewChainService(cfg *config.Config) error {
+func (s *Server) NewChainService(cfg config.Config) error {
 	mainChainAPI := s.rootChainService.Explorer().Explorer()
 	opts := []chainservice.Option{chainservice.WithRootChainAPI(mainChainAPI)}
 	cs, err := chainservice.New(cfg, s.p2p, s.dispatcher, opts...)
@@ -154,7 +154,7 @@ func (s *Server) NewChainService(cfg *config.Config) error {
 }
 
 // NewTestingChainService creates a new testing chain service in this server.
-func (s *Server) NewTestingChainService(cfg *config.Config) error {
+func (s *Server) NewTestingChainService(cfg config.Config) error {
 	opts := []chainservice.Option{
 		chainservice.WithTesting(),
 		chainservice.WithRootChainAPI(s.rootChainService.Explorer().Explorer()),
@@ -200,7 +200,7 @@ func (s *Server) Dispatcher() dispatcher.Dispatcher {
 }
 
 // StartServer starts a node server
-func StartServer(svr *Server, cfg *config.Config) {
+func StartServer(svr *Server, cfg config.Config) {
 	ctx := context.Background()
 	if err := svr.Start(ctx); err != nil {
 		logger.Fatal().Err(err).Msg("Failed to start server.")

--- a/server/itx/subchain.go
+++ b/server/itx/subchain.go
@@ -78,7 +78,7 @@ func (s *Server) startSubChainService(addr string, sc *mainchain.SubChain) error
 					continue
 				}
 				// TODO: get rid of the hack config modification
-				cfg := *s.cfg
+				cfg := s.cfg
 				cfg.Chain.ID = sc.ChainID
 				cfg.Chain.Address = addr
 				cfg.Chain.ChainDBPath = getSubChainDBPath(sc.ChainID, cfg.Chain.ChainDBPath)
@@ -87,7 +87,7 @@ func (s *Server) startSubChainService(addr string, sc *mainchain.SubChain) error
 				cfg.Chain.EnableSubChainStartInGenesis = false
 				cfg.Chain.EmptyGenesis = true
 				cfg.Explorer.Port = cfg.Explorer.Port - int(s.rootChainService.ChainID()) + int(sc.ChainID)
-				if err := s.NewChainService(&cfg); err != nil {
+				if err := s.NewChainService(cfg); err != nil {
 					logger.Error().Err(err).Msgf("error when constructing the sub-chain %d", sc.ChainID)
 					continue
 				}

--- a/server/main.go
+++ b/server/main.go
@@ -16,8 +16,9 @@ import (
 	"fmt"
 	"os"
 
-	_ "go.uber.org/automaxprocs"
 	_ "net/http/pprof"
+
+	_ "go.uber.org/automaxprocs"
 
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/logger"
@@ -56,7 +57,8 @@ func main() {
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to new sub chain config.")
 	}
-	if cfgsub != nil {
+	// Ifminicluster.go the sub-chain config is not empty
+	if cfgsub.Chain.ID != 0 {
 		if err := svr.NewChainService(cfgsub); err != nil {
 			logger.Fatal().Err(err).Msg("Failed to new sub chain.")
 		}
@@ -65,7 +67,7 @@ func main() {
 	itx.StartServer(svr, cfg)
 }
 
-func initLogger(cfg *config.Config) {
+func initLogger(cfg config.Config) {
 	addr, err := cfg.BlockchainAddress()
 	if err != nil {
 		logger.Fatal().Err(err).Msg("Failed to get producer address from pub/kri key.")

--- a/state/contract_test.go
+++ b/state/contract_test.go
@@ -33,7 +33,7 @@ func TestCreateContract(t *testing.T) {
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)
 
-	sf, err := NewFactory(&cfg, DefaultTrieOption())
+	sf, err := NewFactory(cfg, DefaultTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 
@@ -75,7 +75,7 @@ func TestCreateContract(t *testing.T) {
 	require.Nil(sf.Commit(ws))
 	require.Nil(sf.Stop(context.Background()))
 
-	sf, err = NewFactory(&cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, nil)))
+	sf, err = NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, config.DB{})))
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 	// reload same contract
@@ -100,7 +100,7 @@ func TestLoadStoreContract(t *testing.T) {
 
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)
-	sf, err := NewFactory(&cfg, DefaultTrieOption())
+	sf, err := NewFactory(cfg, DefaultTrieOption())
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 
@@ -158,7 +158,7 @@ func TestLoadStoreContract(t *testing.T) {
 	require.Nil(sf.Stop(context.Background()))
 
 	// re-open the StateFactory
-	sf, err = NewFactory(&cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, nil)))
+	sf, err = NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, config.DB{})))
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 	// query first contract

--- a/state/factory.go
+++ b/state/factory.go
@@ -83,11 +83,11 @@ type (
 )
 
 // FactoryOption sets Factory construction parameter
-type FactoryOption func(*factory, *config.Config) error
+type FactoryOption func(*factory, config.Config) error
 
 // PrecreatedTrieDBOption uses pre-created trie DB for state factory
 func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
-	return func(sf *factory, cfg *config.Config) (err error) {
+	return func(sf *factory, cfg config.Config) (err error) {
 		if kv == nil {
 			return errors.New("Invalid empty trie db")
 		}
@@ -108,12 +108,12 @@ func PrecreatedTrieDBOption(kv db.KVStore) FactoryOption {
 
 // DefaultTrieOption creates trie from config for state factory
 func DefaultTrieOption() FactoryOption {
-	return func(sf *factory, cfg *config.Config) (err error) {
+	return func(sf *factory, cfg config.Config) (err error) {
 		dbPath := cfg.Chain.TrieDBPath
 		if len(dbPath) == 0 {
 			return errors.New("Invalid empty trie db path")
 		}
-		trieDB := db.NewBoltDB(dbPath, &cfg.DB)
+		trieDB := db.NewBoltDB(dbPath, cfg.DB)
 		if err = trieDB.Start(context.Background()); err != nil {
 			return errors.Wrap(err, "failed to start trie db")
 		}
@@ -131,7 +131,7 @@ func DefaultTrieOption() FactoryOption {
 
 // InMemTrieOption creates in memory trie for state factory
 func InMemTrieOption() FactoryOption {
-	return func(sf *factory, cfg *config.Config) (err error) {
+	return func(sf *factory, cfg config.Config) (err error) {
 		trieDB := db.NewMemKVStore()
 		if err = trieDB.Start(context.Background()); err != nil {
 			return errors.Wrap(err, "failed to start trie db")
@@ -149,7 +149,7 @@ func InMemTrieOption() FactoryOption {
 }
 
 // NewFactory creates a new state factory
-func NewFactory(cfg *config.Config, opts ...FactoryOption) (Factory, error) {
+func NewFactory(cfg config.Config, opts ...FactoryOption) (Factory, error) {
 	sf := &factory{
 		currentChainHeight: 0,
 		numCandidates:      cfg.Chain.NumCandidates,

--- a/state/factory_test.go
+++ b/state/factory_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/iotexproject/iotex-core/trie"
 )
 
-var cfg = &config.Default
+var cfg = config.Default
 
 const testTriePath = "trie.test"
 
@@ -267,7 +267,7 @@ func TestCandidates(t *testing.T) {
 	defer testutil.CleanupPath(t, testTriePath)
 
 	cfg.Chain.NumCandidates = 2
-	sf, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, &cfg.DB)))
+	sf, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, cfg.DB)))
 	require.NoError(t, err)
 	ws, err := sf.NewWorkingSet()
 	require.NoError(t, err)
@@ -743,7 +743,7 @@ func TestCandidatesByHeight(t *testing.T) {
 	defer testutil.CleanupPath(t, testTriePath)
 
 	cfg.Chain.NumCandidates = 2
-	f, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, &cfg.DB)))
+	f, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, cfg.DB)))
 	require.Nil(t, err)
 	sf, ok := f.(*factory)
 	require.True(t, ok)
@@ -803,7 +803,7 @@ func TestUnvote(t *testing.T) {
 	defer testutil.CleanupPath(t, testTriePath)
 
 	cfg.Chain.NumCandidates = 2
-	f, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, &cfg.DB)))
+	f, err := NewFactory(cfg, PrecreatedTrieDBOption(db.NewBoltDB(testTriePath, cfg.DB)))
 	require.NoError(t, err)
 	sf, ok := f.(*factory)
 	require.True(t, ok)
@@ -901,7 +901,7 @@ func TestLoadStoreHeightInMem(t *testing.T) {
 
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)
-	statefactory, err := NewFactory(&cfg, InMemTrieOption())
+	statefactory, err := NewFactory(cfg, InMemTrieOption())
 	require.Nil(err)
 	require.Nil(statefactory.Start(context.Background()))
 

--- a/tools/actioninjector/actioninjector_test.go
+++ b/tools/actioninjector/actioninjector_test.go
@@ -112,7 +112,7 @@ func TestActionInjector(t *testing.T) {
 	require.Nil(err)
 }
 
-func newConfig() (*config.Config, error) {
+func newConfig() (config.Config, error) {
 	cfg := config.Default
 	cfg.NodeType = config.DelegateType
 	cfg.Consensus.Scheme = config.NOOPScheme
@@ -121,12 +121,12 @@ func newConfig() (*config.Config, error) {
 
 	pk, sk, err := crypto.EC283.NewKeyPair()
 	if err != nil {
-		return nil, err
+		return config.Config{}, err
 	}
 	cfg.Chain.ProducerPubKey = keypair.EncodePublicKey(pk)
 	cfg.Chain.ProducerPrivKey = keypair.EncodePrivateKey(sk)
 	cfg.Network.Port = 0
 	cfg.Network.PeerMaintainerInterval = 100 * time.Millisecond
 	cfg.Explorer.Port = 0
-	return &cfg, nil
+	return cfg, nil
 }

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -55,7 +55,7 @@ func main() {
 	genesisConfigPath := "./tools/minicluster/testnet_actions.yaml"
 
 	// Set mini-cluster configurations
-	configs := make([]*config.Config, numNodes)
+	configs := make([]config.Config, numNodes)
 	for i := 0; i < numNodes; i++ {
 		chainDBPath := fmt.Sprintf("./chain%d.db", i+1)
 		trieDBPath := fmt.Sprintf("./trie%d.db", i+1)
@@ -188,7 +188,7 @@ func newConfig(
 	producerPriKey keypair.PrivateKey,
 	networkPort,
 	explorerPort int,
-) *config.Config {
+) config.Config {
 	cfg := config.Default
 
 	cfg.NodeType = config.DelegateType
@@ -229,7 +229,7 @@ func newConfig(
 	cfg.Explorer.Enabled = true
 	cfg.Explorer.Port = explorerPort
 
-	return &cfg
+	return cfg
 }
 
 func initLogger() {

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
-var cfg = &config.Default.DB
+var cfg = config.Default.DB
 
 const testTriePath = "trie.test"
 


### PR DESCRIPTION
Now the whole system almost share the same copy of a config struct by using the pointer. This PR changes to copying config struct instead of pointer to make every components have an immutable config copy.

BTW, I realize there's another thing need to fix. Most components take the root config as the param. Instead, they should be able to only get the relevant section