### PR TITLE
Ioctl should allow import/export from to keystore file #1191

### DIFF
--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -9,12 +9,20 @@ package account
 import (
 	"bytes"
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"strings"
 	"syscall"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	ecrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
@@ -195,4 +203,102 @@ func newAccountByKey(alias string, privateKey string, walletDir string) (string,
 		return "", err
 	}
 	return addr.String(), nil
+}
+
+func newAccountByKeyStore(alias, passwordOfKeyStore, keyStorePath string, walletDir string) (string, error) {
+	keyJSON, err := ioutil.ReadFile(keyStorePath)
+	if err != nil {
+		return "", fmt.Errorf("keystore file \"%s\" read error", keyStorePath)
+	}
+	key, err := keystore.DecryptKey(keyJSON, passwordOfKeyStore)
+	if key != nil && key.PrivateKey != nil {
+		defer func(k *ecdsa.PrivateKey) {
+			b := k.D.Bits()
+			for i := range b {
+				b[i] = 0
+			}
+		}(key.PrivateKey)
+	}
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Printf("#%s: Set password\n", alias)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		log.L().Error("failed to get password", zap.Error(err))
+		return "", err
+	}
+	password := string(bytePassword)
+	fmt.Printf("#%s: Enter password again\n", alias)
+	bytePassword, err = terminal.ReadPassword(int(syscall.Stdin))
+	if err != nil {
+		log.L().Error("failed to get password", zap.Error(err))
+		return "", err
+	}
+	if password != string(bytePassword) {
+		return "", ErrPasswdNotMatch
+	}
+
+	pubBytes := ecrypto.FromECDSAPub(&key.PrivateKey.PublicKey)
+	addBytes := common.BytesToAddress(ecrypto.Keccak256(pubBytes[1:])[12:])
+
+	// check if address is exist
+	ks := keystore.NewKeyStore(walletDir, keystore.StandardScryptN, keystore.StandardScryptP)
+	if ks.HasAddress(addBytes) {
+		return "", fmt.Errorf("account already exists")
+	}
+
+	addr, err := address.FromBytes(addBytes[:])
+	if err != nil {
+		log.L().Error("failed to convert bytes into address", zap.Error(err))
+		return "", err
+	}
+	err = copyFile(keyStorePath, walletDir+"/"+keyFileName(addBytes))
+	if err != nil {
+		return "", err
+	}
+	return addr.String(), nil
+}
+func copyFile(srcFile, dstFile string) error {
+	sourceFileStat, err := os.Stat(srcFile)
+	if err != nil {
+		return err
+	}
+
+	if !sourceFileStat.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", srcFile)
+	}
+
+	source, err := os.Open(srcFile)
+	if err != nil {
+		return err
+	}
+	defer source.Close()
+	_, err = os.Stat(dstFile)
+	if err == nil {
+		return fmt.Errorf("%s is exist", dstFile)
+	}
+	destination, err := os.Create(dstFile)
+	if err != nil {
+		return err
+	}
+	defer destination.Close()
+	_, err = io.Copy(destination, source)
+	return err
+}
+func keyFileName(keyAddr common.Address) string {
+	ts := time.Now().UTC()
+	return fmt.Sprintf("UTC--%s--%s", toISO8601(ts), hex.EncodeToString(keyAddr[:]))
+}
+
+func toISO8601(t time.Time) string {
+	var tz string
+	name, offset := t.Zone()
+	if name == "UTC" {
+		tz = "Z"
+	} else {
+		tz = fmt.Sprintf("%03d00", offset/3600)
+	}
+	return fmt.Sprintf("%04d-%02d-%02dT%02d-%02d-%02d.%09d%s", t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), tz)
 }

