### PR TITLE
IOTEX-276 Make polling pending actions get rid of expired actions and refactor actpool code

### DIFF
--- a/action/protocol/multichain/mainchain/protocol_test.go
+++ b/action/protocol/multichain/mainchain/protocol_test.go
@@ -101,5 +101,9 @@ func TestAddSubChainActions(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, ap.Add(sscselp))
 
-	assert.Equal(t, 3, len(ap.PickActs()))
+	l := 0
+	for _, part := range ap.PendingActionMap() {
+		l += len(part)
+	}
+	assert.Equal(t, 3, l)
 }

--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -26,8 +26,6 @@ import (
 type ActPool interface {
 	// Reset resets actpool state
 	Reset()
-	// PickActs returns all currently accepted actions in actpool
-	PickActs() []action.SealedEnvelope
 	// PendingActionMap returns an action map with all accepted actions
 	PendingActionMap() map[string][]action.SealedEnvelope
 	// Add adds an action into the pool after passing validation
@@ -94,54 +92,16 @@ func (ap *actPool) Reset() {
 	ap.mutex.Lock()
 	defer ap.mutex.Unlock()
 
-	// Remove confirmed actions in actpool
-	ap.removeConfirmedActs()
-	for from, queue := range ap.accountActs {
-		// Reset pending balance for each account
-		balance, err := ap.bc.Balance(from)
-		if err != nil {
-			log.L().Error("Error when resetting actpool state.", zap.Error(err))
-			return
-		}
-		queue.SetPendingBalance(balance)
-
-		// Reset pending nonce and remove invalid actions for each account
-		confirmedNonce, err := ap.bc.Nonce(from)
-		if err != nil {
-			log.L().Error("Error when resetting actpool state.", zap.Error(err))
-			return
-		}
-		pendingNonce := confirmedNonce + 1
-		queue.SetPendingNonce(pendingNonce)
-		ap.updateAccount(from)
-	}
-}
-
-// PickActs returns all currently accepted transfers and votes for all accounts
-func (ap *actPool) PickActs() []action.SealedEnvelope {
-	ap.mutex.RLock()
-	defer ap.mutex.RUnlock()
-
-	numActs := uint64(0)
-	actions := make([]action.SealedEnvelope, 0)
-	for _, queue := range ap.accountActs {
-		for _, act := range queue.PendingActs() {
-			actions = append(actions, act)
-			numActs++
-			if ap.cfg.MaxNumActsToPick > 0 && numActs >= ap.cfg.MaxNumActsToPick {
-				log.L().Debug("Reach the max number of actions to pick.",
-					zap.Uint64("limit", ap.cfg.MaxNumActsToPick))
-				return actions
-			}
-		}
-	}
-	return actions
+	ap.reset()
 }
 
 // PendingActionIterator returns an action interator with all accepted actions
 func (ap *actPool) PendingActionMap() map[string][]action.SealedEnvelope {
 	ap.mutex.Lock()
 	defer ap.mutex.Unlock()
+
+	// Remove the actions that are already timeout
+	ap.reset()
 
 	actionMap := make(map[string][]action.SealedEnvelope)
 	for from, queue := range ap.accountActs {
@@ -349,5 +309,29 @@ func (ap *actPool) updateAccount(sender string) {
 	// Delete the queue entry if it becomes empty
 	if queue.Empty() {
 		delete(ap.accountActs, sender)
+	}
+}
+
+func (ap *actPool) reset() {
+	// Remove confirmed actions in actpool
+	ap.removeConfirmedActs()
+	for from, queue := range ap.accountActs {
+		// Reset pending balance for each account
+		balance, err := ap.bc.Balance(from)
+		if err != nil {
+			log.L().Error("Error when resetting actpool state.", zap.Error(err))
+			return
+		}
+		queue.SetPendingBalance(balance)
+
+		// Reset pending nonce and remove invalid actions for each account
+		confirmedNonce, err := ap.bc.Nonce(from)
+		if err != nil {
+			log.L().Error("Error when resetting actpool state.", zap.Error(err))
+			return
+		}
+		pendingNonce := confirmedNonce + 1
+		queue.SetPendingNonce(pendingNonce)
+		ap.updateAccount(from)
 	}
 }

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
@@ -356,25 +357,21 @@ func TestActPool_PickActs(t *testing.T) {
 		return ap, []action.SealedEnvelope{tsf1, tsf2, tsf3, tsf4}, []action.SealedEnvelope{vote7}, []action.SealedEnvelope{}
 	}
 
-	t.Run("no-limit", func(t *testing.T) {
+	t.Run("no-expiry", func(t *testing.T) {
 		apConfig := getActPoolCfg()
 		ap, transfers, votes, executions := createActPool(apConfig)
-		pickedActs := ap.PickActs()
-		require.Equal(t, len(transfers)+len(votes)+len(executions), len(pickedActs))
+		pickedActs := ap.PendingActionMap()
+		require.Equal(t, len(transfers)+len(votes)+len(executions), lenPendingActionMap(pickedActs))
 	})
-	t.Run("enough-limit", func(t *testing.T) {
+
+	t.Run("expiry", func(t *testing.T) {
 		apConfig := getActPoolCfg()
-		apConfig.MaxNumActsToPick = 10
-		ap, transfers, votes, executions := createActPool(apConfig)
-		pickedActs := ap.PickActs()
-		require.Equal(t, len(transfers)+len(votes)+len(executions), len(pickedActs))
-	})
-	t.Run("low-limit", func(t *testing.T) {
-		apConfig := getActPoolCfg()
-		apConfig.MaxNumActsToPick = 3
+		apConfig.ActionExpiry = time.Second
 		ap, _, _, _ := createActPool(apConfig)
-		pickedActs := ap.PickActs()
-		require.Equal(t, 3, len(pickedActs))
+		require.NoError(t, testutil.WaitUntil(100*time.Millisecond, 10*time.Second, func() (bool, error) {
+			pickedActs := ap.PendingActionMap()
+			return lenPendingActionMap(pickedActs) == 0, nil
+		}))
 	})
 }
 
@@ -570,7 +567,7 @@ func TestActPool_Reset(t *testing.T) {
 	ap2PBalance3, _ := ap2.getPendingBalance(addr3)
 	require.Equal(big.NewInt(50).Uint64(), ap2PBalance3.Uint64())
 	// Let ap1 be BP's actpool
-	pickedActs := ap1.PickActs()
+	pickedActs := ap1.PendingActionMap()
 	// ap1 commits update of accounts to trie
 	sf := bc.GetFactory()
 	require.NotNil(sf)
@@ -582,7 +579,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, actionMap2Slice(pickedActs))
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -683,7 +680,7 @@ func TestActPool_Reset(t *testing.T) {
 	ap2PBalance3, _ = ap2.getPendingBalance(addr3)
 	require.Equal(big.NewInt(180).Uint64(), ap2PBalance3.Uint64())
 	// Let ap2 be BP's actpool
-	pickedActs = ap2.PickActs()
+	pickedActs = ap2.PendingActionMap()
 	// ap2 commits update of accounts to trie
 	ws, err = sf.NewWorkingSet()
 	require.NoError(err)
@@ -692,7 +689,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, actionMap2Slice(pickedActs))
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -790,7 +787,7 @@ func TestActPool_Reset(t *testing.T) {
 	ap1PBalance5, _ := ap1.getPendingBalance(addr5)
 	require.Equal(big.NewInt(10).Uint64(), ap1PBalance5.Uint64())
 	// Let ap1 be BP's actpool
-	pickedActs = ap1.PickActs()
+	pickedActs = ap1.PendingActionMap()
 	// ap1 commits update of accounts to trie
 	ws, err = sf.NewWorkingSet()
 	require.NoError(err)
@@ -800,7 +797,7 @@ func TestActPool_Reset(t *testing.T) {
 			Producer: testaddress.Addrinfo["producer"],
 			GasLimit: &gasLimit,
 		})
-	_, err = ws.RunActions(ctx, 0, pickedActs)
+	_, err = ws.RunActions(ctx, 0, actionMap2Slice(pickedActs))
 	require.NoError(err)
 	require.Nil(sf.Commit(ws))
 	//Reset
@@ -1079,4 +1076,20 @@ func getActPoolCfg() config.ActPool {
 		MaxNumActsPerPool: maxNumActsPerPool,
 		MaxNumActsPerAcct: maxNumActsPerAcct,
 	}
+}
+
+func actionMap2Slice(actMap map[string][]action.SealedEnvelope) []action.SealedEnvelope {
+	acts := make([]action.SealedEnvelope, 0)
+	for _, parts := range actMap {
+		acts = append(acts, parts...)
+	}
+	return acts
+}
+
+func lenPendingActionMap(acts map[string][]action.SealedEnvelope) int {
+	l := 0
+	for _, part := range acts {
+		l += len(part)
+	}
+	return l
 }

--- a/config/config.go
+++ b/config/config.go
@@ -93,7 +93,6 @@ var (
 		ActPool: ActPool{
 			MaxNumActsPerPool: 32000,
 			MaxNumActsPerAcct: 2000,
-			MaxNumActsToPick:  0,
 			ActionExpiry:      10 * time.Minute,
 		},
 		Consensus: Consensus{
@@ -300,9 +299,6 @@ type (
 		MaxNumActsPerPool uint64 `yaml:"maxNumActsPerPool"`
 		// MaxNumActsPerAcct indicates maximum number of actions an account queue can hold
 		MaxNumActsPerAcct uint64 `yaml:"maxNumActsPerAcct"`
-		// MaxNumActsToPick indicates maximum number of actions to pick to mint a block. Default is 0, which means no
-		// limit on the number of actions to pick.
-		MaxNumActsToPick uint64 `yaml:"maxNumActsToPick"`
 		// ActionExpiry defines how long an action will be kept in action pool.
 		ActionExpiry time.Duration `yaml:"actionExpiry"`
 	}

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -74,8 +74,8 @@ func TestLocalActPool(t *testing.T) {
 	// Wait until server receives the 1st action
 	require.NoError(testutil.WaitUntil(100*time.Millisecond, 60*time.Second, func() (bool, error) {
 		require.NoError(cli.BroadcastOutbound(p2pCtx, tsf1.Proto()))
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1, nil
 	}))
 
 	vote2, err := testutil.SignedVote(identityset.Address(1).String(), identityset.PrivateKey(1), 2, uint64(100000), big.NewInt(0))
@@ -97,9 +97,9 @@ func TestLocalActPool(t *testing.T) {
 
 	// Wait until server receives all the transfers
 	require.NoError(testutil.WaitUntil(100*time.Millisecond, 60*time.Second, func() (bool, error) {
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
 		// 2 valid transfers and 1 valid vote and 1 valid execution
-		return len(acts) == 4, nil
+		return lenPendingActionMap(acts) == 4, nil
 	}))
 }
 
@@ -149,8 +149,8 @@ func TestPressureActPool(t *testing.T) {
 	// Wait until server receives the 1st action
 	require.NoError(testutil.WaitUntil(100*time.Millisecond, 60*time.Second, func() (bool, error) {
 		require.NoError(cli.BroadcastOutbound(p2pCtx, tsf.Proto()))
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1, nil
 	}))
 
 	for i := 2; i <= 1000; i++ {
@@ -161,8 +161,8 @@ func TestPressureActPool(t *testing.T) {
 
 	// Wait until committed blocks contain all broadcasted actions
 	err = testutil.WaitUntil(100*time.Millisecond, 60*time.Second, func() (bool, error) {
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1000, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1000, nil
 	})
 	require.Nil(err)
 }

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -193,8 +193,8 @@ func TestLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act1); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1, nil
 	})
 	require.Nil(err)
 
@@ -228,8 +228,8 @@ func TestLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act2); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 2, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 2, nil
 	})
 	require.Nil(err)
 
@@ -254,8 +254,8 @@ func TestLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act3); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 3, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 3, nil
 	})
 	require.Nil(err)
 
@@ -280,8 +280,8 @@ func TestLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act4); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 4, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 4, nil
 	})
 	require.Nil(err)
 	// wait 4 blocks being picked and committed
