### PR TITLE
Use action.Sign() in ioctl sendAction()

### DIFF
--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -52,8 +52,8 @@ func init() {
 	AccountCmd.AddCommand(accountUpdateCmd)
 }
 
-// Sign use the password to unlock key associated with name, and signs the hash
-func Sign(signer, password string, hash []byte) ([]byte, error) {
+// KsAccountToPrivateKey generates our PrivateKey interface from Keystore account
+func KsAccountToPrivateKey(signer, password string) (keypair.PrivateKey, error) {
 	addr, err := Address(signer)
 	if err != nil {
 		return nil, err
@@ -62,14 +62,14 @@ func Sign(signer, password string, hash []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	// find the key in keystore and sign
+	// find the account in keystore
 	ks := keystore.NewKeyStore(config.Get("wallet"), keystore.StandardScryptN, keystore.StandardScryptP)
-	for _, v := range ks.Accounts() {
-		if bytes.Equal(address.Bytes(), v.Address.Bytes()) {
-			return ks.SignHashWithPassphrase(v, password, hash)
+	for _, account := range ks.Accounts() {
+		if bytes.Equal(address.Bytes(), account.Address.Bytes()) {
+			return keypair.KsAccountToPrivateKey(account, password)
 		}
 	}
-	return nil, errors.Errorf("account %s's address does not match with keys in keystore", signer)
+	return nil, errors.Errorf("account %s does not match all keys in keystore", signer)
 }
 
 // Address returns the address corresponding to name, parameter in can be name or IoTeX address

--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -66,7 +66,7 @@ func KsAccountToPrivateKey(signer, password string) (keypair.PrivateKey, error) 
 	ks := keystore.NewKeyStore(config.Get("wallet"), keystore.StandardScryptN, keystore.StandardScryptP)
 	for _, account := range ks.Accounts() {
 		if bytes.Equal(address.Bytes(), account.Address.Bytes()) {
-			return keypair.KsAccountToPrivateKey(account, password)
+			return keypair.KeystoreToPrivateKey(account, password)
 		}
 	}
 	return nil, errors.Errorf("account %s does not match all keys in keystore", signer)

--- a/cli/ioctl/cmd/account/account_test.go
+++ b/cli/ioctl/cmd/account/account_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package account
+
+import (
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+
+	"github.com/iotexproject/iotex-core/address"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/pkg/hash"
+	"github.com/iotexproject/iotex-core/testutil"
+)
+
+var (
+	testPath = "./kstest"
+)
+
+func TestAccount(t *testing.T) {
+	require := require.New(t)
+
+	testutil.CleanupPath(t, testPath)
+	require.NoError(testInit())
+	defer func() {
+		testutil.CleanupPath(t, testPath)
+	}()
+
+	cfg, err := config.LoadConfig()
+	require.NoError(err)
+	ks := keystore.NewKeyStore(cfg.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
+	require.NotNil(ks)
+
+	// create an account
+	nonce := strconv.FormatInt(rand.Int63(), 10)
+	passwd := "3dj,<>@@SF{}rj0ZF#" + nonce
+	account, err := ks.NewAccount(passwd)
+	require.NoError(err)
+	addr, err := address.FromBytes(account.Address.Bytes())
+	require.NoError(err)
+
+	// test keystore conversion and signing
+	prvkey, err := KsAccountToPrivateKey(addr.String(), passwd)
+	require.NoError(err)
+	msg := hash.Hash256b([]byte(nonce))
+	sig, err := prvkey.Sign(msg[:])
+	require.NoError(err)
+	require.True(prvkey.PublicKey().Verify(msg[:], sig))
+}
+
+func testInit() error {
+	config.ConfigDir = testPath
+	if err := os.MkdirAll(config.ConfigDir, 0700); err != nil {
+		return err
+	}
+	config.DefaultConfigFile = config.ConfigDir + "/config.default"
+	cfg, err := config.LoadConfig()
+	if err != nil {
+		return err
+	}
+	if cfg.Wallet == "" {
+		cfg.Wallet = config.ConfigDir
+	}
+	out, err := yaml.Marshal(&cfg)
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/keypair/keypair.go
+++ b/pkg/keypair/keypair.go
@@ -8,10 +8,11 @@ package keypair
 
 import (
 	"crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
+	"io/ioutil"
 
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/pkg/errors"
 )
 
@@ -41,6 +42,7 @@ type (
 		EcdsaPrivateKey() *ecdsa.PrivateKey
 		PublicKey() PublicKey
 		Sign([]byte) ([]byte, error)
+		Zero()
 	}
 )
 
@@ -77,15 +79,19 @@ func BytesToPrivateKey(prvKey []byte) (PrivateKey, error) {
 	return newSecp256k1PrvKeyFromBytes(prvKey)
 }
 
-// SigToPublicKey returns the uncompressed public key that created the given signature
-func SigToPublicKey(hash, sig []byte) (PublicKey, error) {
-	pk, err := crypto.Ecrecover(hash, sig)
+// KsAccountToPrivateKey generates PrivateKey from Keystore account
+func KsAccountToPrivateKey(account accounts.Account, password string) (PrivateKey, error) {
+	// load the key from the keystore
+	keyjson, err := ioutil.ReadFile(account.URL.Path)
 	if err != nil {
 		return nil, err
 	}
-	x, y := elliptic.Unmarshal(crypto.S256(), pk)
-	return &secp256k1PubKey{
-		PublicKey: &ecdsa.PublicKey{Curve: crypto.S256(), X: x, Y: y},
+	key, err := keystore.DecryptKey(keyjson, password)
+	if err != nil {
+		return nil, err
+	}
+	return &secp256k1PrvKey{
+		PrivateKey: key.PrivateKey,
 	}, nil
 }
 

--- a/pkg/keypair/keypair.go
+++ b/pkg/keypair/keypair.go
@@ -79,14 +79,14 @@ func BytesToPrivateKey(prvKey []byte) (PrivateKey, error) {
 	return newSecp256k1PrvKeyFromBytes(prvKey)
 }
 
-// KsAccountToPrivateKey generates PrivateKey from Keystore account
-func KsAccountToPrivateKey(account accounts.Account, password string) (PrivateKey, error) {
+// KeystoreToPrivateKey generates PrivateKey from Keystore account
+func KeystoreToPrivateKey(account accounts.Account, password string) (PrivateKey, error) {
 	// load the key from the keystore
-	keyjson, err := ioutil.ReadFile(account.URL.Path)
+	keyJSON, err := ioutil.ReadFile(account.URL.Path)
 	if err != nil {
 		return nil, err
 	}
-	key, err := keystore.DecryptKey(keyjson, password)
+	key, err := keystore.DecryptKey(keyJSON, password)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/keypair/keypair_test.go
+++ b/pkg/keypair/keypair_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/address"
-	"github.com/iotexproject/iotex-core/pkg/hash"
 )
 
 const (
@@ -71,18 +70,4 @@ func TestCompatibility(t *testing.T) {
 	addr, err := address.FromBytes(nsk.PublicKey().Hash())
 	require.NoError(err)
 	require.Equal(ethAddr.Bytes(), addr.Bytes())
-}
-
-func TestSigToPublicKey(t *testing.T) {
-	require := require.New(t)
-
-	sk, err := GenerateKey()
-	require.NoError(err)
-	h := hash.Hash256b([]byte("TestSigToPublicKey"))
-	sig, err := sk.Sign(h[:])
-	require.NoError(err)
-	pk, err := SigToPublicKey(h[:], sig)
-	require.NoError(err)
-	require.True(pk.Verify(h[:], sig))
-	require.Equal(sk.PublicKey(), pk)
 }

--- a/pkg/keypair/secp256k1.go
+++ b/pkg/keypair/secp256k1.go
@@ -80,6 +80,14 @@ func (k *secp256k1PrvKey) Sign(hash []byte) ([]byte, error) {
 	return crypto.Sign(hash, k.PrivateKey)
 }
 
+// Zero zeroes the private key data
+func (k *secp256k1PrvKey) Zero() {
+	b := k.D.Bits()
+	for i := range b {
+		b[i] = 0
+	}
+}
+
 //======================================
 // PublicKey function
 //======================================

--- a/pkg/keypair/secp256k1_test.go
+++ b/pkg/keypair/secp256k1_test.go
@@ -13,6 +13,7 @@ func TestSecp256k1(t *testing.T) {
 
 	sk, err := newSecp256k1PrvKey()
 	require.NoError(err)
+	defer sk.Zero()
 	require.Equal(secp256prvKeyLength, len(sk.Bytes()))
 	pk := sk.PublicKey()
 	require.Equal(secp256pubKeyLength, len(pk.Bytes()))


### PR DESCRIPTION
Add KsAccountToPrivateKey() so we can stick to action.Sign() and avoid assigning pubkey and signature bytes to iotextypes.Action{} struct