### PR TITLE
Skip system actions when estimating gas price

### DIFF
--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -33,8 +33,8 @@ func NewGasStation(bc blockchain.Blockchain, cfg config.API, limit uint64) *GasS
 	}
 }
 
-//WhetherSystemAction determine whether input action belongs to system action
-func (gs *GasStation) WhetherSystemAction(act action.SealedEnvelope) bool {
+//IsSystemAction determine whether input action belongs to system action
+func (gs *GasStation) IsSystemAction(act action.SealedEnvelope) bool {
 	switch act.Action().(type) {
 	case *action.GrantReward:
 		return true
@@ -63,10 +63,12 @@ func (gs *GasStation) SuggestGasPrice() (uint64, error) {
 		if len(blk.Actions) == 0 {
 			continue
 		}
-
+		if len(blk.Actions) == 1 && gs.IsSystemAction(blk.Actions[0]) {
+			continue
+		}
 		smallestPrice := blk.Actions[0].GasPrice()
 		for _, act := range blk.Actions {
-			if gs.WhetherSystemAction(act) {
+			if gs.IsSystemAction(act) {
 				continue
 			}
 			if smallestPrice.Cmp(act.GasPrice()) == 1 {

--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -33,6 +33,18 @@ func NewGasStation(bc blockchain.Blockchain, cfg config.API, limit uint64) *GasS
 	}
 }
 
+//WhetherSystemAction determine whether input action belongs to system action
+func (gs *GasStation) WhetherSystemAction(act action.SealedEnvelope) bool {
+	switch act.Action().(type) {
+	case *action.GrantReward:
+		return true
+	case *action.PutPollResult:
+		return true
+	default:
+		return false
+	}
+}
+
 // SuggestGasPrice suggest gas price
 func (gs *GasStation) SuggestGasPrice() (uint64, error) {
 	var smallestPrices []*big.Int
@@ -54,11 +66,8 @@ func (gs *GasStation) SuggestGasPrice() (uint64, error) {
 
 		smallestPrice := blk.Actions[0].GasPrice()
 		for _, act := range blk.Actions {
-			switch act.Action().(type) {
-			case *action.GrantReward:
+			if gs.WhetherSystemAction(act) {
 				continue
-			default:
-				break
 			}
 			if smallestPrice.Cmp(act.GasPrice()) == 1 {
 				smallestPrice = act.GasPrice()


### PR DESCRIPTION
Working on #1205

Write a function to determine whether one action is system action or user action and check skip the block which only have system action.

I separate the TestSuggestGasPrice function in gasstation_test.go file to two function, one for normal block with one transfer user action and a system action, other function is testing for the blocks which only consist of system action. Then test their price result to see whether the logic is worked.