### PR TITLE
mute AlreadyRegisteredError

### DIFF
--- a/pkg/prometheustimer/timer.go
+++ b/pkg/prometheustimer/timer.go
@@ -44,6 +44,10 @@ func New(name, tip string, labelNames []string, defaultLabels []string) (*TimerF
 		labelNames,
 	)
 	err := prometheus.Register(vect)
+	switch err.(type) {
+	case prometheus.AlreadyRegisteredError:
+		err = nil
+	}
 
 	return &TimerFactory{
 		labelNames:    labelNames,


### PR DESCRIPTION
This is a harmless error.

Tested with uint tests: The error won't be returned or printed