### PR TITLE
IOTEX-157 Make blocksync tentatively sync tip height + 1 block

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -18,6 +18,7 @@ import (
 	"github.com/iotexproject/iotex-core/network"
 	"github.com/iotexproject/iotex-core/network/node"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
+	"github.com/iotexproject/iotex-core/pkg/routine"
 	pb "github.com/iotexproject/iotex-core/proto"
 )
 
@@ -41,6 +42,7 @@ type blockSyncer struct {
 	worker         *syncWorker
 	bc             blockchain.Blockchain
 	p2p            network.Overlay
+	chaser         *routine.RecurringTask
 }
 
 // NewBlockSyncer returns a new block syncer instance
@@ -61,7 +63,7 @@ func NewBlockSyncer(
 		size:   cfg.BlockSync.BufferSize,
 	}
 	w := newSyncWorker(chain.ChainID(), cfg, p2p, buf)
-	return &blockSyncer{
+	bs := &blockSyncer{
 		ackBlockCommit: cfg.IsDelegate() || cfg.IsFullnode(),
 		ackBlockSync:   cfg.IsDelegate() || cfg.IsFullnode(),
 		ackSyncReq:     cfg.IsDelegate() || cfg.IsFullnode(),
@@ -69,7 +71,9 @@ func NewBlockSyncer(
 		buf:            buf,
 		p2p:            p2p,
 		worker:         w,
-	}, nil
+	}
+	bs.chaser = routine.NewRecurringTask(bs.Chase, cfg.BlockSync.Interval*10)
+	return bs, nil
 }
 
 // TargetHeight returns the target height to sync to
@@ -85,12 +89,18 @@ func (bs *blockSyncer) P2P() network.Overlay {
 // Start starts a block syncer
 func (bs *blockSyncer) Start(ctx context.Context) error {
 	logger.Debug().Msg("Starting block syncer")
+	if err := bs.chaser.Start(ctx); err != nil {
+		return err
+	}
 	return bs.worker.Start(ctx)
 }
 
 // Stop stops a block syncer
 func (bs *blockSyncer) Stop(ctx context.Context) error {
 	logger.Debug().Msg("Stopping block syncer")
+	if err := bs.chaser.Stop(ctx); err != nil {
+		return err
+	}
 	return bs.worker.Stop(ctx)
 }
 
@@ -149,4 +159,9 @@ func (bs *blockSyncer) ProcessSyncRequest(sender string, sync *pb.BlockSync) err
 		}
 	}
 	return nil
+}
+
+// Chase sets the block sync target height to be blockchain height + 1
+func (bs *blockSyncer) Chase() {
+	bs.worker.SetTargetHeight(bs.bc.TipHeight() + 1)
 }


### PR DESCRIPTION
If a node has temporary outage, but is unfortunately be chosen as the proposer during this period, there's no chance for the whole network to recover, because no flying broadcasted block exist, and the node wouldn't able to proactively catchup the missing blocks.

This PR makes the node to tentatively request tip height + 1 block every 10 block sync interval, so that it could recover and catch up other delegates to continue consensus. This will not be very efficient if a node miss tons of blocks, but a working solution for short-term outage.