### PR TITLE
IOTEX 336 Fix TestLocalTransfer flaky  panic on CircleCI build

### DIFF
--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -496,7 +496,7 @@ func newTransferConfig(
 	cfg.Chain.EnableAsyncIndexWrite = true
 	cfg.Consensus.Scheme = config.StandaloneScheme
 	cfg.API.Port = apiPort
-	cfg.Genesis.BlockInterval = 1 * time.Second
+	cfg.Genesis.BlockInterval = 2 * time.Second
 
 	return cfg, nil
 }


### PR DESCRIPTION
Original TestLocalTransfer uses 1 second as the block produce interval, which is too aggressive for CircleCI server.
So this fix is to increase the block produce interval to  2 seconds.