### PR TITLE
Improve hash cmd for ioctl

### DIFF
--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -100,7 +100,7 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 	switch {
 	case action.Core.GetTransfer() != nil:
 		transfer := action.Core.GetTransfer()
-		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+		return fmt.Sprintf("\nversion: %d  ", action.Core.GetVersion()) +
 			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
 			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
 			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +
@@ -116,7 +116,7 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
 	case action.Core.GetExecution() != nil:
 		execution := action.Core.GetExecution()
-		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+		return fmt.Sprintf("\nversion: %d  ", action.Core.GetVersion()) +
 			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
 			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
 			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +
@@ -131,7 +131,7 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
 	case action.Core.GetClaimFromRewardingFund() != nil:
-		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+		return fmt.Sprintf("\nversion: %d  ", action.Core.GetVersion()) +
 			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
 			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
 			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -82,7 +82,6 @@ func getActionByHash(args []string) string {
 	if err != nil {
 		return err.Error()
 	}
-
 	return output + "\n#This action has been written on blockchain\n" +
 		printReceiptProto(responseReceipt.Receipt)
 }
@@ -101,35 +100,43 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 	switch {
 	case action.Core.GetTransfer() != nil:
 		transfer := action.Core.GetTransfer()
-		return fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
-			match(senderAddress.String(), "address")) +
+		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
+			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
+			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +
+			fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
+				match(senderAddress.String(), "address")) +
 			"transfer: <\n" +
 			fmt.Sprintf("  recipient: %s %s\n", transfer.Recipient,
 				match(transfer.Recipient, "address")) +
-			fmt.Sprintf("  amount: %s\n", transfer.Amount) +
+			fmt.Sprintf("  amount: %s Rau\n", transfer.Amount) +
 			fmt.Sprintf("  payload: %s\n", transfer.Payload) +
 			">\n" +
 			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
 	case action.Core.GetExecution() != nil:
 		execution := action.Core.GetExecution()
-		return fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
-			match(senderAddress.String(), "address")) +
-			fmt.Sprintf("version: %d\n", action.Core.GetVersion()) +
-			fmt.Sprintf("nonce: %d\n", action.Core.GetNonce()) +
-			fmt.Sprintf("gasLimit: %d\n", action.Core.GasLimit) +
-			fmt.Sprintf("gasPrice: %s\n", action.Core.GasPrice) +
+		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
+			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
+			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +
+			fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
+				match(senderAddress.String(), "address")) +
 			"execution: <\n" +
 			fmt.Sprintf("  contract: %s %s\n", execution.Contract,
 				match(execution.Contract, "address")) +
-			fmt.Sprintf("  amount: %s\n", execution.Amount) +
+			fmt.Sprintf("  amount: %s Rau\n", execution.Amount) +
 			fmt.Sprintf("  data: %x\n", execution.Data) +
 			">\n" +
 			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
 	case action.Core.GetClaimFromRewardingFund() != nil:
-		return fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
-			match(senderAddress.String(), "address")) +
+		return fmt.Sprintf("version: %d  ", action.Core.GetVersion()) +
+			fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +
+			fmt.Sprintf("gasLimit: %d  ", action.Core.GasLimit) +
+			fmt.Sprintf("gasPrice: %s Rau\n", action.Core.GasPrice) +
+			fmt.Sprintf("senderAddress: %s %s\n", senderAddress.String(),
+				match(senderAddress.String(), "address")) +
 			proto.MarshalTextString(action.Core) +
 			fmt.Sprintf("senderPubKey: %x\n", action.SenderPubKey) +
 			fmt.Sprintf("signature: %x\n", action.Signature), nil
@@ -151,6 +158,7 @@ func printReceiptProto(receipt *iotextypes.Receipt) string {
 		fmt.Sprintf("status: %d %s\n", receipt.Status,
 			match(strconv.Itoa(int(receipt.Status)), "status")) +
 		fmt.Sprintf("actHash: %x\n", receipt.ActHash) +
+		// TODO: blkHash
 		fmt.Sprintf("gasConsumed: %d\n", receipt.GasConsumed) +
 		fmt.Sprintf("contractAddress: %s %s\n", receipt.ContractAddress,
 			match(receipt.ContractAddress, "address")) +


### PR DESCRIPTION
Tested on local
```
→  ioctl action hash 690fb07fbb5ba3b762a7a16edea35ff1c3b02b43a6331aef88c4daa1bc933ad4

version: 1  nonce: 7  gasLimit: 122222  gasPrice: 2000000000000 Rau
senderAddress: io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw (whale)
transfer: <
  recipient: io18jaldgzc8wlyfnzamgas62yu3kg5nw527czg37 (nani)
  amount: 123000000000000000000 Rau
  payload:
>
senderPubKey: 04d0fade363080b9061844ed6b1009f35595515b31295e37e870106d3201a638856db2c3f870dbbcafc559af54574f3487dbea0d318588608d7aca8e77e4ce5ade
signature: 2e10f265fdc5944fab11afaebd258292afe8f9076157fbaca6bfdd3ece9047483fb3aa10ce187fe55d2d9c591e5eda430833b744f825a6ae34c9b34461d3940f01

#This action has been written on blockchain
returnValue:
status: 1 (Success)
actHash: 690fb07fbb5ba3b762a7a16edea35ff1c3b02b43a6331aef88c4daa1bc933ad4
gasConsumed: 10000
contractAddress:
logs:
[]
```