### PR TITLE
change transfer amount type to big int

### DIFF
--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -41,7 +41,7 @@ var (
 	bytecodeString       string
 	gasPrice             string
 	xrc20ContractAddress string
-	xrc20TransferAmount  uint64
+	xrc20TransferAmount  big.Int
 	xrc20Bytes           []byte
 	xrc20ABI             abi.ABI
 	xrc20OwnerAddress    address.Address

--- a/cli/ioctl/cmd/action/xrc20approve.go
+++ b/cli/ioctl/cmd/action/xrc20approve.go
@@ -8,8 +8,6 @@ package action
 
 import (
 	"fmt"
-	"math/big"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -33,11 +31,7 @@ var Xrc20ApproveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		transfer, err := strconv.ParseInt(args[1], 10, 64)
-		if err != nil {
-			return err
-		}
-		xrc20TransferAmount = uint64(transfer)
+		xrc20TransferAmount.SetString(args[1], 10)
 		output, err := approve(args)
 		if err == nil {
 			fmt.Println(output)
@@ -51,7 +45,7 @@ func approve(args []string) (string, error) {
 	var err error
 	args[0] = xrc20ContractAddress
 	args[1] = "0"
-	xrc20Bytes, err = xrc20ABI.Pack("approve", toEthAddr(xrc20SpenderAddress), new(big.Int).SetUint64(xrc20TransferAmount))
+	xrc20Bytes, err = xrc20ABI.Pack("approve", toEthAddr(xrc20SpenderAddress), &xrc20TransferAmount)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/action/xrc20transfer.go
+++ b/cli/ioctl/cmd/action/xrc20transfer.go
@@ -8,8 +8,6 @@ package action
 
 import (
 	"fmt"
-	"math/big"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -33,11 +31,7 @@ var Xrc20TransferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		transfer, err := strconv.ParseInt(args[1], 10, 64)
-		if err != nil {
-			return err
-		}
-		xrc20TransferAmount = uint64(transfer)
+		xrc20TransferAmount.SetString(args[1], 10)
 		output, err := transferTo(args)
 		if err == nil {
 			fmt.Println(output)
@@ -51,7 +45,7 @@ func transferTo(args []string) (string, error) {
 	args[0] = xrc20ContractAddress
 	args[1] = "0"
 	var err error
-	xrc20Bytes, err = xrc20ABI.Pack("transfer", toEthAddr(xrc20TargetAddress), new(big.Int).SetUint64(xrc20TransferAmount))
+	xrc20Bytes, err = xrc20ABI.Pack("transfer", toEthAddr(xrc20TargetAddress), &xrc20TransferAmount)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/action/xrc20transferfrom.go
+++ b/cli/ioctl/cmd/action/xrc20transferfrom.go
@@ -8,8 +8,6 @@ package action
 
 import (
 	"fmt"
-	"math/big"
-	"strconv"
 
 	"github.com/spf13/cobra"
 
@@ -42,10 +40,7 @@ var Xrc20TransferFromCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		xrc20TransferAmount, err = strconv.ParseUint(args[2], 10, 64)
-		if err != nil {
-			return err
-		}
+		xrc20TransferAmount.SetString(args[2], 10)
 		output, err := transferFrom(args)
 		if err == nil {
 			fmt.Println(output)
@@ -59,7 +54,7 @@ func transferFrom(args []string) (string, error) {
 	args[0] = xrc20ContractAddress
 	args[1] = "0"
 	var err error
-	xrc20Bytes, err = xrc20ABI.Pack("transferFrom", toEthAddr(xrc20OwnerAddress), toEthAddr(xrc20TargetAddress), new(big.Int).SetUint64(xrc20TransferAmount))
+	xrc20Bytes, err = xrc20ABI.Pack("transferFrom", toEthAddr(xrc20OwnerAddress), toEthAddr(xrc20TargetAddress), &xrc20TransferAmount)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
I just change the type of transferAmount variable from uint64 to big.int to have a better ability to store large Integer value.