--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -207,6 +207,7 @@ func newAccountByKeyStore(alias, passwordOfKeyStore, keyStorePath string, wallet
 	}
 	key, err := keystore.DecryptKey(keyJSON, passwordOfKeyStore)
 	if key != nil && key.PrivateKey != nil {
+		// clear private key in memory prevent from attack
 		defer func(k *ecdsa.PrivateKey) {
 			b := k.D.Bits()
 			for i := range b {

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -84,7 +84,7 @@ func writeToFile(alias, addr string) (string, error) {
 		"New account #%s is created. Keep your password, or your will lose your private key.",
 		alias), nil
 }
-func readStdin() (string, error) {
+func readPasswordFromStdin() (string, error) {
 	passwordBytes, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
@@ -104,7 +104,7 @@ func accountImportKey(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("#%s: Enter your private key, which will not be exposed on the screen.\n", alias)
-	privateKey, err := readStdin()
+	privateKey, err := readPasswordFromStdin()
 	if err != nil {
 		return "", nil
 	}
@@ -122,7 +122,7 @@ func accountImportKeyStore(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("#%s: Enter your password of keystore, which will not be exposed on the screen.\n", alias)
-	password, err := readStdin()
+	password, err := readPasswordFromStdin()
 	if err != nil {
 		return "", nil
 	}

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -22,12 +22,13 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
-// accountImportCmd represents the account import command
 var (
+	// accountImportCmd represents the account import command
 	accountImportCmd = &cobra.Command{
 		Use:   "import",
 		Short: "Import IoTeX private key or keystore into wallet",
 	}
+	// accountImportKeyCmd represents the account import key command
 	accountImportKeyCmd = &cobra.Command{
 		Use:   "key ALIAS",
 		Short: "Import IoTeX private key into wallet",
@@ -41,6 +42,7 @@ var (
 			return err
 		},
 	}
+	// accountImportKeyCmd represents the account import keystore command
 	accountImportKeyStoreCmd = &cobra.Command{
 		Use:   "keystore ALIAS FILEPATH",
 		Short: "Import IoTeX keystore into wallet",
@@ -60,29 +62,16 @@ func init() {
 	accountImportCmd.AddCommand(accountImportKeyCmd)
 	accountImportCmd.AddCommand(accountImportKeyStoreCmd)
 }
-func accountImportKey(args []string) (string, error) {
-	// Validate inputs
-	if err := validator.ValidateAlias(args[0]); err != nil {
-		return "", err
+func validataAlias(alias string) error {
+	if err := validator.ValidateAlias(alias); err != nil {
+		return err
 	}
-	alias := args[0]
 	if addr, ok := config.ReadConfig.Aliases[alias]; ok {
-		return "", fmt.Errorf("alias \"%s\" has already used for %s", alias, addr)
+		return fmt.Errorf("alias \"%s\" has already used for %s", alias, addr)
 	}
-	fmt.Printf("#%s: Enter your private key, which will not be exposed on the screen.\n", alias)
-	privateKeyBytes, err := terminal.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		log.L().Error("failed to get private key", zap.Error(err))
-		return "", err
-	}
-	privateKey := strings.TrimSpace(string(privateKeyBytes))
-	for i := 0; i < len(privateKeyBytes); i++ {
-		privateKeyBytes[i] = 0
-	}
-	addr, err := newAccountByKey(alias, privateKey, config.ReadConfig.Wallet)
-	if err != nil {
-		return "", err
-	}
+	return nil
+}
+func writeToFile(alias, addr string) (string, error) {
 	config.ReadConfig.Aliases[alias] = addr
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
@@ -95,16 +84,7 @@ func accountImportKey(args []string) (string, error) {
 		"New account #%s is created. Keep your password, or your will lose your private key.",
 		alias), nil
 }
-func accountImportKeyStore(args []string) (string, error) {
-	// Validate inputs
-	if err := validator.ValidateAlias(args[0]); err != nil {
-		return "", err
-	}
-	alias := args[0]
-	if addr, ok := config.ReadConfig.Aliases[alias]; ok {
-		return "", fmt.Errorf("alias \"%s\" has already used for %s", alias, addr)
-	}
-	fmt.Printf("#%s: Enter your password of keystore, which will not be exposed on the screen.\n", alias)
+func readStdin() (string, error) {
 	passwordBytes, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
@@ -114,19 +94,41 @@ func accountImportKeyStore(args []string) (string, error) {
 	for i := 0; i < len(passwordBytes); i++ {
 		passwordBytes[i] = 0
 	}
+	return password, nil
+}
+func accountImportKey(args []string) (string, error) {
+	// Validate inputs
+	alias := args[0]
+	err := validataAlias(alias)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("#%s: Enter your private key, which will not be exposed on the screen.\n", alias)
+	privateKey, err := readStdin()
+	if err != nil {
+		return "", nil
+	}
+	addr, err := newAccountByKey(alias, privateKey, config.ReadConfig.Wallet)
+	if err != nil {
+		return "", err
+	}
+	return writeToFile(alias, addr)
+}
+func accountImportKeyStore(args []string) (string, error) {
+	// Validate inputs
+	alias := args[0]
+	err := validataAlias(alias)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("#%s: Enter your password of keystore, which will not be exposed on the screen.\n", alias)
+	password, err := readStdin()
+	if err != nil {
+		return "", nil
+	}
 	addr, err := newAccountByKeyStore(alias, password, args[1], config.ReadConfig.Wallet)
 	if err != nil {
 		return "", err
 	}
-	config.ReadConfig.Aliases[alias] = addr
-	out, err := yaml.Marshal(&config.ReadConfig)
-	if err != nil {
-		return "", err
-	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return "", fmt.Errorf("failed to write to config file %s", config.DefaultConfigFile)
-	}
-	return fmt.Sprintf(
-		"New account #%s is created. Keep your password, or your will lose your private key.",
-		alias), nil
+	return writeToFile(alias, addr)
 }

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373 // indirect
 	google.golang.org/appengine v1.5.0 // indirect
 	google.golang.org/grpc v1.20.1
+	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect
 	gopkg.in/yaml.v2 v2.2.2
 )
 


### PR DESCRIPTION
work on #1191 

1、
ioctl account import keystore xx UTC--2019-05-23T09-36-39.493806681Z--3ac6ad0777e76ae6974ff89bf3a719adac600077
#xx: Enter your password of keystore, which will not be exposed on the screen.
#xx: Set password
#xx: Enter password again
New account #xx is created. Keep your password, or your will lose your private key.

2、
ioctl account import keystore xx UTC--2019-05-23T09-36-39.493806681Z--3ac6ad0777e76ae6974ff89bf3a719adac600077
#xx: Enter your password of keystore, which will not be exposed on the screen.
Error: could not decrypt key with given passphrase

3、
ioctl account import keystore xxx ./nofile
#xxx: Enter your password of keystore, which will not be exposed on the screen.
Error: keystore file "./nofile" read error

4、
ioctl account import key aa
#aa: Enter your private key, which will not be exposed on the screen.
#aa: Set password
#aa: Enter password again
New account #aa is created. Keep your password, or your will lose your private key.