### PR TITLE
fix two bugs in consensus

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -466,7 +466,7 @@ func (bc *blockchain) MintNewBlock(
 	ctx := protocol.WithRunActionsCtx(context.Background(),
 		protocol.RunActionsCtx{
 			BlockHeight:    newblockHeight,
-			BlockTimeStamp: bc.now(),
+			BlockTimeStamp: timestamp,
 			Producer:       bc.config.ProducerAddress(),
 			GasLimit:       gasLimitForContext,
 			ActionGasLimit: bc.config.Genesis.ActionGasLimit,
@@ -1071,8 +1071,6 @@ func (bc *blockchain) emitToSubscribers(blk *block.Block) {
 		}(s, blk)
 	}
 }
-
-func (bc *blockchain) now() int64 { return bc.clk.Now().Unix() }
 
 // RecoverToHeight recovers the blockchain to target height
 func (bc *blockchain) recoverToHeight(targetHeight uint64) error {

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -123,8 +123,8 @@ func (ctx *rollDPoSCtx) OnConsensusReached() {
 	}
 	// Commit and broadcast the pending block
 	if err := ctx.chain.CommitBlock(pendingBlock.Block); err != nil {
-		// TODO: review the error handling logic (panic?)
-		ctx.logger().Panic("error when committing a block", zap.Error(err))
+		ctx.logger().Error("error when committing a block", zap.Error(err))
+		return
 	}
 	// Remove transfers in this block from ActPool and reset ActPool state
 	ctx.actPool.Reset()


### PR DESCRIPTION
1. When mint block, pass block creation timestamp as the raCtx blocktimestamp
2. On consensus reached, if commit fails, log error and early return