### PR TITLE
IOTEX-219 Fix the ephemeral bytes read from db

### DIFF
--- a/db/db_bolt.go
+++ b/db/db_bolt.go
@@ -76,9 +76,13 @@ func (b *boltDB) Get(namespace string, key []byte) ([]byte, error) {
 		if bucket == nil {
 			return errors.Wrapf(ErrNotExist, "bucket = %s doesn't exist", namespace)
 		}
-		if value = bucket.Get(key); value == nil {
+		v := bucket.Get(key)
+		if v == nil {
 			return errors.Wrapf(ErrNotExist, "key = %x doesn't exist", key)
 		}
+		value = make([]byte, len(v))
+		// TODO: this is not an efficient way of passing the data
+		copy(value, v)
 		return nil
 	})
 	if err == nil {

--- a/db/db_bolt_test.go
+++ b/db/db_bolt_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package db
+
+import (
+	"context"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/config"
+)
+
+func BenchmarkBoltDB_Get(b *testing.B) {
+	runBenchmark := func(b *testing.B, size int) {
+		path, err := ioutil.TempFile("", "boltdb")
+		require.NoError(b, err)
+		db := boltDB{
+			path:   path.Name(),
+			config: config.Default.DB,
+		}
+		db.Start(context.Background())
+		defer db.Stop(context.Background())
+
+		key := []byte("key")
+		data := make([]byte, size)
+		for i := range data {
+			data[i] = byte(rand.Int())
+		}
+		require.NoError(b, db.Put("ns", key, data[:]))
+
+		b.ResetTimer()
+		for n := 0; n < b.N; n++ {
+			b.StartTimer()
+			_, err := db.Get("ns", key)
+			b.StopTimer()
+			require.NoError(b, err)
+		}
+	}
+
+	b.Run("100", func(b *testing.B) {
+		runBenchmark(b, 100)
+	})
+	b.Run("10000", func(b *testing.B) {
+		runBenchmark(b, 100)
+	})
+	b.Run("1000000", func(b *testing.B) {
+		runBenchmark(b, 100)
+	})
+}


### PR DESCRIPTION
The bytes read are only safe within the transaction lifecycle. Previously we didn't encounter the problem probably because we synchronize db operations.

Verified in a real cluster that the ephemeral bytes problem is gone (so far).

Also I added a benchmark test, which shows that perf are not affected by copying the bytes