### PR TITLE
IOTEX-192 Removing PutIfNotExists API db

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1077,14 +1077,18 @@ func (bc *blockchain) validateBlock(blk *block.Block, containCoinbase bool) erro
 // commitBlock commits a block to the chain
 func (bc *blockchain) commitBlock(blk *block.Block) error {
 	// Check if it is already exists, and return earlier
-	blkHash, _ := bc.dao.getBlockHash(blk.Height())
+	blkHash, err := bc.dao.getBlockHash(blk.Height())
 	if blkHash != hash.ZeroHash32B {
 		logger.Debug().Uint64("height", blk.Height()).Msg("Block already exists")
 		return nil
 	}
+	// If it's a ready db io error, return earlier with the error
+	if errors.Cause(err) != db.ErrNotExist && errors.Cause(err) != bolt.ErrBucketNotFound {
+		return err
+	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	err := bc.dao.putBlock(blk)
+	err = bc.dao.putBlock(blk)
 	putTimer.End()
 	if err != nil {
 		return err

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1076,6 +1076,12 @@ func (bc *blockchain) validateBlock(blk *block.Block, containCoinbase bool) erro
 
 // commitBlock commits a block to the chain
 func (bc *blockchain) commitBlock(blk *block.Block) error {
+	// Check if it is already exists, and return earlier
+	blkHash, _ := bc.dao.getBlockHash(blk.Height())
+	if blkHash != hash.ZeroHash32B {
+		logger.Debug().Uint64("height", blk.Height()).Msg("Block already exists")
+		return nil
+	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
 	err := bc.dao.putBlock(blk)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -303,7 +303,6 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	defer testutil.CleanupPath(t, testDBPath)
 
 	cfg := config.Default
-	cfg.DB.UseBadgerDB = true // test with badgerDB
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Explorer.Enabled = true

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -467,12 +467,11 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	require.NotNil(err)
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 
-	// cannot add existing block again
+	// add existing block again will have no effect
 	blk, err = bc.GetBlockByHeight(3)
 	require.NotNil(blk)
 	require.Nil(err)
-	err = bc.(*blockchain).commitBlock(blk)
-	require.NotNil(err)
+	require.NoError(bc.(*blockchain).commitBlock(blk))
 	fmt.Printf("Cannot add block 3 again: %v\n", err)
 
 	// check all Tx from block 4
@@ -691,12 +690,11 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	err = bc.ValidateBlock(&nblk, true)
 	require.NotNil(err)
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
-	// cannot add existing block again
+	// add existing block again will have no effect
 	blk, err = bc.GetBlockByHeight(3)
 	require.NotNil(blk)
 	require.Nil(err)
-	err = bc.(*blockchain).commitBlock(blk)
-	require.NotNil(err)
+	require.NoError(bc.(*blockchain).commitBlock(blk))
 	fmt.Printf("Cannot add block 3 again: %v\n", err)
 	// check all Tx from block 4
 	blk, err = bc.GetBlockByHeight(4)

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -89,36 +89,41 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 	}
 
 	// set init height value
-	if err := dao.kvstore.PutIfNotExists(blockNS, topHeightKey, make([]byte, 8)); err != nil {
-		// ok on none-fresh db
-		if err == db.ErrAlreadyExist {
-			return nil
+	if _, err := dao.kvstore.Get(blockNS, topHeightKey); err != nil {
+		if err := dao.kvstore.Put(blockNS, topHeightKey, make([]byte, 8)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for top height")
 		}
-
-		return errors.Wrap(err, "failed to write initial value for top height")
 	}
 
 	// TODO: To be deprecated
 	// set init total transfer to be 0
-	if err = dao.kvstore.PutIfNotExists(blockNS, totalTransfersKey, make([]byte, 8)); err != nil {
-		return errors.Wrap(err, "failed to write initial value for total transfers")
+	if _, err := dao.kvstore.Get(blockNS, totalTransfersKey); err != nil {
+		if err = dao.kvstore.Put(blockNS, totalTransfersKey, make([]byte, 8)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for total transfers")
+		}
 	}
 
 	// TODO: To be deprecated
 	// set init total vote to be 0
-	if err = dao.kvstore.PutIfNotExists(blockNS, totalVotesKey, make([]byte, 8)); err != nil {
-		return errors.Wrap(err, "failed to write initial value for total votes")
+	if _, err := dao.kvstore.Get(blockNS, totalVotesKey); err != nil {
+		if err = dao.kvstore.Put(blockNS, totalVotesKey, make([]byte, 8)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for total votes")
+		}
 	}
 
 	// TODO: To be deprecated
 	// set init total executions to be 0
-	if err = dao.kvstore.PutIfNotExists(blockNS, totalExecutionsKey, make([]byte, 8)); err != nil {
-		return errors.Wrap(err, "failed to write initial value for total executions")
+	if _, err := dao.kvstore.Get(blockNS, totalExecutionsKey); err != nil {
+		if err = dao.kvstore.Put(blockNS, totalExecutionsKey, make([]byte, 8)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for total executions")
+		}
 	}
 
 	// set init total actions to be 0
-	if err = dao.kvstore.PutIfNotExists(blockNS, totalActionsKey, make([]byte, 8)); err != nil {
-		return errors.Wrap(err, "failed to write initial value for total actions")
+	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil {
+		if err = dao.kvstore.Put(blockNS, totalActionsKey, make([]byte, 8)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for total actions")
+		}
 	}
 
 	return nil
@@ -667,7 +672,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 		return errors.Wrap(err, "failed to serialize block")
 	}
 	hash := blk.HashBlock()
-	batch.PutIfNotExists(blockNS, hash[:], serialized, "failed to put block")
+	batch.Put(blockNS, hash[:], serialized, "failed to put block")
 
 	hashKey := append(hashPrefix, hash[:]...)
 	batch.Put(blockHashHeightMappingNS, hashKey, height, "failed to put hash -> height mapping")
@@ -800,7 +805,7 @@ func putTransfers(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error 
 		// put new transfer to sender
 		senderKey := append(transferFromPrefix, transfer.Sender()...)
 		senderKey = append(senderKey, byteutil.Uint64ToBytes(senderTransferCount)...)
-		batch.PutIfNotExists(blockAddressTransferMappingNS, senderKey, transferHash[:],
+		batch.Put(blockAddressTransferMappingNS, senderKey, transferHash[:],
 			"failed to put transfer hash %x for sender %x", transfer.Hash(), transfer.Sender())
 
 		// update sender transfers count
@@ -825,7 +830,7 @@ func putTransfers(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error 
 		recipientKey := append(transferToPrefix, transfer.Recipient()...)
 		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientTransferCount)...)
 
-		batch.PutIfNotExists(blockAddressTransferMappingNS, recipientKey, transferHash[:],
+		batch.Put(blockAddressTransferMappingNS, recipientKey, transferHash[:],
 			"failed to put transfer hash %x for recipient %x", transfer.Hash(), transfer.Recipient())
 
 		// update recipient transfers count
@@ -868,7 +873,7 @@ func putVotes(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error {
 		// put new vote to sender
 		senderKey := append(voteFromPrefix, Sender...)
 		senderKey = append(senderKey, byteutil.Uint64ToBytes(senderVoteCount)...)
-		batch.PutIfNotExists(blockAddressVoteMappingNS, senderKey, voteHash[:],
+		batch.Put(blockAddressVoteMappingNS, senderKey, voteHash[:],
 			"failed to put vote hash %x for sender %x", voteHash, Sender)
 
 		// update sender votes count
@@ -892,7 +897,7 @@ func putVotes(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error {
 		// put new vote to recipient
 		recipientKey := append(voteToPrefix, Recipient...)
 		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientVoteCount)...)
-		batch.PutIfNotExists(blockAddressVoteMappingNS, recipientKey, voteHash[:],
+		batch.Put(blockAddressVoteMappingNS, recipientKey, voteHash[:],
 			"failed to put vote hash %x for recipient %x", voteHash, Recipient)
 
 		// update recipient votes count
@@ -930,7 +935,7 @@ func putExecutions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error
 		// put new execution to executor
 		executorKey := append(executionFromPrefix, execution.Executor()...)
 		executorKey = append(executorKey, byteutil.Uint64ToBytes(executorExecutionCount)...)
-		batch.PutIfNotExists(blockAddressExecutionMappingNS, executorKey, executionHash[:],
+		batch.Put(blockAddressExecutionMappingNS, executorKey, executionHash[:],
 			"failed to put execution hash %x for executor %x", execution.Hash(), execution.Executor())
 
 		// update executor executions count
@@ -954,7 +959,7 @@ func putExecutions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error
 		// put new execution to contract
 		contractKey := append(executionToPrefix, execution.Contract()...)
 		contractKey = append(contractKey, byteutil.Uint64ToBytes(contractExecutionCount)...)
-		batch.PutIfNotExists(blockAddressExecutionMappingNS, contractKey, executionHash[:],
+		batch.Put(blockAddressExecutionMappingNS, contractKey, executionHash[:],
 			"failed to put execution hash %x for contract %x", execution.Hash(), execution.Contract())
 
 		// update contract executions count
@@ -988,7 +993,7 @@ func putActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error {
 		// put new action to sender
 		senderKey := append(actionFromPrefix, selp.SrcAddr()...)
 		senderKey = append(senderKey, byteutil.Uint64ToBytes(senderActionCount)...)
-		batch.PutIfNotExists(blockAddressActionMappingNS, senderKey, actHash[:],
+		batch.Put(blockAddressActionMappingNS, senderKey, actHash[:],
 			"failed to put action hash %x for sender %s", actHash, selp.SrcAddr())
 
 		// update sender action count
@@ -1012,7 +1017,7 @@ func putActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error {
 		// put new action to recipient
 		recipientKey := append(actionToPrefix, selp.DstAddr()...)
 		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientActionCount)...)
-		batch.PutIfNotExists(blockAddressActionMappingNS, recipientKey, actHash[:],
+		batch.Put(blockAddressActionMappingNS, recipientKey, actHash[:],
 			"failed to put action hash %x for recipient %s", actHash, selp.DstAddr())
 
 		// update recipient action count

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -91,7 +91,8 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// set init height value
 	// TODO: not working with badger, we shouldn't expose detailed db error (e.g., bolt.ErrBucketExists) to application
-	if _, err = dao.kvstore.Get(blockNS, topHeightKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
+	if _, err = dao.kvstore.Get(blockNS, topHeightKey); err != nil &&
+		(errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err := dao.kvstore.Put(blockNS, topHeightKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for top height")
 		}
@@ -99,7 +100,8 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total transfer to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalTransfersKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
+	if _, err := dao.kvstore.Get(blockNS, totalTransfersKey); err != nil &&
+		(errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalTransfersKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total transfers")
 		}
@@ -107,7 +109,8 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total vote to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalVotesKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
+	if _, err := dao.kvstore.Get(blockNS, totalVotesKey); err != nil &&
+		(errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalVotesKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total votes")
 		}
@@ -115,14 +118,16 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total executions to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalExecutionsKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
+	if _, err := dao.kvstore.Get(blockNS, totalExecutionsKey); err != nil &&
+		(errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalExecutionsKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total executions")
 		}
 	}
 
 	// set init total actions to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
+	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil &&
+		(errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalActionsKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total actions")
 		}

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -9,6 +9,7 @@ package blockchain
 import (
 	"context"
 
+	"github.com/boltdb/bolt"
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-core/action"
@@ -89,7 +90,8 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 	}
 
 	// set init height value
-	if _, err := dao.kvstore.Get(blockNS, topHeightKey); err != nil {
+	// TODO: not working with badger, we shouldn't expose detailed db error (e.g., bolt.ErrBucketExists) to application
+	if _, err = dao.kvstore.Get(blockNS, topHeightKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err := dao.kvstore.Put(blockNS, topHeightKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for top height")
 		}
@@ -97,7 +99,7 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total transfer to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalTransfersKey); err != nil {
+	if _, err := dao.kvstore.Get(blockNS, totalTransfersKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalTransfersKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total transfers")
 		}
@@ -105,7 +107,7 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total vote to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalVotesKey); err != nil {
+	if _, err := dao.kvstore.Get(blockNS, totalVotesKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalVotesKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total votes")
 		}
@@ -113,14 +115,14 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 
 	// TODO: To be deprecated
 	// set init total executions to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalExecutionsKey); err != nil {
+	if _, err := dao.kvstore.Get(blockNS, totalExecutionsKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalExecutionsKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total executions")
 		}
 	}
 
 	// set init total actions to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil {
+	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil && (errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == bolt.ErrBucketNotFound) {
 		if err = dao.kvstore.Put(blockNS, totalActionsKey, make([]byte, 8)); err != nil {
 			return errors.Wrap(err, "failed to write initial value for total actions")
 		}

--- a/blocksync/buffer.go
+++ b/blocksync/buffer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/logger"
 )
 
@@ -74,12 +73,8 @@ func (b *blockBuffer) Flush(blk *block.Block) (bool, bCheckinResult) {
 		}
 		delete(b.blocks, heightToSync)
 		if err := commitBlock(b.bc, b.ap, blk); err != nil {
-			if err == db.ErrAlreadyExist {
-				l.Info().Uint64("syncHeight", heightToSync).Msg("Block already exists.")
-			} else {
-				l.Error().Err(err).Uint64("syncHeight", heightToSync).Msg("Failed to commit the block.")
-				break
-			}
+			l.Error().Err(err).Uint64("syncHeight", heightToSync).Msg("Failed to commit the block.")
+			break
 		}
 		b.commitHeight = heightToSync
 		l.Info().Uint64("syncedHeight", heightToSync).Msg("Successfully committed block.")

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -21,7 +21,6 @@ import (
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/consensus/scheme"
 	"github.com/iotexproject/iotex-core/consensus/scheme/rolldpos"
-	"github.com/iotexproject/iotex-core/db"
 	explorerapi "github.com/iotexproject/iotex-core/explorer/idl/explorer"
 	"github.com/iotexproject/iotex-core/iotxaddress"
 	"github.com/iotexproject/iotex-core/logger"
@@ -106,12 +105,7 @@ func NewConsensus(
 	commitBlockCB := func(blk *block.Block) error {
 		err := bc.CommitBlock(blk)
 		if err != nil {
-			if err == db.ErrAlreadyExist {
-				err = nil
-				logger.Info().Int64("Height", int64(blk.Height())).Msg("Block already exists.")
-			} else {
-				logger.Error().Err(err).Int64("Height", int64(blk.Height())).Msg("Failed to commit the block")
-			}
+			logger.Error().Err(err).Int64("Height", int64(blk.Height())).Msg("Failed to commit the block")
 		}
 		// Remove transfers in this block from ActPool and reset ActPool state
 		ap.Reset()

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -25,7 +25,6 @@ import (
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/consensus/scheme"
 	"github.com/iotexproject/iotex-core/crypto"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/endorsement"
 	"github.com/iotexproject/iotex-core/explorer/idl/explorer"
 	"github.com/iotexproject/iotex-core/iotxaddress"
@@ -91,14 +90,10 @@ func (ctx *rollDPoSCtx) OnConsensusReached() error {
 	}
 	// Commit and broadcast the pending block
 	if err := ctx.chain.CommitBlock(pendingBlock.Block); err != nil {
-		if err == db.ErrAlreadyExist {
-			logger.Info().Uint64("block", pendingBlock.Height()).Msg("Block already exists.")
-		} else {
-			logger.Error().
-				Err(err).
-				Uint64("block", pendingBlock.Height()).
-				Msg("error when committing a block")
-		}
+		logger.Error().
+			Err(err).
+			Uint64("block", pendingBlock.Height()).
+			Msg("error when committing a block")
 	}
 	// Remove transfers in this block from ActPool and reset ActPool state
 	ctx.actPool.Reset()

--- a/db/db.go
+++ b/db/db.go
@@ -34,8 +34,6 @@ type KVStore interface {
 
 	// Put insert or update a record identified by (namespace, key)
 	Put(string, []byte, []byte) error
-	// Put puts a record only if (namespace, key) doesn't exist, otherwise return ErrAlreadyExist
-	PutIfNotExists(string, []byte, []byte) error
 	// Get gets a record by (namespace, key)
 	Get(string, []byte) ([]byte, error)
 	// Delete deletes a record by (namespace, key)
@@ -73,18 +71,6 @@ func (m *memKVStore) Put(namespace string, key, value []byte) error {
 	defer m.mu.Unlock()
 	m.bucket[namespace] = struct{}{}
 	m.data.Store(namespace+keyDelimiter+string(key), value)
-	return nil
-}
-
-// PutIfNotExists inserts a <key, value> record only if it does not exist yet, otherwise return ErrAlreadyExist
-func (m *memKVStore) PutIfNotExists(namespace string, key, value []byte) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.bucket[namespace] = struct{}{}
-	_, loaded := m.data.LoadOrStore(namespace+keyDelimiter+string(key), value)
-	if loaded {
-		return ErrAlreadyExist
-	}
 	return nil
 }
 
@@ -127,11 +113,6 @@ func (m *memKVStore) Commit(b KVStoreBatch) (e error) {
 		}
 		if write.writeType == Put {
 			if err := m.Put(write.namespace, write.key, write.value); err != nil {
-				e = err
-				break
-			}
-		} else if write.writeType == PutIfNotExists {
-			if err := m.PutIfNotExists(write.namespace, write.key, write.value); err != nil {
 				e = err
 				break
 			}


### PR DESCRIPTION
PutIfNotExists semantics is confusing, and shouldn't be decided by the database. Removing it from db api.  In addition, I update the use case accordingly. Some could use regular put api.

Test Plan: updated unit tests, make reboot & run