### PR TITLE
IOTEX-259 Try to make consensus unit tests less likely fail

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -307,8 +307,8 @@ func TestRollDPoSConsensus(t *testing.T) {
 		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 400 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 200 * time.Millisecond
-		cfg.Consensus.RollDPoS.FSM.UnmatchedEventTTL = 400 * time.Millisecond
-		cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 10 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.UnmatchedEventTTL = time.Second
+		cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 1 * time.Millisecond
 		cfg.Consensus.RollDPoS.ToleratedOvertime = 200 * time.Millisecond
 
 		cfg.Genesis.BlockInterval = time.Second
@@ -434,7 +434,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		}()
 		assert.NoError(t, testutil.WaitUntil(200*time.Millisecond, 10*time.Second, func() (bool, error) {
 			for _, chain := range chains {
-				if blk, err := chain.GetBlockByHeight(1); blk == nil || err != nil {
+				if chain.TipHeight() < 1 {
 					return false, nil
 				}
 			}
@@ -473,7 +473,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		}()
 		assert.NoError(t, testutil.WaitUntil(200*time.Millisecond, 60*time.Second, func() (bool, error) {
 			for _, chain := range chains {
-				if blk, err := chain.GetBlockByHeight(48); blk == nil || err != nil {
+				if chain.TipHeight() < 48 {
 					return false, nil
 				}
 			}
@@ -522,8 +522,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				if i == 1 {
 					continue
 				}
-				blk, err := chain.GetBlockByHeight(4)
-				if blk == nil || err != nil {
+				if chain.TipHeight() < 4 {
 					return false, nil
 				}
 			}

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -39,6 +39,7 @@ type GlobalConfig struct {
 func init() {
 	zapCfg := zap.NewDevelopmentConfig()
 	zapCfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+	zapCfg.Level.SetLevel(zap.InfoLevel)
 	l, err := zapCfg.Build()
 	if err != nil {
 		log.Println("Failed to init zap global logger, no zap log will be shown till zap is properly initialized: ", err)


### PR DESCRIPTION
I know it makes sense to have debug level for unit tests, but our debug level logging are too verbose to be useful, and make the test run further slower.

Also tune some parameters. Hopefully the tests could be less fragile. Let's see.