### PR TITLE
implement set nonce for adapter

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -231,6 +231,7 @@ func executeInEVM(evmParams *Params, stateDB *StateDBAdapter, gasLimit *uint64) 
 		contractAddress := address.New(stateDB.cm.ChainID(), evmContractAddress.Bytes())
 		contractRawAddress = contractAddress.IotxAddress()
 	} else {
+		stateDB.SetNonce(evmParams.context.Origin, stateDB.GetNonce(evmParams.context.Origin)+1)
 		// process contract
 		ret, remainingGas, err = evm.Call(executor, *evmParams.contract, evmParams.data, remainingGas, evmParams.amount)
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -158,13 +158,25 @@ func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
 		// stateDB.logError(err)
 		return 0
 	}
-	logger.Debug().Uint64("nonce", state.Nonce).Msg("GetNonce")
+	logger.Debug().Uint64("nonce", state.Nonce).Str("address", addr.IotxAddress()).Msg("GetNonce")
 	return state.Nonce
 }
 
 // SetNonce sets the nonce of account
-func (stateDB *StateDBAdapter) SetNonce(common.Address, uint64) {
-	logger.Error().Msg("SetNonce is not implemented")
+func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64) {
+	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	s, err := stateDB.AccountState(addr.IotxAddress())
+	if err != nil {
+		logger.Error().Err(err).Msg("GetNonce")
+		// stateDB.logError(err)
+		return
+	}
+	logger.Debug().Uint64("nonce", nonce).Str("address", addr.IotxAddress()).Msg("SetNonce")
+	s.Nonce = nonce
+	if err := account.StoreAccount(stateDB.sm, addr.IotxAddress(), s); err != nil {
+		logger.Error().Err(err).Msg("failed to set nonce")
+		// stateDB.logError(err)
+	}
 }
 
 // AddRefund adds refund

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
-	"github.com/iotexproject/iotex-core/action/protocol/account"
 	"github.com/iotexproject/iotex-core/action/protocol/execution/evm"
 	"github.com/iotexproject/iotex-core/iotxaddress"
 )
@@ -47,19 +46,6 @@ func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.St
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to execute contract")
-	}
-
-	executorPKHash, err := iotxaddress.AddressToPKHash(exec.Executor())
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to convert address to PK hash")
-	}
-	acct, err := account.LoadAccount(sm, executorPKHash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load the account of executor %x", executorPKHash)
-	}
-	account.SetNonce(exec, acct)
-	if err := account.StoreAccount(sm, exec.Executor(), acct); err != nil {
-		return nil, errors.Wrapf(err, "failed to update pending account changes to trie")
 	}
 
 	return receipt, nil


### PR DESCRIPTION
Test plan: unit test.

Potential problem: In some cases of contract creation, the nonce won't be increased, e.g., https://github.com/CoderZhi/go-ethereum/blob/master/core/vm/evm.go#L348-L353. The second error type shouldn't happen if we check the balance transfer in action pick. These two errors could only happen when the contract creation call is triggered by another contract execution. Thus, we leave this problem in future investigation.