### PR TITLE
IOTEX-228 Remove chainID from address_v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Default flag values:
 * vote-gas-limit=1000000
 * vote-gas-price=10
 * execution-num=50
-* contract="io1qyqqqqqp3kcd2pyfwus69nzgvkwhg8mk8h336dt8dqgtyy"
+* contract="io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6"
 * execution-amount=0
 * execution-gas-limit=1200000
 * execution-gas-price=10

--- a/accounts/keystore/accountmanager.go
+++ b/accounts/keystore/accountmanager.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/address"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
@@ -67,7 +66,7 @@ func (m *AccountManager) NewAccount() (keypair.PrivateKey, error) {
 	}
 	pkHash := keypair.HashPubKey(pk)
 	// TODO: need to fix the chain ID
-	addr := address.New(config.Default.Chain.ID, pkHash[:])
+	addr := address.New(pkHash[:])
 	if err := m.keystore.Store(addr.Bech32(), sk); err != nil {
 		return keypair.ZeroPrivateKey, errors.Wrapf(err, "failed to store account %s", addr.Bech32())
 	}
@@ -85,7 +84,7 @@ func (m *AccountManager) Import(keyBytes []byte) error {
 		return errors.Wrap(err, "failed to derive public key from private key")
 	}
 	pkHash := keypair.HashPubKey(pubKey)
-	addr := address.New(config.Default.Chain.ID, pkHash[:])
+	addr := address.New(pkHash[:])
 	if err := m.keystore.Store(addr.Bech32(), priKey); err != nil {
 		return errors.Wrapf(err, "failed to store account %s", addr.Bech32())
 	}

--- a/accounts/keystore/accountmanager_test.go
+++ b/accounts/keystore/accountmanager_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/address"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
@@ -171,5 +170,5 @@ func keyToAddress(priKey keypair.PrivateKey) (address.Address, error) {
 		return nil, errors.Wrap(err, "failed to derive public key from private key")
 	}
 	pkHash := keypair.HashPubKey(pubKey)
-	return address.New(config.Default.Chain.ID, pkHash[:]), nil
+	return address.New(pkHash[:]), nil
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -225,7 +225,7 @@ func executeInEVM(evmParams *Params, stateDB *StateDBAdapter, gasLimit *uint64) 
 		if err != nil {
 			return nil, evmParams.gas, remainingGas, action.EmptyAddress, err
 		}
