### PR TITLE
Ensure db is only started and stopped once in the tests

### DIFF
--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -90,12 +90,15 @@ func TestWrongNonce(t *testing.T) {
 	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.NoError(err)
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil))
-	require.NoError(sf.Start(context.Background()))
-	require.NoError(addCreatorToFactory(sf))
 
 	// Create a blockchain from scratch
 	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
+	defer func() {
+		require.NoError(bc.Stop(context.Background()))
+	}()
+
+	require.NoError(addCreatorToFactory(sf))
 
 	val := &validator{sf: sf, validatorAddr: ""}
 	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
@@ -253,12 +256,15 @@ func TestWrongCoinbaseTsf(t *testing.T) {
 	require := require.New(t)
 	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.NoError(err)
-	require.NoError(sf.Start(context.Background()))
-	require.NoError(addCreatorToFactory(sf))
 
 	// Create a blockchain from scratch
 	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
+	defer func() {
+		require.NoError(bc.Stop(context.Background()))
+	}()
+
+	require.NoError(addCreatorToFactory(sf))
 
 	val := &validator{sf: sf, validatorAddr: ""}
 	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))

--- a/db/db_badger.go
+++ b/db/db_badger.go
@@ -24,10 +24,6 @@ type badgerDB struct {
 
 // Start opens the badgerDB (creates new file if not existing yet)
 func (b *badgerDB) Start(_ context.Context) error {
-	if b.db != nil {
-		return nil
-	}
-
 	opts := badger.DefaultOptions
 	opts.Dir = b.path
 	opts.ValueDir = b.path

--- a/db/db_bolt.go
+++ b/db/db_bolt.go
@@ -26,9 +26,6 @@ type boltDB struct {
 
 // Start opens the BoltDB (creates new file if not existing yet)
 func (b *boltDB) Start(_ context.Context) error {
-	if b.db != nil {
-		return nil
-	}
 	db, err := bolt.Open(b.path, fileMode, nil)
 	if err != nil {
 		return errors.Wrap(ErrIO, err.Error())
@@ -44,7 +41,6 @@ func (b *boltDB) Stop(_ context.Context) error {
 			return errors.Wrap(ErrIO, err.Error())
 		}
 	}
-	b.db = nil
 	return nil
 }
 

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -227,8 +227,6 @@ func TestExplorerApi(t *testing.T) {
 
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.Nil(err)
-	require.Nil(sf.Start(context.Background()))
-	require.NoError(addCreatorToFactory(sf))
 
 	// create chain
 	ctx := context.Background()
@@ -244,6 +242,11 @@ func TestExplorerApi(t *testing.T) {
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
+	defer func() {
+		require.NoError(bc.Stop(ctx))
+	}()
+
+	require.NoError(addCreatorToFactory(sf))
 
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
@@ -921,19 +924,17 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.Nil(err)
-	require.Nil(sf.Start(context.Background()))
-	require.NoError(addCreatorToFactory(sf))
 
 	// create chain
 	ctx := context.Background()
 	bc := blockchain.NewBlockchain(cfg, blockchain.PrecreatedStateFactoryOption(sf), blockchain.InMemDaoOption())
 	require.NoError(bc.Start(ctx))
-
-	sf.AddActionHandlers(execution.NewProtocol(bc))
-
 	defer func() {
 		require.NoError(bc.Stop(ctx))
 	}()
+
+	sf.AddActionHandlers(execution.NewProtocol(bc))
+	require.NoError(addCreatorToFactory(sf))
 
 	svc := Service{
 		bc: bc,


### PR DESCRIPTION
Remove the dedup logic on starting db, and make sure db only will be started once
Remove setting db = nil logic to avoid panic of receiving db op request after calling stop