### PR TITLE
updated Dockerfile to include ioctl copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p $GOPATH/pkg/linux_amd64/github.com/iotexproject/ && \
     cp $GOPATH/src/github.com/iotexproject/iotex-core/bin/server /usr/local/bin/iotex-server  && \
     cp $GOPATH/src/github.com/iotexproject/iotex-core/bin/actioninjectorv2 /usr/local/bin/iotex-actioninjectorv2 && \
     cp $GOPATH/src/github.com/iotexproject/iotex-core/bin/addrgen /usr/local/bin/iotex-addrgen && \
+    cp $GOPATH/src/github.com/iotexproject/iotex-core/bin/ioctl /usr/local/bin/ioctl && \
     cp ./crypto/lib/libsect283k1_ubuntu.so /usr/lib/ && \
     cp ./crypto/lib/blslib/libtblsmnt_ubuntu.so /usr/lib/ && \
     mkdir -p /etc/iotex/ && \


### PR DESCRIPTION
This is to copy the ioctl into the container image

After running a docker build and executing the new image interactively you can run command as expected
```
root@a673eb07f202:/go/src/github.com/iotexproject/iotex-core# ioctl 
ioctl is a command-line interface for interacting with IoTeX blockchain.

Usage:
  ioctl [command]

Available Commands:
  account     Deal with accounts of IoTeX blockchain
  action      Deal with actions of IoTeX blockchain
  bc          Deal with block chain of IoTeX blockchain
  config      Set or get configuration for ioctl
  help        Help about any command
  version     Print the version number of ioctl
  wallet      Manage accounts

Flags:
  -h, --help   help for ioctl

Use "ioctl [command] --help" for more information about a command.
```