### PR TITLE
Start minting block right away

### DIFF
--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -145,20 +145,6 @@ func TestStateTransitions(t *testing.T) {
 				require.Equal(sPrepare, state)
 				evt := <-cfsm.evtq
 				require.Equal(ePrepare, evt.Type())
-				time.Sleep(100 * time.Millisecond)
-				// garbage collection
-				mockClock.Add(4 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eFailedToReceiveBlock, evt.Type())
-				mockClock.Add(2 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingProposalEndorsement, evt.Type())
-				mockClock.Add(2 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingLockEndorsement, evt.Type())
-				mockClock.Add(2 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eFailedToReachConsensusInTime, evt.Type())
 			})
 			t.Run("success-to-mint", func(t *testing.T) {
 				mockCtx.EXPECT().IsDelegate().Return(true).Times(1)

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 IoTeX
+// Copyright (c) 2019 IoTeX
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache


### PR DESCRIPTION
As the mint time is fixed, a proposer could start minting block right after receiving last block. Thus, the proposer has more time to mint a block if everything goes fine.