### PR TITLE
Consensus node high availability (Part 1): allow consensus node stand-by

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -173,6 +173,7 @@ var (
 			IndexHistoryList:  []string{IndexTransfer, IndexVote, IndexExecution, IndexAction},
 		},
 		System: System{
+			Active:                true,
 			HeartbeatInterval:     10 * time.Second,
 			HTTPStatsPort:         8080,
 			HTTPAdminPort:         9009,
@@ -311,6 +312,8 @@ type (
 
 	// System is the system config
 	System struct {
+		// Active is the status of the node. True means active and false means stand-by
+		Active            bool          `yaml:"active"`
 		HeartbeatInterval time.Duration `yaml:"heartbeatInterval"`
 		// HTTPProfilingPort is the port number to access golang performance profiling data of a blockchain node. It is
 		// 0 by default, meaning performance profiling has been disabled

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -37,6 +37,8 @@ type Consensus interface {
 	Calibrate(uint64)
 	ValidateBlockFooter(*block.Block) error
 	Metrics() (scheme.ConsensusMetrics, error)
+	Activate(bool)
+	Active() bool
 }
 
 // IotxConsensus implements Consensus
@@ -231,3 +233,11 @@ func (c *IotxConsensus) ValidateBlockFooter(blk *block.Block) error {
 func (c *IotxConsensus) Scheme() scheme.Scheme {
 	return c.scheme
 }
+
+// Activate activates or pauses the consensus component
+func (c *IotxConsensus) Activate(active bool) {
+	c.scheme.Activate(active)
+}
+
+// Active returns true if the consensus component is active or false if it stands by
+func (c *IotxConsensus) Active() bool { return c.scheme.Active() }

--- a/consensus/consensusfsm/context.go
+++ b/consensus/consensusfsm/context.go
@@ -15,6 +15,8 @@ import (
 
 // Context defines the context of the fsm
 type Context interface {
+	Activate(bool)
+	Active() bool
 	IsStaleEvent(*ConsensusEvent) bool
 	IsFutureEvent(*ConsensusEvent) bool
 	IsStaleUnmatchedEvent(*ConsensusEvent) bool
@@ -27,7 +29,7 @@ type Context interface {
 
 	Broadcast(interface{})
 
-	Prepare() (bool, interface{}, bool, bool, time.Duration, error)
+	Prepare() (bool, bool, interface{}, bool, bool, time.Duration, error)
 	NewProposalEndorsement(interface{}) (interface{}, error)
 	NewLockEndorsement(interface{}) (interface{}, error)
 	NewPreCommitEndorsement(interface{}) (interface{}, error)

--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -58,6 +58,9 @@ const (
 
 	// BackdoorEvent indicates a backdoor event type
 	BackdoorEvent fsm.EventType = "E_BACKDOOR"
+
+	// InitState refers the initial state of the consensus fsm
+	InitState = sPrepare
 )
 
 var (
@@ -376,10 +379,12 @@ func (m *ConsensusFSM) calibrate(evt fsm.Event) (fsm.State, error) {
 }
 
 func (m *ConsensusFSM) prepare(_ fsm.Event) (fsm.State, error) {
-	isProposer, proposal, isDelegate, locked, delay, err := m.ctx.Prepare()
+	active, isProposer, proposal, isDelegate, locked, delay, err := m.ctx.Prepare()
 	switch {
 	case err != nil:
 		m.ctx.Logger().Error("Error during prepare", zap.Error(err))
+		fallthrough
+	case !active:
 		fallthrough
 	case !isDelegate:
 		return m.BackToPrepare(delay)

--- a/consensus/consensusfsm/mock_context_test.go
+++ b/consensus/consensusfsm/mock_context_test.go
@@ -35,6 +35,28 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
 }
 
+// Activate mocks base method
+func (m *MockContext) Activate(arg0 bool) {
+	m.ctrl.Call(m, "Activate", arg0)
+}
+
+// Activate indicates an expected call of Activate
+func (mr *MockContextMockRecorder) Activate(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Activate", reflect.TypeOf((*MockContext)(nil).Activate), arg0)
+}
+
+// Active mocks base method
+func (m *MockContext) Active() bool {
+	ret := m.ctrl.Call(m, "Active")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Active indicates an expected call of Active
+func (mr *MockContextMockRecorder) Active() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockContext)(nil).Active))
+}
+
 // IsStaleEvent mocks base method
 func (m *MockContext) IsStaleEvent(arg0 *ConsensusEvent) bool {
 	ret := m.ctrl.Call(m, "IsStaleEvent", arg0)
@@ -130,15 +152,16 @@ func (mr *MockContextMockRecorder) Broadcast(arg0 interface{}) *gomock.Call {
 }
 
 // Prepare mocks base method
-func (m *MockContext) Prepare() (bool, interface{}, bool, bool, time.Duration, error) {
+func (m *MockContext) Prepare() (bool, bool, interface{}, bool, bool, time.Duration, error) {
 	ret := m.ctrl.Call(m, "Prepare")
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(interface{})
-	ret2, _ := ret[2].(bool)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(interface{})
 	ret3, _ := ret[3].(bool)
-	ret4, _ := ret[4].(time.Duration)
-	ret5, _ := ret[5].(error)
-	return ret0, ret1, ret2, ret3, ret4, ret5
+	ret4, _ := ret[4].(bool)
+	ret5, _ := ret[5].(time.Duration)
+	ret6, _ := ret[6].(error)
+	return ret0, ret1, ret2, ret3, ret4, ret5, ret6
 }
 
 // Prepare indicates an expected call of Prepare

--- a/consensus/scheme/noop.go
+++ b/consensus/scheme/noop.go
@@ -46,10 +46,18 @@ func (n *Noop) ValidateBlockFooter(*block.Block) error {
 	return nil
 }
 
-// Metrics is not implemented for standalone scheme
+// Metrics is not implemented for noop scheme
 func (n *Noop) Metrics() (ConsensusMetrics, error) {
 	return ConsensusMetrics{}, errors.Wrapf(
 		ErrNotImplemented,
 		"noop scheme does not supported metrics yet",
 	)
 }
+
+// Activate is not implemented for noop scheme
+func (n *Noop) Activate(_ bool) {
+	log.S().Warn("Noop scheme could not support activate")
+}
+
+// Active is always true for noop scheme
+func (n *Noop) Active() bool { return true }

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -236,6 +236,15 @@ func (r *RollDPoS) CurrentState() fsm.State {
 	return r.cfsm.CurrentState()
 }
 
+// Activate activates or pauses the roll-DPoS consensus. When it is deactivated, the node will finish the current
+// consensus round if it is doing the work and then return the the initial state
+func (r *RollDPoS) Activate(active bool) { r.ctx.Activate(active) }
+
+// Active is true if the roll-DPoS consensus is active, or false if it is stand-by
+func (r *RollDPoS) Active() bool {
+	return r.ctx.Active() || r.cfsm.CurrentState() != consensusfsm.InitState
+}
+
 // Builder is the builder for RollDPoS
 type Builder struct {
 	cfg config.Config
@@ -334,6 +343,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 	}
 	ctx := newRollDPoSCtx(
 		b.cfg.Consensus.RollDPoS,
+		b.cfg.System.Active,
 		b.cfg.Genesis.Blockchain.BlockInterval,
 		b.cfg.Consensus.RollDPoS.ToleratedOvertime,
 		b.cfg.Genesis.TimeBasedRotation,

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -223,6 +223,7 @@ func makeTestRollDPoSCtx(
 	}
 	return newRollDPoSCtx(
 		cfg.Consensus.RollDPoS,
+		cfg.System.Active,
 		cfg.Genesis.BlockInterval,
 		cfg.Consensus.RollDPoS.ToleratedOvertime,
 		cfg.Genesis.TimeBasedRotation,

--- a/consensus/scheme/scheme.go
+++ b/consensus/scheme/scheme.go
@@ -37,6 +37,8 @@ type Scheme interface {
 	Calibrate(uint64)
 	ValidateBlockFooter(*block.Block) error
 	Metrics() (ConsensusMetrics, error)
+	Activate(bool)
+	Active() bool
 }
 
 // ConsensusMetrics contains consensus metrics to expose

--- a/consensus/scheme/standalone.go
+++ b/consensus/scheme/standalone.go
@@ -63,34 +63,42 @@ func NewStandalone(create CreateBlockCB, commit ConsensusDoneCB, pub BroadcastCB
 }
 
 // Start starts the service for a standalone
-func (n *Standalone) Start(ctx context.Context) error {
-	return n.task.Start(ctx)
+func (s *Standalone) Start(ctx context.Context) error {
+	return s.task.Start(ctx)
 }
 
 // Stop stops the service for a standalone
-func (n *Standalone) Stop(ctx context.Context) error {
-	return n.task.Stop(ctx)
+func (s *Standalone) Stop(ctx context.Context) error {
+	return s.task.Stop(ctx)
 }
 
 // HandleConsensusMsg handles incoming consensus message
-func (n *Standalone) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
+func (s *Standalone) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
 	log.L().Warn("Noop scheme does not handle incoming block propose requests.")
 	return nil
 }
 
 // Calibrate triggers an event to calibrate consensus context
-func (n *Standalone) Calibrate(uint64) {}
+func (s *Standalone) Calibrate(uint64) {}
 
 // ValidateBlockFooter validates signatures in block footer
-func (n *Standalone) ValidateBlockFooter(*block.Block) error {
+func (s *Standalone) ValidateBlockFooter(*block.Block) error {
 	log.L().Warn("Standalone scheme always return true for block footer validation")
 	return nil
 }
 
 // Metrics is not implemented for standalone scheme
-func (n *Standalone) Metrics() (ConsensusMetrics, error) {
+func (s *Standalone) Metrics() (ConsensusMetrics, error) {
 	return ConsensusMetrics{}, errors.Wrapf(
 		ErrNotImplemented,
 		"standalone scheme does not supported metrics yet",
 	)
 }
+
+// Activate is not implemented for standalone scheme
+func (s *Standalone) Activate(_ bool) {
+	log.S().Warn("Standalone scheme could not support activate")
+}
+
+// Active is always true for standalone scheme
+func (s *Standalone) Active() bool { return true }

--- a/pkg/ha/ha.go
+++ b/pkg/ha/ha.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package ha
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/iotexproject/iotex-core/consensus"
+	"github.com/iotexproject/iotex-core/pkg/log"
+)
+
+// Controller controls the node high availability status
+type Controller struct {
+	c consensus.Consensus
+}
+
+// New constructs a HA controller instance
+func New(c consensus.Consensus) *Controller {
+	return &Controller{
+		c: c,
+	}
+}
+
+// Handle handles admin request
+func (ha *Controller) Handle(w http.ResponseWriter, r *http.Request) {
+	val := strings.ToLower(r.URL.Query().Get("activate"))
+	switch val {
+	case "true":
+		log.S().Info("Set the node to active mode")
+		ha.c.Activate(true)
+	case "false":
+		log.S().Info("Set the node to stand-by mode")
+		ha.c.Activate(false)
+	case "":
+		type payload struct {
+			Active bool `json:"active"`
+		}
+		enc := json.NewEncoder(w)
+		if err := enc.Encode(&payload{Active: ha.c.Active()}); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -33,6 +33,7 @@ import (
 	"github.com/iotexproject/iotex-core/dispatcher"
 	"github.com/iotexproject/iotex-core/explorer/idl/explorer"
 	"github.com/iotexproject/iotex-core/p2p"
+	"github.com/iotexproject/iotex-core/pkg/ha"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/probe"
 	"github.com/iotexproject/iotex-core/pkg/routine"
@@ -248,6 +249,8 @@ func StartServer(ctx context.Context, svr *Server, probeSvr *probe.Server, cfg c
 	if cfg.System.HTTPAdminPort > 0 {
 		mux := http.NewServeMux()
 		log.RegisterLevelConfigMux(mux)
+		haCtl := ha.New(svr.rootChainService.Consensus())
+		mux.Handle("/ha", http.HandlerFunc(haCtl.Handle))
 		mux.Handle("/debug/pprof/", http.HandlerFunc(pprof.Index))
 		mux.Handle("/debug/pprof/cmdline", http.HandlerFunc(pprof.Cmdline))
 		mux.Handle("/debug/pprof/profile", http.HandlerFunc(pprof.Profile))

--- a/test/mock/mock_consensus/mock_consensus.go
+++ b/test/mock/mock_consensus/mock_consensus.go
@@ -106,3 +106,25 @@ func (m *MockConsensus) Metrics() (scheme.ConsensusMetrics, error) {
 func (mr *MockConsensusMockRecorder) Metrics() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockConsensus)(nil).Metrics))
 }
+
+// Activate mocks base method
+func (m *MockConsensus) Activate(arg0 bool) {
+	m.ctrl.Call(m, "Activate", arg0)
+}
+
+// Activate indicates an expected call of Activate
+func (mr *MockConsensusMockRecorder) Activate(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Activate", reflect.TypeOf((*MockConsensus)(nil).Activate), arg0)
+}
+
+// Active mocks base method
+func (m *MockConsensus) Active() bool {
+	ret := m.ctrl.Call(m, "Active")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Active indicates an expected call of Active
+func (mr *MockConsensusMockRecorder) Active() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockConsensus)(nil).Active))
+}


### PR DESCRIPTION
Per feedback from the community, it seems to be useful to provide HA feature for delegates. In HA, 1 server will be active and the others will standby. Once the active node is down, another will be set to active by leader election (in Part 2). The goal is 99% availability. In terms of consensus node, the two modes behavior are as follows:

- Active: handle block sync + consensus messages
- Standby: handle block sync

> What we need to do?

Add the active flag. When the flag is set to false, wait consensus fsm go back to init state, and stand by there and process no events.

> How about state sharing among the servers?

Active server will have the consensus state for the next block that, but the stand-by servers won't. It's almost okay because the active server will decommission only after it finish the current round. There're  corner cases that the states will be lost, but it should be fine for 99% availability. Once we want to pursue 99.999% availability we could do state persistency