### PR TITLE
Fix two bugs in API

### DIFF
--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -276,7 +276,8 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 }
 
 func (p *governanceChainCommitteeProtocol) readActiveBlockProducersByHeight(height uint64) ([]string, error) {
-	gravityHeight, err := p.getGravityHeight(height)
+	epochHeight := p.getEpochHeight(p.getEpochNum(height))
+	gravityHeight, err := p.getGravityHeight(epochHeight)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get gravity chain height")
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -220,9 +220,9 @@ func (api *Server) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRe
 	}
 	epochNum := rp.GetEpochNum(tipHeight)
 	epochHeight := rp.GetEpochHeight(epochNum)
-	timeDuration := blks[0].Timestamp - blks[len(blks)-1].Timestamp
+	timeDuration := blks[len(blks)-1].Timestamp - blks[0].Timestamp
 	// if time duration is less than 1 second, we set it to be 1 second
-	if timeDuration == 0 {
+	if timeDuration < 1 {
 		timeDuration = 1
 	}
 


### PR DESCRIPTION
1. When reading active BPs, we should always read BPs on Epoch start height.
2. TPS in GetChainMeta is negative because time duration is negative.