### PR TITLE
Remove eFailedToReachConsensusInTime

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,6 @@ var (
 			Scheme: NOOPScheme,
 			RollDPoS: RollDPoS{
 				FSM: consensusfsm.Config{
-					ProposerInterval:             10 * time.Second,
 					UnmatchedEventTTL:            3 * time.Second,
 					UnmatchedEventInterval:       100 * time.Millisecond,
 					AcceptBlockTTL:               4 * time.Second,
@@ -525,7 +524,7 @@ func ValidateRollDPoS(cfg Config) error {
 		return errors.Wrap(ErrInvalidCfg, "roll-DPoS event chan size should be greater than 0")
 	}
 	ttl := fsm.AcceptLockEndorsementTTL + fsm.AcceptBlockTTL + fsm.AcceptProposalEndorsementTTL
-	if ttl >= fsm.ProposerInterval {
+	if ttl >= rollDPoS.DelegateInterval {
 		return errors.Wrap(ErrInvalidCfg, "roll-DPoS ttl sum is larger than proposer interval")
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -289,7 +289,7 @@ func TestValidateRollDPoS(t *testing.T) {
 	cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 3 * time.Second
-	cfg.Consensus.RollDPoS.FSM.ProposerInterval = 8 * time.Second
+	cfg.Consensus.RollDPoS.DelegateInterval = 8 * time.Second
 	err := ValidateRollDPoS(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -197,9 +197,10 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	addr := newTestAddr()
 	r, err := NewRollDPoSBuilder().
 		SetConfig(config.RollDPoS{
-			NumDelegates: 4,
-			NumSubEpochs: 1,
-			FSM:          config.Default.Consensus.RollDPoS.FSM,
+			NumDelegates:     4,
+			NumSubEpochs:     1,
+			FSM:              config.Default.Consensus.RollDPoS.FSM,
+			DelegateInterval: 10 * time.Second,
 		}).
 		SetAddr(addr.encodedAddr).
 		SetPubKey(addr.pubKey).
@@ -214,7 +215,7 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	r.ctx.round = &roundCtx{height: blockHeight + 1}
-	clock.Add(r.ctx.cfg.FSM.ProposerInterval)
+	clock.Add(r.ctx.cfg.DelegateInterval)
 	require.NoError(t, r.ctx.updateEpoch(blockHeight+1))
 	require.NoError(t, r.ctx.updateRound(blockHeight+1))
 
@@ -298,7 +299,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 	newConsensusComponents := func(numNodes int) ([]*RollDPoS, []*directOverlay, []blockchain.Blockchain) {
 		cfg := config.Default
 		cfg.Consensus.RollDPoS.Delay = 300 * time.Millisecond
-		cfg.Consensus.RollDPoS.FSM.ProposerInterval = time.Second
+		cfg.Consensus.RollDPoS.DelegateInterval = time.Second
 		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 400 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 200 * time.Millisecond

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -624,7 +624,7 @@ func (ctx *rollDPoSCtx) roundCtxByTime(
 		return nil, err
 	}
 	// proposer interval should be always larger than 0
-	interval := ctx.cfg.FSM.ProposerInterval
+	interval := ctx.cfg.DelegateInterval
 	if interval <= 0 {
 		ctx.logger().Panic("invalid proposer interval")
 	}

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -68,7 +68,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		clock,
 	)
 	ctx.round = &roundCtx{height: blockHeight + 1}
-	ctx.cfg.FSM.ProposerInterval = 10 * time.Second
+	ctx.cfg.DelegateInterval = 10 * time.Second
 	ctx.cfg.FSM.AcceptBlockTTL = 4 * time.Second
 	ctx.cfg.FSM.AcceptProposalEndorsementTTL = 2 * time.Second
 	ctx.cfg.FSM.AcceptLockEndorsementTTL = 2 * time.Second

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -174,12 +174,12 @@ func main() {
 			}
 			bcHeights[i] = chains[i].TipHeight()
 			cfg := configs[i].Consensus.RollDPoS
-			minTimeout = int(cfg.Delay/time.Second - cfg.FSM.ProposerInterval/time.Second)
+			minTimeout = int(cfg.Delay/time.Second - cfg.DelegateInterval/time.Second)
 			netTimeout = 0
 			if timeout > minTimeout {
 				netTimeout = timeout - minTimeout
 			}
-			idealHeight[i] = uint64((time.Duration(netTimeout) * time.Second) / cfg.FSM.ProposerInterval)
+			idealHeight[i] = uint64((time.Duration(netTimeout) * time.Second) / cfg.DelegateInterval)
 
 			log.S().Infof("Node#%d blockchain height: %d", i, bcHeights[i])
 			log.S().Infof("Node#%d state      height: %d", i, stateHeights[i])
@@ -235,7 +235,6 @@ func newConfig(
 
 	cfg.Consensus.Scheme = config.RollDPoSScheme
 	cfg.Consensus.RollDPoS.DelegateInterval = 10 * time.Second
-	cfg.Consensus.RollDPoS.FSM.ProposerInterval = 10 * time.Second
 	cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 4 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 3 * time.Second


### PR DESCRIPTION
Once a delegate enters the pre-commit status (collect enough lock endorsements), it will for sure collect commit eventually with enough other delegates. If a delegate doesn't collect lock endorsements in time, it will go back to Prepare status. Thus, the eFailedToReachConsensusInTime shouldn't be there.
As the eFailedToReachConsensusInTime is deleted, ProposalInterval could be merged with DelegateInterval.

Test plan: uint test, and make minicluster