### PR TITLE
IOTEX-294 Improve block sync scheduling

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -85,13 +85,13 @@ func NewBlockSyncer(
 	cs consensus.Consensus,
 	opts ...Option,
 ) (BlockSync, error) {
-	bufSize := cfg.BlockSync.BufferSize
 	buf := &blockBuffer{
-		blocks: make(map[uint64]*block.Block),
-		bc:     chain,
-		ap:     ap,
-		cs:     cs,
-		size:   bufSize,
+		blocks:       make(map[uint64]*block.Block),
+		bc:           chain,
+		ap:           ap,
+		cs:           cs,
+		bufferSize:   cfg.BlockSync.BufferSize,
+		intervalSize: cfg.BlockSync.IntervalSize,
 	}
 	bsCfg := Config{}
 	for _, opt := range opts {

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -67,11 +67,11 @@ func TestBlockBufferFlush(t *testing.T) {
 	}()
 
 	b := blockBuffer{
-		bc:     chain,
-		ap:     ap,
-		cs:     cs,
-		blocks: make(map[uint64]*block.Block),
-		size:   16,
+		bc:         chain,
+		ap:         ap,
+		cs:         cs,
+		blocks:     make(map[uint64]*block.Block),
+		bufferSize: 16,
 	}
 	moved, re := b.Flush(nil)
 	assert.Equal(false, moved)
@@ -171,14 +171,24 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 	}()
 
 	b := blockBuffer{
-		bc:     chain,
-		ap:     ap,
-		cs:     cs,
-		blocks: make(map[uint64]*block.Block),
-		size:   16,
+		bc:           chain,
+		ap:           ap,
+		cs:           cs,
+		blocks:       make(map[uint64]*block.Block),
+		bufferSize:   16,
+		intervalSize: 8,
 	}
 
 	out := b.GetBlocksIntervalsToSync(32)
+	require.Equal(2, len(out))
+	require.Equal(uint64(1), out[0].Start)
+	require.Equal(uint64(8), out[0].End)
+	require.Equal(uint64(9), out[1].Start)
+	require.Equal(uint64(16), out[1].End)
+
+	b.intervalSize = 16
+
+	out = b.GetBlocksIntervalsToSync(32)
 	require.Equal(1, len(out))
 	require.Equal(uint64(1), out[0].Start)
 	require.Equal(uint64(16), out[0].End)

--- a/blocksync/slidingwindow.go
+++ b/blocksync/slidingwindow.go
@@ -25,7 +25,7 @@ const (
 	Closed = Closing + 1
 )
 
-// WindowSize defines the size of window
+// WindowSize defines the bufferSize of window
 var WindowSize uint64 = 8
 
 var (

--- a/blocksync/worker.go
+++ b/blocksync/worker.go
@@ -94,7 +94,7 @@ func (w *syncWorker) Sync() {
 	}
 	intervals := w.buf.GetBlocksIntervalsToSync(w.targetHeight)
 	if intervals != nil {
-		log.L().Info("block sync intervals.",
+		log.L().Debug("block sync intervals.",
 			zap.Any("intervals", intervals),
 			zap.Uint64("targetHeight", w.targetHeight))
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -112,8 +112,9 @@ var (
 			},
 		},
 		BlockSync: BlockSync{
-			Interval:   10 * time.Second,
-			BufferSize: 16,
+			Interval:     10 * time.Second,
+			BufferSize:   50,
+			IntervalSize: 10,
 		},
 		Dispatcher: Dispatcher{
 			EventChanSize: 10000,
@@ -225,8 +226,9 @@ type (
 
 	// BlockSync is the config struct for the BlockSync
 	BlockSync struct {
-		Interval   time.Duration `yaml:"interval"` // update duration
-		BufferSize uint64        `yaml:"bufferSize"`
+		Interval     time.Duration `yaml:"interval"` // update duration
+		BufferSize   uint64        `yaml:"bufferSize"`
+		IntervalSize uint64        `yaml:"intervalSize"`
 	}
 
 	// RollDPoS is the config struct for RollDPoS consensus package


### PR DESCRIPTION
This will not necessarily improve the sync speed, because the bottleneck is at committing block side. However, this will prevent network to become the bottleneck and evenly spread the workload among all peers in the syncing mode.

Tested it with testnet v0.5.0-rc2