### PR TITLE
Disable returning state root from runActions

### DIFF
--- a/action/protocol/account/protocol_test.go
+++ b/action/protocol/account/protocol_test.go
@@ -54,7 +54,7 @@ func TestLoadOrCreateAccountState(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(err)
 	require.NoError(sf.Commit(ws))
 	ss, err := sf.AccountState(addrv1.String())

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -80,7 +80,7 @@ func TestCreateContract(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.Nil(err)
 
 	// reload same contract
@@ -183,7 +183,7 @@ func TestLoadStoreContract(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.Nil(err)
 	require.Nil(sf.Commit(ws))
 	require.Nil(sf.Stop(context.Background()))

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -148,7 +148,7 @@ func (sct *smartContractTest) prepareBlockchain(
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	r.NoError(err)
 	r.NoError(sf.Commit(ws))
 
@@ -243,7 +243,7 @@ func TestProtocol_Handle(t *testing.T) {
 				Producer: testaddress.Addrinfo["producer"],
 				GasLimit: &gasLimit,
 			})
-		_, _, err = ws.RunActions(ctx, 0, nil)
+		_, err = ws.RunActions(ctx, 0, nil)
 		require.NoError(err)
 		require.NoError(sf.Commit(ws))
 
@@ -445,7 +445,7 @@ func TestProtocol_Handle(t *testing.T) {
 				Producer: testaddress.Addrinfo["producer"],
 				GasLimit: &gasLimit,
 			})
-		_, _, err = ws.RunActions(ctx, 0, nil)
+		_, err = ws.RunActions(ctx, 0, nil)
 		require.NoError(err)
 		require.NoError(sf.Commit(ws))
 
@@ -621,7 +621,7 @@ func TestProtocol_Handle(t *testing.T) {
 				Producer: testaddress.Addrinfo["producer"],
 				GasLimit: &gasLimit,
 			})
-		_, _, err = ws.RunActions(ctx, 0, nil)
+		_, err = ws.RunActions(ctx, 0, nil)
 		require.NoError(err)
 		require.NoError(sf.Commit(ws))
 

--- a/action/protocol/multichain/mainchain/createdeposit_test.go
+++ b/action/protocol/multichain/mainchain/createdeposit_test.go
@@ -70,7 +70,7 @@ func TestValidateDeposit(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(t, err)
 	require.NoError(t, sf.Commit(ws))
 

--- a/action/protocol/multichain/mainchain/putblock_test.go
+++ b/action/protocol/multichain/mainchain/putblock_test.go
@@ -58,7 +58,7 @@ func TestHandlePutBlock(t *testing.T) {
 			Caller:   testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(t, err)
 	require.NoError(t, sf.Commit(ws))
 

--- a/action/protocol/multichain/mainchain/startsubchain_test.go
+++ b/action/protocol/multichain/mainchain/startsubchain_test.go
@@ -271,7 +271,7 @@ func TestHandleStartSubChain(t *testing.T) {
 			Caller:   testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(t, err)
 	require.NoError(t, sf.Commit(ws))
 

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -107,7 +107,7 @@ func TestActPool_validateGenericAction(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{prevTsf})
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{prevTsf})
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	ap.Reset()
@@ -432,7 +432,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{tsf1, tsf2, tsf3, vote4})
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{tsf1, tsf2, tsf3, vote4})
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	ap.removeConfirmedActs()
@@ -586,7 +586,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, pickedActs)
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -696,7 +696,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, pickedActs)
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -806,7 +806,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, pickedActs)
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -1055,7 +1055,7 @@ func TestActPool_GetSize(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{tsf1, tsf2, tsf3, vote4})
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{tsf1, tsf2, tsf3, vote4})
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	ap.removeConfirmedActs()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -758,7 +758,7 @@ func addProducerToFactory(sf factory.Factory) error {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	if _, _, err = ws.RunActions(ctx, 0, nil); err != nil {
+	if _, err = ws.RunActions(ctx, 0, nil); err != nil {
 		return err
 	}
 	return sf.Commit(ws)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -1004,7 +1004,7 @@ func TestBlocks(t *testing.T) {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(err)
 	require.NoError(sf.Commit(ws))
 
@@ -1069,7 +1069,7 @@ func TestActions(t *testing.T) {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, nil)
+	_, err = ws.RunActions(ctx, 0, nil)
 	require.NoError(err)
 	require.NoError(sf.Commit(ws))
 
@@ -1110,7 +1110,7 @@ func addCreatorToFactory(sf factory.Factory) error {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	if _, _, err = ws.RunActions(ctx, 0, nil); err != nil {
+	if _, err = ws.RunActions(ctx, 0, nil); err != nil {
 		return err
 	}
 	return sf.Commit(ws)

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -122,7 +122,7 @@ func TestWrongNonce(t *testing.T) {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 1, []action.SealedEnvelope{tsf1})
+	_, err = ws.RunActions(ctx, 1, []action.SealedEnvelope{tsf1})
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -360,7 +360,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 						Producer: testaddress.Addrinfo["producer"],
 						GasLimit: &gasLimit,
 					})
-				_, _, err = ws.RunActions(wsctx, 0, nil)
+				_, err = ws.RunActions(wsctx, 0, nil)
 				require.NoError(t, err)
 				require.NoError(t, sf.Commit(ws))
 			}

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -1230,7 +1230,7 @@ func addCreatorToFactory(sf factory.Factory) error {
 			Producer: ta.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	if _, _, err = ws.RunActions(ctx, 0, nil); err != nil {
+	if _, err = ws.RunActions(ctx, 0, nil); err != nil {
 		return err
 	}
 	return sf.Commit(ws)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -237,12 +237,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	newRoot, _, err := ws.RunActions(ctx, 0, []action.SealedEnvelope{selp1, selp2})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp1, selp2})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	balanceB, err := sf.Balance(b)
 	require.NoError(t, err)
 	require.Equal(t, balanceB, big.NewInt(210))
@@ -267,11 +264,11 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &zeroGasLimit,
 		})
