### PR TITLE
Add node productivity cmd for ioctl

### DIFF
--- a/cli/ioctl/cmd/bc/bcheight.go
+++ b/cli/ioctl/cmd/bc/bcheight.go
@@ -7,15 +7,9 @@
 package bc
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
-
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
-	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/protogen/iotexapi"
 )
 
 // bcHeightCmd represents the account height command
@@ -30,23 +24,9 @@ var bcHeightCmd = &cobra.Command{
 
 // currentBlockHeigh get current height of block chain from server
 func currentBlockHeigh() string {
-	endpoint := config.Get("endpoint")
-	if endpoint == config.ErrEmptyEndpoint {
-		log.L().Error(config.ErrEmptyEndpoint)
-		return "use \"ioctl config set endpoint\" to config endpoint first."
-	}
-	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+	chainMeta, err := GetChainMeta()
 	if err != nil {
 		return err.Error()
 	}
-	defer conn.Close()
-
-	cli := iotexapi.NewAPIServiceClient(conn)
-	request := iotexapi.GetChainMetaRequest{}
-	ctx := context.Background()
-	response, err := cli.GetChainMeta(ctx, &request)
-	if err != nil {
-		return err.Error()
-	}
-	return fmt.Sprintf("%d", response.ChainMeta.Height)
+	return fmt.Sprintf("%d", chainMeta.Height)
 }

--- a/cli/ioctl/cmd/node/node.go
+++ b/cli/ioctl/cmd/node/node.go
@@ -10,6 +10,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Flags
+var (
+	epochNum uint64
+)
+
 // NodeCmd represents the node command
 var NodeCmd = &cobra.Command{
 	Use:   "node",
@@ -19,4 +24,6 @@ var NodeCmd = &cobra.Command{
 
 func init() {
 	NodeCmd.AddCommand(nodeDelegateCmd)
+	NodeCmd.AddCommand(nodeProductivityCmd)
+	nodeProductivityCmd.Flags().Uint64VarP(&epochNum,"epoch-num","e",0,"query specific epoch")
 }

--- a/cli/ioctl/cmd/node/nodedelegate.go
+++ b/cli/ioctl/cmd/node/nodedelegate.go
@@ -22,10 +22,10 @@ import (
 	"github.com/iotexproject/iotex-core/protogen/iotexapi"
 )
 
-// nodeDelegateCmd get delegates from IoTeX blockchain
+// nodeDelegateCmd represents the node delegate command
 var nodeDelegateCmd = &cobra.Command{
 	Use:   "delegate",
-	Short: "delegate",
+	Short: "get current delegates",
 	Args:  cobra.ExactArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(delegate())

--- a/cli/ioctl/cmd/node/nodeproductivity.go
+++ b/cli/ioctl/cmd/node/nodeproductivity.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package node
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc"
+
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/bc"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/protogen/iotexapi"
+)
+
+// nodeProductivityCmd represents the node productivity command
+var nodeProductivityCmd = &cobra.Command{
+	Use:   "productivity [delegate]",
+	Short: "get productivity of delegates",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(productivity(args))
+	},
+}
+
+func productivity(args []string) string {
+	delegate := ""
+	var err error
+	if len(args) != 0 {
+		delegate, err = account.Address(args[0])
+		if err != nil {
+			return err.Error()
+		}
+	}
+	if epochNum == 0 {
+		chainMeta, err := bc.GetChainMeta()
+		if err != nil {
+			return err.Error()
+		}
+		epochNum = chainMeta.Epoch.Num
+	}
+	endpoint := config.Get("endpoint")
+	if endpoint == config.ErrEmptyEndpoint {
+		return "use \"ioctl config set endpoint\" to config endpoint first."
+	}
+	conn, err := grpc.Dial(endpoint, grpc.WithInsecure())
+	if err != nil {
+		return err.Error()
+	}
+	defer conn.Close()
+	cli := iotexapi.NewAPIServiceClient(conn)
+	request := &iotexapi.GetProductivityRequest{EpochNumber: epochNum}
+	ctx := context.Background()
+	response, err := cli.GetProductivity(ctx, request)
+	if err != nil {
+		return err.Error()
+	}
+	if len(delegate) != 0 {
+		return fmt.Sprintf("%s: %d (produced) / %d (total of epoch %d)", delegate,
+			response.BlksPerDelegate[delegate], response.TotalBlks, epochNum)
+	}
+	lines := make([]string, 0)
+	for delegate, productivity := range response.BlksPerDelegate {
+		lines = append(lines, fmt.Sprintf("%s: %d (produced) / %d (total of epoch %d)",
+			delegate, productivity, productivity, epochNum))
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
tested on local single-node

➜  ioctl git:(ioctl) ✗ ./ioctl node delegate
blockProducers: "io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd"
blockProducers: "io1llupp3n8q5x8usnr5w08j6hc6hn55x64l46rr7"
blockProducers: "io1hh97f273nhxcq8ajzcpujtt7p9pqyndfmavn9r"
blockProducers: "io1ph0u2psnd7muq5xv9623rmxdsxc4uapxhzpg02"
blockProducers: "io19kshh892255x4h5ularvr3q3al2v8cgl80fqrt"
blockProducers: "io1fxzh50pa6qc6x5cprgmgw4qrp5vw97zk5pxt3q"
blockProducers: "io1xuavja5dwde8pvy4yms06yyncad4yavghjhwra"
blockProducers: "io1eq4ehs6xx6zj9gcsax7h3qydwlxut9xcfcjras"
blockProducers: "io13sj9mzpewn25ymheukte4v39hvjdtrfp00mlyv"
blockProducers: "io158hyzrmf4a8xll7gfc8xnwlv70jgp44tzy5nvd"
blockProducers: "io1jh0ekmccywfkmj7e8qsuzsupnlk3w5337hjjg2"
blockProducers: "io1vrl48nsdm8jaujccd9cx4ve23cskr0ys6urx92"
blockProducers: "io10a298zmzvrt4guq79a9f4x7qedj59y7ery84he"
blockProducers: "io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng"
blockProducers: "io1ed52svvdun2qv8sf2m0xnynuxfaulv6jlww7ur"
blockProducers: "io1skmqp33qme8knyw0fzgt9takwrc2nvz4sevk5c"
blockProducers: "io1l3wc0smczyay8xq747e2hw63mzg3ctp6uf8wsg"
blockProducers: "io1q4tdrahguffdu4e9j9aj4f38p2nee0r9vlhx7s"
blockProducers: "io15flratm0nhh5xpxz2lznrrpmnwteyd86hxdtj0"
blockProducers: "io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw"
blockProducers: "io1cdqx6p5rquudxuewflfndpcl0l8t5aezen9slr"
blockProducers: "io14gnqxf9dpkn05g337rl7eyt2nxasphf5m6n0rd"
blockProducers: "io1ns7y0pxmklk8ceattty6n7makpw76u770u5avy"
blockProducers: "io1yhvu38epz5vmkjaclp45a7t08r27slmcc0zjzh"

➜  ioctl git:(ioctl) ✗ ./ioctl node productivity
io1qktggz76x38ffyethgpsxhy79ceh7svznn79tp: 39 (produced) / 39 (total of epoch 6)

➜  ioctl git:(ioctl) ✗ ./ioctl node productivity io1qktggz76x38ffyethgpsxhy79ceh7svznn79tp -e 5
io1qktggz76x38ffyethgpsxhy79ceh7svznn79tp: 48 (produced) / 48 (total of epoch 5)
