### PR TITLE
Make state recover from empty if the recovery height is lower than the current state height

### DIFF
--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1098,7 +1098,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 	}()
 
 	require.NoError(addTestingTsfBlocks(bc))
-	require.True(5 == bc.TipHeight())
+	require.True(bc.TipHeight() == 5)
 
 	// delete state db and recover to tip
 	testutil.CleanupPath(t, testTriePath)
@@ -1114,7 +1114,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 	height, _ := chain.sf.Height()
 	require.Equal(bc.TipHeight(), height)
 
-	// recover to height 3
+	// recover to height 3 from empty state DB
 	testutil.CleanupPath(t, testTriePath)
 	sf, err = factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.NoError(err)
@@ -1125,7 +1125,13 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.NoError(chain.startExistingBlockchain(3))
 	height, _ = chain.sf.Height()
 	require.Equal(bc.TipHeight(), height)
-	require.True(3 == height)
+	require.True(height == 3)
+
+	// recover to height 2 from an existing state DB with Height 3
+	require.NoError(chain.startExistingBlockchain(2))
+	height, _ = chain.sf.Height()
+	require.Equal(bc.TipHeight(), height)
+	require.True(height == 2)
 }
 
 func addCreatorToFactory(sf factory.Factory) error {

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1098,7 +1098,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 	}()
 
 	require.NoError(addTestingTsfBlocks(bc))
-	require.True(bc.TipHeight() == 5)
+	require.Equal(uint64(5), bc.TipHeight())
 
 	// delete state db and recover to tip
 	testutil.CleanupPath(t, testTriePath)
@@ -1125,13 +1125,13 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.NoError(chain.startExistingBlockchain(3))
 	height, _ = chain.sf.Height()
 	require.Equal(bc.TipHeight(), height)
-	require.True(height == 3)
+	require.Equal(uint64(3), height)
 
 	// recover to height 2 from an existing state DB with Height 3
 	require.NoError(chain.startExistingBlockchain(2))
 	height, _ = chain.sf.Height()
 	require.Equal(bc.TipHeight(), height)
-	require.True(height == 2)
+	require.Equal(uint64(2), height)
 }
 
 func addCreatorToFactory(sf factory.Factory) error {

--- a/server/main.go
+++ b/server/main.go
@@ -25,6 +25,7 @@ import (
 	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/probe"
@@ -50,6 +51,7 @@ func main() {
 	signal.Notify(stop, os.Interrupt)
 	signal.Notify(stop, syscall.SIGTERM)
 	ctx, cancel := context.WithCancel(context.Background())
+	ctxWithValue := context.WithValue(ctx, blockchain.RecoveryHeightKey, uint64(recoveryHeight))
 	stopped := make(chan struct{})
 	livenessCtx, livenessCancel := context.WithCancel(context.Background())
 
@@ -93,7 +95,7 @@ func main() {
 		}
 	}
 
-	itx.StartServer(ctx, svr, probeSvr, cfg)
+	itx.StartServer(ctxWithValue, svr, probeSvr, cfg)
 	close(stopped)
 	<-livenessCtx.Done()
 }


### PR DESCRIPTION
Previously we only support recovering state db to a specific height which is lower than the blockchain height if and only if the existing state db height is lower than the target height. Now the state db can recover to any lower target height by clearing the existing state db and rebuilding it from scratch.