### PR TITLE
IOTEX-205 Modify MintNewBlock to remove the dependency on iotxaddress

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -99,7 +99,9 @@ func runExecution(
 	}
 	blk, err := bc.MintNewBlock(
 		[]action.SealedEnvelope{selp},
-		ta.IotxAddrinfo["producer"],
+		ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress,
 		nil,
 		nil,
 		"",
@@ -260,8 +262,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp, err := action.Sign(elp, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -311,8 +312,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 
 		log.S().Infof("execution %+v", execution)
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -345,8 +345,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 
 		log.S().Infof("execution %+v", execution)
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -369,8 +368,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp, err = action.Sign(elp, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["alfa"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["alfa"].PublicKey, ta.IotxAddrinfo["alfa"].PrivateKey, ta.IotxAddrinfo["alfa"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -438,8 +436,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp, err := action.Sign(elp, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -463,8 +460,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 		log.S().Infof("execution %+v", execution)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -488,8 +484,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 		log.S().Infof("execution %+v\n", execution)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -520,8 +515,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 		log.S().Infof("execution %+v\n", execution)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -587,8 +581,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp, err := action.Sign(elp, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -656,7 +649,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp2, err := action.Sign(elp2, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp, selp2}, ta.IotxAddrinfo["producer"], nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp, selp2}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -682,8 +675,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp3, err := action.Sign(elp, ta.IotxAddrinfo["alfa"].RawAddress, ta.IotxAddrinfo["alfa"].PrivateKey)
 		require.NoError(err)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp3}, ta.IotxAddrinfo["alfa"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp3}, ta.IotxAddrinfo["alfa"].PublicKey, ta.IotxAddrinfo["alfa"].PrivateKey, ta.IotxAddrinfo["alfa"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
@@ -703,8 +695,7 @@ func TestProtocol_Handle(t *testing.T) {
 		selp, err = action.Sign(elp, ta.IotxAddrinfo["producer"].RawAddress, ta.IotxAddrinfo["producer"].PrivateKey)
 		require.NoError(err)
 
-		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-			nil, nil, "")
+		blk, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.NoError(err)
 		require.NoError(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))

--- a/blockchain/block/builder.go
+++ b/blockchain/block/builder.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/crypto"
-	"github.com/iotexproject/iotex-core/iotxaddress"
 	"github.com/iotexproject/iotex-core/pkg/hash"
+	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/version"
 )
 
@@ -91,10 +91,10 @@ func (b *Builder) SetDKG(id, pk, sig []byte) *Builder {
 }
 
 // SignAndBuild signs and then builds a block.
-func (b *Builder) SignAndBuild(signer *iotxaddress.Address) (Block, error) {
-	b.blk.Header.pubkey = signer.PublicKey
+func (b *Builder) SignAndBuild(signerPubKey keypair.PublicKey, signerPriKey keypair.PrivateKey) (Block, error) {
+	b.blk.Header.pubkey = signerPubKey
 	blkHash := b.blk.HashBlock()
-	sig := crypto.EC283.Sign(signer.PrivateKey, blkHash[:])
+	sig := crypto.EC283.Sign(signerPriKey, blkHash[:])
 	if len(sig) == 0 {
 		return Block{}, errors.New("Failed to sign block")
 	}

--- a/blockchain/block/builder_test.go
+++ b/blockchain/block/builder_test.go
@@ -20,12 +20,12 @@ func TestBuilder(t *testing.T) {
 	ra := NewRunnableActionsBuilder().
 		SetHeight(1).
 		SetTimeStamp(testutil.TimestampNow()).
-		Build(ta.IotxAddrinfo["bravo"])
+		Build(ta.IotxAddrinfo["bravo"].RawAddress, ta.IotxAddrinfo["bravo"].PublicKey)
 
 	nblk, err := NewBuilder(ra).
 		SetChainID(0).
 		SetPrevBlockHash(hash.ZeroHash32B).
-		SignAndBuild(ta.IotxAddrinfo["bravo"])
+		SignAndBuild(ta.IotxAddrinfo["bravo"].PublicKey, ta.IotxAddrinfo["bravo"].PrivateKey)
 	require.NoError(t, err)
 
 	require.True(t, nblk.VerifySignature())

--- a/blockchain/block/runnable.go
+++ b/blockchain/block/runnable.go
@@ -8,7 +8,6 @@ package block
 
 import (
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/iotxaddress"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
@@ -79,9 +78,9 @@ func (b *RunnableActionsBuilder) AddActions(acts ...action.SealedEnvelope) *Runn
 }
 
 // Build signs and then builds a block.
-func (b *RunnableActionsBuilder) Build(producer *iotxaddress.Address) RunnableActions {
-	b.ra.blockProducerAddr = producer.RawAddress
-	b.ra.blockProducerPubKey = producer.PublicKey
+func (b *RunnableActionsBuilder) Build(producerAddr string, producerPubKey keypair.PublicKey) RunnableActions {
+	b.ra.blockProducerAddr = producerAddr
+	b.ra.blockProducerPubKey = producerPubKey
 	b.ra.txHash = calculateTxRoot(b.ra.actions)
 	return b.ra
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -122,14 +122,21 @@ type Blockchain interface {
 	// Note: the coinbase transfer will be added to the given transfers when minting a new block
 	MintNewBlock(
 		actions []action.SealedEnvelope,
-		producer *iotxaddress.Address,
+		producerPubKey keypair.PublicKey,
+		producerPriKey keypair.PrivateKey,
+		producerAddr string,
 		dkgAddress *iotxaddress.DKGAddress,
 		seed []byte,
 		data string,
 	) (*block.Block, error)
 	// MintNewSecretBlock creates a new DKG secret block with given DKG secrets and witness
-	MintNewSecretBlock(secretProposals []*action.SecretProposal, secretWitness *action.SecretWitness,
-		producer *iotxaddress.Address) (*block.Block, error)
+	MintNewSecretBlock(
+		secretProposals []*action.SecretProposal,
+		secretWitness *action.SecretWitness,
+		producerPubKey keypair.PublicKey,
+		producerPriKey keypair.PrivateKey,
+		producerAddr string,
+	) (*block.Block, error)
 	// CommitBlock validates and appends a block to the chain
 	CommitBlock(blk *block.Block) error
 	// ValidateBlock validates a new block before adding it to the blockchain
@@ -677,7 +684,9 @@ func (bc *blockchain) ValidateBlock(blk *block.Block, containCoinbase bool) erro
 
 func (bc *blockchain) MintNewBlock(
 	actions []action.SealedEnvelope,
-	producer *iotxaddress.Address,
+	producerPubKey keypair.PublicKey,
+	producerPriKey keypair.PrivateKey,
+	producerAddr string,
 	dkgAddress *iotxaddress.DKGAddress,
 	seed []byte,
 	data string,
@@ -687,14 +696,14 @@ func (bc *blockchain) MintNewBlock(
 	defer bc.timerFactory.NewTimer("MintNewBlock").End()
 
 	// Use block height as the nonce for coinbase transfer
-	cb := action.NewCoinBaseTransfer(bc.tipHeight+1, bc.genesis.BlockReward, producer.RawAddress)
+	cb := action.NewCoinBaseTransfer(bc.tipHeight+1, bc.genesis.BlockReward, producerAddr)
 	bd := action.EnvelopeBuilder{}
 	// TODO the nonce is wrong, if bd also submit actions
 	elp := bd.SetNonce(bc.tipHeight + 1).
-		SetDestinationAddress(producer.RawAddress).
+		SetDestinationAddress(producerAddr).
 		SetGasLimit(cb.GasLimit()).
 		SetAction(cb).Build()
-	selp, err := action.Sign(elp, producer.RawAddress, producer.PrivateKey)
+	selp, err := action.Sign(elp, producerAddr, producerPriKey)
 	if err != nil {
 		return nil, err
 	}
@@ -705,7 +714,7 @@ func (bc *blockchain) MintNewBlock(
 		true,
 		nil,
 		nil,
-		producer.PublicKey,
+		producerPubKey,
 		bc.ChainID(),
 		bc.tipHeight+1,
 	); err != nil {
@@ -713,10 +722,10 @@ func (bc *blockchain) MintNewBlock(
 	}
 
 	ra := block.NewRunnableActionsBuilder().
-		SetHeight(bc.tipHeight + 1).
+		SetHeight(bc.tipHeight+1).
 		SetTimeStamp(bc.now()).
 		AddActions(actions...).
-		Build(producer)
+		Build(producerAddr, producerPubKey)
 
 	// run execution and update state trie root hash
 	ws, err := bc.sf.NewWorkingSet()
@@ -742,7 +751,7 @@ func (bc *blockchain) MintNewBlock(
 
 	blk, err := blkbd.SetStateRoot(root).
 		SetReceipts(rc).
-		SignAndBuild(producer)
+		SignAndBuild(producerPubKey, producerPriKey)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create block")
 	}
@@ -755,15 +764,17 @@ func (bc *blockchain) MintNewBlock(
 func (bc *blockchain) MintNewSecretBlock(
 	secretProposals []*action.SecretProposal,
 	secretWitness *action.SecretWitness,
-	producer *iotxaddress.Address,
+	producerPubKey keypair.PublicKey,
+	producerPriKey keypair.PrivateKey,
+	producerAddr string,
 ) (*block.Block, error) {
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
 
 	ra := block.NewRunnableActionsBuilder().
-		SetHeight(bc.tipHeight + 1).
+		SetHeight(bc.tipHeight+1).
 		SetTimeStamp(bc.now()).
-		Build(producer)
+		Build(producerAddr, producerPubKey)
 
 	// run execution and update state trie root hash
 	ws, err := bc.sf.NewWorkingSet()
@@ -782,7 +793,7 @@ func (bc *blockchain) MintNewSecretBlock(
 		SetSecretProposals(secretProposals).
 		SetReceipts(receipts).
 		SetStateRoot(root).
-		SignAndBuild(producer)
+		SignAndBuild(producerPubKey, producerPriKey)
 	if err != nil {
 		return nil, errors.Wrapf(err, "Failed to create block")
 	}
@@ -953,7 +964,7 @@ func (bc *blockchain) startEmptyBlockchain() error {
 			SetHeight(0).
 			SetTimeStamp(Gen.Timestamp).
 			AddActions(acts...).
-			Build(iaddr)
+			Build(iaddr.RawAddress, iaddr.PublicKey)
 		// run execution and update state trie root hash
 		root, receipts, err := bc.runActions(racts, ws, false)
 		if err != nil {
@@ -965,7 +976,7 @@ func (bc *blockchain) startEmptyBlockchain() error {
 			SetPrevBlockHash(Gen.ParentHash).
 			SetReceipts(receipts).
 			SetStateRoot(root).
-			SignAndBuild(iaddr)
+			SignAndBuild(iaddr.PublicKey, iaddr.PrivateKey)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create block")
 		}
@@ -973,11 +984,11 @@ func (bc *blockchain) startEmptyBlockchain() error {
 		racts := block.NewRunnableActionsBuilder().
 			SetHeight(0).
 			SetTimeStamp(Gen.Timestamp).
-			Build(iaddr)
+			Build(iaddr.RawAddress, iaddr.PublicKey)
 		genesis, err = block.NewBuilder(racts).
 			SetChainID(bc.ChainID()).
 			SetPrevBlockHash(hash.ZeroHash32B).
-			SignAndBuild(iaddr)
+			SignAndBuild(iaddr.PublicKey, iaddr.PrivateKey)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create block")
 		}
@@ -1018,7 +1029,7 @@ func (bc *blockchain) startExistingBlockchain(recoveryHeight uint64) error {
 			SetHeight(0).
 			SetTimeStamp(Gen.Timestamp).
 			AddActions(acts...).
-			Build(iaddr)
+			Build(iaddr.RawAddress, iaddr.PublicKey)
 		// run execution and update state trie root hash
 		if _, _, err := bc.runActions(racts, ws, false); err != nil {
 			return errors.Wrap(err, "failed to update state changes in Genesis block")

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -61,8 +61,8 @@ func addTestingTsfBlocks(bc Blockchain) error {
 
 	selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(config.Default.Chain.ID), pubk, sig)
 
-	blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -99,7 +99,9 @@ func addTestingTsfBlocks(bc Blockchain) error {
 		return err
 	}
 
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -132,7 +134,9 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	if err != nil {
 		return err
 	}
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -161,7 +165,8 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	if err != nil {
 		return err
 	}
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -208,7 +213,8 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	}
 
 	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6, vote1, vote2},
-		ta.IotxAddrinfo["producer"], nil, nil, "")
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -313,7 +319,9 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 			SetGasPrice(big.NewInt(10)).Build()
 
 		selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(config.Default.Chain.ID), pk, sig)
-		_, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"], nil, nil, "")
+		_, err = bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey,
+			ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+			nil, "")
 		if v {
 			require.NoError(t, err)
 		} else {
@@ -862,7 +870,8 @@ func TestCoinbaseTransfer(t *testing.T) {
 	height := bc.TipHeight()
 	require.Equal(0, int(height))
 
-	blk, err := bc.MintNewBlock([]action.SealedEnvelope{}, ta.IotxAddrinfo["alfa"], nil, nil, "")
+	blk, err := bc.MintNewBlock([]action.SealedEnvelope{}, ta.IotxAddrinfo["alfa"].PublicKey,
+		ta.IotxAddrinfo["alfa"].PrivateKey, ta.IotxAddrinfo["alfa"].RawAddress, nil, nil, "")
 	require.Nil(err)
 	s, err := bc.StateByAddr(ta.IotxAddrinfo["alfa"].RawAddress)
 	require.Nil(err)
@@ -946,7 +955,8 @@ func TestBlocks(t *testing.T) {
 			require.NoError(err)
 			acts = append(acts, tsf)
 		}
-		blk, _ := bc.MintNewBlock(acts, ta.IotxAddrinfo["producer"], nil, nil, "")
+		blk, _ := bc.MintNewBlock(acts, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+			ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 		require.Nil(bc.ValidateBlock(blk, true))
 		require.Nil(bc.CommitBlock(blk))
 	}
@@ -1005,8 +1015,8 @@ func TestActions(t *testing.T) {
 		require.NoError(err)
 		acts = append(acts, vote)
 	}
-	blk, _ := bc.MintNewBlock(acts, ta.IotxAddrinfo["producer"], nil,
-		nil, "")
+	blk, _ := bc.MintNewBlock(acts, ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	require.Nil(val.Validate(blk, 0, blk.PrevHash(), true))
 }
 
@@ -1085,7 +1095,7 @@ func TestMintDKGBlock(t *testing.T) {
 			PrivateKey: ec283SKList[i],
 			RawAddress: addresses[i],
 		}
-		blk, err := chain.MintNewBlock(nil, &iotxAddr,
+		blk, err := chain.MintNewBlock(nil, iotxAddr.PublicKey, iotxAddr.PrivateKey, iotxAddr.RawAddress,
 			&iotxaddress.DKGAddress{PrivateKey: askList[i], PublicKey: pkList[i], ID: idList[i]}, lastSeed, "")
 		require.NoError(err)
 		require.NoError(chain.ValidateBlock(blk, true))

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -452,8 +452,8 @@ func TestCoinbaseTransferValidation(t *testing.T) {
 		PrivateKey: sk,
 		RawAddress: addr.IotxAddress(),
 	}
-	blk, err := chain.MintNewBlock(nil, &iotxAddr, nil, nil,
-		"")
+	blk, err := chain.MintNewBlock(nil, iotxAddr.PublicKey, iotxAddr.PrivateKey, iotxAddr.RawAddress,
+		nil, nil, "")
 	require.NoError(t, err)
 	validator := validator{}
 	require.NoError(t, validator.ValidateActionsOnly(

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -35,12 +35,12 @@ func TestGenesis(t *testing.T) {
 		SetHeight(0).
 		SetTimeStamp(Gen.Timestamp).
 		AddActions(acts...).
-		Build(testaddress.IotxAddrinfo["producer"])
+		Build(testaddress.IotxAddrinfo["producer"].RawAddress, testaddress.IotxAddrinfo["producer"].PublicKey)
 
 	genesisBlk, err := block.NewBuilder(racts).
 		SetChainID(cfg.Chain.ID).
 		SetPrevBlockHash(Gen.ParentHash).
-		SignAndBuild(testaddress.IotxAddrinfo["producer"])
+		SignAndBuild(testaddress.IotxAddrinfo["producer"].PublicKey, testaddress.IotxAddrinfo["producer"].PrivateKey)
 	assert.NoError(err)
 
 	t.Log("The Genesis Block has the following header:")

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -257,8 +257,9 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	}()
 
 	h := chain.TipHeight()
-	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk)
 	require.NoError(err)
 	bs.(*blockSyncer).ackBlockCommit = false
@@ -318,18 +319,21 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	}()
 
 	// commit top
-	blk1, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk1, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk1)
 	require.Nil(err)
 	require.Nil(bs1.ProcessBlock(blk1))
-	blk2, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk2, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk2)
 	require.Nil(err)
 	require.Nil(bs1.ProcessBlock(blk2))
-	blk3, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk3, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk3)
 	require.Nil(err)
 	require.Nil(bs1.ProcessBlock(blk3))
@@ -384,18 +388,21 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	}()
 
 	// commit top
-	blk1, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk1, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk1)
 	require.NoError(err)
 	require.Nil(bs1.ProcessBlock(blk1))
-	blk2, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk2, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk2)
 	require.NoError(err)
 	require.Nil(bs1.ProcessBlock(blk2))
-	blk3, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk3, err := chain1.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk3)
 	require.NoError(err)
 	require.Nil(bs1.ProcessBlock(blk3))
@@ -440,14 +447,16 @@ func TestBlockSyncerSync(t *testing.T) {
 		ctrl.Finish()
 	}()
 
-	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk)
 	require.NoError(err)
 	require.Nil(bs.ProcessBlock(blk))
 
-	blk, err = chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err = chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.NotNil(blk)
 	require.NoError(err)
 	require.Nil(bs.ProcessBlock(blk))

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -56,8 +56,9 @@ func TestBlockBufferFlush(t *testing.T) {
 	assert.Equal(false, moved)
 	assert.Equal(bCheckinSkipNil, re)
 
-	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err := chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	moved, re = b.Flush(blk)
 	assert.Equal(true, moved)
@@ -232,8 +233,9 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 	assert.Len(b.GetBlocksIntervalsToSync(5), 2)
 	assert.Len(b.GetBlocksIntervalsToSync(1), 1)
 
-	blk, err = chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err = chain.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	b.Flush(blk)
 	assert.Len(b.GetBlocksIntervalsToSync(0), 0)

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -87,8 +87,8 @@ func NewConsensus(
 		acts := ap.PickActs()
 		log.L().Debug("Pick actions.", zap.Int("actions", len(acts)))
 
-		blk, err := bc.MintNewBlock(acts, GetAddr(cfg), nil,
-			nil, "")
+		blk, err := bc.MintNewBlock(acts, GetAddr(cfg).PublicKey, GetAddr(cfg).PrivateKey, GetAddr(cfg).RawAddress,
+			nil, nil, "")
 		if err != nil {
 			log.L().Error("Failed to mint a block.", zap.Error(err))
 			return nil, err

--- a/consensus/scheme/rolldpos/fsm_test.go
+++ b/consensus/scheme/rolldpos/fsm_test.go
@@ -1441,9 +1441,11 @@ func newTestCFSM(
 			blockchain.EXPECT().GetBlockByHeight(uint64(21)).Return(lastBlk, nil).AnyTimes()
 			blockchain.EXPECT().GetBlockByHeight(uint64(22)).Return(lastBlk, nil).AnyTimes()
 			blockchain.EXPECT().
-				MintNewBlock(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&blkToMint, nil).AnyTimes()
+				MintNewBlock(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(&blkToMint, nil).AnyTimes()
 			blockchain.EXPECT().
-				MintNewSecretBlock(gomock.Any(), gomock.Any(), gomock.Any()).Return(&secretBlkToMint, nil).AnyTimes()
+				MintNewSecretBlock(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any()).Return(&secretBlkToMint, nil).AnyTimes()
 			blockchain.EXPECT().
 				Nonce(gomock.Any()).Return(uint64(0), nil).AnyTimes()
 			if mockChain == nil {

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -430,7 +430,8 @@ func (ctx *rollDPoSCtx) mintSecretBlock() (*block.Block, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create the secret witness")
 	}
-	blk, err := ctx.chain.MintNewSecretBlock(secretProposals, secretWitness, ctx.addr)
+	blk, err := ctx.chain.MintNewSecretBlock(secretProposals, secretWitness, ctx.addr.PublicKey, ctx.addr.PrivateKey,
+		ctx.addr.RawAddress)
 	if err != nil {
 		return nil, err
 	}
@@ -444,8 +445,8 @@ func (ctx *rollDPoSCtx) mintSecretBlock() (*block.Block, error) {
 func (ctx *rollDPoSCtx) mintCommonBlock() (*block.Block, error) {
 	actions := ctx.actPool.PickActs()
 	log.L().Debug("Pick actions from the action pool.", zap.Int("action", len(actions)))
-	blk, err := ctx.chain.MintNewBlock(actions, ctx.addr, &ctx.epoch.dkgAddress,
-		ctx.epoch.seed, "")
+	blk, err := ctx.chain.MintNewBlock(actions, ctx.addr.PublicKey, ctx.addr.PrivateKey, ctx.addr.RawAddress,
+		&ctx.epoch.dkgAddress, ctx.epoch.seed, "")
 	if err != nil {
 		return nil, err
 	}

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -615,9 +615,8 @@ func TestUpdateSeed(t *testing.T) {
 			PrivateKey: ec283SKList[i],
 			RawAddress: addresses[i],
 		}
-		blk, err := chain.MintNewBlock(nil, &iotxAddr,
-			&iotxaddress.DKGAddress{PrivateKey: askList[i], PublicKey: pkList[i], ID: idList[i]},
-			lastSeed, "")
+		blk, err := chain.MintNewBlock(nil, iotxAddr.PublicKey, iotxAddr.PrivateKey, iotxAddr.RawAddress,
+			&iotxaddress.DKGAddress{PrivateKey: askList[i], PublicKey: pkList[i], ID: idList[i]}, lastSeed, "")
 		require.NoError(err)
 		require.NoError(verifyDKGSignature(blk, lastSeed))
 		require.NoError(chain.ValidateBlock(blk, true))

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -185,7 +185,8 @@ func TestLocalCommit(t *testing.T) {
 	require.Nil(err)
 
 	acts := svr.ChainService(chainID).ActionPool().PickActs()
-	blk1, err := chain.MintNewBlock(acts, ta.IotxAddrinfo["producer"], nil,
+	blk1, err := chain.MintNewBlock(acts, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
 		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk1, true))
@@ -197,7 +198,9 @@ func TestLocalCommit(t *testing.T) {
 	tsf2, err := testutil.SignedTransfer(ta.IotxAddrinfo["foxtrot"], ta.IotxAddrinfo["delta"], s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
-	blk2, err := chain.MintNewBlock([]action.SealedEnvelope{tsf2}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk2, err := chain.MintNewBlock([]action.SealedEnvelope{tsf2}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk2, true))
 	require.Nil(chain.CommitBlock(blk2))
@@ -218,7 +221,9 @@ func TestLocalCommit(t *testing.T) {
 	tsf3, err := testutil.SignedTransfer(ta.IotxAddrinfo["bravo"], ta.IotxAddrinfo["bravo"], s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
-	blk3, err := chain.MintNewBlock([]action.SealedEnvelope{tsf3}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk3, err := chain.MintNewBlock([]action.SealedEnvelope{tsf3}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk3, true))
 	require.Nil(chain.CommitBlock(blk3))
@@ -239,7 +244,9 @@ func TestLocalCommit(t *testing.T) {
 	tsf4, err := testutil.SignedTransfer(ta.IotxAddrinfo["producer"], ta.IotxAddrinfo["echo"], s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
-	blk4, err := chain.MintNewBlock([]action.SealedEnvelope{tsf4}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk4, err := chain.MintNewBlock([]action.SealedEnvelope{tsf4}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk4, true))
 	require.Nil(chain.CommitBlock(blk4))
@@ -582,7 +589,8 @@ func TestVoteLocalCommit(t *testing.T) {
 	require.Nil(err)
 
 	acts := svr.ChainService(chainID).ActionPool().PickActs()
-	blk1, err := chain.MintNewBlock(acts, ta.IotxAddrinfo["producer"], nil,
+	blk1, err := chain.MintNewBlock(acts, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
 		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk1, true))
@@ -603,7 +611,9 @@ func TestVoteLocalCommit(t *testing.T) {
 	require.Nil(err)
 	vote5, err := testutil.SignedVote(ta.IotxAddrinfo["charlie"], ta.IotxAddrinfo["alfa"], uint64(7), uint64(100000), big.NewInt(0))
 	require.Nil(err)
-	blk2, err := chain.MintNewBlock([]action.SealedEnvelope{vote4, vote5}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk2, err := chain.MintNewBlock([]action.SealedEnvelope{vote4, vote5}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk2, true))
 	require.Nil(chain.CommitBlock(blk2))
@@ -648,8 +658,9 @@ func TestVoteLocalCommit(t *testing.T) {
 	vote6, err := testutil.SignedVote(ta.IotxAddrinfo["delta"], ta.IotxAddrinfo["delta"], 5, 100000, big.NewInt(0))
 	require.NoError(err)
 
-	blk3, err := chain.MintNewBlock([]action.SealedEnvelope{vote6}, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk3, err := chain.MintNewBlock([]action.SealedEnvelope{vote6}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk3, true))
 	require.Nil(chain.CommitBlock(blk3))
@@ -696,8 +707,9 @@ func TestVoteLocalCommit(t *testing.T) {
 	selp, err := action.Sign(elp, ta.IotxAddrinfo["bravo"].RawAddress, ta.IotxAddrinfo["bravo"].PrivateKey)
 	require.NoError(err)
 
-	blk4, err := chain.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk4, err := chain.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	require.Nil(err)
 	require.Nil(chain.ValidateBlock(blk4, true))
 	require.Nil(chain.CommitBlock(blk4))

--- a/e2etest/util.go
+++ b/e2etest/util.go
@@ -42,7 +42,9 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 		SetGasPrice(big.NewInt(10)).Build()
 	selp := action.AssembleSealedEnvelope(elp, blockchain.Gen.CreatorAddr(config.Default.Chain.ID), pubk, sig)
 
-	blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err := bc.MintNewBlock([]action.SealedEnvelope{selp}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	if err != nil {
 		return err
 	}
@@ -79,7 +81,9 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 		return err
 	}
 
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	if err != nil {
 		return err
 	}
@@ -112,7 +116,9 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	if err != nil {
 		return err
 	}
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -141,7 +147,9 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	if err != nil {
 		return err
 	}
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
+		nil, "")
 	if err != nil {
 		return err
 	}
@@ -178,7 +186,9 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	if err != nil {
 		return err
 	}
-	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -61,8 +61,8 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 		return err
 	}
 
-	blk, err := bc.MintNewBlock([]action.SealedEnvelope{tsf}, ta.IotxAddrinfo["producer"],
-		nil, nil, "")
+	blk, err := bc.MintNewBlock([]action.SealedEnvelope{tsf}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,9 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	if err != nil {
 		return err
 	}
-	if blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, vote1, execution1}, ta.IotxAddrinfo["producer"],
-		nil, nil, ""); err != nil {
+	if blk, err = bc.MintNewBlock([]action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, vote1, execution1},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, ""); err != nil {
 		return err
 	}
 	if err := bc.ValidateBlock(blk, true); err != nil {
@@ -112,7 +113,8 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	}
 
 	// Add block 3
-	if blk, err = bc.MintNewBlock(nil, ta.IotxAddrinfo["producer"], nil,
+	if blk, err = bc.MintNewBlock(nil, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil,
 		nil, ""); err != nil {
 		return err
 	}
@@ -142,8 +144,9 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	if err != nil {
 		return err
 	}
-	if blk, err = bc.MintNewBlock([]action.SealedEnvelope{vote1, vote2, execution1, execution2}, ta.IotxAddrinfo["producer"],
-		nil, nil, ""); err != nil {
+	if blk, err = bc.MintNewBlock([]action.SealedEnvelope{vote1, vote2, execution1, execution2},
+		ta.IotxAddrinfo["producer"].PublicKey, ta.IotxAddrinfo["producer"].PrivateKey,
+		ta.IotxAddrinfo["producer"].RawAddress, nil, nil, ""); err != nil {
 		return err
 	}
 	if err := bc.ValidateBlock(blk, true); err != nil {
@@ -901,7 +904,8 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 	execution, err := testutil.SignedExecution(ta.IotxAddrinfo["producer"], action.EmptyAddress, 1,
 		big.NewInt(0), testutil.TestGasLimit, big.NewInt(testutil.TestGasPrice), data)
 	require.NoError(err)
-	blk, err := bc.MintNewBlock([]action.SealedEnvelope{execution}, ta.IotxAddrinfo["producer"], nil, nil, "")
+	blk, err := bc.MintNewBlock([]action.SealedEnvelope{execution}, ta.IotxAddrinfo["producer"].PublicKey,
+		ta.IotxAddrinfo["producer"].PrivateKey, ta.IotxAddrinfo["producer"].RawAddress, nil, nil, "")
 	require.NoError(err)
 	require.Nil(bc.CommitBlock(blk))
 

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -12,6 +12,7 @@ import (
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	iotxaddress "github.com/iotexproject/iotex-core/iotxaddress"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
+	keypair "github.com/iotexproject/iotex-core/pkg/keypair"
 	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
 	big "math/big"
@@ -529,29 +530,29 @@ func (mr *MockBlockchainMockRecorder) StateByAddr(address interface{}) *gomock.C
 }
 
 // MintNewBlock mocks base method
-func (m *MockBlockchain) MintNewBlock(actions []action.SealedEnvelope, producer *iotxaddress.Address, dkgAddress *iotxaddress.DKGAddress, seed []byte, data string) (*block.Block, error) {
-	ret := m.ctrl.Call(m, "MintNewBlock", actions, producer, dkgAddress, seed, data)
+func (m *MockBlockchain) MintNewBlock(actions []action.SealedEnvelope, producerPubKey keypair.PublicKey, producerPriKey keypair.PrivateKey, producerAddr string, dkgAddress *iotxaddress.DKGAddress, seed []byte, data string) (*block.Block, error) {
+	ret := m.ctrl.Call(m, "MintNewBlock", actions, producerPubKey, producerPriKey, producerAddr, dkgAddress, seed, data)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MintNewBlock indicates an expected call of MintNewBlock
-func (mr *MockBlockchainMockRecorder) MintNewBlock(actions, producer, dkgAddress, seed, data interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actions, producer, dkgAddress, seed, data)
+func (mr *MockBlockchainMockRecorder) MintNewBlock(actions, producerPubKey, producerPriKey, producerAddr, dkgAddress, seed, data interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actions, producerPubKey, producerPriKey, producerAddr, dkgAddress, seed, data)
 }
 
 // MintNewSecretBlock mocks base method
-func (m *MockBlockchain) MintNewSecretBlock(secretProposals []*action.SecretProposal, secretWitness *action.SecretWitness, producer *iotxaddress.Address) (*block.Block, error) {
-	ret := m.ctrl.Call(m, "MintNewSecretBlock", secretProposals, secretWitness, producer)
+func (m *MockBlockchain) MintNewSecretBlock(secretProposals []*action.SecretProposal, secretWitness *action.SecretWitness, producerPubKey keypair.PublicKey, producerPriKey keypair.PrivateKey, producerAddr string) (*block.Block, error) {
+	ret := m.ctrl.Call(m, "MintNewSecretBlock", secretProposals, secretWitness, producerPubKey, producerPriKey, producerAddr)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MintNewSecretBlock indicates an expected call of MintNewSecretBlock
-func (mr *MockBlockchainMockRecorder) MintNewSecretBlock(secretProposals, secretWitness, producer interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewSecretBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewSecretBlock), secretProposals, secretWitness, producer)
+func (mr *MockBlockchainMockRecorder) MintNewSecretBlock(secretProposals, secretWitness, producerPubKey, producerPriKey, producerAddr interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewSecretBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewSecretBlock), secretProposals, secretWitness, producerPubKey, producerPriKey, producerAddr)
 }
 
 // CommitBlock mocks base method


### PR DESCRIPTION
Split parameter iotxaddress to public key, private key, and raw address. This change is a preparation for the full migration to address v1. In next PR, raw address will be replaced by Bech32 encoded string address.