### PR TITLE
iotex-election fix pagination bug, and fix candidates bug

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -291,7 +291,7 @@
   revision = "c26edc20f3d7c9ed16b6d996d162548cda979673"
 
 [[projects]]
-  digest = "1:5238206d7c2d37d30d7f3998967c67fb38d05cf5074432ec150d8140401b878c"
+  digest = "1:1315ec61d3972f2bbb8c3c0fe8bfbeea752c4b28c9a24af25effcd3452c7668c"
   name = "github.com/iotexproject/iotex-election"
   packages = [
     "carrier",
@@ -304,7 +304,7 @@
     "util",
   ]
   pruneopts = "UT"
-  revision = "dd4ecf3f1ea87b252258e4999432b90c4bda9095"
+  revision = "6d2ec35239e826d02fc0fb0bf3ba721364cb158f"
 
 [[projects]]
   digest = "1:9999472bf9c934426d967c507d61f2de84affb8318b8d8c8bc38b3486edbd826"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@
 
 [[constraint]]
   name = "github.com/iotexproject/iotex-election"
-  revision = "dd4ecf3f1ea87b252258e4999432b90c4bda9095"
+  revision = "6d2ec35239e826d02fc0fb0bf3ba721364cb158f"
 
 [prune]
   go-tests = true

--- a/consensus/scheme/rolldpos/epochctx.go
+++ b/consensus/scheme/rolldpos/epochctx.go
@@ -33,12 +33,12 @@ func newEpochCtx(
 	epochNum := rp.GetEpochNum(blockHeight)
 	epochHeight := rp.GetEpochHeight(epochNum)
 	numDelegates := rp.NumDelegates()
-	candidates, err := candidatesByHeight(epochHeight - 1)
+	candidates, err := candidatesByHeight(epochHeight)
 	if err != nil {
 		return nil, errors.Wrapf(
 			err,
 			"failed to get candidates on height %d",
-			epochHeight-1,
+			epochHeight,
 		)
 	}
 	if len(candidates) < int(numDelegates) {

--- a/vendor/github.com/iotexproject/iotex-election/carrier/carrier.go
+++ b/vendor/github.com/iotexproject/iotex-election/carrier/carrier.go
@@ -168,6 +168,13 @@ func (evc *ethereumCarrier) Votes(
 	if err != nil {
 		return nil, nil, evc.redial(err)
 	}
+	bucket, err := caller.Buckets(
+		&bind.CallOpts{BlockNumber: new(big.Int).SetUint64(height)},
+		previousIndex,
+	)
+	if err != nil || bucket.Next.Cmp(big.NewInt(0)) <= 0 {
+		return previousIndex, nil, err
+	}
 	buckets, err := caller.GetActiveBuckets(
 		&bind.CallOpts{BlockNumber: new(big.Int).SetUint64(height)},
 		previousIndex,


### PR DESCRIPTION
1. iotex-election will crash because of a pagination bug, upgrade to latest version which fixed that bug
2. get candidates by the first block height of an epoch