### PR TITLE
Remove producer identity information from mint block method

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -101,9 +101,6 @@ func runExecution(
 	actionMap[ecfg.executor] = []action.SealedEnvelope{selp}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		testaddress.Keyinfo["producer"].PubKey,
-		testaddress.Keyinfo["producer"].PriKey,
-		testaddress.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -279,9 +276,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err := bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -337,9 +331,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -377,9 +368,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -407,9 +395,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["alfa"].PubKey,
-			testaddress.Keyinfo["alfa"].PriKey,
-			testaddress.Addrinfo["alfa"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -488,9 +473,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err := bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -519,9 +501,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -550,9 +529,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -588,9 +564,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["bravo"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -671,9 +644,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err := bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -749,9 +719,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp, selp2}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -782,9 +749,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["alfa"].String()] = []action.SealedEnvelope{selp3}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["alfa"].PubKey,
-			testaddress.Keyinfo["alfa"].PriKey,
-			testaddress.Addrinfo["alfa"].String(),
 			0,
 		)
 		require.NoError(err)
@@ -809,9 +773,6 @@ func TestProtocol_Handle(t *testing.T) {
 		actionMap[testaddress.Addrinfo["producer"].String()] = []action.SealedEnvelope{selp}
 		blk, err = bc.MintNewBlock(
 			actionMap,
-			testaddress.Keyinfo["producer"].PubKey,
-			testaddress.Keyinfo["producer"].PriKey,
-			testaddress.Addrinfo["producer"].String(),
 			0,
 		)
 		require.NoError(err)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/iotexproject/iotex-core/protogen/iotexapi"
 	"github.com/iotexproject/iotex-core/protogen/iotextypes"
 	"github.com/iotexproject/iotex-core/state/factory"
+	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
 	"github.com/iotexproject/iotex-core/test/mock/mock_dispatcher"
 	ta "github.com/iotexproject/iotex-core/test/testaddress"
@@ -320,14 +321,14 @@ var (
 		{
 			protocolID: rewarding.ProtocolID,
 			methodName: "UnclaimedBalance",
-			addr:       ta.Addrinfo["producer"].String(),
+			addr:       identityset.Address(0).String(),
 			returnErr:  false,
 			balance:    unit.ConvertIotxToRau(144), // 4 block * 36 IOTX reward by default = 144 IOTX
 		},
 		{
 			protocolID: rewarding.ProtocolID,
 			methodName: "UnclaimedBalance",
-			addr:       ta.Addrinfo["alfa"].String(),
+			addr:       identityset.Address(1).String(),
 			returnErr:  false,
 			balance:    unit.ConvertIotxToRau(0), // 4 block * 36 IOTX reward by default = 144 IOTX
 		},
@@ -792,9 +793,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr0] = []action.SealedEnvelope{tsf}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	)
 	if err != nil {
@@ -836,9 +834,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr3] = selps
 	if blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -854,9 +849,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	// Empty actions
 	if blk, err = bc.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -897,9 +889,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr1] = []action.SealedEnvelope{vote2, execution2}
 	if blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -945,6 +934,7 @@ func addActsToActPool(ap actpool.ActPool) error {
 }
 
 func setupChain(cfg config.Config) (blockchain.Blockchain, *protocol.Registry, error) {
+	cfg.Chain.ProducerPrivKey = hex.EncodeToString(keypair.PrivateKeyToBytes(identityset.PrivateKey(0)))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	if err != nil {
 		return nil, nil, err

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -66,9 +66,6 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	actionMap[Gen.CreatorAddr()] = []action.SealedEnvelope{selp}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -124,9 +121,6 @@ func addTestingTsfBlocks(bc Blockchain) error {
 
 	blk, err = bc.MintNewBlock(
 		accMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -165,9 +159,6 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	accMap[addr3] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5}
 	blk, err = bc.MintNewBlock(
 		accMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -204,9 +195,6 @@ func addTestingTsfBlocks(bc Blockchain) error {
 	accMap[addr4] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}
 	blk, err = bc.MintNewBlock(
 		accMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 
@@ -261,9 +249,6 @@ func addTestingTsfBlocks(bc Blockchain) error {
 
 	blk, err = bc.MintNewBlock(
 		accMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -381,9 +366,6 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 	actionMap[Gen.CreatorAddr()] = []action.SealedEnvelope{selp}
 	_, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NoError(t, err)
@@ -434,9 +416,6 @@ func TestBlockchain_MintNewBlock_PopAccount(t *testing.T) {
 
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NoError(t, err)
@@ -1075,9 +1054,6 @@ func TestBlocks(t *testing.T) {
 		}
 		blk, _ := bc.MintNewBlock(
 			actionMap,
-			ta.Keyinfo["producer"].PubKey,
-			ta.Keyinfo["producer"].PriKey,
-			ta.Addrinfo["producer"].String(),
 			0,
 		)
 		require.Nil(bc.ValidateBlock(blk))
@@ -1143,9 +1119,6 @@ func TestActions(t *testing.T) {
 	}
 	blk, _ := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(val.Validate(blk, 0, blk.PrevHash()))

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -326,10 +326,7 @@ func TestCoinbaseTransferValidation(t *testing.T) {
 	require.NoError(t, chain.Start(ctx))
 	defer require.NoError(t, chain.Stop(ctx))
 
-	addr := ta.Addrinfo["producer"].String()
-	sk := ta.Keyinfo["producer"].PriKey
-	pk := ta.Keyinfo["producer"].PubKey
-	blk, err := chain.MintNewBlock(nil, pk, sk, addr, 0)
+	blk, err := chain.MintNewBlock(nil, 0)
 	require.NoError(t, err)
 	validator := validator{}
 	require.NoError(t, validator.validateActionsOnly(

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -207,9 +207,6 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	h := chain.TipHeight()
 	blk, err := chain.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk)
@@ -296,9 +293,6 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	// commit top
 	blk1, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk1)
@@ -306,9 +300,6 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	require.Nil(bs1.ProcessBlock(ctx, blk1))
 	blk2, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk2)
@@ -316,9 +307,6 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	require.Nil(bs1.ProcessBlock(ctx, blk2))
 	blk3, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk3)
@@ -405,9 +393,6 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	// commit top
 	blk1, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk1)
@@ -415,9 +400,6 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	require.Nil(bs1.ProcessBlock(ctx, blk1))
 	blk2, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk2)
@@ -425,9 +407,6 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	require.Nil(bs1.ProcessBlock(ctx, blk2))
 	blk3, err := chain1.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk3)
@@ -483,9 +462,6 @@ func TestBlockSyncerSync(t *testing.T) {
 
 	blk, err := chain.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk)
@@ -494,9 +470,6 @@ func TestBlockSyncerSync(t *testing.T) {
 
 	blk, err = chain.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.NotNil(blk)

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -79,9 +79,6 @@ func TestBlockBufferFlush(t *testing.T) {
 
 	blk, err := chain.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -275,9 +272,6 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 
 	blk, err = chain.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)

--- a/config/config.go
+++ b/config/config.go
@@ -75,7 +75,6 @@ var (
 			ChainDBPath:                  "/tmp/chain.db",
 			TrieDBPath:                   "/tmp/trie.db",
 			ID:                           1,
-			Address:                      "",
 			ProducerPrivKey:              keypair.EncodePrivateKey(PrivateKey),
 			GenesisActionsPath:           "",
 			EmptyGenesis:                 false,

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -98,9 +98,7 @@ func NewConsensus(
 	mintBlockCB := func() (*block.Block, error) {
 		actionMap := ap.PendingActionMap()
 		log.L().Debug("Pick actions.", zap.Int("actions", len(actionMap)))
-
-		pk, sk, addr := GetAddr(cfg)
-		blk, err := bc.MintNewBlock(actionMap, pk, sk, addr, clock.Now().Unix())
+		blk, err := bc.MintNewBlock(actionMap, clock.Now().Unix())
 		if err != nil {
 			log.L().Error("Failed to mint a block.", zap.Error(err))
 			return nil, err

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -161,9 +161,6 @@ func (ctx *rollDPoSCtx) MintBlock() (consensusfsm.Endorsement, error) {
 		log.L().Debug("Pick actions from the action pool.", zap.Int("action", len(actionMap)))
 		b, err := ctx.chain.MintNewBlock(
 			actionMap,
-			ctx.pubKey,
-			ctx.priKey,
-			ctx.encodedAddr,
 			ctx.round.timestamp.Unix(),
 		)
 		if err != nil {

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotexproject/iotex-core/test/identityset"
+
 	"github.com/facebookgo/clock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -84,18 +86,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	t.Run("calculate-ctx", func(t *testing.T) {
 		candidates := make([]string, 4)
 		for i := 0; i < len(candidates); i++ {
-			candidates[i] = testAddrs[i].encodedAddr
+			candidates[i] = identityset.Address(i).String()
 		}
 
 		blockHeight := uint64(8)
 		clock := clock.NewMock()
 		var prevHash hash.Hash256
+		sk := identityset.PrivateKey(0)
 		blk := block.NewBlockDeprecated(
 			1,
 			blockHeight,
 			prevHash,
 			testutil.TimestampNowFromClock(clock),
-			testAddrs[0].pubKey,
+			&sk.PublicKey,
 			make([]action.SealedEnvelope, 0),
 		)
 		cfg := config.Default
@@ -109,8 +112,14 @@ func TestRollDPoSCtx(t *testing.T) {
 		cfg.Genesis.NumDelegates = 4
 		cfg.Genesis.NumSubEpochs = 1
 
+		sk0 := identityset.PrivateKey(0)
+		addr0 := addrKeyPair{
+			encodedAddr: identityset.Address(0).String(),
+			pubKey:      &sk0.PublicKey,
+			priKey:      sk0,
+		}
 		ctx := makeTestRollDPoSCtx(
-			testAddrs[0],
+			&addr0,
 			ctrl,
 			cfg,
 			func(blockchain *mock_blockchain.MockBlockchain) {

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -203,9 +203,6 @@ func TestLocalCommit(t *testing.T) {
 	actionMap := svr.ChainService(chainID).ActionPool().PendingActionMap()
 	blk1, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -222,9 +219,6 @@ func TestLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["foxtrot"].String()] = []action.SealedEnvelope{tsf2}
 	blk2, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -251,9 +245,6 @@ func TestLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["bravo"].String()] = []action.SealedEnvelope{tsf3}
 	blk3, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -280,9 +271,6 @@ func TestLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["producer"].String()] = []action.SealedEnvelope{tsf4}
 	blk4, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -640,9 +628,7 @@ func TestVoteLocalCommit(t *testing.T) {
 
 	actionMap := svr.ChainService(chainID).ActionPool().PendingActionMap()
 	blk1, err := chain.MintNewBlock(
-		actionMap, ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
+		actionMap,
 		0,
 	)
 	require.Nil(err)
@@ -670,9 +656,6 @@ func TestVoteLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["charlie"].String()] = []action.SealedEnvelope{vote5}
 	blk2, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -723,9 +706,6 @@ func TestVoteLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["delta"].String()] = []action.SealedEnvelope{vote6}
 	blk3, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)
@@ -778,9 +758,6 @@ func TestVoteLocalCommit(t *testing.T) {
 	actionMap[ta.Addrinfo["bravo"].String()] = []action.SealedEnvelope{selp}
 	blk4, err := chain.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	require.Nil(err)

--- a/e2etest/util.go
+++ b/e2etest/util.go
@@ -47,9 +47,6 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	actionMap[blockchain.Gen.CreatorAddr()] = []action.SealedEnvelope{selp}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -104,9 +101,6 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr0] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}
 	blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -146,9 +140,6 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr3] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5}
 	blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -184,9 +175,6 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr4] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}
 	blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {
@@ -230,9 +218,6 @@ func addTestingTsfBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr5] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, tsf5, tsf6}
 	blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 	if err != nil {

--- a/explorer/explorer_test.go
+++ b/explorer/explorer_test.go
@@ -75,9 +75,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr0] = []action.SealedEnvelope{tsf}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	)
 	if err != nil {
@@ -121,9 +118,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr3] = []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4, vote1, execution1}
 	if blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -138,9 +132,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	// Add block 3
 	if blk, err = bc.MintNewBlock(
 		nil,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -175,9 +166,6 @@ func addTestingBlocks(bc blockchain.Blockchain) error {
 	actionMap[addr1] = []action.SealedEnvelope{vote2, execution2}
 	if blk, err = bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		time.Now().Unix(),
 	); err != nil {
 		return err
@@ -988,9 +976,6 @@ func TestExplorerGetReceiptByExecutionID(t *testing.T) {
 	actionMap[ta.Addrinfo["producer"].String()] = []action.SealedEnvelope{execution}
 	blk, err := bc.MintNewBlock(
 		actionMap,
-		ta.Keyinfo["producer"].PubKey,
-		ta.Keyinfo["producer"].PriKey,
-		ta.Addrinfo["producer"].String(),
 		0,
 	)
 

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -12,7 +12,6 @@ import (
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	hash "github.com/iotexproject/iotex-core/pkg/hash"
-	keypair "github.com/iotexproject/iotex-core/pkg/keypair"
 	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
 	big "math/big"
@@ -529,16 +528,16 @@ func (mr *MockBlockchainMockRecorder) RecoverChainAndState(targetHeight interfac
 }
 
 // MintNewBlock mocks base method
-func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, producerPubKey keypair.PublicKey, producerPriKey keypair.PrivateKey, producerAddr string, timestamp int64) (*block.Block, error) {
-	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, producerPubKey, producerPriKey, producerAddr, timestamp)
+func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, timestamp int64) (*block.Block, error) {
+	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, timestamp)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MintNewBlock indicates an expected call of MintNewBlock
-func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, producerPubKey, producerPriKey, producerAddr, timestamp interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, producerPubKey, producerPriKey, producerAddr, timestamp)
+func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, timestamp interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, timestamp)
 }
 
 // CommitBlock mocks base method


### PR DESCRIPTION
Producer identity is already cached in blockchain struct via config. There's no need to pass it every time we mint a block, which has two risks: always passing secure stuff around; using wrong (or different) key to mint a block.

Test plan: tests + minicluster run