### PR TITLE
 IOTEX-349 Reenable unit tests of ReadActiveBlockProducersByHeight and ReadCommitteeBlockProducersByHeight

### DIFF
--- a/action/protocol/poll/protocol_test.go
+++ b/action/protocol/poll/protocol_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
+	t.Skip()
+
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -42,6 +44,7 @@ func TestInitialize(t *testing.T) {
 	r := types.NewElectionResultForTest(time.Now())
 	committee.EXPECT().ResultByHeight(uint64(123456)).Return(r, nil).Times(1)
 	p, err := NewGovernanceChainCommitteeProtocol(
+		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/action/protocol/poll/protocol_test.go
+++ b/action/protocol/poll/protocol_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestInitialize(t *testing.T) {
-	t.Skip()
-
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/iotex-election/test/mock/mock_committee"
-	"github.com/iotexproject/iotex-election/types"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +41,7 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/protogen/iotexapi"
 	"github.com/iotexproject/iotex-core/protogen/iotextypes"
+	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
@@ -785,17 +785,22 @@ func TestServer_ReadUnclaimedBalance(t *testing.T) {
 }
 
 func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
-	t.Skip()
-
 	require := require.New(t)
 	cfg := newConfig()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	mbc := mock_blockchain.NewMockBlockchain(ctrl)
 	committee := mock_committee.NewMockCommittee(ctrl)
-	r := types.NewElectionResultForTest(time.Now())
-	committee.EXPECT().ResultByHeight(gomock.Any()).Return(r, nil).Times(2)
-	committee.EXPECT().HeightByTime(gomock.Any()).Return(uint64(123456), nil).AnyTimes()
+	candidates := []*state.Candidate{
+		{
+			Address: "address1",
+		},
+		{
+			Address: "address2",
+		},
+	}
+	mbc.EXPECT().CandidatesByHeight(gomock.Any()).Return(candidates, nil).Times(2)
 
 	for _, test := range readActiveBlockProducersByHeightTests {
 		var pol poll.Protocol
@@ -804,7 +809,7 @@ func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				nil,
+				mbc,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -831,17 +836,22 @@ func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
 }
 
 func TestServer_ReadCommitteeBlockProducersByHeight(t *testing.T) {
-	t.Skip()
-
 	require := require.New(t)
 	cfg := newConfig()
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
+	mbc := mock_blockchain.NewMockBlockchain(ctrl)
 	committee := mock_committee.NewMockCommittee(ctrl)
-	r := types.NewElectionResultForTest(time.Now())
-	committee.EXPECT().ResultByHeight(gomock.Any()).Return(r, nil).Times(2)
-	committee.EXPECT().HeightByTime(gomock.Any()).Return(uint64(123456), nil).AnyTimes()
+	candidates := []*state.Candidate{
+		{
+			Address: "address1",
+		},
+		{
+			Address: "address2",
+		},
+	}
+	mbc.EXPECT().CandidatesByHeight(gomock.Any()).Return(candidates, nil).Times(2)
 
 	for _, test := range readCommitteeProducersByHeightTests {
 		var pol poll.Protocol
@@ -850,7 +860,7 @@ func TestServer_ReadCommitteeBlockProducersByHeight(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				nil,
+				mbc,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -785,6 +785,8 @@ func TestServer_ReadUnclaimedBalance(t *testing.T) {
 }
 
 func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
+	t.Skip()
+
 	require := require.New(t)
 	cfg := newConfig()
 
@@ -802,6 +804,7 @@ func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				nil,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -828,6 +831,8 @@ func TestServer_ReadActiveBlockProducersByHeight(t *testing.T) {
 }
 
 func TestServer_ReadCommitteeBlockProducersByHeight(t *testing.T) {
+	t.Skip()
+
 	require := require.New(t)
 	cfg := newConfig()
 
@@ -845,6 +850,7 @@ func TestServer_ReadCommitteeBlockProducersByHeight(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				nil,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -286,6 +286,7 @@ func registerDefaultProtocols(cs *chainservice.ChainService, genesisConfig genes
 		var pollProtocol poll.Protocol
 		if genesisConfig.GravityChainStartHeight != 0 && electionCommittee != nil {
 			if pollProtocol, err = poll.NewGovernanceChainCommitteeProtocol(
+				cs.Blockchain(),
 				electionCommittee,
 				gravityChainStartHeight,
 				func(height uint64) (time.Time, error) {


### PR DESCRIPTION
1. Port hotfix of r0.5 on master
2. Reenable API tests on reading active BPs and committee BPs