### PR TITLE
IOTEX-197 Keep tracking root hash history and serve it via explorer API

### DIFF
--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -820,6 +820,8 @@ func (exp *Service) GetLastBlocksByRange(offset int64, limit int64) ([]explorer.
 			totalSize += transfer.TotalSize()
 		}
 
+		txRoot := blk.TxRoot()
+		stateRoot := blk.StateRoot()
 		explorerBlock := explorer.Block{
 			ID:         hex.EncodeToString(hash[:]),
 			Height:     int64(blockHeaderPb.Height),
@@ -833,6 +835,8 @@ func (exp *Service) GetLastBlocksByRange(offset int64, limit int64) ([]explorer.
 				Name:    "",
 				Address: keypair.EncodePublicKey(blk.PublicKey()),
 			},
+			TxRoot:    hex.EncodeToString(txRoot[:]),
+			StateRoot: hex.EncodeToString(stateRoot[:]),
 		}
 
 		res = append(res, explorerBlock)
@@ -865,6 +869,8 @@ func (exp *Service) GetBlockByID(blkID string) (explorer.Block, error) {
 		totalSize += transfer.TotalSize()
 	}
 
+	txRoot := blk.TxRoot()
+	stateRoot := blk.StateRoot()
 	explorerBlock := explorer.Block{
 		ID:         blkID,
 		Height:     int64(blkHeaderPb.Height),
@@ -878,6 +884,8 @@ func (exp *Service) GetBlockByID(blkID string) (explorer.Block, error) {
 			Name:    "",
 			Address: keypair.EncodePublicKey(blk.PublicKey()),
 		},
+		TxRoot:    hex.EncodeToString(txRoot[:]),
+		StateRoot: hex.EncodeToString(stateRoot[:]),
 	}
 
 	return explorerBlock, nil

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -1526,6 +1526,15 @@ func (exp *Service) EstimateGasForSmartContract(execution explorer.Execution) (i
 	return exp.gs.estimateGasForSmartContract(execution)
 }
 
+// GetStateRootHash gets the state root hash of a given block height
+func (exp *Service) GetStateRootHash(blockHeight int64) (string, error) {
+	rootHash, err := exp.bc.GetFactory().RootHashByHeight(uint64(blockHeight))
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(rootHash[:]), nil
+}
+
 // getTransfer takes in a blockchain and transferHash and returns an Explorer Transfer
 func getTransfer(bc blockchain.Blockchain, ap actpool.ActPool, transferHash hash.Hash32B, idx *indexservice.Server, useRDS bool) (explorer.Transfer, error) {
 	explorerTransfer := explorer.Transfer{}

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
 	"github.com/iotexproject/iotex-core/test/mock/mock_consensus"
 	"github.com/iotexproject/iotex-core/test/mock/mock_dispatcher"
+	"github.com/iotexproject/iotex-core/test/mock/mock_factory"
 	ta "github.com/iotexproject/iotex-core/test/testaddress"
 	"github.com/iotexproject/iotex-core/testutil"
 )
