### PR TITLE
Remove per action gas limit cap

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -37,8 +37,6 @@ type RunActionsCtx struct {
 	Caller address.Address
 	// ActionHash is the hash of the action with the sealed envelope
 	ActionHash hash.Hash256
-	// ActionGasLimit is the action gas limit
-	ActionGasLimit uint64
 	// GasPrice is the action gas price
 	GasPrice *big.Int
 	// IntrinsicGas is the action intrinsic gas

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -87,7 +87,7 @@ func NewParams(raCtx protocol.RunActionsCtx, execution *action.Execution, stateD
 		BlockNumber: new(big.Int).SetUint64(raCtx.BlockHeight),
 		Time:        new(big.Int).SetInt64(raCtx.BlockTimeStamp),
 		Difficulty:  new(big.Int).SetUint64(uint64(50)),
-		GasLimit:    raCtx.ActionGasLimit,
+		GasLimit:    execution.GasLimit(),
 		GasPrice:    execution.GasPrice(),
 	}
 

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -131,7 +131,7 @@ func (sct *smartContractTest) prepareBlockchain(
 		blockchain.GenesisOption(genesisCfg),
 	)
 	r.NotNil(bc)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 	sf := bc.GetFactory()
 	r.NotNil(sf)
@@ -225,7 +225,7 @@ func TestProtocol_Handle(t *testing.T) {
 			blockchain.BoltDBDaoOption(),
 			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		sf := bc.GetFactory()
 		require.NotNil(sf)
@@ -426,7 +426,7 @@ func TestProtocol_Handle(t *testing.T) {
 			blockchain.BoltDBDaoOption(),
 			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		sf := bc.GetFactory()
 		require.NotNil(sf)
@@ -604,7 +604,7 @@ func TestProtocol_Handle(t *testing.T) {
 			blockchain.BoltDBDaoOption(),
 			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		require.NoError(bc.Start(ctx))
 		require.NotNil(bc)

--- a/action/protocol/generic_validator.go
+++ b/action/protocol/generic_validator.go
@@ -19,16 +19,14 @@ import (
 
 // GenericValidator is the validator for generic action verification
 type GenericValidator struct {
-	mu             sync.RWMutex
-	cm             ChainManager
-	actionGasLimit uint64
+	mu sync.RWMutex
+	cm ChainManager
 }
 
 // NewGenericValidator constructs a new genericValidator
-func NewGenericValidator(cm ChainManager, actionGasLimit uint64) *GenericValidator {
+func NewGenericValidator(cm ChainManager) *GenericValidator {
 	return &GenericValidator{
-		cm:             cm,
-		actionGasLimit: actionGasLimit,
+		cm: cm,
 	}
 }
 
@@ -37,10 +35,6 @@ func (v *GenericValidator) Validate(ctx context.Context, act action.SealedEnvelo
 	vaCtx, ok := GetValidateActionsCtx(ctx)
 	if !ok {
 		log.S().Panic("Miss validate action context")
-	}
-	// Reject over-gassed action
-	if act.GasLimit() > v.actionGasLimit {
-		return errors.Wrap(action.ErrGasHigherThanLimit, "gas is higher than gas limit")
 	}
 	// Reject action with insufficient gas limit
 	intrinsicGas, err := act.IntrinsicGas()

--- a/action/protocol/multichain/mainchain/protocol_test.go
+++ b/action/protocol/multichain/mainchain/protocol_test.go
@@ -48,7 +48,7 @@ func TestAddSubChainActions(t *testing.T) {
 	require.NoError(t, err)
 	p := NewProtocol(bc)
 	ap.AddActionValidators(p)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	defer require.NoError(t, bc.Stop(ctx))
 
 	startSubChain := action.NewStartSubChain(

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -887,7 +887,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, error) {
 		return nil, errors.New("failed to create blockchain")
 	}
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil), execution.NewProtocol(bc))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 
@@ -899,8 +899,7 @@ func setupActPool(bc blockchain.Blockchain, cfg config.ActPool) (actpool.ActPool
 	if err != nil {
 		return nil, err
 	}
-	genesisConfig := genesis.Default
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	ap.AddActionValidators(vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -709,7 +709,6 @@ func (bc *blockchain) MintNewBlock(
 			BlockTimeStamp: bc.now(),
 			Producer:       producer,
 			GasLimit:       &gasLimitForContext,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
 			Registry:       bc.registry,
 		})
 	root, rc, actions, err := bc.pickAndRunActions(ctx, actionMap, ws)
@@ -843,7 +842,6 @@ func (bc *blockchain) ExecuteContractRead(caller address.Address, ex *action.Exe
 		Producer:       producer,
 		Caller:         caller,
 		GasLimit:       &gasLimit,
-		ActionGasLimit: bc.genesisConfig.ActionGasLimit,
 		GasPrice:       big.NewInt(0),
 		IntrinsicGas:   0,
 	})
@@ -883,14 +881,13 @@ func (bc *blockchain) CreateState(addr string, init *big.Int) (*state.Account, e
 	}
 	ctx := protocol.WithRunActionsCtx(context.Background(),
 		protocol.RunActionsCtx{
-			EpochNumber:    0,
-			Producer:       producer,
-			GasLimit:       &gasLimit,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
-			Caller:         callerAddr,
-			ActionHash:     hash.ZeroHash256,
-			Nonce:          0,
-			Registry:       bc.registry,
+			EpochNumber: 0,
+			Producer:    producer,
+			GasLimit:    &gasLimit,
+			Caller:      callerAddr,
+			ActionHash:  hash.ZeroHash256,
+			Nonce:       0,
+			Registry:    bc.registry,
 		})
 	if _, _, err = ws.RunActions(ctx, 0, nil); err != nil {
 		return nil, errors.Wrap(err, "failed to run the account creation")
@@ -1154,7 +1151,6 @@ func (bc *blockchain) runActions(
 			BlockTimeStamp: int64(acts.BlockTimeStamp()),
 			Producer:       producer,
 			GasLimit:       &gasLimit,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
 			Registry:       bc.registry,
 		})
 
@@ -1343,7 +1339,6 @@ func (bc *blockchain) createGenesisStates(ws factory.WorkingSet) error {
 		BlockHash:      hash.ZeroHash256,
 		BlockTimeStamp: bc.genesisConfig.Timestamp,
 		GasLimit:       nil,
-		ActionGasLimit: bc.genesisConfig.ActionGasLimit,
 		Producer:       nil,
 		Caller:         nil,
 		ActionHash:     hash.ZeroHash256,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -286,7 +286,7 @@ func TestCreateBlockchain(t *testing.T) {
 
 	// create chain
 	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -338,7 +338,7 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 	cfg := config.Default
 	genesisCfg := genesis.Default
 	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(t, bc.Start(ctx))
@@ -379,7 +379,7 @@ func TestBlockchain_MintNewBlock_PopAccount(t *testing.T) {
 	cfg := config.Default
 	genesisCfg := genesis.Default
 	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(t, bc.Start(ctx))
@@ -476,7 +476,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		BoltDBDaoOption(),
 		GenesisOption(genesisConfig),
 	)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	sf.AddActionHandlers(vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -500,7 +500,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	sf.AddActionHandlers(account.NewProtocol())
 
 	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisConfig))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, 0))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
 	defer func() {
@@ -585,7 +585,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Current tip = %d hash = %x\n", h, blkhash)
 
 	// add block with wrong height
-	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, testutil.TestGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err := block.NewTestingBuilder().
@@ -601,7 +601,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 
 	// add block with zero prev hash
-	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, testutil.TestGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err = block.NewTestingBuilder().
@@ -710,7 +710,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 		BoltDBDaoOption(),
 		GenesisOption(genesisConfig),
 	)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	sf.AddActionHandlers(vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -737,7 +737,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	sf.AddActionHandlers(account.NewProtocol())
 
 	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisConfig))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, 0))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
 	defer func() {
@@ -805,7 +805,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.Equal(blkhash, blk.HashBlock())
 	fmt.Printf("Current tip = %d hash = %x\n", h, blkhash)
 	// add block with wrong height
-	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, testutil.TestGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err := block.NewTestingBuilder().
@@ -820,7 +820,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.NotNil(err)
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 	// add block with zero prev hash
-	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, testutil.TestGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err = block.NewTestingBuilder().
@@ -1068,7 +1068,7 @@ func TestActions(t *testing.T) {
 	require.NoError(sf.Commit(ws))
 
 	val := &validator{sf: sf, validatorAddr: ""}
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, 0))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	actionMap := make(map[string][]action.SealedEnvelope)
 	for i := 0; i < 5000; i++ {

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/hash"
@@ -30,15 +29,14 @@ import (
 func TestBlockDAO(t *testing.T) {
 
 	getBlocks := func() []*block.Block {
-		genesisConfig := genesis.Default
 		amount := uint64(50 << 22)
-		tsf1, err := testutil.SignedTransfer(testaddress.Addrinfo["alfa"].String(), testaddress.Keyinfo["alfa"].PriKey, 1, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf1, err := testutil.SignedTransfer(testaddress.Addrinfo["alfa"].String(), testaddress.Keyinfo["alfa"].PriKey, 1, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
-		tsf2, err := testutil.SignedTransfer(testaddress.Addrinfo["bravo"].String(), testaddress.Keyinfo["bravo"].PriKey, 2, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf2, err := testutil.SignedTransfer(testaddress.Addrinfo["bravo"].String(), testaddress.Keyinfo["bravo"].PriKey, 2, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
-		tsf3, err := testutil.SignedTransfer(testaddress.Addrinfo["charlie"].String(), testaddress.Keyinfo["charlie"].PriKey, 3, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf3, err := testutil.SignedTransfer(testaddress.Addrinfo["charlie"].String(), testaddress.Keyinfo["charlie"].PriKey, 3, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
 		// create testing votes

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -99,7 +99,7 @@ func TestWrongNonce(t *testing.T) {
 	require.NoError(addCreatorToFactory(sf))
 
 	val := &validator{sf: sf, validatorAddr: ""}
-	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	val.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	// correct nonce
@@ -249,7 +249,7 @@ func TestWrongAddress(t *testing.T) {
 		require.NoError(t, err)
 	}()
 	val := &validator{sf: bc.GetFactory(), validatorAddr: ""}
-	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	val.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -50,11 +50,10 @@ func init() {
 func initDefaultConfig() {
 	Default = Genesis{
 		Blockchain: Blockchain{
-			Timestamp:      1546329600,
-			BlockGasLimit:  20000000,
-			ActionGasLimit: 5000000,
-			NumSubEpochs:   1,
-			NumDelegates:   21,
+			Timestamp:     1546329600,
+			BlockGasLimit: 20000000,
+			NumSubEpochs:  1,
+			NumDelegates:  21,
 		},
 		Rewarding: Rewarding{
 			InitAdminAddrStr: defaultAdminAddr.String(),
@@ -78,8 +77,6 @@ type (
 		Timestamp int64
 		// BlockGasLimit is the total gas limit could be consumed in a block
 		BlockGasLimit uint64 `yaml:"blockGasLimit"`
-		// ActionGasLimit is the per action gas limit cap
-		ActionGasLimit uint64 `yaml:"actionGasLimit"`
 		// NumSubEpochs is the number of sub epochs in one epoch of block production
 		NumSubEpochs uint64 `yaml:"numSubEpochs"`
 		// NumDelegates is the number of delegates that participate into one epoch of block production

--- a/blockchain/genesis/genesis_test.go
+++ b/blockchain/genesis/genesis_test.go
@@ -19,7 +19,6 @@ func TestDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	// Validate blockchain
 	assert.Equal(t, Default.BlockGasLimit, cfg.BlockGasLimit)
-	assert.Equal(t, Default.ActionGasLimit, cfg.ActionGasLimit)
 	assert.Equal(t, Default.NumSubEpochs, cfg.NumSubEpochs)
 	assert.Equal(t, Default.NumDelegates, cfg.NumDelegates)
 	// Validate rewarding protocol

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -244,7 +244,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 		bc.InMemDaoOption(),
 		bc.GenesisOption(genesisCfg),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
@@ -309,7 +309,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 		bc.InMemDaoOption(),
 		bc.GenesisOption(genesisCfg),
 	)
-	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesisCfg.ActionGasLimit))
+	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1))
 	chain1.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain1.Start(ctx))
 	require.NotNil(chain1)
@@ -328,7 +328,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 		bc.InMemDaoOption(),
 		bc.GenesisOption(genesisCfg),
 	)
-	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesisCfg.ActionGasLimit))
+	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2))
 	chain2.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain2.Start(ctx))
 	require.NotNil(chain2)
@@ -408,7 +408,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 		bc.InMemDaoOption(),
 		bc.GenesisOption(genesisCfg),
 	)
-	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesisCfg.ActionGasLimit))
+	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1))
 	chain1.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain1.Start(ctx))
 	require.NotNil(chain1)