-		contractAddress := address.New(stateDB.cm.ChainID(), evmContractAddress.Bytes())
+		contractAddress := address.New(evmContractAddress.Bytes())
 		contractRawAddress = contractAddress.Bech32()
 	} else {
 		stateDB.SetNonce(evmParams.context.Origin, stateDB.GetNonce(evmParams.context.Origin)+1)

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -92,7 +92,7 @@ func (stateDB *StateDBAdapter) Error() error {
 
 // CreateAccount creates an account in iotx blockchain
 func (stateDB *StateDBAdapter) CreateAccount(evmAddr common.Address) {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	_, err := account.LoadOrCreateAccount(stateDB.sm, addr.Bech32(), big.NewInt(0))
 	if err != nil {
 		log.L().Error("Failed to create account.", zap.Error(err))
@@ -109,7 +109,7 @@ func (stateDB *StateDBAdapter) SubBalance(evmAddr common.Address, amount *big.In
 	}
 	// stateDB.GetBalance(evmAddr)
 	log.L().Debug(fmt.Sprintf("SubBalance %v from %s", amount, evmAddr.Hex()))
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	state, err := stateDB.AccountState(addr.Bech32())
 	if err != nil {
 		log.L().Error("Failed to sub balance.", zap.Error(err))
@@ -131,7 +131,7 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, amount *big.In
 	// stateDB.GetBalance(evmAddr)
 	log.L().Debug(fmt.Sprintf("AddBalance %v from %s", amount, evmAddr.Hex()))
 
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	state, err := account.LoadOrCreateAccount(stateDB.sm, addr.Bech32(), big.NewInt(0))
 	if err != nil {
 		log.L().Error("Failed to add balance.", log.Hex("addrHash", evmAddr[:]))
@@ -146,7 +146,7 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, amount *big.In
 
 // GetBalance gets the balance of account
 func (stateDB *StateDBAdapter) GetBalance(evmAddr common.Address) *big.Int {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	state, err := stateDB.AccountState(addr.Bech32())
 	if err != nil {
 		log.L().Error("Failed to get balance.", zap.Error(err))
@@ -159,7 +159,7 @@ func (stateDB *StateDBAdapter) GetBalance(evmAddr common.Address) *big.Int {
 
 // GetNonce gets the nonce of account
 func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	state, err := stateDB.AccountState(addr.Bech32())
 	if err != nil {
 		log.L().Error("Failed to get nonce.", zap.Error(err))
@@ -174,7 +174,7 @@ func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
 
 // SetNonce sets the nonce of account
 func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64) {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	s, err := stateDB.AccountState(addr.Bech32())
 	if err != nil {
 		log.L().Error("Failed to set nonce.", zap.Error(err))
@@ -206,7 +206,7 @@ func (stateDB *StateDBAdapter) GetRefund() uint64 {
 
 // Suicide kills the contract
 func (stateDB *StateDBAdapter) Suicide(evmAddr common.Address) bool {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	s, err := stateDB.AccountState(addr.Bech32())
 	if err != nil || s == state.EmptyAccount {
 		log.L().Debug("Account does not exist.", zap.String("address", addr.Bech32()))
@@ -231,7 +231,7 @@ func (stateDB *StateDBAdapter) HasSuicided(evmAddr common.Address) bool {
 
 // Exist checks the existence of an address
 func (stateDB *StateDBAdapter) Exist(evmAddr common.Address) bool {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	log.L().Debug("Check existence.", zap.String("address", addr.Bech32()), log.Hex("addrHash", evmAddr[:]))
 	if s, err := stateDB.AccountState(addr.Bech32()); err != nil || s == state.EmptyAccount {
 		log.L().Debug("Account does not exist.", zap.String("address", addr.Bech32()))
@@ -242,7 +242,7 @@ func (stateDB *StateDBAdapter) Exist(evmAddr common.Address) bool {
 
 // Empty returns true if the the contract is empty
 func (stateDB *StateDBAdapter) Empty(evmAddr common.Address) bool {
-	addr := address.New(stateDB.cm.ChainID(), evmAddr.Bytes())
+	addr := address.New(evmAddr.Bytes())
 	log.L().Debug("Check whether the contract is empty.")
 	s, err := stateDB.AccountState(addr.Bech32())
 	if err != nil || s == state.EmptyAccount {
@@ -318,7 +318,7 @@ func (stateDB *StateDBAdapter) Snapshot() int {
 // AddLog adds log
 func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 	log.L().Debug("Called AddLog.", zap.Any("log", evmLog))
-	addr := address.New(stateDB.cm.ChainID(), evmLog.Address.Bytes())
+	addr := address.New(evmLog.Address.Bytes())
 	var topics []hash.Hash32B
 	for _, evmTopic := range evmLog.Topics {
 		var topic hash.Hash32B

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -46,7 +46,6 @@ func TestAddBalance(t *testing.T) {
 	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
 	stateDB := NewStateDBAdapter(mcm, ws, 1, hash.ZeroHash32B, hash.ZeroHash32B)
 
-	mcm.EXPECT().ChainID().Times(4).Return(uint32(1))
 	addAmount := big.NewInt(40000)
 	stateDB.AddBalance(addr, addAmount)
 	amount := stateDB.GetBalance(addr)
@@ -97,7 +96,6 @@ func TestEmptyAndCode(t *testing.T) {
 	ws, err := sf.NewWorkingSet()
 	require.NoError(err)
 	mcm := mock_chainmanager.NewMockChainManager(ctrl)
-	mcm.EXPECT().ChainID().Times(4).Return(uint32(1))
 	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
 	stateDB := NewStateDBAdapter(mcm, ws, 1, hash.ZeroHash32B, hash.ZeroHash32B)
 	require.True(stateDB.Empty(addr))
@@ -124,7 +122,6 @@ func TestForEachStorage(t *testing.T) {
 	ws, err := sf.NewWorkingSet()
 	require.NoError(err)
 	mcm := mock_chainmanager.NewMockChainManager(ctrl)
-	mcm.EXPECT().ChainID().Times(1).Return(uint32(1))
 
 	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
 	stateDB := NewStateDBAdapter(mcm, ws, 1, hash.ZeroHash32B, hash.ZeroHash32B)
@@ -163,7 +160,6 @@ func TestNonce(t *testing.T) {
 	ws, err := sf.NewWorkingSet()
 	require.NoError(err)
 	mcm := mock_chainmanager.NewMockChainManager(ctrl)
-	mcm.EXPECT().ChainID().Times(3).Return(uint32(1))
 	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
 	stateDB := NewStateDBAdapter(mcm, ws, 1, hash.ZeroHash32B, hash.ZeroHash32B)
 	require.Equal(uint64(0), stateDB.GetNonce(addr))

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -298,7 +298,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.Equal(blk.HashBlock(), blkHash)
 
 		// store to key 0
-		contractAddr := "io1qyqqqqqp3kcd2pyfwus69nzgvkwhg8mk8h336dt8dqgtyy"
+		contractAddr := "io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6"
 		data, _ = hex.DecodeString("60fe47b1000000000000000000000000000000000000000000000000000000000000000f")
 		execution, err = action.NewExecution(
 			testaddress.Addrinfo["producer"].Bech32(), contractAddr, 2, big.NewInt(0), uint64(120000), big.NewInt(0), data)
@@ -334,7 +334,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.Equal(eHash, r.Hash)
 
 		// read from key 0
-		contractAddr = "io1qyqqqqqp3kcd2pyfwus69nzgvkwhg8mk8h336dt8dqgtyy"
+		contractAddr = "io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6"
 		data, _ = hex.DecodeString("6d4ce63c")
 		execution, err = action.NewExecution(
 			testaddress.Addrinfo["producer"].Bech32(), contractAddr, 3, big.NewInt(0), uint64(120000), big.NewInt(0), data)

--- a/action/protocol/multichain/mainchain/createdeposit_test.go
+++ b/action/protocol/multichain/mainchain/createdeposit_test.go
@@ -52,7 +52,7 @@ func TestValidateDeposit(t *testing.T) {
 
 	addr := testaddress.Addrinfo["producer"]
 	addr1 := addr.Bech32()
-	addr2 := address.New(2, addr.Payload()).Bech32()
+	addr2 := address.New(addr.Payload()).Bech32()
 
 	deposit := action.NewCreateDeposit(1, 2, big.NewInt(1000), addr1, addr2, testutil.TestGasLimit, big.NewInt(0))
 	_, _, err = p.validateDeposit(deposit, nil)
@@ -91,7 +91,7 @@ func TestValidateDeposit(t *testing.T) {
 		SubChainsInOperation{
 			InOperation{
 				ID:   2,
-				Addr: address.New(1, subChainAddr[:]).Bytes(),
+				Addr: address.New(subChainAddr[:]).Bytes(),
 			},
 		},
 	))
@@ -122,7 +122,7 @@ func TestMutateDeposit(t *testing.T) {
 
 	addr := testaddress.Addrinfo["producer"]
 	addr1 := addr.Bech32()
-	addr2 := address.New(2, addr.Payload()).Bech32()
+	addr2 := address.New(addr.Payload()).Bech32()
 	subChainAddr, err := createSubChainAddress(addr1, 0)
 	require.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestMutateDeposit(t *testing.T) {
 		},
 		InOperation{
 			ID:   2,
-			Addr: address.New(1, subChainAddr[:]).Bytes(),
+			Addr: address.New(subChainAddr[:]).Bytes(),
 		},
 		ws,
 	)
@@ -165,13 +165,13 @@ func TestMutateDeposit(t *testing.T) {
 	assert.Equal(t, uint64(2), account.Nonce)
 	assert.Equal(t, big.NewInt(1000), account.Balance)
 
-	subChain, err := p.SubChain(address.New(1, subChainAddr[:]))
+	subChain, err := p.SubChain(address.New(subChainAddr[:]))
 	require.NoError(t, err)
 	assert.Equal(t, uint64(301), subChain.DepositCount)
 
-	deposit, err := p.Deposit(address.New(1, subChainAddr[:]), 300)
+	deposit, err := p.Deposit(address.New(subChainAddr[:]), 300)
 	require.NoError(t, err)
-	assert.Equal(t, address.New(2, addr.Payload()).Bytes(), deposit.Addr)
+	assert.Equal(t, address.New(addr.Payload()).Bytes(), deposit.Addr)
 	assert.Equal(t, big.NewInt(1000), deposit.Amount)
 	assert.False(t, deposit.Confirmed)
 
@@ -182,5 +182,5 @@ func TestMutateDeposit(t *testing.T) {
 	gas, err := act.IntrinsicGas()
 	assert.NoError(t, err)
 	assert.Equal(t, gas, receipt.GasConsumed)
-	assert.Equal(t, address.New(1, subChainAddr[:]).Bech32(), receipt.ContractAddress)
+	assert.Equal(t, address.New(subChainAddr[:]).Bech32(), receipt.ContractAddress)
 }

--- a/action/protocol/multichain/mainchain/datamodel.go
+++ b/action/protocol/multichain/mainchain/datamodel.go
@@ -161,7 +161,7 @@ func (s SubChainsInOperation) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 // Sort sorts SubChainsInOperation.
 func (s SubChainsInOperation) Sort() { sort.Sort(s) }
 
-// Get gets an element with given id.
+// Get gets an element with given ID.
 func (s SubChainsInOperation) Get(id uint32) (InOperation, bool) {
 	for _, io := range s {
 		if io.ID == id {

--- a/action/protocol/multichain/mainchain/datamodel_test.go
+++ b/action/protocol/multichain/mainchain/datamodel_test.go
@@ -75,19 +75,19 @@ func TestSubChainsInOperation(t *testing.T) {
 	sc1 = sc1.Append(
 		InOperation{
 			ID:   3,
-			Addr: address.New(1, hash.Hash160b([]byte{3})).Bytes(),
+			Addr: address.New(hash.Hash160b([]byte{3})).Bytes(),
 		},
 	)
 	sc1 = sc1.Append(
 		InOperation{
 			ID:   1,
-			Addr: address.New(1, hash.Hash160b([]byte{1})).Bytes(),
+			Addr: address.New(hash.Hash160b([]byte{1})).Bytes(),
 		},
 	)
 	sc1 = sc1.Append(
 		InOperation{
 			ID:   2,
-			Addr: address.New(1, hash.Hash160b([]byte{2})).Bytes(),
+			Addr: address.New(hash.Hash160b([]byte{2})).Bytes(),
 		},
 	)
 

--- a/action/protocol/multichain/mainchain/startsubchain.go
+++ b/action/protocol/multichain/mainchain/startsubchain.go
@@ -92,7 +92,7 @@ func (p *Protocol) mutateSubChainState(
 	}
 	subChainsInOp = subChainsInOp.Append(InOperation{
 		ID:   start.ChainID(),
-		Addr: address.New(p.rootChain.ChainID(), addr[:]).Bytes(),
+		Addr: address.New(addr[:]).Bytes(),
 	})
 	return sm.PutState(SubChainsInOperationKey, &subChainsInOp)
 }

--- a/action/protocol/multichain/mainchain/startsubchain_test.go
+++ b/action/protocol/multichain/mainchain/startsubchain_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"fmt"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -348,9 +349,9 @@ func TestStartSubChainInGenesis(t *testing.T) {
 	require.NoError(t, bc.Start(ctx))
 	defer require.NoError(t, bc.Stop(ctx))
 
-	scAddr, err := createSubChainAddress(blockchain.Gen.CreatorAddr(1), 0)
+	scAddr, err := createSubChainAddress(blockchain.Gen.CreatorAddr(), 0)
 	require.NoError(t, err)
-	addr := address.New(1, scAddr[:])
+	addr := address.New(scAddr[:])
 	sc, err := p.SubChain(addr)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(2), sc.ChainID)
@@ -360,6 +361,7 @@ func TestStartSubChainInGenesis(t *testing.T) {
 	assert.Equal(t, uint64(10), sc.ParentHeightOffset)
 	subChainsInOp, err := p.SubChainsInOperation()
 	require.NoError(t, err)
+	fmt.Println(len(subChainsInOp))
 	_, ok := subChainsInOp.Get(uint32(2))
 	assert.True(t, ok)
 }

--- a/action/protocol/multichain/mainchain/stopsubchain_test.go
+++ b/action/protocol/multichain/mainchain/stopsubchain_test.go
@@ -84,7 +84,7 @@ func TestHandleStopSubChain(t *testing.T) {
 			}
 			return state.Deserialize(s, data)
 		}).Times(3)
-	subChainAddr := address.New(chain.ChainID(), subChainPKHash[:])
+	subChainAddr := address.New(subChainPKHash[:])
 
 	p := NewProtocol(chain)
 	stop := action.NewStopSubChain(

--- a/address/address.go
+++ b/address/address.go
@@ -34,8 +34,6 @@ var isTestNet bool
 
 // Address defines the interface of the blockchain address
 type Address interface {
-	// ChainID returns the version
-	ChainID() uint32
 	// Version returns the version
 	Version() uint8
 	// Payload returns the payload
@@ -50,10 +48,10 @@ type Address interface {
 }
 
 // New constructs an address instance
-func New(chainID uint32, payload []byte) Address {
+func New(payload []byte) Address {
 	var pkHash hash.PKHash
 	copy(pkHash[:], payload)
-	return V1.New(chainID, pkHash)
+	return V1.New(pkHash)
 }
 
 // Bech32ToAddress decodes an encoded address string into an address struct

--- a/address/address_v1_test.go
+++ b/address/address_v1_test.go
@@ -26,13 +26,12 @@ func TestAddress(t *testing.T) {
 		pkHash := keypair.HashPubKey(pk)
 
 		assertAddr := func(t *testing.T, addr *AddrV1) {
-			assert.Equal(t, uint32(1024), addr.ChainID())
 			assert.Equal(t, uint8(1), addr.Version())
 			assert.Equal(t, pkHash[:], addr.Payload())
 			assert.Equal(t, pkHash, addr.PublicKeyHash())
 		}
 
-		addr1 := V1.New(1024, pkHash)
+		addr1 := V1.New(pkHash)
 		assertAddr(t, addr1)
 
 		encodedAddr := addr1.Bech32()
@@ -68,7 +67,7 @@ func TestAddressError(t *testing.T) {
 	require.NoError(t, err)
 
 	pkHash := keypair.HashPubKey(pk)
-	addr1 := V1.New(1024, pkHash)
+	addr1 := V1.New(pkHash)
 	require.NoError(t, err)
 
 	encodedAddr := addr1.Bech32()

--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -180,7 +180,7 @@ func (b *Block) VerifySignature() bool {
 // ProducerAddress returns the address of producer
 func (b *Block) ProducerAddress() string {
 	pkHash := keypair.HashPubKey(b.Header.pubkey)
-	addr := address.New(b.Header.chainID, pkHash[:])
+	addr := address.New(pkHash[:])
 
 	return addr.Bech32()
 }
@@ -188,7 +188,7 @@ func (b *Block) ProducerAddress() string {
 // RunnableActions abstructs RunnableActions from a Block.
 func (b *Block) RunnableActions() RunnableActions {
 	pkHash := keypair.HashPubKey(b.Header.pubkey)
-	addr := address.New(b.Header.chainID, pkHash[:])
+	addr := address.New(pkHash[:])
 	return RunnableActions{
 		blockHeight:         b.Header.height,
 		blockTimeStamp:      b.Header.timestamp,

--- a/blockchain/block/block_test.go
+++ b/blockchain/block/block_test.go
@@ -100,31 +100,31 @@ func TestMerkle(t *testing.T) {
 	require.NoError(err)
 
 	// verify tx hash
-	hash0, e := hex.DecodeString("debc6d2f6f1dc15a40ba61b29cc55a2c9db5858a8d6a73cec6182ce40770fd25")
+	hash0, e := hex.DecodeString("2e0700057c579478c06de3ecc93035fee468e3b062fe8e624742975d46babff0")
 	require.NoError(e)
 	actual := cbtsf0.Hash()
 	t.Logf("actual hash = %x", actual[:])
 	require.Equal(hash0, actual[:])
 
-	hash1, e := hex.DecodeString("cadd4699d1a5e38da309f929352462c53a397b77707a7fd4efd3957e3e2680c1")
+	hash1, e := hex.DecodeString("1a481941e49463454dc5a5c2d83eef2cfaee7d7adeb9db86a3c6b3b32e70ee1f")
 	require.NoError(e)
 	actual = cbtsf1.Hash()
 	t.Logf("actual hash = %x", actual[:])
 	require.Equal(hash1, actual[:])
 
-	hash2, e := hex.DecodeString("951e1e2083fca4cd92521e45885caaa2d1f1d2ca4f6f77b03484a7d94d0fb145")
+	hash2, e := hex.DecodeString("1c2b3e1c72a8f62e04823401a4a05923d8e56bdea4176ad04d4a851354a07c55")
 	require.NoError(e)
 	actual = cbtsf2.Hash()
 	t.Logf("actual hash = %x", actual[:])
 	require.Equal(hash2, actual[:])
 
-	hash3, e := hex.DecodeString("4de5c01a68ceccac32bbeaeb8b9051c82d090617b58148010235f3e3b15898a2")
+	hash3, e := hex.DecodeString("59acd91b0fb1eba7fd32d8eec7fcaa33563244d93f84c2dbc416b457c4c14685")
 	require.NoError(e)
 	actual = cbtsf3.Hash()
 	t.Logf("actual hash = %x", actual[:])
 	require.Equal(hash3, actual[:])
 
-	hash4, e := hex.DecodeString("bccac6f4514f6a218591135fee6b0f710df641b32c85fac6357fae8acf92dadf")
+	hash4, e := hex.DecodeString("eb055592cc3a110ea5aa6f814f3eb6b63a915d45a96c7d1866ece113d95f1f28")
 	require.NoError(e)
 	actual = cbtsf4.Hash()
 	t.Logf("actual hash = %x", actual[:])

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -287,7 +287,7 @@ func NewBlockchain(cfg config.Config, opts ...Option) Blockchain {
 		return nil
 	}
 	pkHash := keypair.HashPubKey(pubKey)
-	address := address.New(cfg.Chain.ID, pkHash[:])
+	address := address.New(pkHash[:])
 	if err != nil {
 		log.L().Error("Failed to get producer's address by public key.", zap.Error(err))
 		return nil
@@ -946,7 +946,7 @@ func (bc *blockchain) startEmptyBlockchain() error {
 		ws      factory.WorkingSet
 		err     error
 	)
-	addr := address.New(bc.ChainID(), keypair.ZeroPublicKey[:])
+	addr := address.New(keypair.ZeroPublicKey[:])
 	if bc.sf == nil {
 		return errors.New("statefactory cannot be nil")
 	}
@@ -1013,7 +1013,7 @@ func (bc *blockchain) startExistingBlockchain(recoveryHeight uint64) error {
 	}
 	// If restarting factory from fresh db, first update state changes in Genesis block
 	if startHeight == 0 {
-		addr := address.New(bc.ChainID(), keypair.ZeroPublicKey[:])
+		addr := address.New(keypair.ZeroPublicKey[:])
 		acts := NewGenesisActions(bc.config.Chain, ws)
 		racts := block.NewRunnableActionsBuilder().
 			SetHeight(0).

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -43,13 +43,13 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	tsf0, _ := action.NewTransfer(
 		1,
 		big.NewInt(3000000000),
-		Gen.CreatorAddr(config.Default.Chain.ID),
+		Gen.CreatorAddr(),
 		ta.Addrinfo["producer"].Bech32(),
 		[]byte{}, uint64(100000),
 		big.NewInt(10),
 	)
 	pubk, _ := keypair.DecodePublicKey(Gen.CreatorPubKey)
-	sig, _ := hex.DecodeString("b14516e888e78e8dcba9af59607c8deea404f52c3df706a0bb6e1fadfda58113983b9201400ff75202fe486363a2e99052b3866595be932542bc0b860278b0753ab3fd2c66764a01")
+	sig, _ := hex.DecodeString("3584fe777dd090e1a7a825896f532485ea2cc35d7c300c6c56f0e2e78b51c6ded33f7d0069f4f6f6b6762306466fcff6f261bb30d9e1550f2f8be4f988e740903fd734209cb60101")
 	bd := &action.EnvelopeBuilder{}
 	elp := bd.SetAction(tsf0).
 		SetDestinationAddress(ta.Addrinfo["producer"].Bech32()).
@@ -57,7 +57,7 @@ func addTestingTsfBlocks(bc Blockchain) error {
 		SetGasLimit(100000).
 		SetGasPrice(big.NewInt(10)).Build()
 
-	selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(config.Default.Chain.ID), pubk, sig)
+	selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(), pubk, sig)
 	actionMap := make(map[string][]action.SealedEnvelope)
 	actionMap[selp.SrcAddr()] = []action.SealedEnvelope{selp}
 	blk, err := bc.MintNewBlock(actionMap, ta.Keyinfo["producer"].PubKey,
@@ -321,7 +321,7 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 
 	pk, _ := keypair.DecodePublicKey(Gen.CreatorPubKey)
 	// The signature should only matches the transfer amount 3000000000
-	sig, err := hex.DecodeString("0ea4152e8bef2049319d945ac55d21093f9a6e9e4793abf8906e1b9a9f59de1123db31006b3574cb080b7efd623101cb6b175bb881d7361e2341a740cfb8c3db1be1dd3aa4b67901")
+	sig, err := hex.DecodeString("a270828edf414f652564495ffdb3ed4799ae949cd8f0b8c108f36aff5e2ef0ee03c81f0161ef59c64a4590517d7cecabcec1b43b170fd70b1187f95a57975135951d867fd8c14901")
 	require.NoError(t, err)
 
 	cases := make(map[int64]bool)
@@ -331,7 +331,7 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 		tsf, err := action.NewTransfer(
 			1,
 			big.NewInt(3000000000+k),
-			Gen.CreatorAddr(config.Default.Chain.ID),
+			Gen.CreatorAddr(),
 			ta.Addrinfo["producer"].Bech32(),
 			[]byte{}, uint64(100000),
 			big.NewInt(10),
@@ -344,7 +344,7 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 			SetGasLimit(100000).
 			SetGasPrice(big.NewInt(10)).Build()
 
-		selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(config.Default.Chain.ID), pk, sig)
+		selp := action.AssembleSealedEnvelope(elp, Gen.CreatorAddr(), pk, sig)
 		actionMap := make(map[string][]action.SealedEnvelope)
 		actionMap[selp.SrcAddr()] = []action.SealedEnvelope{selp}
 		_, err = bc.MintNewBlock(actionMap, ta.Keyinfo["producer"].PubKey,
@@ -925,7 +925,7 @@ func TestBlockchain_StateByAddr(t *testing.T) {
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
 
-	s, err := bc.StateByAddr(Gen.CreatorAddr(cfg.Chain.ID))
+	s, err := bc.StateByAddr(Gen.CreatorAddr())
 	require.NoError(err)
 	require.Equal(uint64(0), s.Nonce)
 	bal := big.NewInt(7700000000)
@@ -1087,7 +1087,7 @@ func TestMintDKGBlock(t *testing.T) {
 		ec283PKList[i], ec283SKList[i], err = crypto.EC283.NewKeyPair()
 		require.NoError(err)
 		pkHash := keypair.HashPubKey(ec283PKList[i])
-		addresses[i] = address.New(cfg.Chain.ID, pkHash[:]).Bech32()
+		addresses[i] = address.New(pkHash[:]).Bech32()
 		idList[i] = hash.Hash256b([]byte(addresses[i]))
 		skList[i] = crypto.DKG.SkGeneration()
 	}

--- a/blockchain/blockvalidator.go
+++ b/blockchain/blockvalidator.go
@@ -175,7 +175,7 @@ func (v *validator) validateActions(
 ) error {
 	coinbaseCounter := 0
 	producerPK := keypair.HashPubKey(pk)
-	producerAddr := address.New(chainID, producerPK[:])
+	producerAddr := address.New(producerPK[:])
 
 	var wg sync.WaitGroup
 	for _, selp := range actions {

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -445,7 +445,7 @@ func TestCoinbaseTransferValidation(t *testing.T) {
 		"29cf385adfc5b1a84bd7e778ea2c056b85c977771005d545e54100266e224fc276ed7101")
 	require.NoError(t, err)
 	pkHash := keypair.HashPubKey(pk)
-	addr := address.New(cfg.Chain.ID, pkHash[:])
+	addr := address.New(pkHash[:])
 	blk, err := chain.MintNewBlock(nil, pk, sk, addr.Bech32(),
 		nil, nil, "")
 	require.NoError(t, err)
@@ -479,7 +479,7 @@ func TestValidateSecretBlock(t *testing.T) {
 		pk, _, err := crypto.EC283.NewKeyPair()
 		require.NoError(err)
 		pkHash := keypair.HashPubKey(pk)
-		addr := address.New(cfg.Chain.ID, pkHash[:])
+		addr := address.New(pkHash[:])
 		delegates = append(delegates, addr.Bech32())
 	}
 

--- a/blockchain/genesis_test.go
+++ b/blockchain/genesis_test.go
@@ -55,7 +55,7 @@ func TestGenesis(t *testing.T) {
 	assert.Equal(uint64(0), genesisBlk.Height())
 	assert.Equal(int64(1524676419), genesisBlk.Timestamp())
 	assert.Equal(hash.ZeroHash32B, genesisBlk.PrevHash())
-	genesisHash, _ := hex.DecodeString("88cc592ef59baf6c1e39acd216a817c9639753606b7471369880190dc3e8913d")
+	genesisHash, _ := hex.DecodeString("6a7d295b645a9c02738bc975fed498fc2e9aebd5e10d2e6680cf2e33072da863")
 	h := genesisBlk.HashBlock()
 	assert.Equal(genesisHash, h[:])
 }

--- a/config/config.go
+++ b/config/config.go
@@ -415,7 +415,7 @@ func (cfg Config) BlockchainAddress() (address.Address, error) {
 		return nil, errors.Wrapf(err, "error when decoding public key %s", cfg.Chain.ProducerPubKey)
 	}
 	pkHash := keypair.HashPubKey(pk)
-	return address.New(cfg.Chain.ID, pkHash[:]), nil
+	return address.New(pkHash[:]), nil
 }
 
 // KeyPair returns the decoded public and private key pair

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -143,7 +143,7 @@ func NewConsensus(
 					if err != nil {
 						return nil, errors.Wrapf(err, "error when get converting iotex address to address")
 					}
-					subChainAddr := address.New(cfg.Chain.ID, rootChainAddr.Payload())
+					subChainAddr := address.New(rootChainAddr.Payload())
 					pubKey, err := keypair.DecodePublicKey(rawc.PubKey)
 					if err != nil {
 						log.L().Error("Error when convert candidate PublicKey.", zap.Error(err))

--- a/consensus/scheme/rolldpos/fsm_test.go
+++ b/consensus/scheme/rolldpos/fsm_test.go
@@ -1495,7 +1495,7 @@ func newTestAddr() *addrKeyPair {
 		log.L().Panic("Error when creating test address.", zap.Error(err))
 	}
 	pkHash := keypair.HashPubKey(pk)
-	addr := address.New(config.Default.Chain.ID, pkHash[:])
+	addr := address.New(pkHash[:])
 	return &addrKeyPair{pubKey: pk, priKey: sk, encodedAddr: addr.Bech32()}
 }
 

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -595,7 +595,7 @@ func TestUpdateSeed(t *testing.T) {
 			require.NoError(err)
 		}
 		pkHash := keypair.HashPubKey(ec283PKList[i])
-		addresses[i] = address.New(chain.ChainID(), pkHash[:]).Bech32()
+		addresses[i] = address.New(pkHash[:]).Bech32()
 		idList[i] = address.Bech32ToID(addresses[i])
 		skList[i] = crypto.DKG.SkGeneration()
 	}

--- a/consensus/scheme/rolldpos/subchain.go
+++ b/consensus/scheme/rolldpos/subchain.go
@@ -70,14 +70,8 @@ func constructPutSubChainBlockRequest(
 	senderPriKey keypair.PrivateKey,
 	b *block.Block,
 ) (explorerapi.PutSubChainBlockRequest, error) {
-	// get sender address on mainchain
-	subChainAddrSt, err := address.Bech32ToAddress(subChainAddr)
-	if err != nil {
-		return explorerapi.PutSubChainBlockRequest{}, errors.Wrap(err, "fail to convert subChainAddr")
-	}
-	parentChainID := subChainAddrSt.ChainID()
 	senderPKHash := keypair.HashPubKey(senderPubKey)
-	senderPCAddr := address.New(parentChainID, senderPKHash[:]).Bech32()
+	senderPCAddr := address.New(senderPKHash[:]).Bech32()
 
 	// get sender current pending nonce on parent chain
 	senderPCAddrDetails, err := rootChainAPI.GetAddressDetails(senderPCAddr)

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -83,8 +83,8 @@ func TestLocalActPool(t *testing.T) {
 	fromPKHash := keypair.HashPubKey(fromPK)
 	toPKHash := keypair.HashPubKey(toPK)
 
-	from := address.New(cfg.Chain.ID, fromPKHash[:]).Bech32()
-	to := address.New(cfg.Chain.ID, toPKHash[:]).Bech32()
+	from := address.New(fromPKHash[:]).Bech32()
+	to := address.New(toPKHash[:]).Bech32()
 	priKey, _ := keypair.DecodePrivateKey(fromPrivKey)
 
 	// Create three valid actions from "from" to "to"
@@ -172,8 +172,8 @@ func TestPressureActPool(t *testing.T) {
 	fromPKHash := keypair.HashPubKey(fromPK)
 	toPKHash := keypair.HashPubKey(toPK)
 
-	from := address.New(cfg.Chain.ID, fromPKHash[:]).Bech32()
-	to := address.New(cfg.Chain.ID, toPKHash[:]).Bech32()
+	from := address.New(fromPKHash[:]).Bech32()
+	to := address.New(toPKHash[:]).Bech32()
 	priKey, _ := keypair.DecodePrivateKey(fromPrivKey)
 
 	p2pCtx := p2p.WitContext(ctx, p2p.Context{ChainID: chainID})

--- a/e2etest/multichain_test.go
+++ b/e2etest/multichain_test.go
@@ -74,13 +74,13 @@ func TestTwoChains(t *testing.T) {
 	pk1, err := crypto.EC283.NewPubKey(sk1)
 	require.NoError(t, err)
 	pkHash1 := keypair.HashPubKey(pk1)
-	addr1 := address.New(1, pkHash1[:])
+	addr1 := address.New(pkHash1[:])
 	sk2, err := keypair.DecodePrivateKey("574f3b95c1afac4c5541ce705654bd92028e6b06bc07655647dd2637528dd98976f0c401")
 	require.NoError(t, err)
 	pk2, err := crypto.EC283.NewPubKey(sk2)
 	require.NoError(t, err)
 	pkHash2 := keypair.HashPubKey(pk2)
-	addr2 := address.New(2, pkHash2[:])
+	addr2 := address.New(pkHash2[:])
 
 	mainChainClient := exp.NewExplorerProxy(
 		fmt.Sprintf("http://127.0.0.1:%d", svr.ChainService(cfg.Chain.ID).Explorer().Port()),

--- a/e2etest/util.go
+++ b/e2etest/util.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
 	ta "github.com/iotexproject/iotex-core/test/testaddress"
 	"github.com/iotexproject/iotex-core/testutil"
@@ -26,13 +25,13 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	tsf0, _ := action.NewTransfer(
 		1,
 		blockchain.ConvertIotxToRau(3000000000),
-		blockchain.Gen.CreatorAddr(config.Default.Chain.ID),
+		blockchain.Gen.CreatorAddr(),
 		ta.Addrinfo["producer"].Bech32(),
 		[]byte{}, uint64(100000),
 		big.NewInt(0),
 	)
 	pubk, _ := keypair.DecodePublicKey(blockchain.Gen.CreatorPubKey)
-	sig, _ := hex.DecodeString("e19cea05762603b898e32ecac1c6330946c21e668bd5af1f0f47d89887fc6736acf7cd012f21834f4379dfb6ab2badf4c54fb0e61fe8a64ac517c96f41589c9fcec848ecfae1be01")
+	sig, _ := hex.DecodeString("a8c2a0d708cd998725585fa0a8441c57b7f1ca2af1bba625eaca721df4716d5d47ae83017c11d3712bce2883f79dce83aa6f069ed7625771530a3fd51f32aa61ef7a9158a505aa01")
 	bd := &action.EnvelopeBuilder{}
 	elp := bd.SetAction(tsf0).
 		SetDestinationAddress(ta.Addrinfo["producer"].Bech32()).
@@ -40,7 +39,7 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 		SetGasLimit(100000).
 		SetGasPrice(big.NewInt(10)).Build()
 
-	selp := action.AssembleSealedEnvelope(elp, blockchain.Gen.CreatorAddr(config.Default.Chain.ID), pubk, sig)
+	selp := action.AssembleSealedEnvelope(elp, blockchain.Gen.CreatorAddr(), pubk, sig)
 
 	actionMap := make(map[string][]action.SealedEnvelope)
 	actionMap[selp.SrcAddr()] = []action.SealedEnvelope{selp}

--- a/test/testaddress/testaddress.go
+++ b/test/testaddress/testaddress.go
@@ -8,7 +8,6 @@ package testaddress
 
 import (
 	"github.com/iotexproject/iotex-core/address"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
@@ -47,45 +46,43 @@ func init() {
 	Addrinfo = make(map[string]*address.AddrV1)
 	Keyinfo = make(map[string]*Key)
 
-	chainID := config.Default.Chain.ID
-
 	pubKey, _ := keypair.DecodePublicKey(pubkeyProducer)
 	priKey, _ := keypair.DecodePrivateKey(prikeyProducer)
-	Addrinfo["producer"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["producer"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["producer"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyA)
 	priKey, _ = keypair.DecodePrivateKey(prikeyA)
-	Addrinfo["alfa"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["alfa"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["alfa"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyB)
 	priKey, _ = keypair.DecodePrivateKey(prikeyB)
-	Addrinfo["bravo"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["bravo"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["bravo"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyC)
 	priKey, _ = keypair.DecodePrivateKey(prikeyC)
-	Addrinfo["charlie"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["charlie"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["charlie"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyD)
 	priKey, _ = keypair.DecodePrivateKey(prikeyD)
-	Addrinfo["delta"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["delta"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["delta"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyE)
 	priKey, _ = keypair.DecodePrivateKey(prikeyE)
-	Addrinfo["echo"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["echo"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["echo"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyF)
 	priKey, _ = keypair.DecodePrivateKey(prikeyF)
-	Addrinfo["foxtrot"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["foxtrot"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["foxtrot"] = &Key{PubKey: pubKey, PriKey: priKey}
 
 	pubKey, _ = keypair.DecodePublicKey(pubkeyG)
 	priKey, _ = keypair.DecodePrivateKey(prikeyG)
-	Addrinfo["galilei"] = address.V1.New(chainID, keypair.HashPubKey(pubKey))
+	Addrinfo["galilei"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["galilei"] = &Key{PubKey: pubKey, PriKey: priKey}
 }

--- a/tools/actioninjector/actioninjector.go
+++ b/tools/actioninjector/actioninjector.go
@@ -49,7 +49,7 @@ func main() {
 	var voteGasPrice int
 	// number of execution injections. Default is 50
 	var executionNum int
-	// smart contract address. Default is "io1qyqsyqcy3kcd2pyfwus69nzgvkwhg8mk8h336dt86pg6cj"
+	// smart contract address. Default is "io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6"
 	var contract string
 	// execution amount. Default is 0
 	var executionAmount int
@@ -83,7 +83,7 @@ func main() {
 	flag.IntVar(&voteGasLimit, "vote-gas-limit", 20000, "vote gas limit")
 	flag.IntVar(&voteGasPrice, "vote-gas-price", 10, "vote gas price")
 	flag.IntVar(&executionNum, "execution-num", 50, "number of execution injections")
-	flag.StringVar(&contract, "contract", "io1qyqqqqqp3kcd2pyfwus69nzgvkwhg8mk8h336dt8dqgtyy", "smart contract address")
+	flag.StringVar(&contract, "contract", "io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6", "smart contract address")
 	flag.IntVar(&executionAmount, "execution-amount", 50, "execution amount")
 	flag.IntVar(&executionGasLimit, "execution-gas-limit", 20000, "execution gas limit")
 	flag.IntVar(&executionGasPrice, "execution-gas-price", 10, "execution gas price")

--- a/tools/actioninjector/actioninjector_test.go
+++ b/tools/actioninjector/actioninjector_test.go
@@ -76,7 +76,7 @@ func TestActionInjector(t *testing.T) {
 	transferPayload := ""
 	voteGasLimit := 1000000
 	voteGasPrice := 10
-	contract := "io1qyqqqqqp3kcd2pyfwus69nzgvkwhg8mk8h336dt8dqgtyy"
+	contract := "io1qxxmp4gy39mjrgkvfpje6aqlwc77x8f4vu5kl9k6"
 	executionAmount := 0
 	executionGasLimit := 1200000
 	executionGasPrice := 10

--- a/tools/util/injectorutil.go
+++ b/tools/util/injectorutil.go
@@ -68,7 +68,7 @@ func LoadAddresses(keypairsPath string, chainID uint32) ([]*AddressKey, error) {
 			return nil, errors.Wrap(err, "failed to decode private key")
 		}
 		pkHash := keypair.HashPubKey(pk)
-		addrKeys = append(addrKeys, &AddressKey{EncodedAddr: address.New(chainID, pkHash[:]).Bech32(), PriKey: sk})
+		addrKeys = append(addrKeys, &AddressKey{EncodedAddr: address.New(pkHash[:]).Bech32(), PriKey: sk})
 	}
 	return addrKeys, nil
 }


### PR DESCRIPTION
Based on #459 , chain ID is fully removed from address interface and v1 implementation.