### PR TITLE
upgrade iotex-election package to v0.1.6

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -303,7 +303,7 @@
   version = "v0.2.2"
 
 [[projects]]
-  digest = "1:964ac86c1fd96ae838081062b32a3db466c0e6eaea41b6de4aac5a23e4a096c9"
+  digest = "1:706a64a2e4ae89a9a1ea27eaa2ba8ee6efece484b7fe58d015996d67025dfcdd"
   name = "github.com/iotexproject/iotex-election"
   packages = [
     "carrier",
@@ -316,8 +316,8 @@
     "util",
   ]
   pruneopts = "UT"
-  revision = "718d809a98aecb004f1f7440b27adb23aa22a92b"
-  version = "v0.1.3"
+  revision = "b2877eb003e57ff661efc14e7fe57a3d288c1869"
+  version = "v0.1.6"
 
 [[projects]]
   digest = "1:ff780041e005869242b2cf977f1d4fa3b8f9bdd302fd254b4a19f78502a6ee10"
@@ -1390,6 +1390,7 @@
     "github.com/coopernurse/barrister-go",
     "github.com/dgraph-io/badger",
     "github.com/ethereum/go-ethereum/accounts",
+    "github.com/ethereum/go-ethereum/accounts/abi",
     "github.com/ethereum/go-ethereum/accounts/keystore",
     "github.com/ethereum/go-ethereum/common",
     "github.com/ethereum/go-ethereum/common/math",
@@ -1399,6 +1400,7 @@
     "github.com/ethereum/go-ethereum/params",
     "github.com/facebookgo/clock",
     "github.com/go-sql-driver/mysql",
+    "github.com/gogo/protobuf/proto",
     "github.com/golang/groupcache/lru",
     "github.com/golang/mock/gomock",
     "github.com/golang/protobuf/jsonpb",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -64,7 +64,7 @@
 
 [[constraint]]
   name = "github.com/iotexproject/iotex-election"
