### PR TITLE
 Add name management for ioctl

### DIFF
--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -42,6 +42,7 @@ func init() {
 	AccountCmd.AddCommand(accountDeleteCmd)
 	AccountCmd.AddCommand(accountImportCmd)
 	AccountCmd.AddCommand(accountListCmd)
+	AccountCmd.AddCommand(accountNameCmd)
 	AccountCmd.AddCommand(accountNonceCmd)
 	AccountCmd.AddCommand(accountUpdateCmd)
 }
@@ -80,10 +81,14 @@ func Address(in string) (string, error) {
 		return "", err
 	}
 	addr, ok := config.AccountList[in]
-	if !ok {
-		return "", errors.Errorf("can't find account from #" + in)
+	if ok {
+		return addr, nil
 	}
-	return addr, nil
+	addr, ok = config.NameList[in]
+	if ok {
+		return addr, nil
+	}
+	return "", errors.Errorf("cannot find account from #%s", in)
 }
 
 // GetAccountMeta gets account metadata
@@ -159,6 +164,9 @@ func newAccountByKey(name string, privateKey string, walletDir string) (string, 
 	if err != nil {
 		return "", err
 	}
-	addr, _ := address.FromBytes(account.Address.Bytes())
+	addr, err := address.FromBytes(account.Address.Bytes())
+	if err != nil {
+		return "", err
+	}
 	return addr.String(), nil
 }

