### PR TITLE
Disable Snapshot() function before solving the memory thrash/leak (#384)

### DIFF
--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -220,6 +220,10 @@ func (stateDB *StateDBAdapter) Empty(common.Address) bool {
 
 // RevertToSnapshot reverts the state factory to the state at a given snapshot
 func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
+	// TODO: temp disable until we solve the memory thrash/leak issue
+	logger.Debug().Msg("RevertToSnapshot is not implemented")
+	return
+
 	if err := stateDB.sm.Revert(snapshot); err != nil {
 		err := errors.New("unexpected error: state manager's Revert() failed")
 		logger.Error().Err(err).Msg("failed to RevertToSnapshot")
@@ -248,6 +252,10 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 
 // Snapshot returns the snapshot id
 func (stateDB *StateDBAdapter) Snapshot() int {
+	// TODO: temp disable until we solve the memory thrash/leak issue
+	logger.Debug().Msg("Snapshot is not implemented")
+	return 0
+
 	sn := stateDB.sm.Snapshot()
 	if _, ok := stateDB.suicideSnapshot[sn]; ok {
 		err := errors.New("unexpected error: duplicate snapshot version")

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -98,6 +98,9 @@ func TestForEachStorage(t *testing.T) {
 }
 
 func TestSnapshotAndSuicide(t *testing.T) {
+	// TODO: temp disable until we solve the memory thrash/leak issue
+	return
+
 	require := require.New(t)
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)


### PR DESCRIPTION
This reverts commit b473d2e7dd3de6ee65b163365f4a01437a92c65d.