### PR TITLE
#1271 Fix minicluster balance check mismatch

### DIFF
--- a/tools/util/injectorutil.go
+++ b/tools/util/injectorutil.go
@@ -610,9 +610,9 @@ func CheckPendingActionList(
 
 	pendingActionMap.Range(func(selphash, vi interface{}) bool {
 		empty = false
-		selp, err := cs.Blockchain().GetActionByActionHash(selphash.(hash.Hash256))
+		receipt, err := cs.Blockchain().GetReceiptByActionHash(selphash.(hash.Hash256))
 		if err == nil {
-			receipt, err := cs.Blockchain().GetReceiptByActionHash(selphash.(hash.Hash256))
+			selp, err := cs.Blockchain().GetActionByActionHash(selphash.(hash.Hash256))
 			if err != nil {
 				retErr = err
 				return false


### PR DESCRIPTION
The balance doesn't match because some actions are falsely checked as pending, so the balance changes are not counted into expectations.  

So the fix is to get action-receipt by action hash( GetReceiptByActionHash) before getting action by action hash(GetActionByActionHash), not vice versa that caused the issue.  That is because getting action successfully by action hash doesn't guarantee to get action-receipt successfully immediately.