### PR TITLE
Refactor consensus 3

### DIFF
--- a/consensus/scheme/rolldpos/endorsement.go
+++ b/consensus/scheme/rolldpos/endorsement.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2018 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package rolldpos
+
+// Endorsement defines the interface of an endorsement used in consensus
+type Endorsement interface {
+	Hash() []byte
+	Height() uint64
+	Round() uint32
+	Endorser() string
+}

--- a/consensus/scheme/rolldpos/fsm.go
+++ b/consensus/scheme/rolldpos/fsm.go
@@ -17,10 +17,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/zjshen14/go-fsm"
 
-	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/endorsement"
 	"github.com/iotexproject/iotex-core/logger"
-	"github.com/iotexproject/iotex-core/proto"
 )
 
 /**
@@ -42,9 +40,7 @@ func init() {
 
 const (
 	// consensusEvt states
-	sEpochStart            fsm.State = "S_EPOCH_START"
-	sDKGGeneration         fsm.State = "S_DKG_GENERATION"
-	sRoundStart            fsm.State = "S_ROUND_START"
+	sPrepare               fsm.State = "S_PREPARE"
 	sBlockPropose          fsm.State = "S_BLOCK_PROPOSE"
 	sAcceptPropose         fsm.State = "S_ACCEPT_PROPOSE"
 	sAcceptProposalEndorse fsm.State = "S_ACCEPT_PROPOSAL_ENDORSE"
@@ -52,18 +48,16 @@ const (
 	sAcceptCommitEndorse   fsm.State = "S_ACCEPT_COMMIT_ENDORSE"
 
 	// consensusEvt event types
-	eRollDelegates          fsm.EventType = "E_ROLL_DELEGATES"
-	eGenerateDKG            fsm.EventType = "E_GENERATE_DKG"
-	eStartRound             fsm.EventType = "E_START_ROUND"
-	eInitBlockPropose       fsm.EventType = "E_INIT_BLOCK_PROPOSE"
-	eProposeBlock           fsm.EventType = "E_PROPOSE_BLOCK"
-	eProposeBlockTimeout    fsm.EventType = "E_PROPOSE_BLOCK_TIMEOUT"
-	eEndorseProposal        fsm.EventType = "E_ENDORSE_PROPOSAL"
-	eEndorseProposalTimeout fsm.EventType = "E_ENDORSE_PROPOSAL_TIMEOUT"
-	eEndorseLock            fsm.EventType = "E_ENDORSE_LOCK"
-	eEndorseLockTimeout     fsm.EventType = "E_ENDORSE_LOCK_TIMEOUT"
-	eEndorseCommit          fsm.EventType = "E_ENDORSE_COMMIT"
-	eFinishEpoch            fsm.EventType = "E_FINISH_EPOCH"
+	ePrepare                      fsm.EventType = "E_ROLL_DELEGATES"
+	eInitBlockPropose             fsm.EventType = "E_INIT_BLOCK_PROPOSE"
+	eReceiveBlock                 fsm.EventType = "E_RECEIVE_BLOCK"
+	eFailedToReceiveBlock         fsm.EventType = "E_FAILED_TO_RECEIVE_BLOCK"
+	eReceiveProposalEndorsement   fsm.EventType = "E_RECEIVE_PROPOSAL_ENDORSEMENT"
+	eNotEnoughProposalEndorsement fsm.EventType = "E_NOT_ENOUGH_PROPOSAL_ENDORSEMENT"
+	eReceiveLockEndorsement       fsm.EventType = "E_RECEIVE_LOCK_ENDORSEMENT"
+	eNotEnoughLockEndorsement     fsm.EventType = "E_NOT_ENOUGH_LOCK_ENDORSEMENT"
+	eReceiveCommitEndorsement     fsm.EventType = "E_RECEIVE_COMMIT_ENDORSEMENT"
+	// eStopReceivingCommitEndorsement fsm.EventType = "E_STOP_RECEIVING_COMMIT_ENDORSEMENT"
 
 	// eBackdoor indicates an backdoor event type
 	eBackdoor fsm.EventType = "E_BACKDOOR"
@@ -79,9 +73,7 @@ var (
 
 	// consensusStates is a slice consisting of all consensusEvt states
 	consensusStates = []fsm.State{
-		sEpochStart,
-		sDKGGeneration,
-		sRoundStart,
+		sPrepare,
 		sBlockPropose,
 		sAcceptPropose,
 		sAcceptProposalEndorse,
@@ -106,25 +98,25 @@ func newConsensusFSM(ctx *rollDPoSCtx) (*cFSM, error) {
 		ctx:   ctx,
 	}
 	b := fsm.NewBuilder().
-		AddInitialState(sEpochStart).
+		AddInitialState(sPrepare).
 		AddStates(
-			sDKGGeneration,
-			sRoundStart,
 			sBlockPropose,
 			sAcceptPropose,
 			sAcceptProposalEndorse,
 			sAcceptLockEndorse,
 			sAcceptCommitEndorse,
 		).
-		AddTransition(sEpochStart, eRollDelegates, cm.handleRollDelegatesEvt, []fsm.State{sEpochStart, sDKGGeneration}).
-		AddTransition(sDKGGeneration, eGenerateDKG, cm.handleGenerateDKGEvt, []fsm.State{sRoundStart}).
-		AddTransition(sRoundStart, eStartRound, cm.handleStartRoundEvt, []fsm.State{sBlockPropose}).
-		AddTransition(sRoundStart, eFinishEpoch, cm.handleFinishEpochEvt, []fsm.State{sEpochStart, sRoundStart}).
+		AddTransition(sPrepare, ePrepare, cm.prepare, []fsm.State{sPrepare, sBlockPropose}).
 		AddTransition(sBlockPropose, eInitBlockPropose, cm.handleInitBlockProposeEvt, []fsm.State{sAcceptPropose}).
-		AddTransition(sBlockPropose, eProposeBlockTimeout, cm.handleProposeBlockTimeout, []fsm.State{sAcceptProposalEndorse}).
+		AddTransition(
+			sBlockPropose,
+			eFailedToReceiveBlock,
+			cm.handleProposeBlockTimeout,
+			[]fsm.State{sAcceptProposalEndorse},
+		).
 		AddTransition(
 			sAcceptPropose,
-			eProposeBlock,
+			eReceiveBlock,
 			cm.handleProposeBlockEvt,
 			[]fsm.State{
 				sAcceptPropose,         // proposed block invalid
@@ -132,14 +124,14 @@ func newConsensusFSM(ctx *rollDPoSCtx) (*cFSM, error) {
 			}).
 		AddTransition(
 			sAcceptPropose,
-			eProposeBlockTimeout,
+			eFailedToReceiveBlock,
 			cm.handleProposeBlockTimeout,
 			[]fsm.State{
 				sAcceptProposalEndorse, // no valid block, jump to next step
 			}).
 		AddTransition(
 			sAcceptProposalEndorse,
-			eEndorseProposal,
+			eReceiveProposalEndorsement,
 			cm.handleEndorseProposalEvt,
 			[]fsm.State{
 				sAcceptProposalEndorse, // haven't reach agreement yet
@@ -147,14 +139,14 @@ func newConsensusFSM(ctx *rollDPoSCtx) (*cFSM, error) {
 			}).
 		AddTransition(
 			sAcceptProposalEndorse,
-			eEndorseProposalTimeout,
+			eNotEnoughProposalEndorsement,
 			cm.handleEndorseProposalTimeout,
 			[]fsm.State{
 				sAcceptLockEndorse, // timeout, jump to next step
 			}).
 		AddTransition(
 			sAcceptLockEndorse,
-			eEndorseLock,
+			eReceiveLockEndorsement,
 			cm.handleEndorseLockEvt,
 			[]fsm.State{
 				sAcceptLockEndorse,   // haven't reach agreement yet
@@ -162,18 +154,18 @@ func newConsensusFSM(ctx *rollDPoSCtx) (*cFSM, error) {
 			}).
 		AddTransition(
 			sAcceptLockEndorse,
-			eEndorseLockTimeout,
+			eNotEnoughLockEndorsement,
 			cm.handleEndorseLockTimeout,
 			[]fsm.State{
 				sAcceptCommitEndorse, // reach commit agreement, jump to next step
-				sRoundStart,          // timeout, jump to next round
+				sPrepare,             // timeout, jump to next round
 			}).
 		AddTransition(
 			sAcceptCommitEndorse,
-			eEndorseCommit,
+			eReceiveCommitEndorsement,
 			cm.handleEndorseCommitEvt,
 			[]fsm.State{
-				sRoundStart,
+				sPrepare, // reach consensus, start next epoch
 			})
 	// Add the backdoor transition so that we could unit test the transition from any given state
 	for _, state := range consensusStates {
@@ -199,16 +191,6 @@ func (m *cFSM) Start(c context.Context) error {
 				timeoutEvt, ok := evt.(*timeoutEvt)
 				if ok && timeoutEvt.timestamp().Before(m.ctx.round.timestamp) {
 					logger.Debug().Msg("timeoutEvt is stale")
-					continue
-				}
-				chainHeight := m.ctx.chain.TipHeight()
-				eventHeight := evt.height()
-				if _, ok := evt.(*proposeBlkEvt); ok && eventHeight <= chainHeight {
-					logger.Debug().Uint64("event height", eventHeight).Uint64("chain height", chainHeight).Msg("skip old proposal")
-					continue
-				}
-				if eEvt, ok := evt.(*endorseEvt); ok && eventHeight <= chainHeight && eEvt.endorse.Endorser() != m.ctx.addr.RawAddress {
-					logger.Debug().Uint64("event height", eventHeight).Uint64("chain height", chainHeight).Msg("skip old endorsement")
 					continue
 				}
 				src := m.fsm.CurrentState()
@@ -271,129 +253,36 @@ func (m *cFSM) produce(evt iConsensusEvt, delay time.Duration) {
 	}
 }
 
-func (m *cFSM) handleRollDelegatesEvt(_ fsm.Event) (fsm.State, error) {
-	epochNum, epochHeight, err := m.ctx.calcEpochNumAndHeight()
+func (m *cFSM) prepare(_ fsm.Event) (fsm.State, error) {
+	delay, isDelegate, err := m.ctx.PrepareNextRound()
+	if !isDelegate {
+		m.produce(m.newCEvt(ePrepare), delay)
+		return sPrepare, nil
+	}
 	if err != nil {
-		// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
-		m.produce(m.newCEvt(eRollDelegates), m.ctx.cfg.DelegateInterval)
-		return sEpochStart, errors.Wrap(
-			err,
-			"error when determining the epoch ordinal number and start height offset",
-		)
+		m.produce(m.newCEvt(ePrepare), delay)
+		return sPrepare, errors.Wrap(err, "error when prepare next round")
 	}
-	// Update CryptoSort seed
-	// TODO: Consider persist the most recent seed
-	if !m.ctx.cfg.EnableDKG {
-		m.ctx.epoch.seed = crypto.CryptoSeed
-	} else if m.ctx.epoch.seed, err = m.ctx.updateSeed(); err != nil {
-		logger.Error().Err(err).Msg("Failed to generate new seed from last epoch")
-	}
-	delegates, err := m.ctx.rollingDelegates(epochNum)
-	if err != nil {
-		// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
-		m.produce(m.newCEvt(eRollDelegates), m.ctx.cfg.DelegateInterval)
-		return sEpochStart, errors.Wrap(
-			err,
-			"error when determining if the node will participate into next epoch",
-		)
-	}
-	// If the current node is the delegate, move to the next state
-	if m.isDelegate(delegates) {
-		// The epochStart start height is going to be the next block to generate
-		m.ctx.epoch.num = epochNum
-		m.ctx.epoch.height = epochHeight
-		m.ctx.epoch.delegates = delegates
-		m.ctx.epoch.numSubEpochs = m.ctx.getNumSubEpochs()
-		m.ctx.epoch.subEpochNum = uint64(0)
-		m.ctx.epoch.committedSecrets = make(map[string][]uint32)
-
-		// Trigger the event to generate DKG
-		m.produce(m.newCEvt(eGenerateDKG), 0)
-
-		logger.Info().
-			Uint64("epoch", epochNum).
-			Msg("current node is the delegate")
-		return sDKGGeneration, nil
-	}
-	// Else, stay at the current state and check again later
-	m.produce(m.newCEvt(eRollDelegates), m.ctx.cfg.DelegateInterval)
-	logger.Info().
-		Uint64("epoch", epochNum).
-		Msg("current node is not the delegate")
-	return sEpochStart, nil
-}
-
-func (m *cFSM) handleGenerateDKGEvt(_ fsm.Event) (fsm.State, error) {
-	if m.ctx.shouldHandleDKG() {
-		// TODO: numDelegates will be configurable later on
-		if len(m.ctx.epoch.delegates) != 21 {
-			logger.Panic().Msg("Number of delegates is incorrect for DKG generation")
-		}
-		secrets, witness, err := m.ctx.generateDKGSecrets()
-		if err != nil {
-			return sEpochStart, err
-		}
-		m.ctx.epoch.secrets = secrets
-		m.ctx.epoch.witness = witness
-	}
-	if err := m.produceStartRoundEvt(); err != nil {
-		return sEpochStart, errors.Wrapf(err, "error when producing %s", eStartRound)
-	}
-	return sRoundStart, nil
-}
-
-func (m *cFSM) handleStartRoundEvt(_ fsm.Event) (fsm.State, error) {
-	subEpochNum, err := m.ctx.calcSubEpochNum()
-	if err != nil {
-		return sEpochStart, errors.Wrap(
-			err,
-			"error when determining the sub-epoch ordinal number",
-		)
-	}
-	m.ctx.epoch.subEpochNum = subEpochNum
-
-	proposer, height, round, err := m.ctx.rotatedProposer()
-	if err != nil {
-		logger.Error().
-			Err(err).
-			Msg("error when getting the proposer")
-		return sEpochStart, err
-	}
-	if m.ctx.round.height != height {
-		m.ctx.round = roundCtx{
-			height:          height,
-			endorsementSets: make(map[string]*endorsement.Set),
-		}
-	}
-	m.ctx.round.number = round
-	m.ctx.round.proposer = proposer
-	m.ctx.round.timestamp = m.ctx.clock.Now()
-
-	m.produce(m.newCEvt(eInitBlockPropose), 0)
+	m.produce(m.newCEvt(eInitBlockPropose), delay)
 	// Setup timeout for waiting for proposed block
-	ttl := m.ctx.cfg.AcceptProposeTTL
-	m.produce(m.newTimeoutEvt(eProposeBlockTimeout), ttl)
+	ttl := m.ctx.cfg.AcceptProposeTTL + delay
+	m.produce(m.newTimeoutEvt(eFailedToReceiveBlock), ttl)
 	ttl += m.ctx.cfg.AcceptProposalEndorseTTL
-	m.produce(m.newTimeoutEvt(eEndorseProposalTimeout), ttl)
+	m.produce(m.newTimeoutEvt(eNotEnoughProposalEndorsement), ttl)
 	ttl += m.ctx.cfg.AcceptCommitEndorseTTL
-	m.produce(m.newTimeoutEvt(eEndorseLockTimeout), ttl)
+	m.produce(m.newTimeoutEvt(eNotEnoughLockEndorsement), ttl)
+	// TODO add timeout for commit collection
 
 	return sBlockPropose, nil
 }
 
 func (m *cFSM) handleInitBlockProposeEvt(evt fsm.Event) (fsm.State, error) {
-	log := logger.Info().
-		Str("proposer", m.ctx.round.proposer).
-		Uint64("height", m.ctx.round.height).
-		Uint32("round", m.ctx.round.number)
-	if m.ctx.round.proposer != m.ctx.addr.RawAddress {
-		log.Msg("current node is not the proposer")
+	if !m.ctx.IsProposer() {
 		return sAcceptPropose, nil
 	}
-	log.Msg("current node is the proposer")
 	blk, err := m.ctx.MintBlock()
 	if err != nil {
-		return sEpochStart, errors.Wrap(err, "error when minting a block")
+		return sPrepare, errors.Wrap(err, "error when minting a block")
 	}
 	proposeBlkEvt := m.newProposeBlkEvt(blk)
 	proposeBlkEvtProto := proposeBlkEvt.toProtoMsg()
@@ -411,25 +300,24 @@ func (m *cFSM) handleInitBlockProposeEvt(evt fsm.Event) (fsm.State, error) {
 }
 
 func (m *cFSM) handleProposeBlockEvt(evt fsm.Event) (fsm.State, error) {
-	if evt.Type() != eProposeBlock {
-		return sEpochStart, errors.Errorf("invalid event type %s", evt.Type())
+	if evt.Type() != eReceiveBlock {
+		return sPrepare, errors.Errorf("invalid event type %s", evt.Type())
 	}
 	proposeBlkEvt, ok := evt.(*proposeBlkEvt)
 	if !ok {
-		return sEpochStart, errors.Wrap(ErrEvtCast, "the event is not a proposeBlkEvt")
+		return sPrepare, errors.Wrap(ErrEvtCast, "the event is not a proposeBlkEvt")
 	}
-	if !m.ctx.validateProposeBlock(proposeBlkEvt.block, m.ctx.round.proposer) {
-		return sAcceptPropose, nil
+	if err := m.ctx.ProcessProposeBlock(proposeBlkEvt.block); err != nil {
+		return sAcceptPropose, err
 	}
-	m.ctx.round.block = proposeBlkEvt.block
-	m.broadcastConsensusVote(m.ctx.round.block.Hash(), endorsement.PROPOSAL)
+	m.broadcastConsensusVote(proposeBlkEvt.block.Hash(), endorsement.PROPOSAL)
 
 	return sAcceptProposalEndorse, nil
 }
 
 func (m *cFSM) handleProposeBlockTimeout(evt fsm.Event) (fsm.State, error) {
-	if evt.Type() != eProposeBlockTimeout {
-		return sEpochStart, errors.Errorf("invalid event type %s", evt.Type())
+	if evt.Type() != eFailedToReceiveBlock {
+		return sPrepare, errors.Errorf("invalid event type %s", evt.Type())
 	}
 	logger.Warn().
 		Str("proposer", m.ctx.round.proposer).
@@ -541,7 +429,7 @@ func (m *cFSM) broadcastConsensusVote(
 	blkHash []byte,
 	topic endorsement.ConsensusVoteTopic,
 ) {
-	cEvt := m.newEndorseEvt(blkHash, topic)
+	cEvt := m.ctx.newEndorseEvt(blkHash, topic)
 	cEvtProto := cEvt.toProtoMsg()
 	// Notify itself
 	m.produce(cEvt, 0)
@@ -556,14 +444,14 @@ func (m *cFSM) broadcastConsensusVote(
 func (m *cFSM) handleEndorseProposalEvt(evt fsm.Event) (fsm.State, error) {
 	endorsementSet, err := m.processEndorseEvent(
 		evt,
-		eEndorseProposal,
+		eReceiveProposalEndorsement,
 		map[endorsement.ConsensusVoteTopic]bool{
 			endorsement.PROPOSAL: true,
 			endorsement.COMMIT:   true, // commit endorse is counted as one proposal endorse
 		},
 	)
 	if errors.Cause(err) == ErrEvtCast || errors.Cause(err) == ErrEvtType {
-		return sEpochStart, err
+		return sPrepare, err
 	}
 	if err != nil || endorsementSet == nil {
 		return sAcceptProposalEndorse, err
@@ -576,8 +464,8 @@ func (m *cFSM) handleEndorseProposalEvt(evt fsm.Event) (fsm.State, error) {
 }
 
 func (m *cFSM) handleEndorseProposalTimeout(evt fsm.Event) (fsm.State, error) {
-	if evt.Type() != eEndorseProposalTimeout {
-		return sEpochStart, errors.Errorf("invalid event type %s", evt.Type())
+	if evt.Type() != eNotEnoughProposalEndorsement {
+		return sPrepare, errors.Errorf("invalid event type %s", evt.Type())
 	}
 	numProposalEndorsements := 0
 	if m.ctx.round.block != nil {
@@ -605,14 +493,14 @@ func (m *cFSM) handleEndorseProposalTimeout(evt fsm.Event) (fsm.State, error) {
 func (m *cFSM) handleEndorseLockEvt(evt fsm.Event) (fsm.State, error) {
 	endorsementSet, err := m.processEndorseEvent(
 		evt,
-		eEndorseLock,
+		eReceiveLockEndorsement,
 		map[endorsement.ConsensusVoteTopic]bool{
 			endorsement.LOCK:   true,
 			endorsement.COMMIT: true, // commit endorse is counted as one lock endorse
 		},
 	)
 	if errors.Cause(err) == ErrEvtCast || errors.Cause(err) == ErrEvtType {
-		return sEpochStart, err
+		return sPrepare, err
 	}
 	if err != nil || endorsementSet == nil {
 		// Wait for more lock votes to come
@@ -624,8 +512,8 @@ func (m *cFSM) handleEndorseLockEvt(evt fsm.Event) (fsm.State, error) {
 }
 
 func (m *cFSM) handleEndorseLockTimeout(evt fsm.Event) (fsm.State, error) {
-	if evt.Type() != eEndorseLockTimeout {
-		return sEpochStart, errors.Errorf("invalid event type %s", evt.Type())
+	if evt.Type() != eNotEnoughLockEndorsement {
+		return sPrepare, errors.Errorf("invalid event type %s", evt.Type())
 	}
 	numCommitEndorsements := 0
 	if m.ctx.round.block != nil {
@@ -646,8 +534,8 @@ func (m *cFSM) handleEndorseLockTimeout(evt fsm.Event) (fsm.State, error) {
 		Int("numCommitEndorsements", numCommitEndorsements).
 		Msg("didn't collect enough commit endorse before timeout")
 
-	m.produce(m.newCEvt(eFinishEpoch), 0)
-	return sRoundStart, nil
+	m.produce(m.newCEvt(ePrepare), 0)
+	return sPrepare, nil
 }
 
 func (m *cFSM) handleEndorseCommitEvt(evt fsm.Event) (fsm.State, error) {
@@ -658,70 +546,15 @@ func (m *cFSM) handleEndorseCommitEvt(evt fsm.Event) (fsm.State, error) {
 	if err := m.ctx.OnConsensusReached(); err != nil {
 		logger.Error().Err(err).Msg("failed to commit block on consensus reached")
 	}
-	m.produce(m.newCEvt(eFinishEpoch), 0)
-	return sRoundStart, nil
-}
-
-func (m *cFSM) handleFinishEpochEvt(evt fsm.Event) (fsm.State, error) {
-	if m.ctx.shouldHandleDKG() && m.ctx.isDKGFinished() {
-		dkgPubKey, dkgPriKey, err := m.ctx.generateDKGKeyPair()
-		if err != nil {
-			return sEpochStart, errors.Wrap(err, "error when generating DKG key pair")
-		}
-		m.ctx.epoch.dkgAddress.PublicKey = dkgPubKey
-		m.ctx.epoch.dkgAddress.PrivateKey = dkgPriKey
-	}
-
-	epochFinished, err := m.ctx.isEpochFinished()
-	if err != nil {
-		return sEpochStart, errors.Wrap(err, "error when checking if the epoch is finished")
-	}
-	if epochFinished {
-		m.produce(m.newCEvt(eRollDelegates), 0)
-		return sEpochStart, nil
-	}
-	if err := m.produceStartRoundEvt(); err != nil {
-		return sEpochStart, errors.Wrapf(err, "error when producing %s", eStartRound)
-	}
-	return sRoundStart, nil
-}
-
-func (m *cFSM) isDelegate(delegates []string) bool {
-	for _, d := range delegates {
-		if m.ctx.addr.RawAddress == d {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *cFSM) produceStartRoundEvt() error {
-	var (
-		duration time.Duration
-		err      error
-	)
-	// If we have the cached last block, we get the timestamp from it
-	if duration, err = m.ctx.calcDurationSinceLastBlock(); err != nil {
-		// Otherwise, we read it from blockchain
-		return errors.Wrap(err, "error when computing the duration since last block time")
-
-	}
-	// If the proposal interval is not set (not zero), the next round will only be started after the configured duration
-	// after last block's creation time, so that we could keep the constant
-	waitDuration := time.Duration(0)
-	if m.ctx.cfg.ProposerInterval > 0 {
-		waitDuration = (m.ctx.cfg.ProposerInterval - (duration % m.ctx.cfg.ProposerInterval)) % m.ctx.cfg.ProposerInterval
-	}
-	m.produce(m.newCEvt(eStartRound), waitDuration)
-
-	return nil
+	m.produce(m.newCEvt(ePrepare), 0)
+	return sPrepare, nil
 }
 
 // handleBackdoorEvt takes the dst state from the event and move the FSM into it
 func (m *cFSM) handleBackdoorEvt(evt fsm.Event) (fsm.State, error) {
 	bEvt, ok := evt.(*backdoorEvt)
 	if !ok {
-		return sEpochStart, errors.Wrap(ErrEvtCast, "the event is not a backdoorEvt")
+		return sPrepare, errors.Wrap(ErrEvtCast, "the event is not a backdoorEvt")
 	}
 	return bEvt.dst, nil
 }
@@ -732,27 +565,6 @@ func (m *cFSM) newCEvt(t fsm.EventType) *consensusEvt {
 
 func (m *cFSM) newProposeBlkEvt(blk Block) *proposeBlkEvt {
 	return newProposeBlkEvt(blk, m.ctx.round.proofOfLock, m.ctx.round.number, m.ctx.clock)
-}
-
-func (m *cFSM) newProposeBlkEvtFromProposePb(pb *iproto.ProposePb) (*proposeBlkEvt, error) {
-	evt := newProposeBlkEvtFromProtoMsg(pb, m.ctx.clock)
-	if evt == nil {
-		return nil, errors.New("error when casting a proto msg to proposeBlkEvt")
-	}
-
-	return evt, nil
-}
-
-func (m *cFSM) newEndorseEvtWithEndorsePb(ePb *iproto.EndorsePb) (*endorseEvt, error) {
-	en, err := endorsement.FromProtoMsg(ePb)
-	if err != nil {
-		return nil, errors.Wrap(err, "error when casting a proto msg to endorse")
-	}
-	return newEndorseEvtWithEndorse(en, m.ctx.clock), nil
-}
-
-func (m *cFSM) newEndorseEvt(blkHash []byte, topic endorsement.ConsensusVoteTopic) *endorseEvt {
-	return newEndorseEvt(topic, blkHash, m.ctx.round.height, m.ctx.round.number, m.ctx.addr, m.ctx.clock)
 }
 
 func (m *cFSM) newTimeoutEvt(t fsm.EventType) *timeoutEvt {

--- a/consensus/scheme/rolldpos/fsmevent.go
+++ b/consensus/scheme/rolldpos/fsmevent.go
@@ -66,7 +66,7 @@ func newProposeBlkEvt(
 	c clock.Clock,
 ) *proposeBlkEvt {
 	return &proposeBlkEvt{
-		consensusEvt: *newCEvt(eProposeBlock, block.Height(), round, c),
+		consensusEvt: *newCEvt(eReceiveBlock, block.Height(), round, c),
 		block:        block,
 		lockProof:    lockProof,
 	}
@@ -134,11 +134,11 @@ func newEndorseEvtWithEndorse(endorse *endorsement.Endorsement, c clock.Clock) *
 	var eventType fsm.EventType
 	switch vote.Topic {
 	case endorsement.PROPOSAL:
-		eventType = eEndorseProposal
+		eventType = eReceiveProposalEndorsement
 	case endorsement.LOCK:
-		eventType = eEndorseLock
+		eventType = eReceiveLockEndorsement
 	case endorsement.COMMIT:
-		eventType = eEndorseCommit
+		eventType = eReceiveCommitEndorsement
 	}
 	return &endorseEvt{
 		consensusEvt: *newCEvt(eventType, vote.Height, vote.Round, c),

--- a/consensus/scheme/rolldpos/fsmevent.go
+++ b/consensus/scheme/rolldpos/fsmevent.go
@@ -113,7 +113,7 @@ func newProposeBlkEvtFromProtoMsg(pMsg *iproto.ProposePb, c clock.Clock) *propos
 
 type endorseEvt struct {
 	consensusEvt
-	endorse *endorsement.Endorsement
+	endorse Endorsement
 }
 
 func newEndorseEvt(
@@ -142,12 +142,14 @@ func newEndorseEvtWithEndorse(endorse *endorsement.Endorsement, c clock.Clock) *
 	}
 	return &endorseEvt{
 		consensusEvt: *newCEvt(eventType, vote.Height, vote.Round, c),
-		endorse:      endorse,
+		endorse:      &endorsementWrapper{endorse},
 	}
 }
 
 func (en *endorseEvt) toProtoMsg() *iproto.EndorsePb {
-	return en.endorse.ToProtoMsg()
+	endorsement := en.endorse.(*endorsementWrapper)
+
+	return endorsement.ToProtoMsg()
 }
 
 type timeoutEvt struct {

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -8,7 +8,6 @@ package rolldpos
 
 import (
 	"context"
-	"encoding/hex"
 	"time"
 
 	"github.com/facebookgo/clock"
@@ -152,51 +151,83 @@ func (ctx *rollDPoSCtx) MintBlock() (Block, error) {
 	}, nil
 }
 
-func (ctx *rollDPoSCtx) validateProposeBlock(blk Block, expectedProposer string) bool {
-	blkHash := blk.Hash()
-	errorLog := logger.Error().
-		Uint64("expectedHeight", ctx.round.height).
-		Str("expectedProposer", expectedProposer).
-		Str("hash", hex.EncodeToString(blkHash[:]))
+func (ctx *rollDPoSCtx) newEndorseEvt(blkHash []byte, topic endorsement.ConsensusVoteTopic) *endorseEvt {
+	return newEndorseEvt(topic, blkHash, ctx.round.height, ctx.round.number, ctx.addr, ctx.clock)
+}
+
+func (ctx *rollDPoSCtx) newProposeBlkEvtFromProposePb(pb *iproto.ProposePb) (*proposeBlkEvt, error) {
+	evt := newProposeBlkEvtFromProtoMsg(pb, ctx.clock)
+	if evt == nil {
+		return nil, errors.New("error when casting a proto msg to proposeBlkEvt")
+	}
+
+	return evt, nil
+}
+
+func (ctx *rollDPoSCtx) newEndorseEvtWithEndorsePb(ePb *iproto.EndorsePb) (*endorseEvt, error) {
+	en, err := endorsement.FromProtoMsg(ePb)
+	if err != nil {
+		return nil, errors.Wrap(err, "error when casting a proto msg to endorse")
+	}
+	return newEndorseEvtWithEndorse(en, ctx.clock), nil
+}
+
+func (ctx *rollDPoSCtx) calcWaitDuration() (time.Duration, error) {
+	// If the proposal interval is not set (not zero), the next round will only be started after the configured duration
+	// after last block's creation time, so that we could keep the constant
+	waitDuration := time.Duration(0)
+	// If we have the cached last block, we get the timestamp from it
+	duration, err := ctx.calcDurationSinceLastBlock()
+	if err != nil {
+		return waitDuration, err
+	}
+	if ctx.cfg.ProposerInterval > 0 {
+		waitDuration = (ctx.cfg.ProposerInterval - (duration % ctx.cfg.ProposerInterval)) % ctx.cfg.ProposerInterval
+	}
+
+	return waitDuration, nil
+}
+
+func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) error {
 	if blk.Height() != ctx.round.height {
-		errorLog.Uint64("blockHeight", blk.Height()).
-			Msg("error when validating the block height")
-		return false
+		return errors.Errorf(
+			"unexpected block height %d, %d expected",
+			blk.Height(),
+			ctx.round.height,
+		)
 	}
 	producer := blk.Proposer()
-
+	expectedProposer := ctx.round.proposer
 	if producer == "" || producer != expectedProposer {
-		errorLog.Str("proposer", producer).
-			Msg("error when validating the block proposer")
-		return false
+		return errors.Errorf(
+			"unexpected block proposer %s, %s expected",
+			producer,
+			ctx.round.proposer,
+		)
 	}
 	block := blk.(*blockWrapper)
 	if !block.VerifySignature() {
-		errorLog.Msg("error when validating the block signature")
-		return false
+		return errors.Errorf("invalid block signature")
 	}
 	// TODO: in long term, block in process and after process should be represented differently
-	if producer == ctx.addr.RawAddress && block.WorkingSet != nil {
+	if producer != ctx.addr.RawAddress || block.WorkingSet == nil {
 		// If the block is self proposed and working set is not nil (meaning not obtained from wire), skip validation
-		return true
-	}
-	containCoinbase := true
-	if ctx.cfg.EnableDKG {
-		if ctx.shouldHandleDKG() {
-			containCoinbase = false
-		} else if err := verifyDKGSignature(block.Block, ctx.epoch.seed); err != nil {
-			// Verify dkg signature failed
-			errorLog.Err(err).Msg("Failed to verify the DKG signature")
-			return false
+		containCoinbase := true
+		if ctx.cfg.EnableDKG {
+			if ctx.shouldHandleDKG() {
+				containCoinbase = false
+			} else if err := verifyDKGSignature(block.Block, ctx.epoch.seed); err != nil {
+				// Verify dkg signature failed
+				return errors.Wrapf(err, "failed to verify the DKG signature")
+			}
 		}
-
+		if err := ctx.chain.ValidateBlock(block.Block, containCoinbase); err != nil {
+			return errors.Wrapf(err, "error when validating the proposed block")
+		}
 	}
-	if err := ctx.chain.ValidateBlock(block.Block, containCoinbase); err != nil {
-		errorLog.Err(err).Msg("error when validating the proposed block")
-		return false
-	}
+	ctx.round.block = blk
 
-	return true
+	return nil
 }
 
 func verifyDKGSignature(blk *block.Block, seedByte []byte) error {
@@ -228,6 +259,20 @@ func (ctx *rollDPoSCtx) Broadcast(msg proto.Message) error {
 	}
 
 	return ctx.broadcastHandler(consensusMsg)
+}
+
+// RollingDelegates will update seed and rolling delegates
+func (ctx *rollDPoSCtx) RollingDelegates(epochNum uint64) ([]string, error) {
+	// Update CryptoSort seed
+	// TODO: Consider persist the most recent seed
+	var err error
+	if !ctx.cfg.EnableDKG {
+		ctx.epoch.seed = crypto.CryptoSeed
+	} else if ctx.epoch.seed, err = ctx.updateSeed(); err != nil {
+		logger.Error().Err(err).Msg("Failed to generate new seed from last epoch")
+	}
+
+	return ctx.rollingDelegates(epochNum)
 }
 
 // rollingDelegates will only allows the delegates chosen for given epoch to enter the epoch
@@ -344,18 +389,127 @@ func (ctx *rollDPoSCtx) getNumSubEpochs() uint {
 	return num
 }
 
+func (ctx *rollDPoSCtx) IsProposer() bool {
+	log := logger.Info().
+		Str("proposer", ctx.round.proposer).
+		Uint64("height", ctx.round.height).
+		Uint32("round", ctx.round.number)
+	if ctx.round.proposer != ctx.addr.RawAddress {
+		log.Msg("current node is not the proposer")
+		return false
+	}
+	log.Msg("current node is the proposer")
+	return true
+}
+
+func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
+	if ctx.shouldHandleDKG() && ctx.isDKGFinished() {
+		dkgPubKey, dkgPriKey, err := ctx.generateDKGKeyPair()
+		if err != nil {
+			return time.Duration(0), true, errors.Wrap(err, "error when generating DKG key pair")
+		}
+		ctx.epoch.dkgAddress.PublicKey = dkgPubKey
+		ctx.epoch.dkgAddress.PrivateKey = dkgPriKey
+	}
+	epochNum, epochHeight, err := ctx.calcEpochNumAndHeight()
+	if err != nil {
+		// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
+		return ctx.cfg.DelegateInterval, true, errors.Wrap(
+			err,
+			"error when determining the epoch ordinal number and start height offset",
+		)
+	}
+	if epochNum != ctx.epoch.num {
+		delegates, err := ctx.RollingDelegates(epochNum)
+		if err != nil {
+			// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
+			return ctx.cfg.DelegateInterval, true, errors.Wrap(
+				err,
+				"error when determining if the node will participate into next epoch",
+			)
+		}
+		// The epochStart start height is going to be the next block to generate
+		ctx.epoch.num = epochNum
+		ctx.epoch.height = epochHeight
+		ctx.epoch.delegates = delegates
+		ctx.epoch.numSubEpochs = ctx.getNumSubEpochs()
+		ctx.epoch.subEpochNum = uint64(0)
+		ctx.epoch.committedSecrets = make(map[string][]uint32)
+	}
+	// If the current node is the delegate, move to the next state
+	isDelegate := false
+	for _, d := range ctx.epoch.delegates {
+		if ctx.addr.RawAddress == d {
+			isDelegate = true
+			break
+		}
+	}
+	if !isDelegate {
+		return ctx.cfg.DelegateInterval, false, nil
+	}
+	logger.Info().
+		Uint64("epoch", epochNum).
+		Msg("current node is the delegate")
+	if ctx.shouldHandleDKG() {
+		// TODO: numDelegates will be configurable later on
+		if len(ctx.epoch.delegates) != 21 {
+			logger.Panic().Msg("Number of delegates is incorrect for DKG generation")
+		}
+		secrets, witness, err := ctx.generateDKGSecrets()
+		if err != nil {
+			return time.Duration(0), true, err
+		}
+		ctx.epoch.secrets = secrets
+		ctx.epoch.witness = witness
+	}
+	waitDuration, err := ctx.calcWaitDuration()
+	if err != nil {
+		return waitDuration, true, err
+	}
+	subEpochNum, err := ctx.calcSubEpochNum()
+	if err != nil {
+		return waitDuration, true, err
+	}
+	ctx.epoch.subEpochNum = subEpochNum
+
+	proposer, height, round, err := ctx.rotatedProposer(waitDuration)
+	if err != nil {
+		return waitDuration, true, err
+	}
+	if ctx.round.height != height {
+		ctx.round = roundCtx{
+			height:          height,
+			endorsementSets: make(map[string]*endorsement.Set),
+		}
+	}
+	ctx.round.number = round
+	ctx.round.proposer = proposer
+	ctx.round.timestamp = ctx.clock.Now()
+
+	return waitDuration, true, nil
+}
+
 // rotatedProposer will rotate among the delegates to choose the proposer. It is pseudo order based on the position
 // in the delegate list and the block height
-func (ctx *rollDPoSCtx) rotatedProposer() (string, uint64, uint32, error) {
+func (ctx *rollDPoSCtx) rotatedProposer(offsetDuration time.Duration) (
+	proposer string,
+	height uint64,
+	round uint32,
+	err error,
+) {
 	// Next block height
-	height := ctx.chain.TipHeight() + 1
-	round, proposer, err := ctx.calcProposer(height, ctx.epoch.delegates)
+	height = ctx.chain.TipHeight() + 1
+	round, proposer, err = ctx.calcProposer(height, ctx.epoch.delegates, offsetDuration)
 
 	return proposer, height, round, err
 }
 
 // calcProposer calculates the proposer for the block at a given height
-func (ctx *rollDPoSCtx) calcProposer(height uint64, delegates []string) (uint32, string, error) {
+func (ctx *rollDPoSCtx) calcProposer(
+	height uint64,
+	delegates []string,
+	offsetDuration time.Duration,
+) (uint32, string, error) {
 	numDelegates := len(delegates)
 	if numDelegates == 0 {
 		return 0, "", ErrZeroDelegate
@@ -369,6 +523,7 @@ func (ctx *rollDPoSCtx) calcProposer(height uint64, delegates []string) (uint32,
 			}
 			return 0, "", errors.Wrap(err, "error when computing the duration since last block time")
 		}
+		duration += offsetDuration
 		if duration > ctx.cfg.ProposerInterval {
 			timeSlotIndex = uint32(duration/ctx.cfg.ProposerInterval) - 1
 		}
@@ -567,7 +722,7 @@ func (r *RollDPoS) Start(ctx context.Context) error {
 	if err := r.cfsm.Start(ctx); err != nil {
 		return errors.Wrap(err, "error when starting the consensus FSM")
 	}
-	r.cfsm.produce(r.cfsm.newCEvt(eRollDelegates), r.ctx.cfg.Delay)
+	r.cfsm.produce(r.cfsm.newCEvt(ePrepare), r.ctx.cfg.Delay)
 	return nil
 }
 
@@ -586,7 +741,7 @@ func (r *RollDPoS) HandleConsensusMsg(msg *iproto.ConsensusPb) error {
 		if err := proto.Unmarshal(data, pPb); err != nil {
 			return err
 		}
-		pbEvt, err := r.cfsm.newProposeBlkEvtFromProposePb(pPb)
+		pbEvt, err := r.ctx.newProposeBlkEvtFromProposePb(pPb)
 		if err != nil {
 			return errors.Wrap(err, "error when casting a proto msg to proposeBlkEvt")
 		}
@@ -599,7 +754,7 @@ func (r *RollDPoS) HandleConsensusMsg(msg *iproto.ConsensusPb) error {
 		if err := proto.Unmarshal(data, ePb); err != nil {
 			return err
 		}
-		eEvt, err := r.cfsm.newEndorseEvtWithEndorsePb(ePb)
+		eEvt, err := r.ctx.newEndorseEvtWithEndorsePb(ePb)
 		if err != nil {
 			return errors.Wrap(err, "error when casting a proto msg to endorse")
 		}
@@ -633,7 +788,7 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 	// Compute the height
 	height := r.ctx.chain.TipHeight()
 	// Compute block producer
-	_, producer, err := r.ctx.calcProposer(height+1, delegates)
+	_, producer, err := r.ctx.calcProposer(height+1, delegates, time.Duration(0))
 	if err != nil {
 		return metrics, errors.Wrap(err, "error when calculating the block producer")
 	}

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -7,13 +7,16 @@
 package rolldpos
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"time"
 
 	"github.com/facebookgo/clock"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog"
 	"github.com/zjshen14/go-fsm"
 
 	"github.com/iotexproject/iotex-core/action"
@@ -136,8 +139,25 @@ func (bw *blockWrapper) Round() uint32 {
 	return bw.round
 }
 
+type endorsementWrapper struct {
+	*endorsement.Endorsement
+}
+
+func (ew endorsementWrapper) Hash() []byte {
+	return ew.ConsensusVote().BlkHash[:]
+}
+
+func (ew *endorsementWrapper) Height() uint64 {
+	return ew.ConsensusVote().Height
+}
+
+func (ew endorsementWrapper) Round() uint32 {
+	return ew.ConsensusVote().Round
+}
+
 func (ctx *rollDPoSCtx) MintBlock() (Block, error) {
 	if blk := ctx.round.block; blk != nil {
+		blk.(*blockWrapper).round = ctx.round.number
 		return blk, nil
 	}
 	blk, err := ctx.mintBlock()
@@ -188,9 +208,14 @@ func (ctx *rollDPoSCtx) calcWaitDuration() (time.Duration, error) {
 	return waitDuration, nil
 }
 
-func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) error {
+func (ctx *rollDPoSCtx) Logger() *zerolog.Logger {
+	return logger.Logger()
+}
+
+func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) (iConsensusEvt, error) {
+	// TODO: delete the following check
 	if blk.Height() != ctx.round.height {
-		return errors.Errorf(
+		return nil, errors.Errorf(
 			"unexpected block height %d, %d expected",
 			blk.Height(),
 			ctx.round.height,
@@ -199,7 +224,7 @@ func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) error {
 	producer := blk.Proposer()
 	expectedProposer := ctx.round.proposer
 	if producer == "" || producer != expectedProposer {
-		return errors.Errorf(
+		return nil, errors.Errorf(
 			"unexpected block proposer %s, %s expected",
 			producer,
 			ctx.round.proposer,
@@ -207,7 +232,7 @@ func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) error {
 	}
 	block := blk.(*blockWrapper)
 	if !block.VerifySignature() {
-		return errors.Errorf("invalid block signature")
+		return nil, errors.Errorf("invalid block signature")
 	}
 	// TODO: in long term, block in process and after process should be represented differently
 	if producer != ctx.addr.RawAddress || block.WorkingSet == nil {
@@ -218,20 +243,189 @@ func (ctx *rollDPoSCtx) ProcessProposeBlock(blk Block) error {
 				containCoinbase = false
 			} else if err := verifyDKGSignature(block.Block, ctx.epoch.seed); err != nil {
 				// Verify dkg signature failed
-				return errors.Wrapf(err, "failed to verify the DKG signature")
+				return nil, errors.Wrapf(err, "failed to verify the DKG signature")
 			}
 		}
 		if err := ctx.chain.ValidateBlock(block.Block, containCoinbase); err != nil {
-			return errors.Wrapf(err, "error when validating the proposed block")
+			return nil, errors.Wrapf(err, "error when validating the proposed block")
 		}
 	}
-	ctx.round.block = blk
+	ctx.round.block = block
 
-	return nil
+	return ctx.broadcastConsensusVote(endorsement.PROPOSAL)
 }
 
 func verifyDKGSignature(blk *block.Block, seedByte []byte) error {
 	return crypto.BLS.Verify(blk.DKGPubkey(), seedByte, blk.DKGSignature())
+}
+
+func (ctx *rollDPoSCtx) LogProposalEndorsementStats() {
+	numProposalEndorsements := 0
+	if ctx.round.block != nil {
+		blkHashHex := hex.EncodeToString(ctx.round.block.Hash())
+		endorsementSet := ctx.round.endorsementSets[blkHashHex]
+		if endorsementSet != nil {
+			numProposalEndorsements = endorsementSet.NumOfValidEndorsements(
+				map[endorsement.ConsensusVoteTopic]bool{
+					endorsement.PROPOSAL: true,
+					endorsement.COMMIT:   false,
+				},
+				ctx.epoch.delegates,
+			)
+		}
+	}
+
+	logger.Warn().
+		Uint64("height", ctx.round.height).
+		Int("numProposalEndorsements", numProposalEndorsements).
+		Msg("didn't collect enough proposal endorses before timeout")
+}
+
+func (ctx *rollDPoSCtx) LogLockEndorsementStats() {
+	numCommitEndorsements := 0
+	if ctx.round.block != nil {
+		blkHashHex := hex.EncodeToString(ctx.round.block.Hash())
+		endorsementSet := ctx.round.endorsementSets[blkHashHex]
+		if endorsementSet != nil {
+			numCommitEndorsements = endorsementSet.NumOfValidEndorsements(
+				map[endorsement.ConsensusVoteTopic]bool{
+					endorsement.PROPOSAL: false,
+					endorsement.COMMIT:   true,
+				},
+				ctx.epoch.delegates,
+			)
+		}
+	}
+	logger.Warn().
+		Uint64("height", ctx.round.height).
+		Int("numCommitEndorsements", numCommitEndorsements).
+		Msg("didn't collect enough commit endorse before timeout")
+}
+
+func (ctx *rollDPoSCtx) isProposedBlock(hash []byte) bool {
+	if ctx.round.block == nil {
+		logger.Error().Msg("block is nil")
+		return false
+	}
+	blkHash := ctx.round.block.Hash()
+
+	return bytes.Equal(hash[:], blkHash[:])
+}
+
+func (ctx *rollDPoSCtx) isDelegateEndorsement(endorser string) bool {
+	for _, delegate := range ctx.epoch.delegates {
+		if delegate == endorser {
+			return true
+		}
+	}
+	return false
+}
+
+func (ctx *rollDPoSCtx) ProcessProposalEndorsement(en Endorsement) (bool, iConsensusEvt, error) {
+	enough, err := ctx.processEndorsement(
+		en,
+		map[endorsement.ConsensusVoteTopic]bool{
+			endorsement.PROPOSAL: true,
+			endorsement.COMMIT:   true, // commit endorse is counted as one proposal endorse
+		},
+	)
+	if err != nil || !enough {
+		return false, nil, err
+	}
+	ctx.round.proofOfLock = ctx.round.endorsementSets[hex.EncodeToString(ctx.round.block.Hash())]
+	cEvt, err := ctx.broadcastConsensusVote(endorsement.LOCK)
+
+	return true, cEvt, err
+}
+
+func (ctx *rollDPoSCtx) ProcessLockEndorsement(en Endorsement) (bool, error) {
+	return ctx.processEndorsement(
+		en,
+		map[endorsement.ConsensusVoteTopic]bool{
+			endorsement.LOCK:   true,
+			endorsement.COMMIT: true, // commit endorse is counted as one proposal endorse
+		},
+	)
+}
+
+func (ctx *rollDPoSCtx) LockBlock() (iConsensusEvt, error) {
+	ctx.round.proofOfLock = ctx.round.endorsementSets[hex.EncodeToString(ctx.round.block.Hash())]
+
+	return ctx.broadcastConsensusVote(endorsement.LOCK)
+}
+
+func (ctx *rollDPoSCtx) PreCommitBlock() (iConsensusEvt, error) {
+	return ctx.broadcastConsensusVote(endorsement.COMMIT)
+}
+
+func (ctx *rollDPoSCtx) broadcastConsensusVote(
+	topic endorsement.ConsensusVoteTopic,
+) (iConsensusEvt, error) {
+	cEvt := ctx.newEndorseEvt(ctx.round.block.Hash(), topic)
+	cEvtProto := cEvt.toProtoMsg()
+	if err := ctx.Broadcast(cEvtProto); err != nil {
+		logger.Error().
+			Err(err).
+			Msg("error when broadcasting commitEvtProto")
+	}
+
+	return cEvt, nil
+}
+
+func (ctx *rollDPoSCtx) processEndorsement(
+	en Endorsement,
+	expectedTopics map[endorsement.ConsensusVoteTopic]bool,
+) (bool, error) {
+	endorse, ok := en.(*endorsementWrapper)
+	if !ok {
+		return false, errors.New("invalid endorsement")
+	}
+	vote := endorse.ConsensusVote()
+	if !ctx.isProposedBlock(vote.BlkHash[:]) {
+		logger.Error().Msgf("Not the proposed block %+v\n%+v", vote, ctx.round)
+		return false, errors.New("the endorsed block was not the proposed block")
+	}
+	if !ctx.isDelegateEndorsement(endorse.Endorser()) {
+		return false, errors.Errorf("invalid endorser %s", endorse.Endorser())
+	}
+	if _, ok := expectedTopics[vote.Topic]; !ok {
+		return false, errors.Errorf("invalid consensus topic %s", vote.Topic)
+	}
+	if vote.Height != ctx.round.height {
+		return false, errors.Errorf(
+			"invalid endorsement height %d, %d expected",
+			vote.Height,
+			ctx.round.height,
+		)
+	}
+
+	return ctx.addEndorsement(endorse.Endorsement, expectedTopics)
+}
+
+func (ctx *rollDPoSCtx) addEndorsement(
+	en *endorsement.Endorsement,
+	expectedConsensusTopics map[endorsement.ConsensusVoteTopic]bool,
+) (bool, error) {
+	blkHash := en.ConsensusVote().BlkHash
+	blkHashHex := hex.EncodeToString(blkHash)
+	endorsementSet, ok := ctx.round.endorsementSets[blkHashHex]
+	if !ok {
+		endorsementSet = endorsement.NewSet(blkHash)
+		ctx.round.endorsementSets[blkHashHex] = endorsementSet
+	}
+	if err := endorsementSet.AddEndorsement(en); err != nil {
+		return false, err
+	}
+	validNum := endorsementSet.NumOfValidEndorsements(
+		expectedConsensusTopics,
+		ctx.epoch.delegates,
+	)
+	numDelegates := len(ctx.epoch.delegates)
+	if numDelegates >= 4 && validNum > numDelegates*2/3 || numDelegates < 4 && validNum >= numDelegates {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (ctx *rollDPoSCtx) Broadcast(msg proto.Message) error {
@@ -389,24 +583,81 @@ func (ctx *rollDPoSCtx) getNumSubEpochs() uint {
 	return num
 }
 
-func (ctx *rollDPoSCtx) IsProposer() bool {
-	log := logger.Info().
-		Str("proposer", ctx.round.proposer).
-		Uint64("height", ctx.round.height).
-		Uint32("round", ctx.round.number)
-	if ctx.round.proposer != ctx.addr.RawAddress {
-		log.Msg("current node is not the proposer")
-		return false
+func (ctx *rollDPoSCtx) IsStaleEvent(evt iConsensusEvt) bool {
+	switch castedEvt := evt.(type) {
+	case *timeoutEvt:
+		if castedEvt.timestamp().Before(ctx.round.timestamp) {
+			return true
+		}
+	case *endorseEvt:
+		if castedEvt.h < ctx.round.height {
+			return true
+		}
+		if castedEvt.h == ctx.round.height && castedEvt.r < ctx.round.number {
+			return true
+		}
+	case *proposeBlkEvt:
+		if castedEvt.h < ctx.round.height {
+			return true
+		}
+		if castedEvt.h == ctx.round.height && castedEvt.r < ctx.round.number {
+			return true
+		}
+	default:
+		if evt.Type() != ePrepare {
+			logger.Warn().Msgf("Unknown event type %s", evt.Type())
+		}
 	}
-	log.Msg("current node is the proposer")
-	return true
+
+	return false
 }
 
-func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
+func (ctx *rollDPoSCtx) IsFutureEvent(evt iConsensusEvt) bool {
+	switch castedEvt := evt.(type) {
+	case *timeoutEvt:
+		break
+	case *endorseEvt:
+		if castedEvt.h > ctx.round.height {
+			return true
+		}
+		if castedEvt.h == ctx.round.height && castedEvt.r > ctx.round.number {
+			return true
+		}
+	case *proposeBlkEvt:
+		if castedEvt.h > ctx.round.height {
+			return true
+		}
+		if castedEvt.h == ctx.round.height && castedEvt.r > ctx.round.number {
+			return true
+		}
+	default:
+		if evt.Type() != ePrepare {
+			logger.Warn().Msgf("Unknown event type %s", evt.Type())
+		}
+	}
+
+	return false
+}
+
+func (ctx *rollDPoSCtx) IsStaleUnmatchedEvent(evt iConsensusEvt) bool {
+	return ctx.clock.Now().Sub(evt.timestamp()) > ctx.cfg.UnmatchedEventTTL
+}
+
+func (ctx *rollDPoSCtx) PrepareNextRound() (
+	delay time.Duration,
+	isDelegate bool,
+	isProposer bool,
+	err error,
+) {
+	isDelegate = false
+	isProposer = false
 	if ctx.shouldHandleDKG() && ctx.isDKGFinished() {
 		dkgPubKey, dkgPriKey, err := ctx.generateDKGKeyPair()
 		if err != nil {
-			return time.Duration(0), true, errors.Wrap(err, "error when generating DKG key pair")
+			return time.Duration(0), isDelegate, isProposer, errors.Wrap(
+				err,
+				"error when generating DKG key pair",
+			)
 		}
 		ctx.epoch.dkgAddress.PublicKey = dkgPubKey
 		ctx.epoch.dkgAddress.PrivateKey = dkgPriKey
@@ -414,7 +665,7 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 	epochNum, epochHeight, err := ctx.calcEpochNumAndHeight()
 	if err != nil {
 		// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
-		return ctx.cfg.DelegateInterval, true, errors.Wrap(
+		return ctx.cfg.DelegateInterval, isDelegate, isProposer, errors.Wrap(
 			err,
 			"error when determining the epoch ordinal number and start height offset",
 		)
@@ -423,7 +674,7 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 		delegates, err := ctx.RollingDelegates(epochNum)
 		if err != nil {
 			// Even if error happens, we still need to schedule next check of delegate to tolerate transit error
-			return ctx.cfg.DelegateInterval, true, errors.Wrap(
+			return ctx.cfg.DelegateInterval, isDelegate, isProposer, errors.Wrap(
 				err,
 				"error when determining if the node will participate into next epoch",
 			)
@@ -437,7 +688,7 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 		ctx.epoch.committedSecrets = make(map[string][]uint32)
 	}
 	// If the current node is the delegate, move to the next state
-	isDelegate := false
+	isDelegate = false
 	for _, d := range ctx.epoch.delegates {
 		if ctx.addr.RawAddress == d {
 			isDelegate = true
@@ -445,7 +696,7 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 		}
 	}
 	if !isDelegate {
-		return ctx.cfg.DelegateInterval, false, nil
+		return ctx.cfg.DelegateInterval, isDelegate, isProposer, nil
 	}
 	logger.Info().
 		Uint64("epoch", epochNum).
@@ -457,24 +708,24 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 		}
 		secrets, witness, err := ctx.generateDKGSecrets()
 		if err != nil {
-			return time.Duration(0), true, err
+			return time.Duration(0), isDelegate, isProposer, err
 		}
 		ctx.epoch.secrets = secrets
 		ctx.epoch.witness = witness
 	}
 	waitDuration, err := ctx.calcWaitDuration()
 	if err != nil {
-		return waitDuration, true, err
+		return waitDuration, isDelegate, isProposer, err
 	}
 	subEpochNum, err := ctx.calcSubEpochNum()
 	if err != nil {
-		return waitDuration, true, err
+		return waitDuration, isDelegate, isProposer, err
 	}
 	ctx.epoch.subEpochNum = subEpochNum
 
 	proposer, height, round, err := ctx.rotatedProposer(waitDuration)
 	if err != nil {
-		return waitDuration, true, err
+		return waitDuration, isDelegate, isProposer, err
 	}
 	if ctx.round.height != height {
 		ctx.round = roundCtx{
@@ -485,8 +736,18 @@ func (ctx *rollDPoSCtx) PrepareNextRound() (time.Duration, bool, error) {
 	ctx.round.number = round
 	ctx.round.proposer = proposer
 	ctx.round.timestamp = ctx.clock.Now()
+	isProposer = proposer == ctx.addr.RawAddress
 
-	return waitDuration, true, nil
+	log := logger.Info().
+		Str("proposer", ctx.round.proposer).
+		Uint64("height", ctx.round.height).
+		Uint32("round", ctx.round.number)
+	if isProposer {
+		log.Msg("current node is the proposer")
+	} else {
+		log.Msg("current node is not the proposer")
+	}
+	return waitDuration, true, isProposer, nil
 }
 
 // rotatedProposer will rotate among the delegates to choose the proposer. It is pseudo order based on the position
@@ -815,7 +1076,11 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 
 // NumPendingEvts returns the number of pending events
 func (r *RollDPoS) NumPendingEvts() int {
-	return len(r.cfsm.evtq)
+	num := len(r.cfsm.evtq)
+	if num > 100 {
+		logger.Error().Msgf("Pending events: %+v", r.cfsm.evtq)
+	}
+	return num
 }
 
 // CurrentState returns the current state

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -113,7 +113,7 @@ func TestRollDPoSCtx(t *testing.T) {
 	ctx.epoch.numSubEpochs = 2
 	ctx.epoch.delegates = delegates
 
-	proposer, height, round, err := ctx.rotatedProposer()
+	proposer, height, round, err := ctx.rotatedProposer(time.Duration(0))
 	require.NoError(t, err)
 	assert.Equal(t, candidates[1], proposer)
 	assert.Equal(t, uint64(9), height)
@@ -502,7 +502,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 		Proposer: addr.RawAddress,
 		Round:    roundNum,
 	}
-	pEvt, err := r.cfsm.newProposeBlkEvtFromProposePb(&pMsg)
+	pEvt, err := r.ctx.newProposeBlkEvtFromProposePb(&pMsg)
 	assert.NoError(t, err)
 	assert.NotNil(t, pEvt)
 	assert.NotNil(t, pEvt.block)
@@ -519,7 +519,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 	)
 	msg := en.ToProtoMsg()
 
-	eEvt, err := r.cfsm.newEndorseEvtWithEndorsePb(msg)
+	eEvt, err := r.ctx.newEndorseEvtWithEndorsePb(msg)
 	assert.NoError(t, err)
 	assert.NotNil(t, eEvt)
 
@@ -534,7 +534,7 @@ func TestRollDPoS_convertToConsensusEvt(t *testing.T) {
 		addr,
 	)
 	msg = en.ToProtoMsg()
-	eEvt, err = r.cfsm.newEndorseEvtWithEndorsePb(msg)
+	eEvt, err = r.ctx.newEndorseEvtWithEndorsePb(msg)
 	assert.NoError(t, err)
 	assert.NotNil(t, eEvt)
 }


### PR DESCRIPTION
This is on top of refactor 2. In this pr:
1. Further merge sBlockPropose and sRoundStart to sPrepare
2. Move all blockchain related code out of fsm.go

Test plan: testing on cluster, has been stable for 700 blocks, and will run it for a whole day.