@@ -426,7 +426,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 		bc.InMemDaoOption(),
 		bc.GenesisOption(genesisCfg),
 	)
-	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesisCfg.ActionGasLimit))
+	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2))
 	chain2.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain2.Start(ctx))
 	require.NotNil(chain2)

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -42,7 +42,7 @@ func TestBlockBufferFlush(t *testing.T) {
 		blockchain.InMemDaoOption(),
 		blockchain.GenesisOption(genesisCfg),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -372,7 +372,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				blockchain.PrecreatedStateFactoryOption(sf),
 				blockchain.GenesisOption(genesisCfg),
 			)
-			chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, 0))
+			chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain))
 			chain.Validator().AddActionValidators(account.NewProtocol())
 			chains = append(chains, chain)
 

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -163,7 +163,7 @@ func TestLocalCommit(t *testing.T) {
 		blockchain.GenesisOption(genesisCfg),
 		blockchain.RegistryOption(&registry),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.Blockchain.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	chain.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(chain), rewardingProtocol)
 	require.NoError(chain.Start(ctx))
@@ -546,7 +546,7 @@ func TestVoteLocalCommit(t *testing.T) {
 		blockchain.GenesisOption(genesisCfg),
 		blockchain.RegistryOption(&registry),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.Blockchain.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain))
 	chain.Validator().AddActionValidators(account.NewProtocol(),
 		vote.NewProtocol(chain))
 	require.NotNil(chain)

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -244,10 +244,10 @@ func TestExplorerApi(t *testing.T) {
 	ap, err := actpool.NewActPool(bc, cfg.ActPool)
 	require.Nil(err)
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil), execution.NewProtocol(bc))
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	ap.AddActionValidators(vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -88,11 +88,11 @@ func newServer(cfg config.Config, testing bool) (*Server, error) {
 	// Add action validators
 	cs.ActionPool().
 		AddActionEnvelopeValidators(
-			protocol.NewGenericValidator(cs.Blockchain(), genesisConfig.Blockchain.ActionGasLimit),
+			protocol.NewGenericValidator(cs.Blockchain()),
 		)
 	cs.Blockchain().Validator().
 		AddActionEnvelopeValidators(
-			protocol.NewGenericValidator(cs.Blockchain(), genesisConfig.Blockchain.ActionGasLimit),
+			protocol.NewGenericValidator(cs.Blockchain()),
 		)
 	// Install protocols
 	if err := registerDefaultProtocols(cs, genesisConfig); err != nil {
@@ -187,11 +187,11 @@ func (s *Server) newSubChainService(cfg config.Config, opts ...chainservice.Opti
 	}
 	cs.ActionPool().
 		AddActionEnvelopeValidators(
-			protocol.NewGenericValidator(cs.Blockchain(), genesisConfig.Blockchain.ActionGasLimit),
+			protocol.NewGenericValidator(cs.Blockchain()),
 		)
 	cs.Blockchain().Validator().
 		AddActionEnvelopeValidators(
-			protocol.NewGenericValidator(cs.Blockchain(), genesisConfig.Blockchain.ActionGasLimit),
+			protocol.NewGenericValidator(cs.Blockchain()),
 		)
 	if err := registerDefaultProtocols(cs, genesisConfig); err != nil {
 		return err


### PR DESCRIPTION
Remove per action gas limit cap as we already calculate the actual gas consumption per block, and restrict the total gas consumption by block gas limit. By doing this, there's no need to setup a per action gas limit if we think the block gas limit is affordable. And the gas consumption per action various quite a lot. Some big contract deployment will actually a lot.