### PR TITLE
IOTEX-333 Add set reward cmd for ioctl

### DIFF
--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -51,7 +51,9 @@ func init() {
 	ActionCmd.AddCommand(actionDeployCmd)
 	ActionCmd.AddCommand(actionInvokeCmd)
 	ActionCmd.AddCommand(actionClaimCmd)
-	setActionFlags(actionTransferCmd, actionDeployCmd, actionInvokeCmd, actionClaimCmd)
+	ActionCmd.AddCommand(actionSetRewardCmd)
+	setActionFlags(actionTransferCmd, actionDeployCmd, actionInvokeCmd,
+		actionClaimCmd, actionSetRewardCmd)
 }
 
 func setActionFlags(cmds ...*cobra.Command) {
@@ -82,7 +84,6 @@ func sendAction(elp action.Envelope) string {
 	ehash := elp.Hash()
 	sig, err := account.Sign(signer, password, ehash[:])
 	if err != nil {
-		log.L().Error("fail to sign", zap.Error(err))
 		return err.Error()
 	}
 	pubKey, err := keypair.SigToPublicKey(ehash[:], sig)

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -117,6 +117,20 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 			">\n" +
 			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
+	case action.Core.GetSetReward() != nil:
+		setReward := action.Core.GetSetReward()
+		return fmt.Sprintf("senderAddress: %s\n", senderAddress.String()) +
+			fmt.Sprintf("version: %d\n", action.Core.GetVersion()) +
+			fmt.Sprintf("nonce: %d\n", action.Core.GetNonce()) +
+			fmt.Sprintf("gasLimit: %d\n", action.Core.GasLimit) +
+			fmt.Sprintf("gasPrice: %s\n", action.Core.GasPrice) +
+			"setReward: <\n" +
+			fmt.Sprintf("  amount: %s\n", setReward.Amount) +
+			fmt.Sprintf("  type: %d\n", setReward.Type) +
+			fmt.Sprintf("  data: %x\n", setReward.Data) +
+			">\n" +
+			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
+			fmt.Sprintf("signature: %x\n", action.Signature), nil
 	}
 	return "", errors.New("action can not match")
 }

--- a/cli/ioctl/cmd/action/actionsetreward.go
+++ b/cli/ioctl/cmd/action/actionsetreward.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
+)
+
+// actionSetRewardCmd represents the action setreward command
+var actionSetRewardCmd = &cobra.Command{
+	Use: "setreward AMOUNT_IOTX REWARD_TYPE DATA",
+	Short: "Set reward for producers on IoTeX blockchain. " +
+		"Reward types: 0 (block reward), 1 (epoch reward)",
+	Args: cobra.ExactArgs(3),
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(setReward(args))
+	},
+}
+
+// setReward sets reward for producers on IoTeX blockchain
+func setReward(args []string) string {
+	amount := big.NewInt(0)
+	var err error
+	amount, err = util.StringToRau(args[0], util.IotxDecimalNum)
+	if err != nil {
+		return err.Error()
+	}
+	var rewardType int
+	switch args[1] {
+	case "0":
+		rewardType = action.BlockReward
+	case "1":
+		rewardType = action.EpochReward
+	default:
+		return "invalid REWARD_TYPE: 0 (block reward), 1 (epoch reward)"
+	}
+	payload := []byte(args[2])
+	sender, err := account.Address(signer)
+	if err != nil {
+		return err.Error()
+	}
+	gasPriceRau, err := util.StringToRau(gasPrice, util.GasPriceDecimalNum)
+	if err != nil {
+		return err.Error()
+	}
+	if nonce == 0 {
+		accountMeta, err := account.GetAccountMeta(sender)
+		if err != nil {
+			return err.Error()
+		}
+		nonce = accountMeta.PendingNonce
+	}
+	b := action.SetRewardBuilder{}
+	act := b.SetAmount(amount).SetRewardType(rewardType).SetData(payload).Build()
+	bd := &action.EnvelopeBuilder{}
+	elp := bd.SetNonce(nonce).
+		SetGasPrice(gasPriceRau).
+		SetGasLimit(gasLimit).
+		SetAction(&act).Build()
+	return sendAction(elp)
+}


### PR DESCRIPTION
Tested on local single-node.

➜  iotex-core git:(ioctl) ioctl action setreward 0.01 0 ddidi -l 202300 -p 1 -s pro
Enter password #pro:

senderAddress: io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd
version: 1
nonce: 8
gasLimit: 202300
gasPrice: 1000000000000
setReward: <
  amount: 10000000000000000
  type: 0
  data: 6464696469
>
senderPubKey: 04e93b5b1c8fba69263652a483ad55318e4eed5b5122314cb7fdb077d8c7295097cec92ee50b1108dc7495a9720e5921e56d3048e37abe6a6716d7c9b913e9f2e6
signature: 88acc65be97d86ad736461ff232374df966f5671db790f074d4dfc9d448ce8d758cdc3d97184822d98d92e3439b49411a84d4e4aeaff08c5413b700189389bfb00

Please confirm your action.
Type 'YES' to continue, quit for anything else.
yes

Action has been sent to blockchain.
Wait for several seconds and query this action by hash:
9220d3771fa73e5583dee4a807b8fbbb10ad384771ca68edce71321f5ce2c72a
➜  iotex-core git:(ioctl) ioctl action hash 9220d3771fa73e5583dee4a807b8fbbb10ad384771ca68edce71321f5ce2c72a
senderAddress: io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd
version: 1
nonce: 8
gasLimit: 202300
gasPrice: 1000000000000
setReward: <
  amount: 10000000000000000
  type: 0
  data: 6464696469
>
senderPubKey: 04e93b5b1c8fba69263652a483ad55318e4eed5b5122314cb7fdb077d8c7295097cec92ee50b1108dc7495a9720e5921e56d3048e37abe6a6716d7c9b913e9f2e6
signature: 88acc65be97d86ad736461ff232374df966f5671db790f074d4dfc9d448ce8d758cdc3d97184822d98d92e3439b49411a84d4e4aeaff08c5413b700189389bfb00

#This action has been written on blockchain
returnValue 
status: 1 (Success)
actHash: 9220d3771fa73e5583dee4a807b8fbbb10ad384771ca68edce71321f5ce2c72a
gasConsumed: 10500
contractAddress: io154mvzs09vkgn0hw6gg3ayzw5w39jzp47f8py9v