### PR TITLE
ioctl action transfer uses IOTX for amount rather than Rau #1215

### DIFF
--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -114,7 +114,15 @@ func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
 	output += fmt.Sprintf("actHash: %s\n", actionInfo.ActHash)
 	return output, nil
 }
-
+func toIOTX(amount string) (iotx string, err error) {
+	amountInt, err := util.StringToRau(amount, 0)
+	if err != nil {
+		log.L().Error("failed to convert amount into int", zap.Error(err))
+		return "", err
+	}
+	iotx = util.RauToString(amountInt, 18)
+	return
+}
 func printActionProto(action *iotextypes.Action) (string, error) {
 	pubKey, err := crypto.BytesToPublicKey(action.SenderPubKey)
 	if err != nil {
@@ -137,10 +145,14 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 		output += proto.MarshalTextString(action.Core)
 	case action.Core.GetTransfer() != nil:
 		transfer := action.Core.GetTransfer()
+		amount, err := toIOTX(transfer.Amount)
+		if err != nil {
+			return "", err
+		}
 		output += "transfer: <\n" +
 			fmt.Sprintf("  recipient: %s %s\n", transfer.Recipient,
 				Match(transfer.Recipient, "address")) +
-			fmt.Sprintf("  amount: %s Rau\n", transfer.Amount)
+			fmt.Sprintf("  amount: %s IOTX\n", amount)
 		if len(transfer.Payload) != 0 {
 			output += fmt.Sprintf("  payload: %s\n", transfer.Payload)
 		}

--- a/cli/ioctl/cmd/action/actionhash.go
+++ b/cli/ioctl/cmd/action/actionhash.go
@@ -114,15 +114,7 @@ func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
 	output += fmt.Sprintf("actHash: %s\n", actionInfo.ActHash)
 	return output, nil
 }
-func toIOTX(amount string) (iotx string, err error) {
-	amountInt, err := util.StringToRau(amount, 0)
-	if err != nil {
-		log.L().Error("failed to convert amount into int", zap.Error(err))
-		return "", err
-	}
-	iotx = util.RauToString(amountInt, 18)
-	return
-}
+
 func printActionProto(action *iotextypes.Action) (string, error) {
 	pubKey, err := crypto.BytesToPublicKey(action.SenderPubKey)
 	if err != nil {
@@ -145,7 +137,7 @@ func printActionProto(action *iotextypes.Action) (string, error) {
 		output += proto.MarshalTextString(action.Core)
 	case action.Core.GetTransfer() != nil:
 		transfer := action.Core.GetTransfer()
-		amount, err := toIOTX(transfer.Amount)
+		amount, err := util.StringToIOTX(transfer.Amount)
 		if err != nil {
 			return "", err
 		}

--- a/cli/ioctl/util/util.go
+++ b/cli/ioctl/util/util.go
@@ -111,4 +111,5 @@ func StringToIOTX(amount string) (iotx string, err error) {
 		return "", err
 	}
 	iotx = RauToString(amountInt, 18)
+	return
 }

--- a/cli/ioctl/util/util.go
+++ b/cli/ioctl/util/util.go
@@ -12,9 +12,6 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/iotexproject/iotex-core/pkg/log"
-	"go.uber.org/zap"
-
 	"github.com/ethereum/go-ethereum/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -107,7 +104,6 @@ func IoAddrToEvmAddr(ioAddr string) (common.Address, error) {
 func StringToIOTX(amount string) (iotx string, err error) {
 	amountInt, err := StringToRau(amount, 0)
 	if err != nil {
-		log.L().Error("failed to convert amount into int", zap.Error(err))
 		return "", err
 	}
 	iotx = RauToString(amountInt, 18)

--- a/cli/ioctl/util/util.go
+++ b/cli/ioctl/util/util.go
@@ -12,6 +12,9 @@ import (
 	"math/big"
 	"strings"
 
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"go.uber.org/zap"
+
 	"github.com/ethereum/go-ethereum/common"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -98,4 +101,14 @@ func IoAddrToEvmAddr(ioAddr string) (common.Address, error) {
 		return common.Address{}, err
 	}
 	return common.BytesToAddress(address.Bytes()), nil
+}
+
+// StringToIOTX converts Rau string to Iotx string
+func StringToIOTX(amount string) (iotx string, err error) {
+	amountInt, err := StringToRau(amount, 0)
+	if err != nil {
+		log.L().Error("failed to convert amount into int", zap.Error(err))
+		return "", err
+	}
+	iotx = RauToString(amountInt, 18)
 }


### PR DESCRIPTION
work on #1215 


1、ioctl account balance bb
io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms: 0 IOTX

2、ioctl action transfer bb 1.111111111 -s aa
Enter password #aa:


version: 1  nonce: 4  gasLimit: 10000  gasPrice: 1000000000000 Rau
senderAddress: io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg (aa)
transfer: <
  recipient: io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms (bb)
  **amount: 1.111111111 IOTX**
>
senderPubKey: 04ea8046cf8dc5bc9cda5f2e83e5d2d61932ad7e0e402b4f4cb65b58e9618891f54cba5cfcda873351ad9da1f5a819f54bba9e8343f2edd1ad34dcf7f35de552f3
signature: ba9822f15390ac48c63bc0efb9c2decfcc765f347ca3a92ed6892c2291f14f674d8b0f2e4a410ea88211e6b164d6d1cfcbf3a4d47a23f48786d3a678e730f1d801

Please confirm your action.
Type 'YES' to continue, quit for anything else.
yes

Action has been sent to blockchain.
Wait for several seconds and query this action by hash:
87109576e6335e1154b7a12d5c1855c0e52c0f81ac2ad0179854a5cb70b4728d

3、ioctl account balance bb
io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms: 1.111111111 IOTX