### PR TITLE
Differentiate APIs that need and don't need action index #1030

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -217,7 +217,6 @@ func (api *Server) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRe
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-
 	blockLimit := int64(api.cfg.TpsWindow)
 	if blockLimit <= 0 {
 		return nil, status.Errorf(codes.Internal, "block limit is %d", blockLimit)

--- a/api/api.go
+++ b/api/api.go
@@ -122,7 +122,7 @@ func NewServer(
 		gs:               gasstation.NewGasStation(chain, cfg.API, cfg.Genesis.ActionGasLimit),
 	}
 	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok {
-		svr.hasPlugin = true
+		svr.hasActionIndex = true
 	}
 	svr.grpcserver = grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),

--- a/api/api.go
+++ b/api/api.go
@@ -83,6 +83,7 @@ type Server struct {
 	registry         *protocol.Registry
 	blockListener    *blockListener
 	grpcserver       *grpc.Server
+	hasPlugin        bool
 }
 
 // NewServer creates a new server
@@ -120,7 +121,9 @@ func NewServer(
 		blockListener:    newBlockListener(),
 		gs:               gasstation.NewGasStation(chain, cfg.API, cfg.Genesis.ActionGasLimit),
 	}
-
+	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok {
+		svr.hasPlugin = true
+	}
 	svr.grpcserver = grpc.NewServer(
 		grpc.StreamInterceptor(grpc_prometheus.StreamServerInterceptor),
 		grpc.UnaryInterceptor(grpc_prometheus.UnaryServerInterceptor),
@@ -158,6 +161,9 @@ func (api *Server) GetAccount(ctx context.Context, in *iotexapi.GetAccountReques
 
 // GetActions returns actions
 func (api *Server) GetActions(ctx context.Context, in *iotexapi.GetActionsRequest) (*iotexapi.GetActionsResponse, error) {
+	if !api.hasPlugin && in.GetByBlk() == nil {
+		return nil, status.Error(codes.NotFound, "plugin is not running")
+	}
 	switch {
 	case in.GetByIndex() != nil:
 		request := in.GetByIndex()
@@ -303,6 +309,9 @@ func (api *Server) SendAction(ctx context.Context, in *iotexapi.SendActionReques
 
 // GetReceiptByAction gets receipt with corresponding action hash
 func (api *Server) GetReceiptByAction(ctx context.Context, in *iotexapi.GetReceiptByActionRequest) (*iotexapi.GetReceiptByActionResponse, error) {
+	if !api.hasPlugin {
+		return nil, status.Error(codes.NotFound, "plugin is not running")
+	}
 	actHash, err := hash.HexStringToHash256(in.ActionHash)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Error())

--- a/api/api.go
+++ b/api/api.go
@@ -201,9 +201,6 @@ func (api *Server) GetBlockMetas(ctx context.Context, in *iotexapi.GetBlockMetas
 
 // GetChainMeta returns blockchain metadata
 func (api *Server) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRequest) (*iotexapi.GetChainMetaResponse, error) {
-	if !api.hasActionIndex {
-		return nil, status.Error(codes.NotFound, "Action index is not available.")
-	}
 	tipHeight := api.bc.TipHeight()
 	if tipHeight == 0 {
 		return &iotexapi.GetChainMetaResponse{
@@ -212,7 +209,11 @@ func (api *Server) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRe
 			},
 		}, nil
 	}
-	totalActions, err := api.bc.GetTotalActions()
+	totalActions := uint64(0)
+	var err error
+	if api.hasActionIndex {
+		totalActions, err = api.bc.GetTotalActions()
+	}
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -83,7 +83,7 @@ type Server struct {
 	registry         *protocol.Registry
 	blockListener    *blockListener
 	grpcserver       *grpc.Server
-	hasPlugin        bool
+	hasActionIndex   bool
 }
 
 // NewServer creates a new server
@@ -161,8 +161,8 @@ func (api *Server) GetAccount(ctx context.Context, in *iotexapi.GetAccountReques
 
 // GetActions returns actions
 func (api *Server) GetActions(ctx context.Context, in *iotexapi.GetActionsRequest) (*iotexapi.GetActionsResponse, error) {
-	if !api.hasPlugin && in.GetByBlk() == nil {
-		return nil, status.Error(codes.NotFound, "plugin is not running")
+	if !api.hasActionIndex && in.GetByBlk() == nil {
+		return nil, status.Error(codes.NotFound, "Action index is not available.")
 	}
 	switch {
 	case in.GetByIndex() != nil:
@@ -309,8 +309,8 @@ func (api *Server) SendAction(ctx context.Context, in *iotexapi.SendActionReques
 
 // GetReceiptByAction gets receipt with corresponding action hash
 func (api *Server) GetReceiptByAction(ctx context.Context, in *iotexapi.GetReceiptByActionRequest) (*iotexapi.GetReceiptByActionResponse, error) {
-	if !api.hasPlugin {
-		return nil, status.Error(codes.NotFound, "plugin is not running")
+	if !api.hasActionIndex {
+		return nil, status.Error(codes.NotFound, "Receipt index is not available")
 	}
 	actHash, err := hash.HexStringToHash256(in.ActionHash)
 	if err != nil {

--- a/api/api.go
+++ b/api/api.go
@@ -201,6 +201,9 @@ func (api *Server) GetBlockMetas(ctx context.Context, in *iotexapi.GetBlockMetas
 
 // GetChainMeta returns blockchain metadata
 func (api *Server) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRequest) (*iotexapi.GetChainMetaResponse, error) {
+	if !api.hasActionIndex {
+		return nil, status.Error(codes.NotFound, "Action index is not available.")
+	}
 	tipHeight := api.bc.TipHeight()
 	if tipHeight == 0 {
 		return &iotexapi.GetChainMetaResponse{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -913,7 +913,7 @@ func TestServer_SendAction(t *testing.T) {
 func TestServer_GetReceiptByAction(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.Plugins[config.GatewayPlugin] = true
+
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
 
@@ -1634,13 +1634,13 @@ func createServer(cfg config.Config, needActPool bool) (*Server, error) {
 	}
 
 	apiCfg := config.API{TpsWindow: cfg.API.TpsWindow, GasStation: cfg.API.GasStation, RangeQueryLimit: 100}
-
 	svr := &Server{
-		bc:       bc,
-		ap:       ap,
-		cfg:      apiCfg,
-		gs:       gasstation.NewGasStation(bc, apiCfg, config.Default.Genesis.ActionGasLimit),
-		registry: registry,
+		bc:        bc,
+		ap:        ap,
+		cfg:       apiCfg,
+		gs:        gasstation.NewGasStation(bc, apiCfg, config.Default.Genesis.ActionGasLimit),
+		registry:  registry,
+		hasPlugin: true,
 	}
 
 	return svr, nil

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1635,12 +1635,12 @@ func createServer(cfg config.Config, needActPool bool) (*Server, error) {
 
 	apiCfg := config.API{TpsWindow: cfg.API.TpsWindow, GasStation: cfg.API.GasStation, RangeQueryLimit: 100}
 	svr := &Server{
-		bc:        bc,
-		ap:        ap,
-		cfg:       apiCfg,
-		gs:        gasstation.NewGasStation(bc, apiCfg, config.Default.Genesis.ActionGasLimit),
-		registry:  registry,
-		hasPlugin: true,
+		bc:             bc,
+		ap:             ap,
+		cfg:            apiCfg,
+		gs:             gasstation.NewGasStation(bc, apiCfg, config.Default.Genesis.ActionGasLimit),
+		registry:       registry,
+		hasActionIndex: true,
 	}
 
 	return svr, nil

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -913,7 +913,7 @@ func TestServer_SendAction(t *testing.T) {
 func TestServer_GetReceiptByAction(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-
+	cfg.Plugins[config.GatewayPlugin] = true
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
 

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -189,21 +189,19 @@ func New(
 	}
 
 	var apiSvr *api.Server
-	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok {
-		apiSvr, err = api.NewServer(
-			cfg,
-			chain,
-			dispatcher,
-			actPool,
-			&registry,
-			api.WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
-				ctx = p2p.WitContext(ctx, p2p.Context{ChainID: chainID})
-				return p2pAgent.BroadcastOutbound(ctx, msg)
-			}),
-		)
-		if err != nil {
-			return nil, err
-		}
+	apiSvr, err = api.NewServer(
+		cfg,
+		chain,
+		dispatcher,
+		actPool,
+		&registry,
+		api.WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
+			ctx = p2p.WitContext(ctx, p2p.Context{ChainID: chainID})
+			return p2pAgent.BroadcastOutbound(ctx, msg)
+		}),
+	)
+	if err != nil {
+		return nil, err
 	}
 
 	return &ChainService{


### PR DESCRIPTION
work on #1030 
There's 6 apis need action index

1、grpcurl -v -plaintext -d '{"byIndex": {"start": 10, "count": 2}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

2、grpcurl -v -plaintext -d '{"byHash": {"actionHash": "61397a469bff69296c9dad88850bee167a13cd3a982b406a79321026b9bf80ab", "checkPending": false}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

3、grpcurl -v -plaintext -d '{"byAddr": {"address": "io1nyjs526mnqcsx4twa7nptkg08eclsw5c2dywp4", "start": 0, "count": 1}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

4、grpcurl -v -plaintext -d '{"unconfirmedByAddr": {"address": "io1nyjs526mnqcsx4twa7nptkg08eclsw5c2dywp4", "start": 1, "count": 1}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

5、grpcurl -v -plaintext -d '{"actionHash": "61397a469bff69296c9dad88850bee167a13cd3a982b406a79321026b9bf80ab"}' 127.0.0.1:14014 iotexapi.APIService.GetReceiptByAction

I add check code for those 5 apis,now they all return:

**Response trailers received:
content-type: application/grpc
Sent 1 request and received 0 responses
ERROR:
  Code: NotFound
  Message: Action index is not available**


according to commets,api GetChainMeta also need index when call GetTotalActions:
6、GetChainMeta
grpcurl -v -plaintext 127.0.0.1:14014 iotexapi.APIService.GetChainMeta
**Response trailers received:
content-type: application/grpc
Sent 0 requests and received 0 responses
ERROR:
  Code: NotFound
  Message: Action index is not available.**
