### PR TITLE
print endorsement details when validation failed

### DIFF
--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -243,3 +243,16 @@ func (b *Block) Finalize(set *endorsement.Set, ts time.Time) error {
 
 	return nil
 }
+
+// FooterLogger logs the endorsements in block footer
+func (b *Block) FooterLogger(l *zap.Logger) *zap.Logger {
+	if b.endorsements == nil {
+		h := b.HashBlock()
+		return l.With(
+			log.Hex("blockHash", h[:]),
+			zap.Uint64("blockHeight", b.Height()),
+			zap.Int("numOfEndorsements", 0),
+		)
+	}
+	return b.endorsements.EndorsementsLogger(l)
+}

--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -192,7 +192,20 @@ func (bs *blockSyncer) ProcessSyncRequest(ctx context.Context, peer peerstore.Pe
 		return nil
 	}
 
-	for i := sync.Start; i <= sync.End; i++ {
+	end := bs.bc.TipHeight()
+	switch {
+	case sync.End < end:
+		end = sync.End
+	case sync.End > end:
+		log.L().Info(
+			"Do not have requested blocks",
+			zap.String("peerID", peer.ID.Pretty()),
+			zap.Uint64("start", sync.Start),
+			zap.Uint64("end", sync.End),
+			zap.Uint64("tipHeight", end),
+		)
+	}
+	for i := sync.Start; i <= end; i++ {
 		blk, err := bs.bc.GetBlockByHeight(i)
 		if err != nil {
 			return err

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -210,6 +210,16 @@ func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 		)
 	}
 	if 3*blk.NumOfDelegateEndorsements(epoch.delegates) <= 2*len(epoch.delegates) {
+		log.L().Warn(
+			"Insufficient endorsements in receiving block",
+			zap.Uint64("blockHeight", blk.Height()),
+			zap.Uint64("epoch", epoch.num),
+			zap.Uint32("round", round.number),
+			zap.Int("numOfDelegates", len(epoch.delegates)),
+			zap.Int("numOfDelegateEndorsements", blk.NumOfDelegateEndorsements(epoch.delegates)),
+			zap.Strings("delegates", epoch.delegates),
+		)
+		blk.FooterLogger(log.L()).Info("Endorsements in footer")
 		return errors.New("insufficient endorsements from delegates")
 	}
 

--- a/endorsement/endorsement.go
+++ b/endorsement/endorsement.go
@@ -7,10 +7,13 @@
 package endorsement
 
 import (
+	"encoding/hex"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/crypto/blake2b"
 
 	"github.com/iotexproject/iotex-core/pkg/hash"
@@ -191,6 +194,17 @@ func (en *Endorsement) Deserialize(bs []byte) error {
 	if err := en.FromProtoMsg(&pb); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// MarshalLogObject marshals the endorsement to a zap object
+func (en *Endorsement) MarshalLogObject(oe zapcore.ObjectEncoder) error {
+	oe.AddUint8("topic", uint8(en.object.Topic))
+	oe.AddString("warrantee", hex.EncodeToString(en.object.BlkHash))
+	oe.AddUint64("height", en.object.Height)
+	oe.AddUint32("round", en.object.Round)
+	oe.AddString("endorser", en.endorser)
 
 	return nil
 }

--- a/endorsement/endorsementset.go
+++ b/endorsement/endorsementset.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/proto"
 )
@@ -162,4 +163,13 @@ func (s *Set) ToProto() *iproto.EndorsementSet {
 		Round:        s.round,
 		Endorsements: endorsements,
 	}
+}
+
+// EndorsementsLogger logs the details of the endorsements in the set
+func (s *Set) EndorsementsLogger(l *zap.Logger) *zap.Logger {
+	for i, en := range s.endorsements {
+		l = l.With(zap.Object(string(i), en))
+	}
+
+	return l
 }


### PR DESCRIPTION
1. Print endorsement details on block footer validation failure
2. Don't print error if the block height is lower than requested block sync height, and update unit test