### PR TITLE
check all api again to find out these depend on gateway plugin #1265

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -161,7 +161,7 @@ func (api *Server) GetAccount(ctx context.Context, in *iotexapi.GetAccountReques
 
 // GetActions returns actions
 func (api *Server) GetActions(ctx context.Context, in *iotexapi.GetActionsRequest) (*iotexapi.GetActionsResponse, error) {
-	if !api.hasActionIndex && in.GetByBlk() == nil {
+	if !api.hasActionIndex && (in.GetByHash() != nil || in.GetByAddr() != nil) {
 		return nil, status.Error(codes.NotFound, "Action index is not available.")
 	}
 	switch {


### PR DESCRIPTION
work on #1265 

There's only 3 apis depend on gateway plugin：
1、grpcurl -v -plaintext -d '{"byHash": {"actionHash": "61397a469bff69296c9dad88850bee167a13cd3a982b406a79321026b9bf80ab", "checkPending": false}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

2、grpcurl -v -plaintext -d '{"byAddr": {"address": "io1nyjs526mnqcsx4twa7nptkg08eclsw5c2dywp4", "start": 1, "count": 1}}' 127.0.0.1:14014 iotexapi.APIService.GetActions

3、grpcurl -v -plaintext -d '{"actionHash": "61397a469bff69296c9dad88850bee167a13cd3a982b406a79321026b9bf80ab"}' 127.0.0.1:14014 iotexapi.APIService.GetReceiptByAction