### PR TITLE
IOTEX-152 Add block height info into the coinbase transfer as the nonce

### DIFF
--- a/action/protocols/account/protocol_test.go
+++ b/action/protocols/account/protocol_test.go
@@ -88,7 +88,7 @@ func TestProtocol_Validate(t *testing.T) {
 	require := require.New(t)
 	protocol := NewProtocol()
 	// Case I: Coinbase transfer
-	coinbaseTsf := action.NewCoinBaseTransfer(big.NewInt(1), "1")
+	coinbaseTsf := action.NewCoinBaseTransfer(1, big.NewInt(1), "1")
 	err := protocol.Validate(context.Background(), coinbaseTsf)
 	require.Equal(action.ErrTransfer, errors.Cause(err))
 	// Case II: Oversized data

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -69,9 +69,10 @@ func NewTransfer(
 }
 
 // NewCoinBaseTransfer returns a coinbase Transfer
-func NewCoinBaseTransfer(amount *big.Int, recipient string) *Transfer {
+func NewCoinBaseTransfer(nonce uint64, amount *big.Int, recipient string) *Transfer {
 	return &Transfer{
 		AbstractAction: AbstractAction{
+			nonce:   nonce,
 			version: version.ProtocolVersion,
 			dstAddr: recipient,
 		},

--- a/action/transfer_test.go
+++ b/action/transfer_test.go
@@ -94,7 +94,7 @@ func TestCoinbaseTsf(t *testing.T) {
 	require := require.New(t)
 	recipient, err := iotxaddress.NewAddress(iotxaddress.IsTestnet, chainid)
 	require.NoError(err)
-	coinbaseTsf := NewCoinBaseTransfer(big.NewInt(int64(5)), recipient.RawAddress)
+	coinbaseTsf := NewCoinBaseTransfer(1, big.NewInt(int64(5)), recipient.RawAddress)
 	require.NotNil(t, coinbaseTsf)
 	require.True(coinbaseTsf.isCoinbase)
 }

--- a/blockchain/block_test.go
+++ b/blockchain/block_test.go
@@ -55,48 +55,47 @@ func TestMerkle(t *testing.T) {
 
 	amount := uint64(50 << 22)
 	// create testing transactions
-	cbtsf0 := action.NewCoinBaseTransfer(big.NewInt(int64(amount)), ta.Addrinfo["producer"].RawAddress)
+	cbtsf0 := action.NewCoinBaseTransfer(1, big.NewInt(int64(amount)), ta.Addrinfo["producer"].RawAddress)
 	require.NotNil(cbtsf0)
-	cbtsf1 := action.NewCoinBaseTransfer(big.NewInt(int64(amount)), ta.Addrinfo["alfa"].RawAddress)
+	cbtsf1 := action.NewCoinBaseTransfer(1, big.NewInt(int64(amount)), ta.Addrinfo["alfa"].RawAddress)
 	require.NotNil(cbtsf1)
-	cbtsf2 := action.NewCoinBaseTransfer(big.NewInt(int64(amount)), ta.Addrinfo["bravo"].RawAddress)
+	cbtsf2 := action.NewCoinBaseTransfer(1, big.NewInt(int64(amount)), ta.Addrinfo["bravo"].RawAddress)
 	require.NotNil(cbtsf2)
-	cbtsf3 := action.NewCoinBaseTransfer(big.NewInt(int64(amount)), ta.Addrinfo["charlie"].RawAddress)
+	cbtsf3 := action.NewCoinBaseTransfer(1, big.NewInt(int64(amount)), ta.Addrinfo["charlie"].RawAddress)
 	require.NotNil(cbtsf3)
-	cbtsf4 := action.NewCoinBaseTransfer(big.NewInt(int64(amount)), ta.Addrinfo["echo"].RawAddress)
+	cbtsf4 := action.NewCoinBaseTransfer(1, big.NewInt(int64(amount)), ta.Addrinfo["echo"].RawAddress)
 	require.NotNil(cbtsf4)
 
 	// verify tx hash
-	hash0, e := hex.DecodeString("a6707cec4886bceb8bd7a4e970c1a30133196fea40b7d35c3934f71fafd6139a")
+	hash0, e := hex.DecodeString("78c04c2e332ffb5ccdf7b85bc0e0f02e286cb56afcce578cbde1c451cec0eac4")
 	require.NoError(e)
 	actual := cbtsf0.Hash()
-	require.Equal(hash0, actual[:])
 	t.Logf("actual hash = %x", actual[:])
+	require.Equal(hash0, actual[:])
 
-	hash1, e := hex.DecodeString("59fe0fd0dd0ab4c96a7129f2a0ffee47d2e44a9914e99f64d9a64fad9c020d89")
+	hash1, e := hex.DecodeString("7d40d6455a5793aa488fc8da5f3e9e3799ec90af54311dc0316fd278cd605b2b")
 	require.NoError(e)
 	actual = cbtsf1.Hash()
-	require.Equal(hash1, actual[:])
 	t.Logf("actual hash = %x", actual[:])
+	require.Equal(hash1, actual[:])
 
-	hash2, e := hex.DecodeString("be6aff36dc22cde8bc240fa8fd2ac7fd1c7ddfadde1b8f9111d0028d4446316c")
+	hash2, e := hex.DecodeString("d45228407c49101ba1a9f83e153a6f8014607ae84f4c68d9519304336cb3d30f")
 	require.NoError(e)
 	actual = cbtsf2.Hash()
-	require.Equal(hash2, actual[:])
-	//require.Equal(hash2, actual[:])
 	t.Logf("actual hash = %x", actual[:])
+	require.Equal(hash2, actual[:])
 
-	hash3, e := hex.DecodeString("2816ca41c060572ceb6d217d671528380f3d0d091efd8c967fb73c260db5f778")
+	hash3, e := hex.DecodeString("9294552e7f22722ef89c7f3821f61a4b4b5a85c8a240a473b3ac64b1e331026f")
 	require.NoError(e)
 	actual = cbtsf3.Hash()
-	require.Equal(hash3, actual[:])
 	t.Logf("actual hash = %x", actual[:])
+	require.Equal(hash3, actual[:])
 
-	hash4, e := hex.DecodeString("519fbf378f5f44565fb6de829e37de1e407a4603ab64febb8db39fa4f3971182")
+	hash4, e := hex.DecodeString("aeea782239f6d11743a86cc7789ce4beaab03eb2bbc275787d29ea079f3fca7a")
 	require.NoError(e)
 	actual = cbtsf4.Hash()
-	require.Equal(hash4, actual[:])
 	t.Logf("actual hash = %x", actual[:])
+	require.Equal(hash4, actual[:])
 
 	// manually compute merkle root
 	cat := append(hash0, hash1...)
@@ -259,7 +258,7 @@ func TestWrongNonce(t *testing.T) {
 	val := validator{sf, ""}
 
 	// correct nonce
-	coinbaseTsf := action.NewCoinBaseTransfer(Gen.BlockReward, ta.Addrinfo["producer"].RawAddress)
+	coinbaseTsf := action.NewCoinBaseTransfer(1, Gen.BlockReward, ta.Addrinfo["producer"].RawAddress)
 	tsf1, err := action.NewTransfer(1, big.NewInt(20), ta.Addrinfo["producer"].RawAddress, ta.Addrinfo["alfa"].RawAddress, []byte{}, uint64(100000), big.NewInt(10))
 	require.NoError(err)
 	require.NoError(action.Sign(tsf1, ta.Addrinfo["producer"].PrivateKey))
@@ -425,7 +424,7 @@ func TestWrongCoinbaseTsf(t *testing.T) {
 	val := validator{sf, ""}
 
 	// no coinbase tsf
-	coinbaseTsf := action.NewCoinBaseTransfer(Gen.BlockReward, ta.Addrinfo["producer"].RawAddress)
+	coinbaseTsf := action.NewCoinBaseTransfer(1, Gen.BlockReward, ta.Addrinfo["producer"].RawAddress)
 	tsf1, err := action.NewTransfer(1, big.NewInt(20), ta.Addrinfo["producer"].RawAddress, ta.Addrinfo["alfa"].RawAddress, []byte{}, uint64(100000), big.NewInt(10))
 	require.NoError(err)
 	require.NoError(action.Sign(tsf1, ta.Addrinfo["producer"].PrivateKey))

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -605,7 +605,8 @@ func (bc *blockchain) MintNewBlock(
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
 
-	actions = append(actions, action.NewCoinBaseTransfer(bc.genesis.BlockReward, producer.RawAddress))
+	// Use block height as the nonce for coinbase transfer
+	actions = append(actions, action.NewCoinBaseTransfer(bc.tipHeight+1, bc.genesis.BlockReward, producer.RawAddress))
 	blk := NewBlock(bc.config.Chain.ID, bc.tipHeight+1, bc.tipHash, bc.now(), producer.PublicKey, actions)
 	blk.Header.DKGID = []byte{}
 	blk.Header.DKGPubkey = []byte{}

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -356,7 +356,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Current tip = %d hash = %x\n", h, hash)
 
 	// add block with wrong height
-	cbTsf := action.NewCoinBaseTransfer(big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
+	cbTsf := action.NewCoinBaseTransfer(1, big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
 	require.NotNil(cbTsf)
 	blk = NewBlock(0, h+2, hash, testutil.TimestampNow(), ta.Addrinfo["bravo"].PublicKey, []action.Action{cbTsf})
 	err = bc.ValidateBlock(blk, true)
@@ -364,7 +364,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 
 	// add block with zero prev hash
-	cbTsf2 := action.NewCoinBaseTransfer(big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
+	cbTsf2 := action.NewCoinBaseTransfer(1, big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
 	require.NotNil(cbTsf2)
 	blk = NewBlock(
 		0,
@@ -564,14 +564,14 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.Equal(hash, blk.HashBlock())
 	fmt.Printf("Current tip = %d hash = %x\n", h, hash)
 	// add block with wrong height
-	cbTsf := action.NewCoinBaseTransfer(big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
+	cbTsf := action.NewCoinBaseTransfer(1, big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
 	require.NotNil(cbTsf)
 	blk = NewBlock(0, h+2, hash, testutil.TimestampNow(), ta.Addrinfo["bravo"].PublicKey, []action.Action{cbTsf})
 	err = bc.ValidateBlock(blk, true)
 	require.NotNil(err)
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 	// add block with zero prev hash
-	cbTsf2 := action.NewCoinBaseTransfer(big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
+	cbTsf2 := action.NewCoinBaseTransfer(1, big.NewInt(50), ta.Addrinfo["bravo"].RawAddress)
 	require.NotNil(cbTsf2)
 	blk = NewBlock(
 		0,

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -788,6 +788,7 @@ func putTransfers(dao *blockDAO, blk *Block, batch db.KVStoreBatch) error {
 		// put new transfer to recipient
 		recipientKey := append(transferToPrefix, transfer.Recipient()...)
 		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientTransferCount)...)
+
 		batch.PutIfNotExists(blockAddressTransferMappingNS, recipientKey, transferHash[:],
 			"failed to put transfer hash %x for recipient %x", transfer.Hash(), transfer.Recipient())
 

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -29,11 +29,11 @@ func TestBlockDAO(t *testing.T) {
 	getBlocks := func() []*Block {
 		amount := uint64(50 << 22)
 		// create testing transfers
-		cbTsf1 := action.NewCoinBaseTransfer(big.NewInt(int64((amount))), testaddress.Addrinfo["alfa"].RawAddress)
+		cbTsf1 := action.NewCoinBaseTransfer(1, big.NewInt(int64((amount))), testaddress.Addrinfo["alfa"].RawAddress)
 		assert.NotNil(t, cbTsf1)
-		cbTsf2 := action.NewCoinBaseTransfer(big.NewInt(int64((amount))), testaddress.Addrinfo["bravo"].RawAddress)
+		cbTsf2 := action.NewCoinBaseTransfer(1, big.NewInt(int64((amount))), testaddress.Addrinfo["bravo"].RawAddress)
 		assert.NotNil(t, cbTsf2)
-		cbTsf3 := action.NewCoinBaseTransfer(big.NewInt(int64((amount))), testaddress.Addrinfo["charlie"].RawAddress)
+		cbTsf3 := action.NewCoinBaseTransfer(1, big.NewInt(int64((amount))), testaddress.Addrinfo["charlie"].RawAddress)
 		assert.NotNil(t, cbTsf3)
 
 		// create testing votes

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -1796,14 +1796,15 @@ func convertTsfToExplorerTsf(transfer *action.Transfer, isPending bool) (explore
 	}
 	hash := transfer.Hash()
 	explorerTransfer := explorer.Transfer{
-		Nonce:     int64(transfer.Nonce()),
-		ID:        hex.EncodeToString(hash[:]),
-		Sender:    transfer.Sender(),
-		Recipient: transfer.Recipient(),
-		Fee:       "", // TODO: we need to get the actual fee.
-		Payload:   hex.EncodeToString(transfer.Payload()),
-		GasLimit:  int64(transfer.GasLimit()),
-		IsPending: isPending,
+		Nonce:      int64(transfer.Nonce()),
+		ID:         hex.EncodeToString(hash[:]),
+		Sender:     transfer.Sender(),
+		Recipient:  transfer.Recipient(),
+		Fee:        "", // TODO: we need to get the actual fee.
+		Payload:    hex.EncodeToString(transfer.Payload()),
+		GasLimit:   int64(transfer.GasLimit()),
+		IsCoinbase: transfer.IsCoinbase(),
+		IsPending:  isPending,
 	}
 	if transfer.Amount() != nil && len(transfer.Amount().String()) > 0 {
 		explorerTransfer.Amount = transfer.Amount().String()


### PR DESCRIPTION
Previously all coinbase transfers have the same hash, so that indexing them via hash was broken. This PR will leverage block height to set nonce of coinbase transfer, so that the hash will be unique then.

Additionally, fix a coinbase flag bug in the explorer together