--- a/cli/ioctl/cmd/account/accountdelete.go
+++ b/cli/ioctl/cmd/account/accountdelete.go
@@ -26,7 +26,7 @@ import (
 // accountDeleteCmd represents the account delete command
 var accountDeleteCmd = &cobra.Command{
 	Use:   "delete (NAME|ADDRESS)",
-	Short: "Delete an IoTeX account/address from wallet",
+	Short: "Delete an IoTeX account/address from wallet/config",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(accountDelete(args))

--- a/cli/ioctl/cmd/account/accountdelete.go
+++ b/cli/ioctl/cmd/account/accountdelete.go
@@ -26,7 +26,7 @@ import (
 // accountDeleteCmd represents the account delete command
 var accountDeleteCmd = &cobra.Command{
 	Use:   "delete (NAME|ADDRESS)",
-	Short: "delete an IoTeX keypair from wallet",
+	Short: "Delete an IoTeX account/address from wallet",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(accountDelete(args))
@@ -34,6 +34,25 @@ var accountDeleteCmd = &cobra.Command{
 }
 
 func accountDelete(args []string) string {
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err.Error()
+	}
+
+	for name, addr := range cfg.NameList {
+		if name == args[0] || addr == args[0] {
+			delete(cfg.NameList, name)
+			out, err := yaml.Marshal(&cfg)
+			if err != nil {
+				return err.Error()
+			}
+			if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+				return "Failed to write to config file %s." + config.DefaultConfigFile
+			}
+			return fmt.Sprintf("Name \"%s\":%s has been removed", name, addr)
+		}
+	}
+
 	var confirm string
 	fmt.Println("** This is an irreversible action!\n" +
 		"Once an account is deleted, all the assets under this account may be lost!\n" +
@@ -42,10 +61,7 @@ func accountDelete(args []string) string {
 	if confirm != "YES" && confirm != "yes" {
 		return "Quit"
 	}
-	cfg, err := config.LoadConfig()
-	if err != nil {
-		return err.Error()
-	}
+
 	found := false
 	name, addr := "", ""
 	var account address.Address

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -22,10 +22,10 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
-// accountImportCmd represents the account create command
+// accountImportCmd represents the account import command
 var accountImportCmd = &cobra.Command{
 	Use:   "import NAME",
-	Short: "import IoTeX private key into wallet",
+	Short: "Import IoTeX private key into wallet",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(accountImport(args))
@@ -42,8 +42,11 @@ func accountImport(args []string) string {
 	if err != nil {
 		return err.Error()
 	}
-	if _, ok := cfg.AccountList[name]; ok {
-		return fmt.Sprintf("A account named \"%s\" already exists.", name)
+	if addr, ok := cfg.AccountList[name]; ok {
+		return fmt.Sprintf("An account #%s:%s already exists.", name, addr)
+	}
+	if addr, ok := cfg.NameList[name]; ok {
+		return fmt.Sprintf("Name \"%s\" has already used for %s.", name, addr)
 	}
 	wallet := cfg.Wallet
 	fmt.Printf("#%s: Enter your private key, which will not be exposed on the screen.\n", name)
@@ -66,7 +69,7 @@ func accountImport(args []string) string {
 		return fmt.Sprintf("Failed to write to config file %s.", config.DefaultConfigFile)
 	}
 	return fmt.Sprintf(
-		"New account \"%s\" is created. Keep your password, or your will lose your private key.",
+		"New account #%s is created. Keep your password, or your will lose your private key.",
 		name,
 	)
 }

--- a/cli/ioctl/cmd/account/accountlist.go
+++ b/cli/ioctl/cmd/account/accountlist.go
@@ -34,13 +34,13 @@ func accountList() string {
 	if len(w.AccountList) != 0 {
 		lines = append(lines, "Account:")
 		for name, addr := range w.AccountList {
-			lines = append(lines, fmt.Sprintf("  name: %s, address:%s", name, addr))
+			lines = append(lines, fmt.Sprintf("  %s - %s", addr, name))
 		}
 	}
 	if len(w.NameList) != 0 {
 		lines = append(lines, "Name:")
 		for name, addr := range w.NameList {
-			lines = append(lines, fmt.Sprintf("  name: %s, address:%s", name, addr))
+			lines = append(lines, fmt.Sprintf("  %s - %s", addr, name))
 		}
 	}
 	return strings.Join(lines, "\n")

--- a/cli/ioctl/cmd/account/accountlist.go
+++ b/cli/ioctl/cmd/account/accountlist.go
@@ -31,8 +31,17 @@ func accountList() string {
 		return err.Error()
 	}
 	lines := make([]string, 0)
-	for n, addr := range w.AccountList {
-		lines = append(lines, fmt.Sprintf("name: %s, address:%s", n, addr))
+	if len(w.AccountList) != 0 {
+		lines = append(lines, "Account:")
+		for name, addr := range w.AccountList {
+			lines = append(lines, fmt.Sprintf("  name: %s, address:%s", name, addr))
+		}
+	}
+	if len(w.NameList) != 0 {
+		lines = append(lines, "Name:")
+		for name, addr := range w.NameList {
+			lines = append(lines, fmt.Sprintf("  name: %s, address:%s", name, addr))
+		}
 	}
 	return strings.Join(lines, "\n")
 }

--- a/cli/ioctl/cmd/account/accountnonce.go
+++ b/cli/ioctl/cmd/account/accountnonce.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// accountNonceCmd represents the account balance command
+// accountNonceCmd represents the account nonce command
 var accountNonceCmd = &cobra.Command{
 	Use:   "nonce (NAME|ADDRESS)",
 	Short: "Get nonce of an account",

--- a/cli/ioctl/cmd/account/accountupdate.go
+++ b/cli/ioctl/cmd/account/accountupdate.go
@@ -22,10 +22,10 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
-// accountUpdateCmd represents the account create command
+// accountUpdateCmd represents the account update command
 var accountUpdateCmd = &cobra.Command{
 	Use:   "update (NAME|ADDRESS)",
-	Short: "update password for IoTeX account",
+	Short: "Update password for IoTeX account",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(accountUpdate(args))
@@ -77,7 +77,7 @@ func accountUpdate(args []string) string {
 				log.L().Error("fail to update keystore", zap.Error(err))
 				return err.Error()
 			}
-			return fmt.Sprintf("Account \"%s\" has been updated.", account)
+			return fmt.Sprintf("Account #%s has been updated.", account)
 		}
 	}
 	return fmt.Sprintf("Account #%s not found", account)

--- a/cli/ioctl/cmd/node/nodereward.go
+++ b/cli/ioctl/cmd/node/nodereward.go
@@ -22,7 +22,7 @@ import (
 // nodeRewardCmd represents the node reward command
 var nodeRewardCmd = &cobra.Command{
 	Use:   "reward (NAME|ADDRESS)",
-	Short: "query unclaimed rewards",
+	Short: "Query unclaimed rewards",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println(reward(args))


### PR DESCRIPTION
Tested on local.

-> ioctl account list
Account:
  name: frank, address:io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37
  name: i, address:io1vrl48nsdm8jaujccd9cx4ve23cskr0ys6urx92
  name: node, address:io1u90mvrdx7tz02fh92vjd6y73et7j4d4srcl4ek
  name: pro, address:io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd
  name: test123, address:io1ns7y0pxmklk8ceattty6n7makpw76u770u5avy
  name: a, address:io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw
  name: boss, address:io1ed52svvdun2qv8sf2m0xnynuxfaulv6jlww7ur

-> ioctl account name io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw hihi
An account #a:io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw already exists.

-> ioctl account name io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe hihi
Succeed to name io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe "hihi".

-> ioctl account list
Account:
  name: boss, address:io1ed52svvdun2qv8sf2m0xnynuxfaulv6jlww7ur
  name: frank, address:io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37
  name: i, address:io1vrl48nsdm8jaujccd9cx4ve23cskr0ys6urx92
  name: node, address:io1u90mvrdx7tz02fh92vjd6y73et7j4d4srcl4ek
  name: pro, address:io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd
  name: test123, address:io1ns7y0pxmklk8ceattty6n7makpw76u770u5avy
  name: a, address:io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw
Name:
  name: hihi, address:io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe

-> ioctl account name io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe gigi
Name "hihi" has been used for io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe.

-> ioctl account delete hihi
Name "hihi":io1m8rge0h4xvmfzkc4yup766slcvn5cwymqeenpe has been removed