-	_, _, err = ws.RunActions(zctx, 0, []action.SealedEnvelope{selp})
+	_, err = ws.RunActions(zctx, 0, []action.SealedEnvelope{selp})
 	require.NotNil(t, err)
 	_, err = ws.RunAction(ctx, selp)
 	require.NoError(t, err)
-	newRoot = ws.UpdateBlockLevelInfo(0)
+	newRoot := ws.UpdateBlockLevelInfo(0)
 	if checkStateRoot {
 		require.NotEqual(t, hash.ZeroHash256, newRoot)
 	}
@@ -381,12 +378,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 5, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 5, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":210", b + ":70"}))
@@ -403,12 +397,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 6, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 6, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":0", b + ":280"}))
@@ -425,12 +416,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 7, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 7, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":0", b + ":280"}))
@@ -447,12 +435,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 8, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 8, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":0", b + ":300"}))
@@ -469,12 +454,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 9, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 9, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":300", b + ":300"}))
@@ -491,12 +473,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 10, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 10, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":300", b + ":90"}))
@@ -513,12 +492,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 11, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 11, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":510", b + ":90"}))
@@ -535,12 +511,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyD)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 12, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 12, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":510", b + ":90"}))
@@ -557,12 +530,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyD)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 13, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 13, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":510", d + ":100"}))
@@ -579,12 +549,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyD)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 14, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 14, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":510", a + ":100"}))
@@ -601,12 +568,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 15, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 15, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":210", d + ":300"}))
@@ -623,12 +587,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 16, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 16, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":510", a + ":100"}))
@@ -654,12 +615,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp2, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 17, []action.SealedEnvelope{selp1, selp2})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 17, []action.SealedEnvelope{selp1, selp2})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":110", a + ":100"}))
@@ -676,12 +634,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyE)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 18, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 18, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":110", e + ":500"}))
@@ -698,12 +653,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyF)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 19, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 19, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{f + ":300", e + ":500"}))
@@ -754,12 +706,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyF)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 21, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 21, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":310", e + ":500"}))
@@ -777,12 +726,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyB)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 22, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 22, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{c + ":300", e + ":500"}))
@@ -799,12 +745,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyE)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 23, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 23, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, err = sf.Height()
 	require.Equal(t, uint64(23), h)
 	require.NoError(t, err)
@@ -832,12 +775,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp2, err = action.Sign(elp, priKeyD)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 24, []action.SealedEnvelope{selp1, selp2})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 24, []action.SealedEnvelope{selp1, selp2})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, err = sf.Height()
 	require.Equal(t, uint64(24), h)
 	require.NoError(t, err)
@@ -856,13 +796,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyC)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 25, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, hash.ZeroHash256, newRoot)
-	}
-	root := newRoot
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 25, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	require.Equal(t, uint64(25), h)
 	require.NoError(t, err)
@@ -881,12 +817,9 @@ func testCandidates(sf Factory, t *testing.T, checkStateRoot bool) {
 	selp, err = action.Sign(elp, priKeyF)
 	require.NoError(t, err)
 
-	newRoot, _, err = ws.RunActions(ctx, 26, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	if checkStateRoot {
-		require.NotEqual(t, newRoot, root)
-	}
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 26, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	require.Equal(t, uint64(26), h)
 	require.NoError(t, err)
@@ -1107,9 +1040,9 @@ func testUnvote(sf Factory, t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ := sf.Height()
 	cand, _ := sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{}))
@@ -1123,9 +1056,9 @@ func testUnvote(sf Factory, t *testing.T) {
 	selp, err = action.Sign(elp, priKeyA)
 	require.NoError(t, err)
 
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{a + ":100"}))
@@ -1139,9 +1072,9 @@ func testUnvote(sf Factory, t *testing.T) {
 	selp, err = action.Sign(elp, priKeyA)
 	require.NoError(t, err)
 
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
-	require.NoError(t, err)
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{}))
@@ -1173,9 +1106,9 @@ func testUnvote(sf Factory, t *testing.T) {
 	selp3, err := action.Sign(elp, priKeyA)
 	require.NoError(t, err)
 
-	_, _, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp1, selp2, selp3})
-	require.NoError(t, err)
-	require.NoError(t, sf.Commit(ws))
+	_, err = ws.RunActions(ctx, 0, []action.SealedEnvelope{selp1, selp2, selp3})
+	require.Nil(t, err)
+	require.Nil(t, sf.Commit(ws))
 	h, _ = sf.Height()
 	cand, _ = sf.CandidatesByHeight(h)
 	require.True(t, compareStrings(voteForm(h, cand), []string{b + ":200"}))
