### PR TITLE
IOTEX-275 Move network-wide consensus config to genesis config and refactor code

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -123,15 +123,13 @@ func (sct *smartContractTest) prepareBlockchain(
 ) blockchain.Blockchain {
 	cfg := config.Default
 	cfg.Chain.EnableIndex = true
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blockchain.InMemDaoOption(),
 		blockchain.InMemStateFactoryOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	r.NotNil(bc)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 	sf := bc.GetFactory()
 	r.NotNil(sf)
@@ -218,14 +216,12 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Chain.TrieDBPath = testTriePath
 		cfg.Chain.ChainDBPath = testDBPath
 		cfg.Chain.EnableIndex = true
-		genesisCfg := genesis.Default
 		bc := blockchain.NewBlockchain(
 			cfg,
 			blockchain.DefaultStateFactoryOption(),
 			blockchain.BoltDBDaoOption(),
-			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		sf := bc.GetFactory()
 		require.NotNil(sf)
@@ -419,14 +415,12 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Chain.TrieDBPath = testTriePath
 		cfg.Chain.ChainDBPath = testDBPath
 		cfg.Chain.EnableIndex = true
-		genesisCfg := genesis.Default
 		bc := blockchain.NewBlockchain(
 			cfg,
 			blockchain.DefaultStateFactoryOption(),
 			blockchain.BoltDBDaoOption(),
-			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		sf := bc.GetFactory()
 		require.NotNil(sf)
@@ -597,14 +591,12 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Chain.TrieDBPath = testTriePath
 		cfg.Chain.ChainDBPath = testDBPath
 		cfg.Chain.EnableIndex = true
-		genesisCfg := genesis.Default
 		bc := blockchain.NewBlockchain(
 			cfg,
 			blockchain.DefaultStateFactoryOption(),
 			blockchain.BoltDBDaoOption(),
-			blockchain.GenesisOption(genesisCfg),
 		)
-		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc))
 		require.NoError(bc.Start(ctx))
 		require.NotNil(bc)

--- a/action/protocol/multichain/mainchain/protocol_test.go
+++ b/action/protocol/multichain/mainchain/protocol_test.go
@@ -11,6 +11,8 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -18,7 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/unit"
@@ -31,12 +32,10 @@ func TestAddSubChainActions(t *testing.T) {
 
 	ctx := context.Background()
 	cfg := config.Default
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(t, bc.Start(ctx))
 	_, err := bc.CreateState(
@@ -48,7 +47,7 @@ func TestAddSubChainActions(t *testing.T) {
 	require.NoError(t, err)
 	p := NewProtocol(bc)
 	ap.AddActionValidators(p)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	defer require.NoError(t, bc.Stop(ctx))
 
 	startSubChain := action.NewStartSubChain(

--- a/action/protocol/multichain/mainchain/startsubchain_test.go
+++ b/action/protocol/multichain/mainchain/startsubchain_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/address"
 	"github.com/iotexproject/iotex-core/blockchain"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/unit"
@@ -319,13 +318,11 @@ func TestHandleStartSubChain(t *testing.T) {
 
 func TestNoStartSubChainInGenesis(t *testing.T) {
 	cfg := config.Default
-	genesisCfg := genesis.Default
 	ctx := context.Background()
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	p := NewProtocol(bc)
 	bc.GetFactory().AddActionHandlers(p)
@@ -340,14 +337,12 @@ func TestNoStartSubChainInGenesis(t *testing.T) {
 func TestStartSubChainInGenesis(t *testing.T) {
 	cfg := config.Default
 	cfg.Chain.EnableSubChainStartInGenesis = true
-	genesisCfg := genesis.Default
 
 	ctx := context.Background()
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	p := NewProtocol(bc)
 	bc.GetFactory().AddActionHandlers(p)

--- a/action/protocol/multichain/subchain/protocol_test.go
+++ b/action/protocol/multichain/subchain/protocol_test.go
@@ -12,15 +12,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
-
-	"github.com/iotexproject/iotex-core/action/protocol"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/explorer/idl/explorer"
@@ -32,12 +29,10 @@ import (
 func TestValidateDeposit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
-	gensisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(gensisCfg),
 	)
 	require.NoError(t, bc.Start(ctx))
 	exp := mock_explorer.NewMockExplorer(ctrl)
@@ -98,12 +93,10 @@ func TestValidateDeposit(t *testing.T) {
 func TestMutateDeposit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(t, bc.Start(ctx))
 	exp := mock_explorer.NewMockExplorer(ctrl)

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -11,13 +11,14 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account/util"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/state"
@@ -31,7 +32,6 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, factory.F
 	defer ctrl.Finish()
 
 	cfg := config.Default
-	genesisCfg := genesis.Default
 	stateDB, err := factory.NewStateDB(cfg, factory.InMemStateDBOption())
 	require.NoError(t, err)
 	require.NoError(t, stateDB.Start(context.Background()))
@@ -56,7 +56,7 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, factory.F
 			Votes:   unit.ConvertIotxToRau(1000000),
 		},
 	}, nil).AnyTimes()
-	p := NewProtocol(chain, genesisCfg.NumDelegates, genesisCfg.NumSubEpochs)
+	p := NewProtocol(chain, genesis.Default.NumDelegates, genesis.Default.NumSubEpochs)
 
 	// Initialize the protocol
 	ctx := protocol.WithRunActionsCtx(
@@ -64,7 +64,7 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, factory.F
 		protocol.RunActionsCtx{
 			Producer:    testaddress.Addrinfo["producer"],
 			Caller:      testaddress.Addrinfo["alfa"],
-			BlockHeight: genesisCfg.NumDelegates * genesisCfg.NumSubEpochs,
+			BlockHeight: genesis.Default.NumDelegates * genesis.Default.NumSubEpochs,
 		},
 	)
 	ws, err := stateDB.NewWorkingSet()

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -51,13 +51,11 @@ var (
 
 func TestActPool_validateGenericAction(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	bc.GetFactory().AddActionHandlers(account.NewProtocol())
 	require.NoError(bc.Start(context.Background()))
@@ -68,10 +66,10 @@ func TestActPool_validateGenericAction(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	validator := ap.actionEnvelopeValidators[0]
 	// Case I: Over-gassed transfer
-	tsf, err := testutil.SignedTransfer(addr1, priKey1, 1, big.NewInt(1), nil, genesisCfg.Blockchain.ActionGasLimit+1, big.NewInt(0))
+	tsf, err := testutil.SignedTransfer(addr1, priKey1, 1, big.NewInt(1), nil, genesis.Default.ActionGasLimit+1, big.NewInt(0))
 	require.NoError(err)
 
 	ctx := protocol.WithValidateActionsCtx(context.Background(), protocol.ValidateActionsCtx{})
@@ -124,7 +122,6 @@ func TestActPool_validateGenericAction(t *testing.T) {
 
 func TestActPool_AddActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	genesisCfg := genesis.Default
 
 	defer ctrl.Finish()
 	require := require.New(t)
@@ -132,7 +129,6 @@ func TestActPool_AddActs(t *testing.T) {
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -145,7 +141,7 @@ func TestActPool_AddActs(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 	// Test actpool status after adding a sequence of Tsfs/votes: need to check confirmed nonce, pending nonce, and pending balance
@@ -257,7 +253,7 @@ func TestActPool_AddActs(t *testing.T) {
 		action.EmptyAddress,
 		uint64(5),
 		big.NewInt(int64(0)),
-		genesisCfg.Blockchain.ActionGasLimit,
+		genesis.Default.ActionGasLimit,
 		big.NewInt(10),
 		[]byte{},
 	)
@@ -266,7 +262,7 @@ func TestActPool_AddActs(t *testing.T) {
 	bd = &action.EnvelopeBuilder{}
 	elp = bd.SetNonce(5).
 		SetGasPrice(big.NewInt(10)).
-		SetGasLimit(genesisCfg.Blockchain.ActionGasLimit + 1).
+		SetGasLimit(genesis.Default.ActionGasLimit + 1).
 		SetAction(creationExecution).
 		SetDestinationAddress(action.EmptyAddress).Build()
 	selp, err = action.Sign(elp, priKey1)
@@ -302,12 +298,10 @@ func TestActPool_AddActs(t *testing.T) {
 func TestActPool_PickActs(t *testing.T) {
 	createActPool := func(cfg config.ActPool) (*actPool, []action.SealedEnvelope, []action.SealedEnvelope, []action.SealedEnvelope) {
 		require := require.New(t)
-		genesisCfg := genesis.Default
 		bc := blockchain.NewBlockchain(
 			config.Default,
 			blockchain.InMemStateFactoryOption(),
 			blockchain.InMemDaoOption(),
-			blockchain.GenesisOption(genesisCfg),
 		)
 		require.NoError(bc.Start(context.Background()))
 		_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -319,7 +313,7 @@ func TestActPool_PickActs(t *testing.T) {
 		require.NoError(err)
 		ap, ok := Ap.(*actPool)
 		require.True(ok)
-		ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+		ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 		ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 		tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
@@ -390,12 +384,10 @@ func TestActPool_PickActs(t *testing.T) {
 
 func TestActPool_removeConfirmedActs(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(context.Background()))
@@ -407,7 +399,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
@@ -450,12 +442,10 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 
 func TestActPool_Reset(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(context.Background()))
@@ -471,14 +461,14 @@ func TestActPool_Reset(t *testing.T) {
 	require.NoError(err)
 	ap1, ok := Ap1.(*actPool)
 	require.True(ok)
-	ap1.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap1.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap1.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 	Ap2, err := NewActPool(bc, apConfig)
 	require.NoError(err)
 	ap2, ok := Ap2.(*actPool)
 	require.True(ok)
-	ap2.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap2.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap2.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 
@@ -837,12 +827,10 @@ func TestActPool_Reset(t *testing.T) {
 
 func TestActPool_removeInvalidActs(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -853,7 +841,7 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
@@ -886,12 +874,10 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 
 func TestActPool_GetPendingNonce(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -904,7 +890,7 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
@@ -932,12 +918,10 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 
 func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -950,7 +934,7 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
@@ -976,12 +960,10 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 
 func TestActPool_GetActionByHash(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(context.Background()))
 	_, err := bc.CreateState(addr1, big.NewInt(100))
@@ -1030,12 +1012,10 @@ func TestActPool_GetCapacity(t *testing.T) {
 
 func TestActPool_GetSize(t *testing.T) {
 	require := require.New(t)
-	genesisCfg := genesis.Default
 	bc := blockchain.NewBlockchain(
 		config.Default,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(context.Background()))
@@ -1047,7 +1027,7 @@ func TestActPool_GetSize(t *testing.T) {
 	require.NoError(err)
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	require.Zero(ap.GetSize())
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -943,13 +943,11 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, *protocol.Registry, e
 	}
 
 	// create chain
-	genesisConfig := genesis.Default
 	registry := protocol.Registry{}
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blockchain.PrecreatedStateFactoryOption(sf),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisConfig),
 		blockchain.RegistryOption(&registry),
 	)
 	if bc == nil {
@@ -959,13 +957,13 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, *protocol.Registry, e
 	acc := account.NewProtocol()
 	v := vote.NewProtocol(bc)
 	evm := execution.NewProtocol(bc)
-	r := rewarding.NewProtocol(bc, genesisConfig.NumDelegates, genesisConfig.NumSubEpochs)
+	r := rewarding.NewProtocol(bc, genesis.Default.NumDelegates, genesis.Default.NumSubEpochs)
 	registry.Register(account.ProtocolID, acc)
 	registry.Register(vote.ProtocolID, v)
 	registry.Register(execution.ProtocolID, evm)
 	registry.Register(rewarding.ProtocolID, r)
 	sf.AddActionHandlers(acc, v, evm, r)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(acc, v, evm, r)
 
 	return bc, &registry, nil
@@ -976,10 +974,8 @@ func setupActPool(bc blockchain.Blockchain, cfg config.ActPool) (actpool.ActPool
 	if err != nil {
 		return nil, err
 	}
-	genesisConfig := genesis.Default
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
-	ap.AddActionValidators(vote.NewProtocol(bc),
-		execution.NewProtocol(bc))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
+	ap.AddActionValidators(vote.NewProtocol(bc), execution.NewProtocol(bc))
 
 	return ap, nil
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -29,7 +29,6 @@ import (
 	"github.com/iotexproject/iotex-core/actpool/actioniterator"
 	"github.com/iotexproject/iotex-core/address"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/db"
@@ -184,8 +183,7 @@ type blockchain struct {
 	// used by account-based model
 	sf factory.Factory
 
-	genesisConfig genesis.Genesis
-	registry      *protocol.Registry
+	registry *protocol.Registry
 }
 
 // Option sets blockchain construction parameter
@@ -271,14 +269,6 @@ func ClockOption(clk clock.Clock) Option {
 func RegistryOption(registry *protocol.Registry) Option {
 	return func(bc *blockchain, conf config.Config) error {
 		bc.registry = registry
-		return nil
-	}
-}
-
-// GenesisOption sets the blockchain with the genesis configs
-func GenesisOption(genesisConfig genesis.Genesis) Option {
-	return func(bc *blockchain, conf config.Config) error {
-		bc.genesisConfig = genesisConfig
 		return nil
 	}
 }
@@ -711,14 +701,14 @@ func (bc *blockchain) MintNewBlock(
 		return nil, err
 	}
 
-	gasLimitForContext := bc.genesisConfig.BlockGasLimit
+	gasLimitForContext := bc.config.Genesis.BlockGasLimit
 	ctx := protocol.WithRunActionsCtx(context.Background(),
 		protocol.RunActionsCtx{
 			BlockHeight:    newblockHeight,
 			BlockTimeStamp: bc.now(),
 			Producer:       producer,
 			GasLimit:       &gasLimitForContext,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
+			ActionGasLimit: bc.config.Genesis.ActionGasLimit,
 			Registry:       bc.registry,
 		})
 	_, rc, actions, err := bc.pickAndRunActions(ctx, actionMap, ws)
@@ -727,7 +717,7 @@ func (bc *blockchain) MintNewBlock(
 	}
 
 	blockMtc.WithLabelValues("numActions").Set(float64(len(actions)))
-	blockMtc.WithLabelValues("gasConsumed").Set(float64(bc.genesisConfig.BlockGasLimit - gasLimitForContext))
+	blockMtc.WithLabelValues("gasConsumed").Set(float64(bc.config.Genesis.BlockGasLimit - gasLimitForContext))
 
 	ra := block.NewRunnableActionsBuilder().
 		SetHeight(newblockHeight).
@@ -833,14 +823,14 @@ func (bc *blockchain) ExecuteContractRead(caller address.Address, ex *action.Exe
 	if err != nil {
 		return nil, err
 	}
-	gasLimit := bc.genesisConfig.BlockGasLimit
+	gasLimit := bc.config.Genesis.BlockGasLimit
 	ctx := protocol.WithRunActionsCtx(context.Background(), protocol.RunActionsCtx{
 		BlockHeight:    blk.Height(),
 		BlockTimeStamp: blk.Timestamp(),
 		Producer:       producer,
 		Caller:         caller,
 		GasLimit:       &gasLimit,
-		ActionGasLimit: bc.genesisConfig.ActionGasLimit,
+		ActionGasLimit: bc.config.Genesis.ActionGasLimit,
 		GasPrice:       big.NewInt(0),
 		IntrinsicGas:   0,
 	})
@@ -869,7 +859,7 @@ func (bc *blockchain) CreateState(addr string, init *big.Int) (*state.Account, e
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get genesis block")
 	}
-	gasLimit := bc.genesisConfig.BlockGasLimit
+	gasLimit := bc.config.Genesis.BlockGasLimit
 	callerAddr, err := address.FromString(addr)
 	if err != nil {
 		return nil, err
@@ -882,7 +872,7 @@ func (bc *blockchain) CreateState(addr string, init *big.Int) (*state.Account, e
 		protocol.RunActionsCtx{
 			Producer:       producer,
 			GasLimit:       &gasLimit,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
+			ActionGasLimit: bc.config.Genesis.ActionGasLimit,
 			Caller:         callerAddr,
 			ActionHash:     hash.ZeroHash256,
 			Nonce:          0,
@@ -1123,7 +1113,7 @@ func (bc *blockchain) runActions(
 	if bc.sf == nil {
 		return hash.ZeroHash256, nil, errors.New("statefactory cannot be nil")
 	}
-	gasLimit := bc.genesisConfig.BlockGasLimit
+	gasLimit := bc.config.Genesis.BlockGasLimit
 	// update state factory
 	producer, err := address.FromString(acts.BlockProducerAddr())
 	if err != nil {
@@ -1136,7 +1126,7 @@ func (bc *blockchain) runActions(
 			BlockTimeStamp: int64(acts.BlockTimeStamp()),
 			Producer:       producer,
 			GasLimit:       &gasLimit,
-			ActionGasLimit: bc.genesisConfig.ActionGasLimit,
+			ActionGasLimit: bc.config.Genesis.ActionGasLimit,
 			Registry:       bc.registry,
 		})
 
@@ -1195,8 +1185,8 @@ func (bc *blockchain) pickAndRunActions(ctx context.Context, actionMap map[strin
 	executedActions = append(executedActions, grant)
 
 	// Process grant epoch reward action if the block is the last one in an epoch
-	epochNum := rolldpos.GetEpochNum(raCtx.BlockHeight, bc.genesisConfig.NumDelegates, bc.genesisConfig.NumSubEpochs)
-	lastBlkHeight := rolldpos.GetEpochLastBlockHeight(epochNum, bc.genesisConfig.NumDelegates, bc.genesisConfig.NumSubEpochs)
+	epochNum := rolldpos.GetEpochNum(raCtx.BlockHeight, bc.config.Genesis.NumDelegates, bc.config.Genesis.NumSubEpochs)
+	lastBlkHeight := rolldpos.GetEpochLastBlockHeight(epochNum, bc.config.Genesis.NumDelegates, bc.config.Genesis.NumSubEpochs)
 	if raCtx.BlockHeight == lastBlkHeight {
 		grant, err = bc.createGrantRewardAction(action.EpochReward)
 		if err != nil {
@@ -1333,9 +1323,9 @@ func (bc *blockchain) createGenesisStates(ws factory.WorkingSet) error {
 	}
 	ctx := protocol.WithRunActionsCtx(context.Background(), protocol.RunActionsCtx{
 		BlockHeight:    0,
-		BlockTimeStamp: bc.genesisConfig.Timestamp,
+		BlockTimeStamp: bc.config.Genesis.Timestamp,
 		GasLimit:       nil,
-		ActionGasLimit: bc.genesisConfig.ActionGasLimit,
+		ActionGasLimit: bc.config.Genesis.ActionGasLimit,
 		Producer:       nil,
 		Caller:         nil,
 		ActionHash:     hash.ZeroHash256,
@@ -1353,11 +1343,11 @@ func (bc *blockchain) createGenesisStates(ws factory.WorkingSet) error {
 	return rp.Initialize(
 		ctx,
 		ws,
-		bc.genesisConfig.Rewarding.InitAdminAddr(),
-		bc.genesisConfig.InitBalance(),
-		bc.genesisConfig.BlockReward(),
-		bc.genesisConfig.EpochReward(),
-		bc.genesisConfig.NumDelegatesForEpochReward,
+		bc.config.Genesis.Rewarding.InitAdminAddr(),
+		bc.config.Genesis.InitBalance(),
+		bc.config.Genesis.BlockReward(),
+		bc.config.Genesis.EpochReward(),
+		bc.config.Genesis.NumDelegatesForEpochReward,
 	)
 }
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -282,11 +282,9 @@ func TestCreateBlockchain(t *testing.T) {
 	// disable account-based testing
 	cfg.Chain.TrieDBPath = ""
 
-	genesisCfg := genesis.Default
-
 	// create chain
-	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -336,9 +334,8 @@ func TestCreateBlockchain(t *testing.T) {
 func TestBlockchain_MintNewBlock(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.Default
-	genesisCfg := genesis.Default
-	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(t, bc.Start(ctx))
@@ -377,9 +374,8 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 func TestBlockchain_MintNewBlock_PopAccount(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.Default
-	genesisCfg := genesis.Default
-	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.ActionGasLimit))
+	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(t, bc.Start(ctx))
@@ -463,7 +459,6 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.EnableIndex = true
-	genesisConfig := genesis.Default
 
 	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.Nil(err)
@@ -474,9 +469,8 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		cfg,
 		PrecreatedStateFactoryOption(sf),
 		BoltDBDaoOption(),
-		GenesisOption(genesisConfig),
 	)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	sf.AddActionHandlers(vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -499,7 +493,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	require.Nil(err)
 	sf.AddActionHandlers(account.NewProtocol())
 
-	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisConfig))
+	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, 0))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -585,7 +579,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Current tip = %d hash = %x\n", h, blkhash)
 
 	// add block with wrong height
-	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err := block.NewTestingBuilder().
@@ -600,7 +594,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 
 	// add block with zero prev hash
-	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err = block.NewTestingBuilder().
@@ -696,7 +690,6 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	cfg.DB.UseBadgerDB = false // test with boltDB
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
-	genesisConfig := genesis.Default
 
 	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.Nil(err)
@@ -706,9 +699,8 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 		cfg,
 		PrecreatedStateFactoryOption(sf),
 		BoltDBDaoOption(),
-		GenesisOption(genesisConfig),
 	)
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisConfig.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	sf.AddActionHandlers(vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -734,7 +726,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.Nil(err)
 	sf.AddActionHandlers(account.NewProtocol())
 
-	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisConfig))
+	bc = NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, 0))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -803,7 +795,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.Equal(blkhash, blk.HashBlock())
 	fmt.Printf("Current tip = %d hash = %x\n", h, blkhash)
 	// add block with wrong height
-	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err := block.NewTestingBuilder().
@@ -817,7 +809,7 @@ func TestLoadBlockchainfromDBWithoutExplorer(t *testing.T) {
 	require.NotNil(err)
 	fmt.Printf("Cannot validate block %d: %v\n", blk.Height(), err)
 	// add block with zero prev hash
-	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+	selp2, err := testutil.SignedTransfer(ta.Addrinfo["bravo"].String(), ta.Keyinfo["producer"].PriKey, 1, big.NewInt(50), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 	require.NoError(err)
 
 	nblk, err = block.NewTestingBuilder().
@@ -882,10 +874,9 @@ func TestBlockchain_Validator(t *testing.T) {
 	cfg := config.Default
 	// disable account-based testing
 	cfg.Chain.TrieDBPath = ""
-	genesisCfg := genesis.Default
 
 	ctx := context.Background()
-	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption(), GenesisOption(genesisCfg))
+	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption())
 	require.NoError(t, bc.Start(ctx))
 	defer func() {
 		err := bc.Stop(ctx)
@@ -912,12 +903,10 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.NumCandidates = 2
 
-	genesisCfg := genesis.Default
-
 	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
 	require.Nil(err)
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil))
-	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisCfg))
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
@@ -935,10 +924,9 @@ func TestBlockchain_StateByAddr(t *testing.T) {
 	require := require.New(t)
 
 	cfg := config.Default
-	genesisCfg := genesis.Default
 	// disable account-based testing
 	// create chain
-	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption(), GenesisOption(genesisCfg))
+	bc := NewBlockchain(cfg, InMemDaoOption(), InMemStateFactoryOption())
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
 

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -13,13 +13,14 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/hash"
@@ -30,15 +31,14 @@ import (
 func TestBlockDAO(t *testing.T) {
 
 	getBlocks := func() []*block.Block {
-		genesisConfig := genesis.Default
 		amount := uint64(50 << 22)
-		tsf1, err := testutil.SignedTransfer(testaddress.Addrinfo["alfa"].String(), testaddress.Keyinfo["alfa"].PriKey, 1, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf1, err := testutil.SignedTransfer(testaddress.Addrinfo["alfa"].String(), testaddress.Keyinfo["alfa"].PriKey, 1, big.NewInt(int64(amount)), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
-		tsf2, err := testutil.SignedTransfer(testaddress.Addrinfo["bravo"].String(), testaddress.Keyinfo["bravo"].PriKey, 2, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf2, err := testutil.SignedTransfer(testaddress.Addrinfo["bravo"].String(), testaddress.Keyinfo["bravo"].PriKey, 2, big.NewInt(int64(amount)), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
-		tsf3, err := testutil.SignedTransfer(testaddress.Addrinfo["charlie"].String(), testaddress.Keyinfo["charlie"].PriKey, 3, big.NewInt(int64(amount)), nil, genesisConfig.Blockchain.ActionGasLimit, big.NewInt(0))
+		tsf3, err := testutil.SignedTransfer(testaddress.Addrinfo["charlie"].String(), testaddress.Keyinfo["charlie"].PriKey, 3, big.NewInt(int64(amount)), nil, genesis.Default.ActionGasLimit, big.NewInt(0))
 		require.NoError(t, err)
 
 		// create testing votes

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -77,7 +77,6 @@ func TestSignBlock(t *testing.T) {
 
 func TestWrongNonce(t *testing.T) {
 	cfg := config.Default
-	genesisCfg := genesis.Default
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	defer testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
@@ -88,7 +87,7 @@ func TestWrongNonce(t *testing.T) {
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil))
 
 	// Create a blockchain from scratch
-	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption(), GenesisOption(genesisCfg))
+	bc := NewBlockchain(cfg, PrecreatedStateFactoryOption(sf), BoltDBDaoOption())
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
@@ -97,7 +96,7 @@ func TestWrongNonce(t *testing.T) {
 	require.NoError(addCreatorToFactory(sf))
 
 	val := &validator{sf: sf, validatorAddr: ""}
-	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	val.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc))
 
 	// correct nonce
@@ -230,8 +229,7 @@ func TestWrongNonce(t *testing.T) {
 func TestWrongAddress(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.Default
-	genesisCfg := genesis.Default
-	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption(), GenesisOption(genesisCfg))
+	bc := NewBlockchain(cfg, InMemStateFactoryOption(), InMemDaoOption())
 	bc.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(bc))
 	require.NoError(t, bc.Start(ctx))
 	require.NotNil(t, bc)
@@ -240,7 +238,7 @@ func TestWrongAddress(t *testing.T) {
 		require.NoError(t, err)
 	}()
 	val := &validator{sf: bc.GetFactory(), validatorAddr: ""}
-	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	val.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	val.AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -9,6 +9,7 @@ package genesis
 import (
 	"flag"
 	"math/big"
+	"time"
 
 	"github.com/pkg/errors"
 	"go.uber.org/config"
@@ -50,11 +51,13 @@ func init() {
 func initDefaultConfig() {
 	Default = Genesis{
 		Blockchain: Blockchain{
-			Timestamp:      1546329600,
-			BlockGasLimit:  20000000,
-			ActionGasLimit: 5000000,
-			NumSubEpochs:   1,
-			NumDelegates:   21,
+			Timestamp:         1546329600,
+			BlockGasLimit:     20000000,
+			ActionGasLimit:    5000000,
+			BlockInterval:     10 * time.Second,
+			NumSubEpochs:      1,
+			NumDelegates:      21,
+			TimeBasedRotation: false,
 		},
 		Rewarding: Rewarding{
 			InitAdminAddrStr:           defaultAdminAddr.String(),
@@ -68,7 +71,7 @@ func initDefaultConfig() {
 
 type (
 	// Genesis is the root level of genesis config. Genesis config is the network-wide blockchain config. All the nodes
-	// participating into the same network should use the same genesis config.
+	// participating into the same network should use EXACTLY SAME genesis config.
 	Genesis struct {
 		Blockchain `yaml:"blockchain"`
 		Rewarding  `yaml:"rewarding"`
@@ -81,10 +84,14 @@ type (
 		BlockGasLimit uint64 `yaml:"blockGasLimit"`
 		// ActionGasLimit is the per action gas limit cap
 		ActionGasLimit uint64 `yaml:"actionGasLimit"`
+		// BlockInterval is the interval between two blocks
+		BlockInterval time.Duration
 		// NumSubEpochs is the number of sub epochs in one epoch of block production
 		NumSubEpochs uint64 `yaml:"numSubEpochs"`
 		// NumDelegates is the number of delegates that participate into one epoch of block production
 		NumDelegates uint64 `yaml:"numDelegates"`
+		// TimeBasedRotation is the flag to enable rotating delegates' time slots on a block height
+		TimeBasedRotation bool `yaml:"timeBasedRotation"`
 	}
 	// Rewarding contains the configs for rewarding protocol
 	Rewarding struct {

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -85,7 +85,7 @@ type (
 		// ActionGasLimit is the per action gas limit cap
 		ActionGasLimit uint64 `yaml:"actionGasLimit"`
 		// BlockInterval is the interval between two blocks
-		BlockInterval time.Duration
+		BlockInterval time.Duration `yaml:"blockInterval"`
 		// NumSubEpochs is the number of sub epochs in one epoch of block production
 		NumSubEpochs uint64 `yaml:"numSubEpochs"`
 		// NumDelegates is the number of delegates that participate into one epoch of block production

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -233,7 +233,6 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
@@ -242,9 +241,8 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 		cfg,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.GenesisOption(genesisCfg),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesis.Default.ActionGasLimit))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
@@ -298,7 +296,6 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
@@ -307,9 +304,8 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 		cfg,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.GenesisOption(genesisCfg),
 	)
-	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesisCfg.ActionGasLimit))
+	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesis.Default.ActionGasLimit))
 	chain1.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain1.Start(ctx))
 	require.NotNil(chain1)
@@ -326,9 +322,8 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 		cfg,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.GenesisOption(genesisCfg),
 	)
-	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesisCfg.ActionGasLimit))
+	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesis.Default.ActionGasLimit))
 	chain2.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain2.Start(ctx))
 	require.NotNil(chain2)
@@ -397,7 +392,6 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
@@ -406,9 +400,8 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 		cfg,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.GenesisOption(genesisCfg),
 	)
-	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesisCfg.ActionGasLimit))
+	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1, genesis.Default.ActionGasLimit))
 	chain1.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain1.Start(ctx))
 	require.NotNil(chain1)
@@ -424,9 +417,8 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 		cfg,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.GenesisOption(genesisCfg),
 	)
-	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesisCfg.ActionGasLimit))
+	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2, genesis.Default.ActionGasLimit))
 	chain2.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain2.Start(ctx))
 	require.NotNil(chain2)
@@ -494,12 +486,11 @@ func TestBlockSyncerSync(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
 
-	chain := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption(), bc.GenesisOption(genesisCfg))
+	chain := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption())
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
 	ap, err := actpool.NewActPool(chain, cfg.ActPool)
@@ -567,10 +558,9 @@ func TestBlockSyncerChaser(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.NoError(err)
 
-	chain := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption(), bc.GenesisOption(genesisCfg))
+	chain := bc.NewBlockchain(cfg, bc.InMemStateFactoryOption(), bc.InMemDaoOption())
 	require.NoError(chain.Start(ctx))
 	ap, err := actpool.NewActPool(chain, cfg.ActPool)
 	require.NoError(err)

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -31,7 +31,6 @@ func TestBlockBufferFlush(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
@@ -40,9 +39,8 @@ func TestBlockBufferFlush(t *testing.T) {
 		cfg,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesis.Default.ActionGasLimit))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
@@ -137,7 +135,6 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	genesisCfg := genesis.Default
 	require.Nil(err)
 	testutil.CleanupPath(t, cfg.Chain.ChainDBPath)
 	testutil.CleanupPath(t, cfg.Chain.TrieDBPath)
@@ -146,7 +143,6 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 		cfg,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -110,7 +110,7 @@ func New(
 		}
 	}
 	registry := protocol.Registry{}
-	chainOpts = append(chainOpts, blockchain.GenesisOption(ops.genesisConfig), blockchain.RegistryOption(&registry))
+	chainOpts = append(chainOpts, blockchain.RegistryOption(&registry))
 
 	// create Blockchain
 	chain := blockchain.NewBlockchain(cfg, chainOpts...)

--- a/config/config.go
+++ b/config/config.go
@@ -12,13 +12,12 @@ import (
 	"os"
 	"time"
 
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
-
 	"github.com/iotexproject/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	uconfig "go.uber.org/config"
 
 	"github.com/iotexproject/iotex-core/address"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/pkg/hash"
 	"github.com/iotexproject/iotex-core/pkg/keypair"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/iotexproject/go-ethereum/crypto"
 	"github.com/pkg/errors"
@@ -224,18 +223,6 @@ func TestValidateChain(t *testing.T) {
 		t,
 		strings.Contains(err.Error(), "candidate number should be greater than 0"),
 	)
-
-	cfg.NodeType = DelegateType
-	cfg.Consensus.Scheme = RollDPoSScheme
-	cfg.Consensus.RollDPoS.NumDelegates = 5
-	cfg.Chain.NumCandidates = 3
-	err = ValidateChain(cfg)
-	require.Error(t, err)
-	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
-	require.True(
-		t,
-		strings.Contains(err.Error(), "candidate number should be greater than or equal to delegate number"),
-	)
 }
 
 func TestValidateConsensusScheme(t *testing.T) {
@@ -286,35 +273,13 @@ func TestValidateRollDPoS(t *testing.T) {
 	cfg.NodeType = DelegateType
 	cfg.Consensus.Scheme = RollDPoSScheme
 
-	cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 3 * time.Second
-	cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 3 * time.Second
-	cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 3 * time.Second
-	cfg.Consensus.RollDPoS.DelegateInterval = 8 * time.Second
+	cfg.Consensus.RollDPoS.FSM.EventChanSize = 0
 	err := ValidateRollDPoS(cfg)
 	require.NotNil(t, err)
 	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
 	require.True(
 		t,
-		strings.Contains(err.Error(), "roll-DPoS ttl sum is larger than proposer interval"),
-	)
-
-	cfg.Consensus.RollDPoS.FSM.EventChanSize = 0
-	err = ValidateRollDPoS(cfg)
-	require.NotNil(t, err)
-	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
-	require.True(
-		t,
 		strings.Contains(err.Error(), "roll-DPoS event chan size should be greater than 0"),
-	)
-
-	cfg.Consensus.RollDPoS.FSM.EventChanSize = 1
-	cfg.Consensus.RollDPoS.NumDelegates = 0
-	err = ValidateRollDPoS(cfg)
-	require.NotNil(t, err)
-	require.Equal(t, ErrInvalidCfg, errors.Cause(err))
-	require.True(
-		t,
-		strings.Contains(err.Error(), "roll-DPoS event delegate number should be greater than 0"),
 	)
 }
 

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -126,7 +126,7 @@ func NewConsensus(
 			SetAddr(addr).
 			SetPubKey(pk).
 			SetPriKey(sk).
-			SetConfig(cfg.Consensus.RollDPoS).
+			SetConfig(cfg).
 			SetBlockchain(bc).
 			SetActPool(ap).
 			SetClock(clock).

--- a/consensus/scheme/rolldpos/epochctx.go
+++ b/consensus/scheme/rolldpos/epochctx.go
@@ -26,13 +26,13 @@ type epochCtx struct {
 }
 
 func newEpochCtx(
-	numDelegates uint,
-	numSubEpochs uint,
+	numDelegates uint64,
+	numSubEpochs uint64,
 	blockHeight uint64,
 	candidatesByHeight func(uint64) ([]*state.Candidate, error),
 ) (*epochCtx, error) {
-	epochNum := rolldpos.GetEpochNum(blockHeight, uint64(numDelegates), uint64(numSubEpochs))
-	epochHeight := rolldpos.GetEpochHeight(epochNum, uint64(numDelegates), uint64(numSubEpochs))
+	epochNum := rolldpos.GetEpochNum(blockHeight, numDelegates, numSubEpochs)
+	epochHeight := rolldpos.GetEpochHeight(epochNum, numDelegates, numSubEpochs)
 	candidates, err := candidatesByHeight(epochHeight - 1)
 	if err != nil {
 		return nil, errors.Wrapf(

--- a/consensus/scheme/rolldpos/epochctx_test.go
+++ b/consensus/scheme/rolldpos/epochctx_test.go
@@ -19,8 +19,8 @@ import (
 
 func TestNewEpochCtx(t *testing.T) {
 	require := require.New(t)
-	numDelegates := uint(24)
-	numSubEpochs := uint(360)
+	numDelegates := uint64(24)
+	numSubEpochs := uint64(360)
 	candidates := []*state.Candidate{}
 	addrs := []string{}
 	for i := 0; i < 24; i++ {

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -265,7 +265,7 @@ func (r *RollDPoS) CurrentState() fsm.State {
 
 // Builder is the builder for RollDPoS
 type Builder struct {
-	cfg config.RollDPoS
+	cfg config.Config
 	// TODO: we should use keystore in the future
 	encodedAddr            string
 	pubKey                 keypair.PublicKey
@@ -283,8 +283,8 @@ func NewRollDPoSBuilder() *Builder {
 	return &Builder{}
 }
 
-// SetConfig sets RollDPoS config
-func (b *Builder) SetConfig(cfg config.RollDPoS) *Builder {
+// SetConfig sets config
+func (b *Builder) SetConfig(cfg config.Config) *Builder {
 	b.cfg = cfg
 	return b
 }
@@ -360,7 +360,8 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.clock = clock.New()
 	}
 	ctx := rollDPoSCtx{
-		cfg:                    b.cfg,
+		cfg:                    b.cfg.Consensus.RollDPoS,
+		genesisCfg:             b.cfg.Genesis.Blockchain,
 		encodedAddr:            b.encodedAddr,
 		pubKey:                 b.pubKey,
 		priKey:                 b.priKey,
@@ -371,7 +372,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		rootChainAPI:           b.rootChainAPI,
 		candidatesByHeightFunc: b.candidatesByHeightFunc,
 	}
-	cfsm, err := consensusfsm.NewConsensusFSM(b.cfg.FSM, &ctx, b.clock)
+	cfsm, err := consensusfsm.NewConsensusFSM(b.cfg.Consensus.RollDPoS.FSM, &ctx, b.clock)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing the consensus FSM")
 	}

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/protogen/iotexrpc"
 
 	"github.com/facebookgo/clock"
@@ -92,10 +91,12 @@ func TestNewRollDPoS(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	cfg := config.Default
+
 	t.Run("normal", func(t *testing.T) {
 		addr := newTestAddr()
 		r, err := NewRollDPoSBuilder().
-			SetConfig(config.RollDPoS{}).
+			SetConfig(cfg).
 			SetAddr(addr.encodedAddr).
 			SetPubKey(addr.pubKey).
 			SetPriKey(addr.priKey).
@@ -111,7 +112,7 @@ func TestNewRollDPoS(t *testing.T) {
 	t.Run("mock-clock", func(t *testing.T) {
 		addr := newTestAddr()
 		r, err := NewRollDPoSBuilder().
-			SetConfig(config.RollDPoS{}).
+			SetConfig(cfg).
 			SetAddr(addr.encodedAddr).
 			SetPubKey(addr.pubKey).
 			SetPriKey(addr.priKey).
@@ -131,7 +132,7 @@ func TestNewRollDPoS(t *testing.T) {
 	t.Run("root chain API", func(t *testing.T) {
 		addr := newTestAddr()
 		r, err := NewRollDPoSBuilder().
-			SetConfig(config.RollDPoS{}).
+			SetConfig(cfg).
 			SetAddr(addr.encodedAddr).
 			SetPubKey(addr.pubKey).
 			SetPriKey(addr.priKey).
@@ -150,7 +151,7 @@ func TestNewRollDPoS(t *testing.T) {
 	t.Run("missing-dep", func(t *testing.T) {
 		addr := newTestAddr()
 		r, err := NewRollDPoSBuilder().
-			SetConfig(config.RollDPoS{}).
+			SetConfig(cfg).
 			SetAddr(addr.encodedAddr).
 			SetPubKey(addr.pubKey).
 			SetPriKey(addr.priKey).
@@ -201,13 +202,12 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	}, nil).AnyTimes()
 
 	addr := newTestAddr()
+	cfg := config.Default
+	cfg.Genesis.NumDelegates = 4
+	cfg.Genesis.NumSubEpochs = 1
+	cfg.Genesis.BlockInterval = 10 * time.Second
 	r, err := NewRollDPoSBuilder().
-		SetConfig(config.RollDPoS{
-			NumDelegates:     4,
-			NumSubEpochs:     1,
-			FSM:              config.Default.Consensus.RollDPoS.FSM,
-			DelegateInterval: 10 * time.Second,
-		}).
+		SetConfig(cfg).
 		SetAddr(addr.encodedAddr).
 		SetPubKey(addr.pubKey).
 		SetPriKey(addr.priKey).
@@ -221,7 +221,7 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	r.ctx.round = &roundCtx{height: blockHeight + 1}
-	clock.Add(r.ctx.cfg.DelegateInterval)
+	clock.Add(r.ctx.genesisCfg.BlockInterval)
 	require.NoError(t, r.ctx.updateEpoch(blockHeight+1))
 	require.NoError(t, r.ctx.updateRound(blockHeight+1))
 
@@ -237,7 +237,7 @@ func TestRollDPoS_Metrics(t *testing.T) {
 func makeTestRollDPoSCtx(
 	addr *addrKeyPair,
 	ctrl *gomock.Controller,
-	cfg config.RollDPoS,
+	cfg config.Config,
 	mockChain func(*mock_blockchain.MockBlockchain),
 	mockActPool func(*mock_actpool.MockActPool),
 	broadcastCB func(proto.Message) error,
@@ -253,7 +253,8 @@ func makeTestRollDPoSCtx(
 		}
 	}
 	return &rollDPoSCtx{
-		cfg:              cfg,
+		cfg:              cfg.Consensus.RollDPoS,
+		genesisCfg:       cfg.Genesis.Blockchain,
 		encodedAddr:      addr.encodedAddr,
 		pubKey:           addr.pubKey,
 		priKey:           addr.priKey,
@@ -303,17 +304,16 @@ func TestRollDPoSConsensus(t *testing.T) {
 	newConsensusComponents := func(numNodes int) ([]*RollDPoS, []*directOverlay, []blockchain.Blockchain) {
 		cfg := config.Default
 		cfg.Consensus.RollDPoS.Delay = 300 * time.Millisecond
-		cfg.Consensus.RollDPoS.DelegateInterval = time.Second
 		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 400 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.UnmatchedEventTTL = 400 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 10 * time.Millisecond
 		cfg.Consensus.RollDPoS.ToleratedOvertime = 200 * time.Millisecond
-		cfg.Consensus.RollDPoS.NumDelegates = uint(numNodes)
-		cfg.Consensus.RollDPoS.NumSubEpochs = 1
 
-		genesisCfg := genesis.Default
+		cfg.Genesis.BlockInterval = time.Second
+		cfg.Genesis.Blockchain.NumDelegates = uint64(numNodes)
+		cfg.Genesis.Blockchain.NumSubEpochs = 1
 
 		chainAddrs := make([]*addrKeyPair, 0, numNodes)
 		networkAddrs := make([]net.Addr, 0, numNodes)
@@ -368,7 +368,6 @@ func TestRollDPoSConsensus(t *testing.T) {
 				cfg,
 				blockchain.InMemDaoOption(),
 				blockchain.PrecreatedStateFactoryOption(sf),
-				blockchain.GenesisOption(genesisCfg),
 			)
 			chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, 0))
 			chain.Validator().AddActionValidators(account.NewProtocol())
@@ -387,7 +386,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				SetAddr(chainAddrs[i].encodedAddr).
 				SetPubKey(&chainAddrs[i].priKey.PublicKey).
 				SetPriKey(chainAddrs[i].priKey).
-				SetConfig(cfg.Consensus.RollDPoS).
+				SetConfig(cfg).
 				SetBlockchain(chain).
 				SetActPool(actPool).
 				SetBroadcast(p2p.Broadcast).
@@ -503,7 +502,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		for i := 0; i < 21; i++ {
 			go func(idx int) {
 				defer wg.Done()
-				cs[idx].ctx.cfg.TimeBasedRotation = true
+				cs[idx].ctx.genesisCfg.TimeBasedRotation = true
 				err := cs[idx].Start(ctx)
 				require.NoError(t, err)
 			}(i)

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -98,13 +98,21 @@ func TestRollDPoSCtx(t *testing.T) {
 			testAddrs[0].pubKey,
 			make([]action.SealedEnvelope, 0),
 		)
+		cfg := config.Default
+
+		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 4 * time.Second
+		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 2 * time.Second
+		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 2 * time.Second
+		cfg.Consensus.RollDPoS.ToleratedOvertime = 2 * time.Second
+
+		cfg.Genesis.BlockInterval = 10 * time.Second
+		cfg.Genesis.NumDelegates = 4
+		cfg.Genesis.NumSubEpochs = 1
+
 		ctx := makeTestRollDPoSCtx(
 			testAddrs[0],
 			ctrl,
-			config.RollDPoS{
-				NumSubEpochs: 1,
-				NumDelegates: 4,
-			},
+			cfg,
 			func(blockchain *mock_blockchain.MockBlockchain) {
 				blockchain.EXPECT().GetBlockByHeight(blockHeight).Return(blk, nil).Times(4)
 				blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
@@ -119,11 +127,6 @@ func TestRollDPoSCtx(t *testing.T) {
 			clock,
 		)
 		ctx.round = &roundCtx{height: blockHeight + 1}
-		ctx.cfg.DelegateInterval = 10 * time.Second
-		ctx.cfg.FSM.AcceptBlockTTL = 4 * time.Second
-		ctx.cfg.FSM.AcceptProposalEndorsementTTL = 2 * time.Second
-		ctx.cfg.FSM.AcceptLockEndorsementTTL = 2 * time.Second
-		ctx.cfg.ToleratedOvertime = 2 * time.Second
 
 		epoch, err := ctx.epochCtxByHeight(blockHeight + 1)
 		require.NoError(t, err)

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -50,7 +50,6 @@ func TestLocalCommit(t *testing.T) {
 
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	genesisCfg := genesis.Default
 
 	// create server
 	ctx := context.Background()
@@ -158,12 +157,11 @@ func TestLocalCommit(t *testing.T) {
 		cfg,
 		blockchain.DefaultStateFactoryOption(),
 		blockchain.BoltDBDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 		blockchain.RegistryOption(&registry),
 	)
-	rewardingProtocol := rewarding.NewProtocol(chain, genesisCfg.NumDelegates, genesisCfg.NumSubEpochs)
+	rewardingProtocol := rewarding.NewProtocol(chain, genesis.Default.NumDelegates, genesis.Default.NumSubEpochs)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.Blockchain.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesis.Default.ActionGasLimit))
 	chain.Validator().AddActionValidators(account.NewProtocol())
 	chain.GetFactory().AddActionHandlers(account.NewProtocol(), vote.NewProtocol(chain), rewardingProtocol)
 	require.NoError(chain.Start(ctx))
@@ -496,7 +494,6 @@ func TestVoteLocalCommit(t *testing.T) {
 	cfg, err := newTestConfig()
 	cfg.Chain.NumCandidates = 2
 	require.Nil(err)
-	genesisCfg := genesis.Default
 
 	// create node
 	ctx := context.Background()
@@ -541,12 +538,11 @@ func TestVoteLocalCommit(t *testing.T) {
 		cfg,
 		blockchain.DefaultStateFactoryOption(),
 		blockchain.BoltDBDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 		blockchain.RegistryOption(&registry),
 	)
-	rewardingProtocol := rewarding.NewProtocol(chain, genesisCfg.NumDelegates, genesisCfg.NumSubEpochs)
+	rewardingProtocol := rewarding.NewProtocol(chain, genesis.Default.NumDelegates, genesis.Default.NumSubEpochs)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
-	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesisCfg.Blockchain.ActionGasLimit))
+	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain, genesis.Default.ActionGasLimit))
 	chain.Validator().AddActionValidators(account.NewProtocol(),
 		vote.NewProtocol(chain))
 	require.NotNil(chain)

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -222,7 +222,6 @@ func TestExplorerApi(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.EnableIndex = true
-	genesisCfg := genesis.Default
 
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)
@@ -238,16 +237,15 @@ func TestExplorerApi(t *testing.T) {
 		cfg,
 		blockchain.PrecreatedStateFactoryOption(sf),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NotNil(bc)
 	ap, err := actpool.NewActPool(bc, cfg.ActPool)
 	require.Nil(err)
 	sf.AddActionHandlers(account.NewProtocol(), vote.NewProtocol(nil), execution.NewProtocol(bc))
-	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	ap.AddActionValidators(vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
-	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesisCfg.Blockchain.ActionGasLimit))
+	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc, genesis.Default.ActionGasLimit))
 	bc.Validator().AddActionValidators(account.NewProtocol(), vote.NewProtocol(bc),
 		execution.NewProtocol(bc))
 	require.NoError(bc.Start(ctx))
@@ -935,7 +933,6 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.EnableIndex = true
-	genesisCfg := genesis.Default
 
 	testutil.CleanupPath(t, testTriePath)
 	defer testutil.CleanupPath(t, testTriePath)
@@ -951,7 +948,6 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 		cfg,
 		blockchain.PrecreatedStateFactoryOption(sf),
 		blockchain.InMemDaoOption(),
-		blockchain.GenesisOption(genesisCfg),
 	)
 	require.NoError(bc.Start(ctx))
 	defer func() {

--- a/server/main.go
+++ b/server/main.go
@@ -20,6 +20,8 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+
 	_ "net/http/pprof"
 
 	_ "go.uber.org/automaxprocs"
@@ -52,11 +54,18 @@ func main() {
 	stopped := make(chan struct{})
 	livenessCtx, livenessCancel := context.WithCancel(context.Background())
 
+	genesisCfg, err := genesis.New()
+	if err != nil {
+		glog.Fatalln("Failed to new genesis config.", zap.Error(err))
+	}
+
 	cfg, err := config.New()
 	if err != nil {
 		glog.Fatalln("Failed to new config.", zap.Error(err))
 	}
 	initLogger(cfg)
+
+	cfg.Genesis = genesisCfg
 
 	// liveness start
 	probeSvr := probe.New(cfg.System.HTTPProbePort)

--- a/server/main.go
+++ b/server/main.go
@@ -67,6 +67,8 @@ func main() {
 
 	cfg.Genesis = genesisCfg
 
+	log.S().Infof("Config in use: %+v", cfg)
+
 	// liveness start
 	probeSvr := probe.New(cfg.System.HTTPProbePort)
 	if err := probeSvr.Start(ctx); err != nil {

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -175,13 +175,12 @@ func main() {
 				log.S().Errorf("Node %d: Can not get State height", i)
 			}
 			bcHeights[i] = chains[i].TipHeight()
-			cfg := configs[i].Consensus.RollDPoS
-			minTimeout = int(cfg.Delay/time.Second - cfg.DelegateInterval/time.Second)
+			minTimeout = int(configs[i].Consensus.RollDPoS.Delay/time.Second - configs[i].Genesis.BlockInterval/time.Second)
 			netTimeout = 0
 			if timeout > minTimeout {
 				netTimeout = timeout - minTimeout
 			}
-			idealHeight[i] = uint64((time.Duration(netTimeout) * time.Second) / cfg.DelegateInterval)
+			idealHeight[i] = uint64((time.Duration(netTimeout) * time.Second) / configs[i].Genesis.BlockInterval)
 
 			log.S().Infof("Node#%d blockchain height: %d", i, bcHeights[i])
 			log.S().Infof("Node#%d state      height: %d", i, stateHeights[i])
@@ -236,7 +235,6 @@ func newConfig(
 	cfg.Chain.ProducerPrivKey = keypair.EncodePrivateKey(producerPriKey)
 
 	cfg.Consensus.Scheme = config.RollDPoSScheme
-	cfg.Consensus.RollDPoS.DelegateInterval = 10 * time.Second
 	cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 4 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 3 * time.Second
 	cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 3 * time.Second
@@ -244,9 +242,6 @@ func newConfig(
 	cfg.Consensus.RollDPoS.FSM.EventChanSize = 100000
 	cfg.Consensus.RollDPoS.ToleratedOvertime = 2 * time.Second
 	cfg.Consensus.RollDPoS.Delay = 10 * time.Second
-	cfg.Consensus.RollDPoS.NumSubEpochs = 2
-	cfg.Consensus.RollDPoS.NumDelegates = numNodes
-	cfg.Consensus.RollDPoS.TimeBasedRotation = true
 
 	cfg.ActPool.MaxNumActsToPick = 2000
 
@@ -254,6 +249,11 @@ func newConfig(
 
 	cfg.Explorer.Enabled = true
 	cfg.Explorer.Port = explorerPort
+
+	cfg.Genesis.Blockchain.BlockInterval = 10 * time.Second
+	cfg.Genesis.Blockchain.NumSubEpochs = 2
+	cfg.Genesis.Blockchain.NumDelegates = numNodes
+	cfg.Genesis.Blockchain.TimeBasedRotation = true
 
 	return cfg
 }


### PR DESCRIPTION
Append genesis to the config struct internally to make it easy to pass genesis around. It's a breaking change.