### PR TITLE
use consensus height to filter incoming messages

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -134,11 +134,11 @@ func (r *RollDPoS) Stop(ctx context.Context) error {
 
 // HandleConsensusMsg handles incoming consensus message
 func (r *RollDPoS) HandleConsensusMsg(msg *iproto.ConsensusPb) error {
-	chainHeight := r.ctx.chain.TipHeight()
-	if msg.Height <= chainHeight {
+	consensusHeight := r.ctx.Height()
+	if consensusHeight != 0 && msg.Height < consensusHeight {
 		log.L().Debug(
 			"old consensus message",
-			zap.Uint64("chainHeight", chainHeight),
+			zap.Uint64("consensusHeight", consensusHeight),
 			zap.Uint64("msgHeight", msg.Height),
 		)
 		return nil

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -421,6 +421,16 @@ func (ctx *rollDPoSCtx) IsProposer() bool {
 	return ctx.round.proposer == ctx.encodedAddr
 }
 
+func (ctx *rollDPoSCtx) Height() uint64 {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	if ctx.round == nil {
+		return 0
+	}
+
+	return ctx.round.height
+}
+
 ///////////////////////////////////////////
 // private functions
 ///////////////////////////////////////////


### PR DESCRIPTION
This will prevent the potential discarding of consensus messages if blockchain height was increased by block sync.