@@ -1266,7 +1199,7 @@ func TestFactory_RootHashByHeight(t *testing.T) {
 
 	ws, err := sf.NewWorkingSet()
 	require.NoError(t, err)
-	_, _, err = ws.RunActions(context.Background(), 1, nil)
+	_, err = ws.RunActions(context.Background(), 1, nil)
 	require.NoError(t, err)
 	require.NoError(t, sf.Commit(ws))
 
@@ -1321,7 +1254,7 @@ func testRunActions(ws WorkingSet, t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, _, err = ws.RunActions(ctx, 1, []action.SealedEnvelope{selp1, selp2})
+	_, err = ws.RunActions(ctx, 1, []action.SealedEnvelope{selp1, selp2})
 	require.NoError(err)
 	rootHash1 := ws.UpdateBlockLevelInfo(1)
 	require.NoError(ws.Commit())
@@ -1543,7 +1476,7 @@ func benchRunAction(sf Factory, b *testing.B) {
 				Producer: testaddress.Addrinfo["producer"],
 				GasLimit: &gasLimit,
 			})
-		_, _, err = ws.RunActions(zctx, uint64(n), acts)
+		_, err = ws.RunActions(zctx, uint64(n), acts)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -63,19 +63,20 @@ func (stx *stateTX) RunActions(
 	ctx context.Context,
 	blockHeight uint64,
 	elps []action.SealedEnvelope,
-) (hash.Hash256, []*action.Receipt, error) {
+) ([]*action.Receipt, error) {
 	// Handle actions
 	receipts := make([]*action.Receipt, 0)
 	for _, elp := range elps {
 		receipt, err := stx.RunAction(ctx, elp)
 		if err != nil {
-			return hash.ZeroHash256, nil, errors.Wrap(err, "error when run action")
+			return nil, errors.Wrap(err, "error when run action")
 		}
 		if receipt != nil {
 			receipts = append(receipts, receipt)
 		}
 	}
-	return stx.UpdateBlockLevelInfo(blockHeight), receipts, nil
+	stx.UpdateBlockLevelInfo(blockHeight)
+	return receipts, nil
 }
 
 // RunAction runs action in the block and track pending changes in working set

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -52,10 +52,10 @@ type (
 	// WorkingSet defines an interface for working set of states changes
 	WorkingSet interface {
 		// states and actions
-		//RunActions(context.Context, uint64, []action.SealedEnvelope) (hash.Hash32B, map[hash.Hash32B]*action.Receipt, error)
+		//RunActions(context.Context, uint64, []action.SealedEnvelope) (map[hash.Hash32B]*action.Receipt, error)
 		RunAction(context.Context, action.SealedEnvelope) (*action.Receipt, error)
 		UpdateBlockLevelInfo(blockHeight uint64) hash.Hash256
-		RunActions(context.Context, uint64, []action.SealedEnvelope) (hash.Hash256, []*action.Receipt, error)
+		RunActions(context.Context, uint64, []action.SealedEnvelope) ([]*action.Receipt, error)
 		Snapshot() int
 		Revert(int) error
 		Commit() error
@@ -135,19 +135,20 @@ func (ws *workingSet) RunActions(
 	ctx context.Context,
 	blockHeight uint64,
 	elps []action.SealedEnvelope,
-) (hash.Hash256, []*action.Receipt, error) {
+) ([]*action.Receipt, error) {
 	// Handle actions
 	receipts := make([]*action.Receipt, 0)
 	for _, elp := range elps {
 		receipt, err := ws.RunAction(ctx, elp)
 		if err != nil {
-			return hash.ZeroHash256, nil, errors.Wrap(err, "error when run action")
+			return nil, errors.Wrap(err, "error when run action")
 		}
 		if receipt != nil {
 			receipts = append(receipts, receipt)
 		}
 	}
-	return ws.UpdateBlockLevelInfo(blockHeight), receipts, nil
+	ws.UpdateBlockLevelInfo(blockHeight)
+	return receipts, nil
 }
 
 // RunAction runs action in the block and track pending changes in working set


### PR DESCRIPTION
Since we don't need state root anymore, there is no need to return state root after processing actions in block.