@@ -619,8 +619,8 @@ func TestVoteLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, acttsf4); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 7, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 7, nil
 	})
 	require.Nil(err)
 
@@ -669,8 +669,8 @@ func TestVoteLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act5); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 2, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 2, nil
 	})
 	require.Nil(err)
 
@@ -715,8 +715,8 @@ func TestVoteLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act6); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1, nil
 	})
 	require.Nil(err)
 
@@ -767,8 +767,8 @@ func TestVoteLocalCommit(t *testing.T) {
 		if err := p.BroadcastOutbound(p2pCtx, act7); err != nil {
 			return false, err
 		}
-		acts := svr.ChainService(chainID).ActionPool().PickActs()
-		return len(acts) == 1, nil
+		acts := svr.ChainService(chainID).ActionPool().PendingActionMap()
+		return lenPendingActionMap(acts) == 1, nil
 	})
 	require.Nil(err)
 

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -383,8 +383,7 @@ func TestLocalTransfer(t *testing.T) {
 			//This checking procedue is simplied for this test case, because of the complexity of
 			//handling pending transfers.
 			time.Sleep(cfg.Genesis.BlockInterval + time.Second)
-			acts := ap.PickActs()
-			require.Equal(len(acts), 0, tsfTest.message)
+			require.Equal(0, lenPendingActionMap(ap.PendingActionMap()), tsfTest.message)
 
 		default:
 			require.True(false, tsfTest.message)
@@ -496,4 +495,12 @@ func newTransferConfig(
 	cfg.Genesis.BlockInterval = 1 * time.Second
 
 	return cfg, nil
+}
+
+func lenPendingActionMap(acts map[string][]action.SealedEnvelope) int {
+	l := 0
+	for _, part := range acts {
+		l += len(part)
+	}
+	return l
 }

--- a/test/mock/mock_actpool/mock_actpool.go
+++ b/test/mock/mock_actpool/mock_actpool.go
@@ -45,18 +45,6 @@ func (mr *MockActPoolMockRecorder) Reset() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockActPool)(nil).Reset))
 }
 
-// PickActs mocks base method
-func (m *MockActPool) PickActs() []action.SealedEnvelope {
-	ret := m.ctrl.Call(m, "PickActs")
-	ret0, _ := ret[0].([]action.SealedEnvelope)
-	return ret0
-}
-
-// PickActs indicates an expected call of PickActs
-func (mr *MockActPoolMockRecorder) PickActs() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PickActs", reflect.TypeOf((*MockActPool)(nil).PickActs))
-}
-
 // PendingActionMap mocks base method
 func (m *MockActPool) PendingActionMap() map[string][]action.SealedEnvelope {
 	ret := m.ctrl.Call(m, "PendingActionMap")

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -244,8 +244,6 @@ func newConfig(
 	cfg.Consensus.RollDPoS.ToleratedOvertime = 2 * time.Second
 	cfg.Consensus.RollDPoS.Delay = 10 * time.Second
 
-	cfg.ActPool.MaxNumActsToPick = 2000
-
 	cfg.System.HTTPMetricsPort = 0
 
 	cfg.API.Enabled = true


### PR DESCRIPTION
Two things:

1. Make polling pending actions get rid of expired actions, so that if there's a bad action, it will eventually be removed and the block production will not be blocked forever.

2. Cleanup unused action pool API and config