### PR TITLE
Add cryptokey interface and change action.srcPubkey to bytes to reduc…

### DIFF
--- a/action/actctx.go
+++ b/action/actctx.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
 // AbstractAction is an abstract implementation of Action interface
@@ -18,7 +17,7 @@ type AbstractAction struct {
 	version   uint32
 	nonce     uint64
 	srcAddr   string
-	srcPubkey keypair.PublicKey
+	srcPubkey []byte
 	dstAddr   string
 	gasLimit  uint64
 	gasPrice  *big.Int
@@ -35,7 +34,7 @@ func (act *AbstractAction) Nonce() uint64 { return act.nonce }
 func (act *AbstractAction) SrcAddr() string { return act.srcAddr }
 
 // SrcPubkey returns the source public key
-func (act *AbstractAction) SrcPubkey() keypair.PublicKey { return act.srcPubkey }
+func (act *AbstractAction) SrcPubkey() []byte { return act.srcPubkey }
 
 // DstAddr returns the destination address
 func (act *AbstractAction) DstAddr() string { return act.dstAddr }
@@ -59,7 +58,7 @@ func (act *AbstractAction) Hash() hash.Hash32B { return act.hash }
 func (act *AbstractAction) BasicActionSize() uint32 {
 	// VersionSizeInBytes + NonceSizeInBytes + GasSizeInBytes
 	size := 4 + 8 + 8
-	size += len(act.srcAddr) + len(act.dstAddr) + len(keypair.PublicKeyToBytes(act.srcPubkey))
+	size += len(act.srcAddr) + len(act.dstAddr) + len(act.srcPubkey)
 	if act.gasPrice != nil && len(act.gasPrice.Bytes()) > 0 {
 		size += len(act.gasPrice.Bytes())
 	}

--- a/action/builder.go
+++ b/action/builder.go
@@ -9,7 +9,6 @@ package action
 import (
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/version"
 )
 
@@ -43,7 +42,7 @@ func (b *Builder) SetDestinationAddress(addr string) *Builder {
 }
 
 // SetSourcePublicKey sets action's source's public key.
-func (b *Builder) SetSourcePublicKey(key keypair.PublicKey) *Builder {
+func (b *Builder) SetSourcePublicKey(key []byte) *Builder {
 	b.act.srcPubkey = key
 	return b
 }

--- a/action/createdeposit.go
+++ b/action/createdeposit.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -66,7 +65,7 @@ func (d *CreateDeposit) Amount() *big.Int { return d.amount }
 func (d *CreateDeposit) Sender() string { return d.SrcAddr() }
 
 // SenderPublicKey returns the sender public key. It's the wrapper of Action.SrcPubkey
-func (d *CreateDeposit) SenderPublicKey() keypair.PublicKey { return d.SrcPubkey() }
+func (d *CreateDeposit) SenderPublicKey() []byte { return d.SrcPubkey() }
 
 // Recipient returns the recipient address. It's the wrapper of Action.DstAddr. The recipient should be an address on
 // the sub-chain

--- a/action/execution.go
+++ b/action/execution.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -61,7 +60,7 @@ func (ex *Execution) Executor() string {
 }
 
 // ExecutorPublicKey returns the executor's public key
-func (ex *Execution) ExecutorPublicKey() keypair.PublicKey {
+func (ex *Execution) ExecutorPublicKey() []byte {
 	return ex.SrcPubkey()
 }
 

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -10,7 +10,6 @@ import (
 	"context"
 
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
 type runActionsCtxKey struct{}
@@ -24,7 +23,7 @@ type RunActionsCtx struct {
 	// hash of block containing those actions
 	BlockHash hash.Hash32B
 	// public key of producer who compose those actions
-	ProducerPubKey keypair.PublicKey
+	ProducerPubKey []byte
 	// timestamp of block containing those actions
 	BlockTimeStamp int64
 	// producer who compose those actions

--- a/action/protocol/multichain/mainchain/datamodel.go
+++ b/action/protocol/multichain/mainchain/datamodel.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/action/protocol/multichain/mainchain/mainchainpb"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
@@ -26,7 +25,7 @@ type SubChain struct {
 	StartHeight        uint64
 	StopHeight         uint64
 	ParentHeightOffset uint64
-	OwnerPublicKey     keypair.PublicKey
+	OwnerPublicKey     []byte
 	CurrentHeight      uint64
 	DepositCount       uint64
 }
@@ -38,7 +37,7 @@ func (bs SubChain) Serialize() ([]byte, error) {
 		StartHeight:        bs.StartHeight,
 		StopHeight:         bs.StopHeight,
 		ParentHeightOffset: bs.ParentHeightOffset,
-		OwnerPublicKey:     keypair.PublicKeyToBytes(bs.OwnerPublicKey),
+		OwnerPublicKey:     bs.OwnerPublicKey,
 		CurrentHeight:      bs.CurrentHeight,
 		DepositCount:       bs.DepositCount,
 	}
@@ -57,11 +56,6 @@ func (bs *SubChain) Deserialize(data []byte) error {
 	if err := proto.Unmarshal(data, gen); err != nil {
 		return err
 	}
-	pub, err := keypair.BytesToPublicKey(gen.OwnerPublicKey)
-	if err != nil {
-		return err
-	}
-
 	*bs = SubChain{
 		ChainID:            gen.ChainID,
 		SecurityDeposit:    &big.Int{},
@@ -69,7 +63,7 @@ func (bs *SubChain) Deserialize(data []byte) error {
 		StartHeight:        gen.StartHeight,
 		StopHeight:         gen.StopHeight,
 		ParentHeightOffset: gen.ParentHeightOffset,
-		OwnerPublicKey:     pub,
+		OwnerPublicKey:     gen.OwnerPublicKey,
 		CurrentHeight:      gen.CurrentHeight,
 		DepositCount:       gen.DepositCount,
 	}
@@ -89,7 +83,7 @@ type BlockProof struct {
 	SubChainAddress   string
 	Height            uint64
 	Roots             []MerkleRoot
-	ProducerPublicKey keypair.PublicKey
+	ProducerPublicKey []byte
 	ProducerAddress   string
 }
 
@@ -107,7 +101,7 @@ func (bp BlockProof) Serialize() ([]byte, error) {
 		SubChainAddress:   bp.SubChainAddress,
 		Height:            bp.Height,
 		Roots:             r,
-		ProducerPublicKey: keypair.PublicKeyToBytes(bp.ProducerPublicKey),
+		ProducerPublicKey: bp.ProducerPublicKey,
 		ProducerAddress:   bp.ProducerAddress,
 	}
 	return proto.Marshal(gen)
@@ -117,10 +111,6 @@ func (bp BlockProof) Serialize() ([]byte, error) {
 func (bp *BlockProof) Deserialize(data []byte) error {
 	gen := &mainchainpb.BlockProof{}
 	if err := proto.Unmarshal(data, gen); err != nil {
-		return err
-	}
-	pub, err := keypair.BytesToPublicKey(gen.ProducerPublicKey)
-	if err != nil {
 		return err
 	}
 	r := make([]MerkleRoot, len(gen.Roots))
@@ -134,7 +124,7 @@ func (bp *BlockProof) Deserialize(data []byte) error {
 		SubChainAddress:   gen.SubChainAddress,
 		Height:            gen.Height,
 		Roots:             r,
-		ProducerPublicKey: pub,
+		ProducerPublicKey: gen.ProducerPublicKey,
 		ProducerAddress:   gen.ProducerAddress,
 	}
 	return nil

--- a/action/putblock.go
+++ b/action/putblock.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -116,7 +115,7 @@ func (pb *PutBlock) Roots() map[string]hash.Hash32B { return pb.roots }
 func (pb *PutBlock) ProducerAddress() string { return pb.srcAddr }
 
 // ProducerPublicKey return producer public key.
-func (pb *PutBlock) ProducerPublicKey() keypair.PublicKey { return pb.SrcPubkey() }
+func (pb *PutBlock) ProducerPublicKey() []byte { return pb.SrcPubkey() }
 
 // ByteStream returns the byte representation of put block action.
 func (pb *PutBlock) ByteStream() []byte {

--- a/action/settledeposit.go
+++ b/action/settledeposit.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -64,7 +63,7 @@ func (sd *SettleDeposit) Index() uint64 { return sd.index }
 func (sd *SettleDeposit) Sender() string { return sd.SrcAddr() }
 
 // SenderPublicKey returns the sender public key. It's the wrapper of Action.SrcPubkey
-func (sd *SettleDeposit) SenderPublicKey() keypair.PublicKey { return sd.SrcPubkey() }
+func (sd *SettleDeposit) SenderPublicKey() []byte { return sd.SrcPubkey() }
 
 // Recipient returns the recipient address. It's the wrapper of Action.DstAddr. The recipient should be an address on
 // the sub-chain

--- a/action/startsubchain.go
+++ b/action/startsubchain.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -101,7 +100,7 @@ func (start *StartSubChain) ParentHeightOffset() uint64 { return start.parentHei
 func (start *StartSubChain) OwnerAddress() string { return start.SrcAddr() }
 
 // OwnerPublicKey returns the owner public key, which is the wrapper of SrcPubkey
-func (start *StartSubChain) OwnerPublicKey() keypair.PublicKey { return start.SrcPubkey() }
+func (start *StartSubChain) OwnerPublicKey() []byte { return start.SrcPubkey() }
 
 // ByteStream returns the byte representation of sub-chain action
 func (start *StartSubChain) ByteStream() []byte {

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -73,7 +72,7 @@ func (tsf *Transfer) Payload() []byte { return tsf.payload }
 func (tsf *Transfer) Sender() string { return tsf.SrcAddr() }
 
 // SenderPublicKey returns the sender public key. It's the wrapper of Action.SrcPubkey
-func (tsf *Transfer) SenderPublicKey() keypair.PublicKey { return tsf.SrcPubkey() }
+func (tsf *Transfer) SenderPublicKey() []byte { return tsf.SrcPubkey() }
 
 // Recipient returns the recipient address. It's the wrapper of Action.DstAddr
 func (tsf *Transfer) Recipient() string { return tsf.DstAddr() }

--- a/action/vote.go
+++ b/action/vote.go
@@ -12,7 +12,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/proto"
@@ -51,7 +50,7 @@ func (v *Vote) Voter() string {
 }
 
 // VoterPublicKey returns the voter's public key
-func (v *Vote) VoterPublicKey() keypair.PublicKey {
+func (v *Vote) VoterPublicKey() []byte {
 	return v.SrcPubkey()
 }
 

--- a/blockchain/block/builder.go
+++ b/blockchain/block/builder.go
@@ -7,12 +7,11 @@
 package block
 
 import (
-	"github.com/iotexproject/go-ethereum/crypto"
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/crypto/key"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/version"
 )
 
@@ -100,10 +99,14 @@ func (b *Builder) SetDKG(id, pk, sig []byte) *Builder {
 }
 
 // SignAndBuild signs and then builds a block.
-func (b *Builder) SignAndBuild(signerPubKey keypair.PublicKey, signerPriKey keypair.PrivateKey) (Block, error) {
+func (b *Builder) SignAndBuild(signerPubKey, signerPriKey []byte) (Block, error) {
 	b.blk.Header.pubkey = signerPubKey
 	blkHash := b.blk.HashBlock()
-	sig, err := crypto.Sign(blkHash[:], signerPriKey)
+	sk, err := key.NewPrivateKeyFromBytes(signerPriKey)
+	if err != nil {
+		return Block{}, err
+	}
+	sig, err := sk.Sign(blkHash[:])
 	if err != nil {
 		return Block{}, errors.New("Failed to sign block")
 	}

--- a/blockchain/block/header.go
+++ b/blockchain/block/header.go
@@ -11,27 +11,26 @@ import (
 
 	"github.com/iotexproject/iotex-core/pkg/enc"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // Header defines the struct of block header
 // make sure the variable type and order of this struct is same as "BlockHeaderPb" in blockchain.pb.go
 type Header struct {
-	version          uint32            // version
-	chainID          uint32            // this chain's ID
-	height           uint64            // block height
-	timestamp        int64             // unix timestamp
-	prevBlockHash    hash.Hash32B      // hash of previous block
-	txRoot           hash.Hash32B      // merkle root of all transactions
-	stateRoot        hash.Hash32B      // root of state trie
-	deltaStateDigest hash.Hash32B      // digest of state change by this block
-	receiptRoot      hash.Hash32B      // root of receipt trie
-	blockSig         []byte            // block signature
-	pubkey           keypair.PublicKey // block producer's public key
-	dkgID            []byte            // dkg ID of producer
-	dkgPubkey        []byte            // dkg public key of producer
-	dkgBlockSig      []byte            // dkg signature of producer
+	version          uint32       // version
+	chainID          uint32       // this chain's ID
+	height           uint64       // block height
+	timestamp        int64        // unix timestamp
+	prevBlockHash    hash.Hash32B // hash of previous block
+	txRoot           hash.Hash32B // merkle root of all transactions
+	stateRoot        hash.Hash32B // root of state trie
+	deltaStateDigest hash.Hash32B // digest of state change by this block
+	receiptRoot      hash.Hash32B // root of receipt trie
+	blockSig         []byte       // block signature
+	pubkey           []byte       // block producer's public key
+	dkgID            []byte       // dkg ID of producer
+	dkgPubkey        []byte       // dkg public key of producer
+	dkgBlockSig      []byte       // dkg signature of producer
 }
 
 // Version returns the version of this block.
@@ -59,7 +58,7 @@ func (h Header) StateRoot() hash.Hash32B { return h.stateRoot }
 func (h Header) DeltaStateDigest() hash.Hash32B { return h.deltaStateDigest }
 
 // PublicKey returns the public key of this header.
-func (h Header) PublicKey() keypair.PublicKey { return h.pubkey }
+func (h Header) PublicKey() []byte { return h.pubkey }
 
 // ReceiptRoot returns the receipt root after apply this block
 func (h Header) ReceiptRoot() hash.Hash32B { return h.receiptRoot }

--- a/blockchain/block/runnable.go
+++ b/blockchain/block/runnable.go
@@ -9,14 +9,13 @@ package block
 import (
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
 // RunnableActions is abstructed from block which contains information to execute all actions in a block.
 type RunnableActions struct {
 	blockHeight         uint64
 	blockTimeStamp      int64
-	blockProducerPubKey keypair.PublicKey
+	blockProducerPubKey []byte
 	blockProducerAddr   string
 	txHash              hash.Hash32B
 	actions             []action.SealedEnvelope
@@ -33,7 +32,7 @@ func (ra RunnableActions) BlockTimeStamp() int64 {
 }
 
 // BlockProducerPubKey return BlockProducerPubKey.
-func (ra RunnableActions) BlockProducerPubKey() keypair.PublicKey {
+func (ra RunnableActions) BlockProducerPubKey() []byte {
 	return ra.blockProducerPubKey
 }
 
@@ -78,7 +77,7 @@ func (b *RunnableActionsBuilder) AddActions(acts ...action.SealedEnvelope) *Runn
 }
 
 // Build signs and then builds a block.
-func (b *RunnableActionsBuilder) Build(producerAddr string, producerPubKey keypair.PublicKey) RunnableActions {
+func (b *RunnableActionsBuilder) Build(producerAddr string, producerPubKey []byte) RunnableActions {
 	b.ra.blockProducerAddr = producerAddr
 	b.ra.blockProducerPubKey = producerPubKey
 	b.ra.txHash = calculateTxRoot(b.ra.actions)

--- a/blockchain/genesis.go
+++ b/blockchain/genesis.go
@@ -137,7 +137,7 @@ func NewGenesisActions(chainCfg config.Chain, ws factory.WorkingSet) []action.Se
 		bd := action.EnvelopeBuilder{}
 		elp := bd.SetDestinationAddress(address).
 			SetAction(vote).Build()
-		selp := action.FakeSeal(elp, address, pk)
+		selp := action.FakeSeal(elp, address, keypair.PublicKeyToBytes(pk))
 		acts = append(acts, selp)
 	}
 
@@ -158,7 +158,7 @@ func NewGenesisActions(chainCfg config.Chain, ws factory.WorkingSet) []action.Se
 			bd := action.EnvelopeBuilder{}
 			elp := bd.SetAction(start).Build()
 			pk, _ := decodeKey(Gen.CreatorPubKey, "")
-			selp := action.FakeSeal(elp, creatorAddr, pk)
+			selp := action.FakeSeal(elp, creatorAddr, keypair.PublicKeyToBytes(pk))
 			acts = append(acts, selp)
 		}
 	}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -8,6 +8,7 @@ package consensus
 
 import (
 	"context"
+	"encoding/hex"
 	"math/big"
 
 	"github.com/facebookgo/clock"
@@ -22,7 +23,6 @@ import (
 	"github.com/iotexproject/iotex-core/consensus/scheme"
 	"github.com/iotexproject/iotex-core/consensus/scheme/rolldpos"
 	explorerapi "github.com/iotexproject/iotex-core/explorer/idl/explorer"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/proto"
@@ -146,7 +146,7 @@ func NewConsensus(
 						return nil, errors.Wrapf(err, "error when get converting iotex address to address")
 					}
 					subChainAddr := address.New(rootChainAddr.Payload())
-					pubKey, err := keypair.DecodePublicKey(rawc.PubKey)
+					pubKey, err := hex.DecodeString(rawc.PubKey)
 					if err != nil {
 						log.L().Error("Error when convert candidate PublicKey.", zap.Error(err))
 					}
@@ -235,16 +235,16 @@ func (c *IotxConsensus) Scheme() scheme.Scheme {
 }
 
 // GetAddr returns the iotex address
-func GetAddr(cfg config.Config) (keypair.PublicKey, keypair.PrivateKey, string) {
+func GetAddr(cfg config.Config) ([]byte, []byte, string) {
 	addr, err := cfg.BlockchainAddress()
 	if err != nil {
 		log.L().Panic("Fail to create new consensus.", zap.Error(err))
 	}
-	pk, err := keypair.DecodePublicKey(cfg.Chain.ProducerPubKey)
+	pk, err := hex.DecodeString(cfg.Chain.ProducerPubKey)
 	if err != nil {
 		log.L().Panic("Fail to create new consensus.", zap.Error(err))
 	}
-	sk, err := keypair.DecodePrivateKey(cfg.Chain.ProducerPrivKey)
+	sk, err := hex.DecodeString(cfg.Chain.ProducerPrivKey)
 	if err != nil {
 		log.L().Panic("Fail to create new consensus.", zap.Error(err))
 	}

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -25,7 +25,6 @@ import (
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/endorsement"
 	"github.com/iotexproject/iotex-core/explorer/idl/explorer"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/proto"
 )
@@ -273,8 +272,8 @@ type Builder struct {
 	cfg config.RollDPoS
 	// TODO: we should use keystore in the future
 	encodedAddr            string
-	pubKey                 keypair.PublicKey
-	priKey                 keypair.PrivateKey
+	pubKey                 []byte
+	priKey                 []byte
 	chain                  blockchain.Blockchain
 	actPool                actpool.ActPool
 	broadcastHandler       scheme.Broadcast
@@ -301,13 +300,13 @@ func (b *Builder) SetAddr(encodedAddr string) *Builder {
 }
 
 // SetPubKey sets the public key
-func (b *Builder) SetPubKey(pubKey keypair.PublicKey) *Builder {
+func (b *Builder) SetPubKey(pubKey []byte) *Builder {
 	b.pubKey = pubKey
 	return b
 }
 
 // SetPriKey sets the private key
-func (b *Builder) SetPriKey(priKey keypair.PrivateKey) *Builder {
+func (b *Builder) SetPriKey(priKey []byte) *Builder {
 	b.priKey = priKey
 	return b
 }

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -25,7 +25,6 @@ import (
 	"github.com/iotexproject/iotex-core/consensus/scheme"
 	"github.com/iotexproject/iotex-core/endorsement"
 	"github.com/iotexproject/iotex-core/explorer/idl/explorer"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/proto"
 	"github.com/iotexproject/iotex-core/state"
@@ -48,8 +47,8 @@ type roundCtx struct {
 type rollDPoSCtx struct {
 	cfg              config.RollDPoS
 	encodedAddr      string
-	pubKey           keypair.PublicKey
-	priKey           keypair.PrivateKey
+	pubKey           []byte
+	priKey           []byte
 	chain            blockchain.Blockchain
 	actPool          actpool.ActPool
 	broadcastHandler scheme.Broadcast

--- a/e2etest/util.go
+++ b/e2etest/util.go
@@ -39,7 +39,7 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 		SetGasLimit(100000).
 		SetGasPrice(big.NewInt(10)).Build()
 
-	selp := action.AssembleSealedEnvelope(elp, blockchain.Gen.CreatorAddr(), pubk, sig)
+	selp := action.AssembleSealedEnvelope(elp, blockchain.Gen.CreatorAddr(), keypair.PublicKeyToBytes(pubk), sig)
 
 	actionMap := make(map[string][]action.SealedEnvelope)
 	actionMap[selp.SrcAddr()] = []action.SealedEnvelope{selp}

--- a/explorer/explorer.go
+++ b/explorer/explorer.go
@@ -820,7 +820,7 @@ func (exp *Service) GetLastBlocksByRange(offset int64, limit int64) ([]explorer.
 			Size:       int64(totalSize),
 			GenerateBy: explorer.BlockGenerator{
 				Name:    "",
-				Address: keypair.EncodePublicKey(blk.PublicKey()),
+				Address: hex.EncodeToString(blk.PublicKey()),
 			},
 			TxRoot:           hex.EncodeToString(txRoot[:]),
 			StateRoot:        hex.EncodeToString(stateRoot[:]),
@@ -871,7 +871,7 @@ func (exp *Service) GetBlockByID(blkID string) (explorer.Block, error) {
 		Size:       int64(totalSize),
 		GenerateBy: explorer.BlockGenerator{
 			Name:    "",
-			Address: keypair.EncodePublicKey(blk.PublicKey()),
+			Address: hex.EncodeToString(blk.PublicKey()),
 		},
 		TxRoot:           hex.EncodeToString(txRoot[:]),
 		StateRoot:        hex.EncodeToString(stateRoot[:]),
@@ -1018,7 +1018,7 @@ func (exp *Service) GetCandidateMetricsByHeight(h int64) (explorer.CandidateMetr
 	}
 	candidates := make([]explorer.Candidate, 0, len(allCandidates))
 	for _, c := range allCandidates {
-		pubKey := keypair.EncodePublicKey(c.PublicKey)
+		pubKey := hex.EncodeToString(c.PublicKey)
 		candidates = append(candidates, explorer.Candidate{
 			Address:          c.Address,
 			PubKey:           pubKey,
@@ -1833,7 +1833,7 @@ func convertVoteToExplorerVote(selp action.SealedEnvelope, isPending bool) (expl
 		ID:          hex.EncodeToString(hash[:]),
 		Nonce:       int64(selp.Nonce()),
 		Voter:       vote.Voter(),
-		VoterPubKey: keypair.EncodePublicKey(voterPubkey),
+		VoterPubKey: hex.EncodeToString(voterPubkey),
 		Votee:       vote.Votee(),
 		GasLimit:    int64(selp.GasLimit()),
 		GasPrice:    selp.GasPrice().String(),

--- a/p2p/agent.go
+++ b/p2p/agent.go
@@ -79,7 +79,7 @@ type Agent struct {
 // NewAgent instantiates a local P2P agent instance
 func NewAgent(cfg config.Network, broadcastHandler HandleBroadcastInbound, unicastHandler HandleUnicastInboundAsync) *Agent {
 	return &Agent{
-		cfg:                        cfg,
+		cfg: cfg,
 		broadcastInboundHandler:    broadcastHandler,
 		unicastInboundAsyncHandler: unicastHandler,
 	}

--- a/state/candidate.go
+++ b/state/candidate.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/address"
 	"github.com/iotexproject/iotex-core/pkg/hash"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 	"github.com/iotexproject/iotex-core/proto"
 )
 
@@ -34,7 +33,7 @@ var (
 type Candidate struct {
 	Address          string
 	Votes            *big.Int
-	PublicKey        keypair.PublicKey
+	PublicKey        []byte
 	CreationHeight   uint64
 	LastUpdateHeight uint64
 }
@@ -90,7 +89,7 @@ func candidateToPb(cand *Candidate) (*iproto.Candidate, error) {
 	}
 	candidatePb := &iproto.Candidate{
 		Address:          cand.Address,
-		PubKey:           keypair.PublicKeyToBytes(cand.PublicKey),
+		PubKey:           cand.PublicKey,
 		CreationHeight:   cand.CreationHeight,
 		LastUpdateHeight: cand.LastUpdateHeight,
 	}
@@ -106,14 +105,10 @@ func pbToCandidate(candPb *iproto.Candidate) (*Candidate, error) {
 		return nil, errors.Wrap(ErrCandidatePb, "protobuf's candidate message cannot be nil")
 	}
 
-	pk, err := keypair.BytesToPublicKey(candPb.PubKey)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal public key")
-	}
 	candidate := &Candidate{
 		Address:          candPb.Address,
 		Votes:            big.NewInt(0).SetBytes(candPb.Votes),
-		PublicKey:        pk,
+		PublicKey:        candPb.PubKey,
 		CreationHeight:   candPb.CreationHeight,
 		LastUpdateHeight: candPb.LastUpdateHeight,
 	}

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -11,7 +11,6 @@ import (
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
-	keypair "github.com/iotexproject/iotex-core/pkg/keypair"
 	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
 	big "math/big"
@@ -516,16 +515,16 @@ func (mr *MockBlockchainMockRecorder) StateByAddr(address interface{}) *gomock.C
 }
 
 // MintNewBlock mocks base method
-func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, producerPubKey keypair.PublicKey, producerPriKey keypair.PrivateKey, producerAddr string, timestamp int64) (*block.Block, error) {
-	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, producerPubKey, producerPriKey, producerAddr, timestamp)
+func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, producerPubKey, producerPrvKey []byte, producerAddr string, timestamp int64) (*block.Block, error) {
+	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, producerPubKey, producerPrvKey, producerAddr, timestamp)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MintNewBlock indicates an expected call of MintNewBlock
-func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, producerPubKey, producerPriKey, producerAddr, timestamp interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, producerPubKey, producerPriKey, producerAddr, timestamp)
+func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, producerPubKey, producerPrvKey, producerAddr, timestamp interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, producerPubKey, producerPrvKey, producerAddr, timestamp)
 }
 
 // CommitBlock mocks base method

--- a/test/testaddress/testaddress.go
+++ b/test/testaddress/testaddress.go
@@ -7,10 +7,13 @@
 package testaddress
 
 import (
+	"encoding/hex"
 	"fmt"
 
 	"github.com/iotexproject/iotex-core/address"
+	"github.com/iotexproject/iotex-core/crypto/key"
 	"github.com/iotexproject/iotex-core/pkg/keypair"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 const (
@@ -36,9 +39,19 @@ var Addrinfo map[string]*address.AddrV1
 // Keyinfo contains the private key information
 var Keyinfo map[string]*Key
 
+type testkey struct {
+	PubKey  []byte
+	PrvKey  []byte
+	Address *address.AddrV1
+}
+
+// testkey contains the public/private key information
+var Testkey map[string]*testkey
+
 func init() {
 	Addrinfo = make(map[string]*address.AddrV1)
 	Keyinfo = make(map[string]*Key)
+	Testkey = make(map[string]*testkey)
 
 	priKey, _ := keypair.DecodePrivateKey(prikeyProducer)
 	pubKey := &priKey.PublicKey
@@ -82,4 +95,67 @@ func init() {
 	pubKey = &priKey.PublicKey
 	Addrinfo["galilei"] = address.V1.New(keypair.HashPubKey(pubKey))
 	Keyinfo["galilei"] = &Key{PubKey: pubKey, PriKey: priKey}
+
+	b, _ := hex.DecodeString(prikeyProducer)
+	sk, _ := key.NewPrivateKeyFromBytes(b)
+	pk := sk.PubKey()
+	Testkey["producer"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyA)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["alfa"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyB)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["bravo"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyC)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["charlie"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyD)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["delta"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyE)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["echo"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
+
+	b, _ = hex.DecodeString(prikeyF)
+	sk, _ = key.NewPrivateKeyFromBytes(b)
+	pk = sk.PubKey()
+	Testkey["foxtrot"] = &testkey{
+		PubKey:  pk.PubKeyBytes(),
+		PrvKey:  b,
+		Address: address.V1.New(byteutil.BytesTo20B(pk.PubKeyHash())),
+	}
 }

--- a/testutil/signedaction.go
+++ b/testutil/signedaction.go
@@ -12,11 +12,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/pkg/keypair"
 )
 
 // SignedTransfer return a signed transfer
-func SignedTransfer(senderAddr string, recipientAddr string, senderPriKey keypair.PrivateKey, nonce uint64, amount *big.Int, payload []byte, gasLimit uint64, gasPrice *big.Int) (action.SealedEnvelope, error) {
+func SignedTransfer(senderAddr string, recipientAddr string, senderPriKey []byte, nonce uint64, amount *big.Int, payload []byte, gasLimit uint64, gasPrice *big.Int) (action.SealedEnvelope, error) {
 	transfer, err := action.NewTransfer(nonce, amount, senderAddr, recipientAddr, payload, gasLimit, gasPrice)
 	if err != nil {
 		return action.SealedEnvelope{}, err
@@ -35,7 +34,7 @@ func SignedTransfer(senderAddr string, recipientAddr string, senderPriKey keypai
 }
 
 // SignedVote return a signed vote
-func SignedVote(voterAddr string, voteeAddr string, voterPriKey keypair.PrivateKey, nonce uint64, gasLimit uint64, gasPrice *big.Int) (action.SealedEnvelope, error) {
+func SignedVote(voterAddr string, voteeAddr string, voterPriKey []byte, nonce uint64, gasLimit uint64, gasPrice *big.Int) (action.SealedEnvelope, error) {
 	vote, err := action.NewVote(nonce, voterAddr, voteeAddr, gasLimit, gasPrice)
 	if err != nil {
 		return action.SealedEnvelope{}, err
@@ -54,7 +53,7 @@ func SignedVote(voterAddr string, voteeAddr string, voterPriKey keypair.PrivateK
 }
 
 // SignedExecution return a signed execution
-func SignedExecution(executorAddr string, contractAddr string, executorPriKey keypair.PrivateKey, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) (action.SealedEnvelope, error) {
+func SignedExecution(executorAddr string, contractAddr string, executorPriKey []byte, nonce uint64, amount *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) (action.SealedEnvelope, error) {
 	execution, err := action.NewExecution(executorAddr, contractAddr, nonce, amount, gasLimit, gasPrice, data)
 	if err != nil {
 		return action.SealedEnvelope{}, err


### PR DESCRIPTION
…e dependency

1. added a new interface for public/private key
2. data objects like block/action/header does not need to know the specific type of crypto key (ECDSA, or RSA, etc.), passing the key's serialized bytes makes more sense
3. at the time of signing or verifying, the key is extracted from serialized bytes, and Sign() or Verify() is called