-  version = "v0.1.3"
+  version = "v0.1.6"
 
 [prune]
   go-tests = true

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -111,8 +111,8 @@ func New(
 	var electionCommittee committee.Committee
 	if cfg.Genesis.EnableGravityChainVoting {
 		committeeConfig := cfg.Chain.Committee
-		committeeConfig.BeaconChainStartHeight = cfg.Genesis.GravityChainStartHeight
-		committeeConfig.BeaconChainHeightInterval = cfg.Genesis.GravityChainHeightInterval
+		committeeConfig.GravityChainStartHeight = cfg.Genesis.GravityChainStartHeight
+		committeeConfig.GravityChainHeightInterval = cfg.Genesis.GravityChainHeightInterval
 		committeeConfig.RegisterContractAddress = cfg.Genesis.RegisterContractAddress
 		committeeConfig.StakingContractAddress = cfg.Genesis.StakingContractAddress
 		committeeConfig.VoteThreshold = cfg.Genesis.VoteThreshold
@@ -121,7 +121,7 @@ func New(
 		committeeConfig.SelfStakingThreshold = cfg.Genesis.SelfStakingThreshold
 
 		kvstore := db.NewOnDiskDB(cfg.Chain.GravityChainDB)
-		if committeeConfig.BeaconChainStartHeight != 0 {
+		if committeeConfig.GravityChainStartHeight != 0 {
 			if electionCommittee, err = committee.NewCommitteeWithKVStoreWithNamespace(
 				kvstore,
 				committeeConfig,

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,7 @@ var (
 			EmptyGenesis:    false,
 			GravityChainDB:  DB{DbPath: "./poll.db", NumRetries: 10},
 			Committee: committee.Config{
-				BeaconChainAPIs: []string{},
+				GravityChainAPIs: []string{},
 			},
 			EnableFallBackToFreshDB: false,
 			EnableTrielessStateDB:   true,

--- a/vendor/github.com/iotexproject/iotex-election/db/kvstore.go
+++ b/vendor/github.com/iotexproject/iotex-election/db/kvstore.go
@@ -124,7 +124,7 @@ type boltDB struct {
 	numRetries uint8
 }
 
-// NewBoltDB creates a new boltdb
+// NewBoltDB creates a new boltDB
 func NewBoltDB(cfg Config) KVStoreWithNamespace {
 	return &boltDB{
 		numRetries: cfg.NumOfRetries,

--- a/vendor/github.com/iotexproject/iotex-election/test/mock/mock_committee/mock_committee.go
+++ b/vendor/github.com/iotexproject/iotex-election/test/mock/mock_committee/mock_committee.go
@@ -7,6 +7,7 @@ package mock_committee
 import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
+	committee "github.com/iotexproject/iotex-election/committee"
 	types "github.com/iotexproject/iotex-election/types"
 	reflect "reflect"
 	time "time"
@@ -120,4 +121,18 @@ func (m *MockCommittee) LatestHeight() uint64 {
 func (mr *MockCommitteeMockRecorder) LatestHeight() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LatestHeight", reflect.TypeOf((*MockCommittee)(nil).LatestHeight))
+}
+
+// Status mocks base method
+func (m *MockCommittee) Status() committee.STATUS {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Status")
+	ret0, _ := ret[0].(committee.STATUS)
+	return ret0
+}
+
+// Status indicates an expected call of Status
+func (mr *MockCommitteeMockRecorder) Status() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockCommittee)(nil).Status))
 }

--- a/vendor/github.com/iotexproject/iotex-election/types/candidate.go
+++ b/vendor/github.com/iotexproject/iotex-election/types/candidate.go
@@ -113,7 +113,7 @@ func (c *Candidate) Name() []byte {
 	return util.CopyBytes(c.name)
 }
 
-// Address returns the address of this candidate on beacon chain
+// Address returns the address of this candidate on gravity chain
 func (c *Candidate) Address() []byte {
 	return util.CopyBytes(c.address)
 }
@@ -133,9 +133,19 @@ func (c *Candidate) Score() *big.Int {
 	return new(big.Int).Set(c.score)
 }
 
+// SetScore set score value in Candidate
+func (c *Candidate) SetScore(score *big.Int) {
+	c.score = score
+}
+
 // SelfStakingTokens returns the total self votes (weighted)
 func (c *Candidate) SelfStakingTokens() *big.Int {
 	return new(big.Int).Set(c.selfStakingTokens)
+}
+
+// SetSelfStakingTokens set selfStakingTokens value in Candidate
+func (c *Candidate) SetSelfStakingTokens(selfStakingTokens *big.Int) {
+	c.selfStakingTokens = selfStakingTokens
 }
 
 // SelfStakingWeight returns the extra weight for self staking

--- a/vendor/github.com/iotexproject/iotex-election/types/result.go
+++ b/vendor/github.com/iotexproject/iotex-election/types/result.go
@@ -8,7 +8,9 @@ package types
 
 import (
 	"encoding/hex"
+	"fmt"
 	"math/big"
+	"strings"
 	"time"
 
 	"github.com/golang/protobuf/proto"
@@ -30,7 +32,7 @@ type ElectionResult struct {
 	totalVotedStakes *big.Int
 }
 
-// MintTime returns the mint time of the corresponding beacon chain block
+// MintTime returns the mint time of the corresponding gravity chain block
 func (r *ElectionResult) MintTime() time.Time {
 	return r.mintTime
 }
@@ -152,6 +154,30 @@ func (r *ElectionResult) Deserialize(data []byte) error {
 	}
 
 	return r.FromProtoMsg(pb)
+}
+
+func (r *ElectionResult) String() string {
+	var builder strings.Builder
+	fmt.Fprintf(
+		&builder,
+		"Timestamp: %s\nTotal Voted Stakes: %d\nTotal Votes: %d\n",
+		r.mintTime,
+		r.totalVotedStakes,
+		r.totalVotes,
+	)
+	for i, d := range r.delegates {
+		fmt.Fprintf(
+			&builder,
+			"%d: %s %x\n\toperator address: %s\n\treward: %s\n\tvotes: %s\n",
+			i,
+			string(d.name),
+			d.name,
+			string(d.operatorAddress),
+			string(d.rewardAddress),
+			d.score,
+		)
+	}
+	return builder.String()
 }
 
 // NewElectionResultForTest creates an election result for test purpose only


### PR DESCRIPTION
Upgrade iotex-election package to v0.1.6:
1. Faster sync
2. Fix fork bug by delaying 12 blocks
3. Fix candidate filter issue

Default config is changed, but no change to iotex-cluster is needed.