@@ -1121,6 +1122,22 @@ func TestService_GetDeposits(t *testing.T) {
 	deposits, err = svc.GetDeposits(2, 0, 2)
 	assert.NoError(err)
 	assert.Equal(1, len(deposits))
+}
+
+func TestService_GetStateRootHash(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	bc := mock_blockchain.NewMockBlockchain(ctrl)
+	sf := mock_factory.NewMockFactory(ctrl)
+	bc.EXPECT().GetFactory().Return(sf).AnyTimes()
+	rootHash := byteutil.BytesTo32B(hash.Hash256b([]byte("test")))
+	sf.EXPECT().RootHashByHeight(gomock.Any()).Return(rootHash, nil).Times(1)
+
+	defer ctrl.Finish()
+
+	svc := Service{bc: bc}
+	rootHashStr, err := svc.GetStateRootHash(1)
+	assert.NoError(t, err)
+	assert.Equal(t, hex.EncodeToString(rootHash[:]), rootHashStr)
 }
 
 func addCreatorToFactory(sf factory.Factory) error {

--- a/explorer/idl/explorer.idl
+++ b/explorer/idl/explorer.idl
@@ -40,6 +40,8 @@ struct Block {
     amount string
     forged int
     size int
+    txRoot string
+    stateRoot string
 }
 
 struct Transfer {

--- a/explorer/idl/explorer.idl
+++ b/explorer/idl/explorer.idl
@@ -439,4 +439,7 @@ interface Explorer {
 
     // estimate gas for smart contract
     estimateGasForSmartContract(request Execution) int
+
+    // get the state root hash of a given block height
+    getStateRootHash(blockHeight int) string
 }

--- a/explorer/idl/explorer/explorer.go
+++ b/explorer/idl/explorer/explorer.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "28e3e4647ba0a2e4a57cd17c9d907fae"
-const BarristerDateGenerated int64 = 1546551471062000000
+const BarristerChecksum string = "930ad8ed4154e09b1263a8f435f6934d"
+const BarristerDateGenerated int64 = 1546625898440000000
 
 type CoinStatistic struct {
 	Height     int64  `json:"height"`
@@ -36,6 +36,8 @@ type Block struct {
 	Amount     string         `json:"amount"`
 	Forged     int64          `json:"forged"`
 	Size       int64          `json:"size"`
+	TxRoot     string         `json:"txRoot"`
+	StateRoot  string         `json:"stateRoot"`
 }
 
 type Transfer struct {
@@ -1406,6 +1408,20 @@ var IdlJsonRaw = `[
             {
                 "name": "size",
                 "type": "int",
+                "optional": false,
+                "is_array": false,
+                "comment": ""
+            },
+            {
+                "name": "txRoot",
+                "type": "string",
+                "optional": false,
+                "is_array": false,
+                "comment": ""
+            },
+            {
+                "name": "stateRoot",
+                "type": "string",
                 "optional": false,
                 "is_array": false,
                 "comment": ""
@@ -4153,7 +4169,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1546551471062,
-        "checksum": "28e3e4647ba0a2e4a57cd17c9d907fae"
+        "date_generated": 1546625898440,
+        "checksum": "930ad8ed4154e09b1263a8f435f6934d"
     }
 ]`

--- a/explorer/idl/explorer/explorer.go
+++ b/explorer/idl/explorer/explorer.go
@@ -8,8 +8,8 @@ import (
 )
 
 const BarristerVersion string = "0.1.6"
-const BarristerChecksum string = "a3ce028b4a2de9f843ff6b5bb8234da8"
-const BarristerDateGenerated int64 = 1545331373998000000
+const BarristerChecksum string = "28e3e4647ba0a2e4a57cd17c9d907fae"
+const BarristerDateGenerated int64 = 1546551471062000000
 
 type CoinStatistic struct {
 	Height     int64  `json:"height"`
@@ -346,6 +346,7 @@ type Explorer interface {
 	EstimateGasForTransfer(request SendTransferRequest) (int64, error)
 	EstimateGasForVote() (int64, error)
 	EstimateGasForSmartContract(request Execution) (int64, error)
+	GetStateRootHash(blockHeight int64) (string, error)
 }
 
 func NewExplorerProxy(c barrister.Client) Explorer {
@@ -1165,6 +1166,24 @@ func (_p ExplorerProxy) EstimateGasForSmartContract(request Execution) (int64, e
 		return _cast, nil
 	}
 	return int64(0), _err
+}
+
+func (_p ExplorerProxy) GetStateRootHash(blockHeight int64) (string, error) {
+	_res, _err := _p.client.Call("Explorer.getStateRootHash", blockHeight)
+	if _err == nil {
+		_retType := _p.idl.Method("Explorer.getStateRootHash").Returns
+		_res, _err = barrister.Convert(_p.idl, &_retType, reflect.TypeOf(""), _res, "")
+	}
+	if _err == nil {
+		_cast, _ok := _res.(string)
+		if !_ok {
+			_t := reflect.TypeOf(_res)
+			_msg := fmt.Sprintf("Explorer.getStateRootHash returned invalid type: %v", _t)
+			return "", &barrister.JsonRpcError{Code: -32000, Message: _msg}
+		}
+		return _cast, nil
+	}
+	return "", _err
 }
 
 func NewJSONServer(idl *barrister.Idl, forceASCII bool, explorer Explorer) barrister.Server {
@@ -4098,6 +4117,26 @@ var IdlJsonRaw = `[
                     "is_array": false,
                     "comment": ""
                 }
+            },
+            {
+                "name": "getStateRootHash",
+                "comment": "get the state root hash of a given block height",
+                "params": [
+                    {
+                        "name": "blockHeight",
+                        "type": "int",
+                        "optional": false,
+                        "is_array": false,
+                        "comment": ""
+                    }
+                ],
+                "returns": {
+                    "name": "",
+                    "type": "string",
+                    "optional": false,
+                    "is_array": false,
+                    "comment": ""
+                }
             }
         ],
         "barrister_version": "",
@@ -4114,7 +4153,7 @@ var IdlJsonRaw = `[
         "values": null,
         "functions": null,
         "barrister_version": "0.1.6",
-        "date_generated": 1545331373998,
-        "checksum": "a3ce028b4a2de9f843ff6b5bb8234da8"
+        "date_generated": 1546551471062,
+        "checksum": "28e3e4647ba0a2e4a57cd17c9d907fae"
     }
 ]`

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -217,7 +217,7 @@ func (sf *factory) RootHashByHeight(blockHeight uint64) (hash.Hash32B, error) {
 
 	data, err := sf.dao.Get(AccountKVNameSpace, []byte(fmt.Sprintf("%s-%d", AccountTrieRootKey, blockHeight)))
 	if err != nil {
-		return hash.ZeroHash32B, nil
+		return hash.ZeroHash32B, err
 	}
 	var rootHash hash.Hash32B
 	copy(rootHash[:], data)

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -51,6 +51,7 @@ type (
 		Nonce(string) (uint64, error) // Note that Nonce starts with 1.
 		AccountState(string) (*state.Account, error)
 		RootHash() hash.Hash32B
+		RootHashByHeight(uint64) (hash.Hash32B, error)
 		Height() (uint64, error)
 		NewWorkingSet() (WorkingSet, error)
 		Commit(WorkingSet) error
@@ -207,6 +208,20 @@ func (sf *factory) RootHash() hash.Hash32B {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	return sf.rootHash()
+}
+
+// RootHashByHeight returns the hash of the root node of the state trie at a given height
+func (sf *factory) RootHashByHeight(blockHeight uint64) (hash.Hash32B, error) {
+	sf.mutex.RLock()
+	defer sf.mutex.RUnlock()
+
+	data, err := sf.dao.Get(AccountKVNameSpace, []byte(fmt.Sprintf("%s-%d", AccountTrieRootKey, blockHeight)))
+	if err != nil {
+		return hash.ZeroHash32B, nil
+	}
+	var rootHash hash.Hash32B
+	copy(rootHash[:], data)
+	return rootHash, nil
 }
 
 // Height returns factory's height

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -1051,6 +1051,25 @@ func TestLoadStoreHeightInMem(t *testing.T) {
 	require.Equal(uint64(10), height)
 }
 
+func TestFactory_RootHashByHeight(t *testing.T) {
+	cfg := config.Default
+	ctx := context.Background()
+	sf, err := NewFactory(cfg, InMemTrieOption())
+	require.NoError(t, err)
+	require.NoError(t, sf.Start(ctx))
+	defer require.NoError(t, sf.Stop(ctx))
+
+	ws, err := sf.NewWorkingSet()
+	require.NoError(t, err)
+	_, _, err = ws.RunActions(nil, 1, nil)
+	require.NoError(t, err)
+	require.NoError(t, sf.Commit(ws))
+
+	rootHash, err := sf.RootHashByHeight(1)
+	require.NoError(t, err)
+	require.NotEqual(t, hash.ZeroHash32B, rootHash)
+}
+
 func compareStrings(actual []string, expected []string) bool {
 	act := make(map[string]bool)
 	for i := 0; i < len(actual); i++ {

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -8,6 +8,7 @@ package factory
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -128,6 +129,13 @@ func (ws *workingSet) RunActions(
 	// Persist current chain Height
 	h := byteutil.Uint64ToBytes(blockHeight)
 	ws.cb.Put(AccountKVNameSpace, []byte(CurrentHeightKey), h, "failed to store accountTrie's current Height")
+	// Persis the historical accountTrie's root hash
+	ws.cb.Put(
+		AccountKVNameSpace,
+		[]byte(fmt.Sprintf("%s-%d", AccountTrieRootKey, blockHeight)),
+		rootHash[:],
+		"failed to store accountTrie's root hash",
+	)
 
 	return ws.RootHash(), receipts, nil
 }

--- a/test/mock/mock_explorer/mock_explorer.go
+++ b/test/mock/mock_explorer/mock_explorer.go
@@ -617,3 +617,16 @@ func (m *MockExplorer) EstimateGasForSmartContract(request explorer.Execution) (
 func (mr *MockExplorerMockRecorder) EstimateGasForSmartContract(request interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateGasForSmartContract", reflect.TypeOf((*MockExplorer)(nil).EstimateGasForSmartContract), request)
 }
+
+// GetStateRootHash mocks base method
+func (m *MockExplorer) GetStateRootHash(blockHeight int64) (string, error) {
+	ret := m.ctrl.Call(m, "GetStateRootHash", blockHeight)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetStateRootHash indicates an expected call of GetStateRootHash
+func (mr *MockExplorerMockRecorder) GetStateRootHash(blockHeight interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStateRootHash", reflect.TypeOf((*MockExplorer)(nil).GetStateRootHash), blockHeight)
+}

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -113,6 +113,19 @@ func (mr *MockFactoryMockRecorder) RootHash() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockFactory)(nil).RootHash))
 }
 
+// RootHashByHeight mocks base method
+func (m *MockFactory) RootHashByHeight(arg0 uint64) (hash.Hash32B, error) {
+	ret := m.ctrl.Call(m, "RootHashByHeight", arg0)
+	ret0, _ := ret[0].(hash.Hash32B)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RootHashByHeight indicates an expected call of RootHashByHeight
+func (mr *MockFactoryMockRecorder) RootHashByHeight(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHashByHeight", reflect.TypeOf((*MockFactory)(nil).RootHashByHeight), arg0)
+}
+
 // Height mocks base method
 func (m *MockFactory) Height() (uint64, error) {
 	ret := m.ctrl.Call(m, "Height")


### PR DESCRIPTION
The API is added for us to debug state related issues.

Test plan: unit tests added for factory and explorer, and verified it a real cluster