### PR TITLE
Avoid flooding of calibrate events

### DIFF
--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -262,6 +262,11 @@ func (m *ConsensusFSM) NumPendingEvents() int {
 
 // Calibrate calibrates the state if necessary
 func (m *ConsensusFSM) Calibrate(height uint64) {
+	// If the fsm is already at prepare state, there's no need to calibrate
+	// TODO: revisit if calibrate should be replaced by timeout
+	if m.fsm.CurrentState() == sPrepare {
+		return
+	}
 	m.produce(m.ctx.NewConsensusEvent(eCalibrate, height), 0)
 }
 


### PR DESCRIPTION
First of all, this fix is hacky, and we need to look for a more appropriate strategy of handling block height being updated when running consensus.

Anyway, this PR is trying to prevent calibrate events from flooding, especially when a node are syncing bunch of blocks from peers. When the node is already at prepare stage, there's no sense to calibrate it any more.