### PR TITLE
Print time stamp in action hash cmd for ioctl

### DIFF
--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -101,14 +101,15 @@ func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ts, err := ptypes.Timestamp(actionInfo.Timestamp)
-	if err != nil {
-		output += fmt.Sprintf("timeStamp: %s\n", err.Error())
-	} else {
+	if actionInfo.Timestamp != nil {
+		ts, err := ptypes.Timestamp(actionInfo.Timestamp)
+		if err != nil {
+			return "", err
+		}
 		output += fmt.Sprintf("timeStamp: %d\n", ts.Unix())
+		output += fmt.Sprintf("blkHash: %s\n", actionInfo.BlkHash)
 	}
-	output += fmt.Sprintf("actHash: %s\n", actionInfo.ActHash) +
-		fmt.Sprintf("blkHash: %s\n", actionInfo.BlkHash)
+	output += fmt.Sprintf("actHash: %s\n", actionInfo.ActHash)
 	return output, nil
 }
 

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -55,27 +55,27 @@ func getActionByHash(args []string) (string, error) {
 	cli := iotexapi.NewAPIServiceClient(conn)
 	ctx := context.Background()
 
-	requestCheckPending := iotexapi.GetActionsRequest{
+	requestGetActionByHash := &iotexapi.GetActionByHashRequest{
+		ActionHash:   hash,
+		CheckPending: false,
+	}
+	requestGetAction := iotexapi.GetActionsRequest{
 		Lookup: &iotexapi.GetActionsRequest_ByHash{
-			ByHash: &iotexapi.GetActionByHashRequest{
-				ActionHash:   hash,
-				CheckPending: true,
-			},
+			ByHash: requestGetActionByHash,
 		},
 	}
-	response, err := cli.GetActions(ctx, &requestCheckPending)
+	response, err := cli.GetActions(ctx, &requestGetAction)
 	if err != nil {
-		sta, ok := status.FromError(err)
-		if ok {
-			return "", fmt.Errorf(sta.Message())
+		requestGetActionByHash.CheckPending = true
+		response, err = cli.GetActions(ctx, &requestGetAction)
+		if err != nil {
+			return "", err
 		}
-		return "", err
 	}
 	if len(response.ActionInfo) == 0 {
 		return "", fmt.Errorf("no action info returned")
 	}
-	action := response.ActionInfo[0]
-	output, err := printAction(action)
+	output, err := printAction(response.ActionInfo[0])
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
@@ -74,7 +75,7 @@ func getActionByHash(args []string) (string, error) {
 		return "", fmt.Errorf("no action info returned")
 	}
 	action := response.ActionInfo[0]
-	output, err := printActionProto(action.Action)
+	output, err := printAction(action)
 	if err != nil {
 		return "", err
 	}
@@ -93,6 +94,22 @@ func getActionByHash(args []string) (string, error) {
 	}
 	return "\n#This action has been written on blockchain\n" +
 		printReceiptProto(responseReceipt.ReceiptInfo.Receipt), nil
+}
+
+func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
+	output, err := printActionProto(actionInfo.Action)
+	if err != nil {
+		return "", err
+	}
+	ts, err := ptypes.Timestamp(actionInfo.Timestamp)
+	if err != nil {
+		output += fmt.Sprintf("timeStamp: %s\n", err.Error())
+	} else {
+		output += fmt.Sprintf("timeStamp: %d\n", ts.Unix())
+	}
+	output += fmt.Sprintf("actHash: %s\n", actionInfo.ActHash) +
+		fmt.Sprintf("blkHash: %s\n", actionInfo.BlkHash)
+	return output, nil
 }
 
 func printActionProto(action *iotextypes.Action) (string, error) {

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -55,6 +55,7 @@ func getActionByHash(args []string) (string, error) {
 	cli := iotexapi.NewAPIServiceClient(conn)
 	ctx := context.Background()
 
+	// search action on blockchain
 	requestGetActionByHash := &iotexapi.GetActionByHashRequest{
 		ActionHash:   hash,
 		CheckPending: false,
@@ -66,6 +67,7 @@ func getActionByHash(args []string) (string, error) {
 	}
 	response, err := cli.GetActions(ctx, &requestGetAction)
 	if err != nil {
+		// search action in action pool
 		requestGetActionByHash.CheckPending = true
 		response, err = cli.GetActions(ctx, &requestGetAction)
 		if err != nil {


### PR DESCRIPTION
#1040
timestamp and blkhash can be printed now but not right.
```
version: 1  nonce: 1499  gasLimit: 10000  gasPrice: 1000000000000 Rau
senderAddress: io1znka733xefxjjw2wqddegplwtefun0mfdmz7dw (whale)
transfer: <
  recipient: io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms (35)
  amount: 21000000000000000000 Rau
>
senderPubKey: 04d0fade363080b9061844ed6b1009f35595515b31295e37e870106d3201a638856db2c3f870dbbcafc559af54574f3487dbea0d318588608d7aca8e77e4ce5ade
signature: 9cf2dbc00b181ea0dba35bbbe8eb41f73948f496a9f529bd684ef19aebcdd9311f3f4a72563d6b4ec4752a6e7cfcd22ac97ccfa1b8122d9899b3788a179d64a001
timeStamp: timestamp: nil Timestamp
actHash: 1170ae2da4ceefc03200eb8b93cc42ee62f0ad5407e3c782b99f8ba36117a330
blkHash: 0000000000000000000000000000000000000000000000000000000000000000
```