### PR TITLE
rebroadcast precommit endorsement on timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -125,6 +125,7 @@ var (
 					AcceptBlockTTL:               4 * time.Second,
 					AcceptProposalEndorsementTTL: 2 * time.Second,
 					AcceptLockEndorsementTTL:     2 * time.Second,
+					CommitTTL:                    2 * time.Second,
 					EventChanSize:                10000,
 				},
 				ToleratedOvertime: 2 * time.Second,

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -294,6 +294,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 400 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 200 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.CommitTTL = 200 * time.Millisecond
 		cfg.Consensus.RollDPoS.FSM.UnmatchedEventTTL = time.Second
 		cfg.Consensus.RollDPoS.FSM.UnmatchedEventInterval = 10 * time.Millisecond
 		cfg.Consensus.RollDPoS.ToleratedOvertime = 200 * time.Millisecond

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -413,7 +413,7 @@ func (ctx *rollDPoSCtx) IsStaleEvent(evt *consensusfsm.ConsensusEvent) bool {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
 
-	return ctx.round.IsStale(evt.Height(), ctx.round.Number())
+	return ctx.round.IsStale(evt.Height(), evt.Round(), evt.Data())
 }
 
 func (ctx *rollDPoSCtx) IsFutureEvent(evt *consensusfsm.ConsensusEvent) bool {
@@ -505,7 +505,7 @@ func (ctx *rollDPoSCtx) newConsensusEvent(
 			data,
 			ed.Height(),
 			roundNum,
-			ed.Endorsement().Timestamp(),
+			ctx.clock.Now(),
 		)
 	default:
 		return consensusfsm.NewConsensusEvent(

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -129,8 +129,26 @@ func (ctx *roundCtx) ProofOfLock() []*endorsement.Endorsement {
 	return ctx.proofOfLock
 }
 
-func (ctx *roundCtx) IsStale(height uint64, num uint32) bool {
-	return height < ctx.height || height == ctx.height && num < ctx.roundNum
+func (ctx *roundCtx) IsStale(height uint64, num uint32, data interface{}) bool {
+	switch {
+	case height < ctx.height:
+		return true
+	case height > ctx.height:
+		return false
+	case num >= ctx.roundNum:
+		return false
+	default:
+		msg, ok := data.(*EndorsedConsensusMessage)
+		if !ok {
+			return true
+		}
+		vote, ok := msg.Document().(*ConsensusVote)
+		if !ok {
+			return true
+		}
+
+		return vote.Topic() != COMMIT
+	}
 }
 
 func (ctx *roundCtx) IsFuture(height uint64, num uint32) bool {

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -372,6 +372,7 @@ func newConfig(
 	cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 1800 * time.Millisecond
 	cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 1800 * time.Millisecond
 	cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 1800 * time.Millisecond
+	cfg.Consensus.RollDPoS.FSM.CommitTTL = 600 * time.Millisecond
 	cfg.Consensus.RollDPoS.FSM.EventChanSize = 100000
 	cfg.Consensus.RollDPoS.ToleratedOvertime = 1200 * time.Millisecond
 	cfg.Consensus.RollDPoS.Delay = 6 * time.Second


### PR DESCRIPTION
In a corner case that only 2/3 or less nodes enter the commit step, the chain will get stuck. To fix the issue, the nodes in commit step should rebroadcast their commit endorsements every few seconds. Meanwhile, for the other nodes, they should process those commit endorsements from the same height but previous round.

This PR changes three things:
1. Introduce a new field COMMIT_TTL to the config for FSM, and rebroadcast commit endorsement every COMMIT_TTL
2. Update IsStaleEvent logic to accept COMMIT endorsement from previous round
3. Fix a consensus event creation time of incoming events to clock.Now()