### PR TITLE
refactor ioctl action and xrc20 commands

### DIFF
--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -65,15 +65,15 @@ func init() {
 }
 
 func decodeBytecode() ([]byte, error) {
-	return hex.DecodeString(strings.TrimLeft(bytecodeFlag.Value, "0x"))
+	return hex.DecodeString(strings.TrimLeft(bytecodeFlag.Value().(string), "0x"))
 }
 
 func signer() (string, error) {
-	return alias.Address(signerFlag.Value)
+	return alias.Address(signerFlag.Value().(string))
 }
 
 func nonce(executor string) (uint64, error) {
-	nonce := nonceFlag.Value
+	nonce := nonceFlag.Value().(uint64)
 	if nonce != 0 {
 		return nonce, nil
 	}
@@ -94,7 +94,7 @@ func registerWriteCommand(cmd *cobra.Command) {
 
 // gasPriceInRau returns the suggest gas price
 func gasPriceInRau() (*big.Int, error) {
-	gasPrice := gasPriceFlag.Value
+	gasPrice := gasPriceFlag.Value().(string)
 	if len(gasPrice) != 0 {
 		return util.StringToRau(gasPrice, util.GasPriceDecimalNum)
 	}
@@ -126,7 +126,8 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 	if err != nil {
 		return
 	}
-	tx, err := action.NewExecution(contract, nonce, amount, gasLimitFlag.Value, gasPriceRau, bytecode)
+	gasLimit := gasLimitFlag.Value().(uint64)
+	tx, err := action.NewExecution(contract, nonce, amount, gasLimit, gasPriceRau, bytecode)
 	if err != nil || tx == nil {
 		err = errors.Wrap(err, "cannot make a Execution instance")
 		log.L().Error("error when invoke an execution", zap.Error(err))
@@ -136,7 +137,7 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 		(&action.EnvelopeBuilder{}).
 			SetNonce(nonce).
 			SetGasPrice(gasPriceRau).
-			SetGasLimit(gasLimitFlag.Value).
+			SetGasLimit(gasLimit).
 			SetAction(tx).Build(),
 		signer,
 	)

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -14,39 +14,34 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/golang/protobuf/proto"
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/cli/ioctl/flag"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 )
 
+const defaultSigner = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
+
 // Flags
 var (
-	gasLimit             uint64
-	nonce                uint64
-	signer               string
-	bytecodeString       string
-	gasPrice             string
-	xrc20ContractAddress string
-	xrc20TransferAmount  uint64
-	xrc20Bytes           []byte
-	xrc20ABI             abi.ABI
-	xrc20OwnerAddress    address.Address
-	xrc20TargetAddress   address.Address
-	xrc20SpenderAddress  address.Address
+	gasLimitFlag = flag.NewUint64VarP("gas-limit", "l", 300000, "set gas limit")
+	gasPriceFlag = flag.NewStringVarP("gas-price", "p", "1", "set gas price (unit: 10^(-6)IOTX), use suggested gas price if input is \"0\"")
+	nonceFlag    = flag.NewUint64VarP("nonce", "n", 0, "set nonce (default using pending nonce)")
+	signerFlag   = flag.NewStringVarP("signer", "s", "", "choose a signing account")
+	bytecodeFlag = flag.NewStringVarP("bytecode", "b", "", "set the byte code")
 )
 
 // ActionCmd represents the account command
@@ -55,29 +50,7 @@ var ActionCmd = &cobra.Command{
 	Short: "Manage actions of IoTeX blockchain",
 }
 
-//Xrc20Cmd represent erc20 standard command-line
-var Xrc20Cmd = &cobra.Command{
-	Use:   "xrc20",
-	Short: "Supporting ERC20 standard command-line from ioctl",
-}
-
 func init() {
-	var err error
-	xrc20ABI, err = abi.JSON(strings.NewReader(abiConst))
-	if err != nil {
-		log.L().Error("cannot get abi JSON data", zap.Error(err))
-		return
-	}
-	Xrc20Cmd.AddCommand(Xrc20TotalsupplyCmd)
-	Xrc20Cmd.AddCommand(Xrc20BalanceofCmd)
-	Xrc20Cmd.AddCommand(Xrc20TransferCmd)
-	Xrc20Cmd.AddCommand(Xrc20TransferFromCmd)
-	Xrc20Cmd.AddCommand(Xrc20ApproveCmd)
-	Xrc20Cmd.AddCommand(Xrc20AllowanceCmd)
-	Xrc20Cmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
-		config.ReadConfig.Endpoint, "set endpoint for once")
-	Xrc20Cmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,
-		"insecure connection for once")
 	ActionCmd.AddCommand(actionHashCmd)
 	ActionCmd.AddCommand(actionTransferCmd)
 	ActionCmd.AddCommand(actionDeployCmd)
@@ -89,81 +62,42 @@ func init() {
 		config.ReadConfig.Endpoint, "set endpoint for once")
 	ActionCmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,
 		"insecure connection for once")
-	setActionFlagsAction(actionTransferCmd, actionDeployCmd, actionInvokeCmd, actionReadCmd, actionClaimCmd,
-		actionDepositCmd)
-	setActionFlagsXrc(Xrc20TotalsupplyCmd, Xrc20BalanceofCmd, Xrc20TransferCmd, Xrc20TransferFromCmd, Xrc20ApproveCmd, Xrc20AllowanceCmd)
-
 }
 
-func inputToExecution(contract string, amount *big.Int) (*action.Execution, error) {
-	executor, err := alias.Address(signer)
+func decodeBytecode() ([]byte, error) {
+	return hex.DecodeString(strings.TrimLeft(bytecodeFlag.Value, "0x"))
+}
+
+func signer() (string, error) {
+	return alias.Address(signerFlag.Value)
+}
+
+func nonce(executor string) (uint64, error) {
+	nonce := nonceFlag.Value
+	if nonce != 0 {
+		return nonce, nil
+	}
+	accountMeta, err := account.GetAccountMeta(executor)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
-	var gasPriceRau *big.Int
-	if len(gasPrice) == 0 {
-		gasPriceRau, err = GetGasPrice()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		gasPriceRau, err = util.StringToRau(gasPrice, util.GasPriceDecimalNum)
-		if err != nil {
-			return nil, err
-		}
-	}
-	if nonce == 0 {
-		accountMeta, err := account.GetAccountMeta(executor)
-		if err != nil {
-			return nil, err
-		}
-		nonce = accountMeta.PendingNonce
-	}
-	var bytecodeBytes []byte
-	if bytecodeString != "" {
-		bytecodeBytes, err = hex.DecodeString(strings.TrimLeft(bytecodeString, "0x"))
-	} else {
-		bytecodeBytes = xrc20Bytes
-	}
-	if err != nil {
-		log.L().Error("cannot decode bytecode string", zap.Error(err))
-		return nil, err
-	}
-	return action.NewExecution(contract, nonce, amount, gasLimit, gasPriceRau, bytecodeBytes)
+	return accountMeta.PendingNonce, nil
 }
 
-func setActionFlagsAction(cmds ...*cobra.Command) {
-	for _, cmd := range cmds {
-		cmd.Flags().Uint64VarP(&gasLimit, "gas-limit", "l", 0, "set gas limit")
-		cmd.Flags().StringVarP(&gasPrice, "gas-price", "p", "1",
-			"set gas price (unit: 10^(-6)Iotx)")
-		cmd.Flags().StringVarP(&signer, "signer", "s", "", "choose a signing account")
-		cmd.Flags().Uint64VarP(&nonce, "nonce", "n", 0, "set nonce")
-		cmd.MarkFlagRequired("signer")
-		if cmd == actionDeployCmd || cmd == actionInvokeCmd || cmd == actionReadCmd {
-			cmd.Flags().StringVarP(&bytecodeString, "bytecode", "b", "", "set the byte code")
-
-			cmd.MarkFlagRequired("gas-limit")
-			cmd.MarkFlagRequired("bytecode")
-		}
-	}
+func registerWriteCommand(cmd *cobra.Command) {
+	gasLimitFlag.RegisterCommand(cmd)
+	gasPriceFlag.RegisterCommand(cmd)
+	signerFlag.RegisterCommand(cmd)
+	nonceFlag.RegisterCommand(cmd)
+	signerFlag.MarkFlagRequired(cmd)
 }
 
-func setActionFlagsXrc(cmds ...*cobra.Command) {
-	for _, cmd := range cmds {
-		cmd.Flags().StringVarP(&xrc20ContractAddress, "contract-address", "c", "1",
-			"set contract address")
-		if cmd == Xrc20TransferCmd || cmd == Xrc20TransferFromCmd || cmd == Xrc20ApproveCmd {
-			cmd.Flags().Uint64VarP(&gasLimit, "gas-limit", "l", 0, "set gas limit")
-			cmd.Flags().StringVarP(&signer, "signer", "s", "", "choose a signing account")
-			cmd.Flags().StringVarP(&gasPrice, "gas-price", "p", "1",
-				"set gas price (unit: 10^(-6)Iotx)")
-		}
+// gasPriceInRau returns the suggest gas price
+func gasPriceInRau() (*big.Int, error) {
+	gasPrice := gasPriceFlag.Value
+	if len(gasPrice) != 0 {
+		return util.StringToRau(gasPrice, util.GasPriceDecimalNum)
 	}
-}
-
-// GetGasPrice gets the suggest gas price
-func GetGasPrice() (*big.Int, error) {
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
 		return nil, err
@@ -179,29 +113,58 @@ func GetGasPrice() (*big.Int, error) {
 	return new(big.Int).SetUint64(response.GasPrice), nil
 }
 
-func sendAction(elp action.Envelope) (string, error) {
+func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
+	gasPriceRau, err := gasPriceInRau()
+	if err != nil {
+		return
+	}
+	signer, err := signer()
+	if err != nil {
+		return err
+	}
+	nonce, err := nonce(signer)
+	if err != nil {
+		return
+	}
+	tx, err := action.NewExecution(contract, nonce, amount, gasLimitFlag.Value, gasPriceRau, bytecode)
+	if err != nil || tx == nil {
+		err = errors.Wrap(err, "cannot make a Execution instance")
+		log.L().Error("error when invoke an execution", zap.Error(err))
+		return
+	}
+	return sendAction(
+		(&action.EnvelopeBuilder{}).
+			SetNonce(nonce).
+			SetGasPrice(gasPriceRau).
+			SetGasLimit(gasLimitFlag.Value).
+			SetAction(tx).Build(),
+		signer,
+	)
+}
+
+func sendAction(elp action.Envelope, signer string) error {
 	fmt.Printf("Enter password #%s:\n", signer)
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return err
 	}
 	prvKey, err := account.KsAccountToPrivateKey(signer, string(bytePassword))
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer prvKey.Zero()
 	sealed, err := action.Sign(elp, prvKey)
 	prvKey.Zero()
 	if err != nil {
 		log.L().Error("failed to sign action", zap.Error(err))
-		return "", err
+		return err
 	}
 	selp := sealed.Proto()
 
 	actionInfo, err := printActionProto(selp)
 	if err != nil {
-		return "", err
+		return err
 	}
 	var confirm string
 	fmt.Println("\n" + actionInfo + "\n" +
@@ -209,13 +172,13 @@ func sendAction(elp action.Envelope) (string, error) {
 		"Type 'YES' to continue, quit for anything else.")
 	fmt.Scanf("%s", &confirm)
 	if confirm != "YES" && confirm != "yes" {
-		return "Quit", nil
+		return nil
 	}
 	fmt.Println()
 
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return "", err
+		return err
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -224,35 +187,12 @@ func sendAction(elp action.Envelope) (string, error) {
 	request := &iotexapi.SendActionRequest{Action: selp}
 	if _, err = cli.SendAction(ctx, request); err != nil {
 		if sta, ok := status.FromError(err); ok {
-			return "", fmt.Errorf(sta.Message())
+			return fmt.Errorf(sta.Message())
 		}
-		return "", err
+		return err
 	}
 	shash := hash.Hash256b(byteutil.Must(proto.Marshal(selp)))
-	return "Action has been sent to blockchain.\n" +
-		"Wait for several seconds and query this action by hash:\n" +
-		hex.EncodeToString(shash[:]), nil
-}
-
-func readAction(exec *action.Execution, caller string) (string, error) {
-	fmt.Println()
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
-	if err != nil {
-		return "", err
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	request := &iotexapi.ReadContractRequest{
-		Execution:     exec.Proto(),
-		CallerAddress: caller}
-	res, err := cli.ReadContract(ctx, request)
-	if err != nil {
-		if sta, ok := status.FromError(err); ok {
-			return "", fmt.Errorf(sta.Message())
-		}
-		return "", err
-	}
-	return res.Data, nil
+	fmt.Println("Action has been sent to blockchain.")
+	fmt.Printf("Wait for several seconds and query this action by hash: %s\n", hex.EncodeToString(shash[:]))
+	return nil
 }

--- a/cli/ioctl/cmd/action/actionclaim.go
+++ b/cli/ioctl/cmd/action/actionclaim.go
@@ -32,7 +32,7 @@ var actionClaimCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		gasLimit := gasLimitFlag.Value
+		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
 			gasLimit = action.ClaimFromRewardingFundBaseGas +
 				action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))

--- a/cli/ioctl/cmd/action/actionclaim.go
+++ b/cli/ioctl/cmd/action/actionclaim.go
@@ -7,14 +7,9 @@
 package action
 
 import (
-	"fmt"
-	"math/big"
-
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 )
 
@@ -25,57 +20,39 @@ var actionClaimCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := claim(args)
-		if err == nil {
-			fmt.Println(output)
+		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
+		if err != nil {
+			return err
 		}
-		return err
+		payload := make([]byte, 0)
+		if len(args) == 2 {
+			payload = []byte(args[1])
+		}
+		sender, err := signer()
+		if err != nil {
+			return err
+		}
+		gasLimit := gasLimitFlag.Value
+		if gasLimit == 0 {
+			gasLimit = action.ClaimFromRewardingFundBaseGas +
+				action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))
+		}
+		gasPriceRau, err := gasPriceInRau()
+		nonce, err := nonce(sender)
+		if err != nil {
+			return err
+		}
+		act := (&action.ClaimFromRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
+
+		return sendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
+			SetGasPrice(gasPriceRau).
+			SetGasLimit(gasLimit).
+			SetAction(&act).Build(),
+			sender,
+		)
 	},
 }
 
-// claim claims rewards from rewarding fund
-func claim(args []string) (string, error) {
-	amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
-	if err != nil {
-		return "", err
-	}
-	payload := make([]byte, 0)
-	if len(args) == 2 {
-		payload = []byte(args[1])
-	}
-	sender, err := alias.Address(signer)
-	if err != nil {
-		return "", err
-	}
-	if gasLimit == 0 {
-		gasLimit = action.ClaimFromRewardingFundBaseGas +
-			action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))
-	}
-	var gasPriceRau *big.Int
-	if len(gasPrice) == 0 {
-		gasPriceRau, err = GetGasPrice()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		gasPriceRau, err = util.StringToRau(gasPrice, util.GasPriceDecimalNum)
-		if err != nil {
-			return "", err
-		}
-	}
-	if nonce == 0 {
-		accountMeta, err := account.GetAccountMeta(sender)
-		if err != nil {
-			return "", err
-		}
-		nonce = accountMeta.PendingNonce
-	}
-	b := &action.ClaimFromRewardingFundBuilder{}
-	act := b.SetAmount(amount).SetData(payload).Build()
-	bd := &action.EnvelopeBuilder{}
-	elp := bd.SetNonce(nonce).
-		SetGasPrice(gasPriceRau).
-		SetGasLimit(gasLimit).
-		SetAction(&act).Build()
-	return sendAction(elp)
+func init() {
+	registerWriteCommand(actionClaimCmd)
 }

--- a/cli/ioctl/cmd/action/actiondeposit.go
+++ b/cli/ioctl/cmd/action/actiondeposit.go
@@ -7,14 +7,9 @@
 package action
 
 import (
-	"fmt"
-	"math/big"
-
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 )
 
@@ -25,57 +20,39 @@ var actionDepositCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := deposit(args)
-		if err == nil {
-			fmt.Println(output)
+		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
+		if err != nil {
+			return err
 		}
-		return err
+		payload := make([]byte, 0)
+		if len(args) == 2 {
+			payload = []byte(args[1])
+		}
+		sender, err := signer()
+		if err != nil {
+			return err
+		}
+		gasLimit := gasLimitFlag.Value
+		if gasLimit == 0 {
+			gasLimit = action.DepositToRewardingFundBaseGas +
+				action.DepositToRewardingFundGasPerByte*uint64(len(payload))
+		}
+		gasPriceRau, err := gasPriceInRau()
+		nonce, err := nonce(sender)
+		if err != nil {
+			return err
+		}
+		act := (&action.DepositToRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
+
+		return sendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
+			SetGasPrice(gasPriceRau).
+			SetGasLimit(gasLimit).
+			SetAction(&act).Build(),
+			sender,
+		)
 	},
 }
 
-// deposit deposits token into rewarding fund
-func deposit(args []string) (string, error) {
-	amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
-	if err != nil {
-		return "", err
-	}
-	payload := make([]byte, 0)
-	if len(args) == 2 {
-		payload = []byte(args[1])
-	}
-	sender, err := alias.Address(signer)
-	if err != nil {
-		return "", err
-	}
-	if gasLimit == 0 {
-		gasLimit = action.DepositToRewardingFundBaseGas +
-			action.DepositToRewardingFundGasPerByte*uint64(len(payload))
-	}
-	var gasPriceRau *big.Int
-	if len(gasPrice) == 0 {
-		gasPriceRau, err = GetGasPrice()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		gasPriceRau, err = util.StringToRau(gasPrice, util.GasPriceDecimalNum)
-		if err != nil {
-			return "", err
-		}
-	}
-	if nonce == 0 {
-		accountMeta, err := account.GetAccountMeta(sender)
-		if err != nil {
-			return "", err
-		}
-		nonce = accountMeta.PendingNonce
-	}
-	b := &action.DepositToRewardingFundBuilder{}
-	act := b.SetAmount(amount).SetData(payload).Build()
-	bd := &action.EnvelopeBuilder{}
-	elp := bd.SetNonce(nonce).
-		SetGasPrice(gasPriceRau).
-		SetGasLimit(gasLimit).
-		SetAction(&act).Build()
-	return sendAction(elp)
+func init() {
+	registerWriteCommand(actionDepositCmd)
 }

--- a/cli/ioctl/cmd/action/actiondeposit.go
+++ b/cli/ioctl/cmd/action/actiondeposit.go
@@ -32,7 +32,7 @@ var actionDepositCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		gasLimit := gasLimitFlag.Value
+		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
 			gasLimit = action.DepositToRewardingFundBaseGas +
 				action.DepositToRewardingFundGasPerByte*uint64(len(payload))

--- a/cli/ioctl/cmd/action/actioninvoke.go
+++ b/cli/ioctl/cmd/action/actioninvoke.go
@@ -7,68 +7,43 @@
 package action
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
-	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // actionInvokeCmd represents the action invoke command
 var actionInvokeCmd = &cobra.Command{
 	Use: "invoke (ALIAS|CONTRACT_ADDRESS) [AMOUNT_IOTX]" +
-		" -s SIGNER -b BYTE_CODE -l GAS_LIMIT [-p GAS_PRICE]",
+		" -s SIGNER -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE]",
 	Short: "Invoke smart contract on IoTeX blockchain",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := invoke(args)
-		if err == nil {
-			fmt.Println(output)
+		contract, err := alias.Address(args[0])
+		if err != nil {
+			return err
 		}
-		return err
+		amount := big.NewInt(0)
+		if len(args) == 2 {
+			amount, err = util.StringToRau(args[1], util.IotxDecimalNum)
+			if err != nil {
+				return err
+			}
+		}
+		bytecode, err := decodeBytecode()
+		if err != nil {
+			return err
+		}
+		return execute(contract, amount, bytecode)
 	},
 }
 
-// invoke invokes smart contract on IoTeX blockchain
-func invoke(args []string) (string, error) {
-	contract, err := alias.Address(args[0])
-	if err != nil {
-		return "", err
-	}
-	amount := big.NewInt(0)
-	if len(args) == 2 {
-		amount, err = util.StringToRau(args[1], util.IotxDecimalNum)
-		if err != nil {
-			return "", err
-		}
-	}
-	var gasPriceRau *big.Int
-	if len(gasPrice) == 0 {
-		gasPriceRau, err = GetGasPrice()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		gasPriceRau, err = util.StringToRau(gasPrice, util.GasPriceDecimalNum)
-		if err != nil {
-			return "", err
-		}
-	}
-	tx, err := inputToExecution(contract, amount)
-	if err != nil || tx == nil {
-		log.L().Error("cannot make a Execution instance", zap.Error(err))
-		return "", err
-	}
-	bd := &action.EnvelopeBuilder{}
-	elp := bd.SetNonce(nonce).
-		SetGasPrice(gasPriceRau).
-		SetGasLimit(gasLimit).
-		SetAction(tx).Build()
-	return sendAction(elp)
+func init() {
+	registerWriteCommand(actionInvokeCmd)
+	bytecodeFlag.RegisterCommand(actionInvokeCmd)
+	bytecodeFlag.MarkFlagRequired(actionInvokeCmd)
 }

--- a/cli/ioctl/cmd/action/actionread.go
+++ b/cli/ioctl/cmd/action/actionread.go
@@ -7,25 +7,42 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/status"
 
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 )
+
+var defaultGasPrice = new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 
 // actionReadCmd represents the action read command
 var actionReadCmd = &cobra.Command{
-	Use: "read (ALIAS|CONTRACT_ADDRESS)" +
-		" -s SIGNER -b BYTE_CODE -l GAS_LIMIT [-p GAS_PRICE]",
+	Use:   "read (ALIAS|CONTRACT_ADDRESS) -b BYTE_CODE [-s SIGNER]",
 	Short: "Read smart contract on IoTeX blockchain",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := read(args)
+		contract, err := alias.Address(args[0])
+		if err != nil {
+			return err
+		}
+		bytecode, err := decodeBytecode()
+		if err != nil {
+			return err
+		}
+		output, err := read(contract, bytecode)
 		if err == nil {
 			fmt.Println(output)
 		}
@@ -33,20 +50,44 @@ var actionReadCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	signerFlag.RegisterCommand(actionReadCmd)
+	bytecodeFlag.RegisterCommand(actionReadCmd)
+	bytecodeFlag.MarkFlagRequired(actionReadCmd)
+}
+
 // read reads smart contract on IoTeX blockchain
-func read(args []string) (string, error) {
-	contract, err := alias.Address(args[0])
+func read(contract address.Address, bytecode []byte) (string, error) {
+	signer := signerFlag.Value
+	if len(signer) == 0 {
+		signer = defaultSigner
+	}
+	caller, err := alias.Address(signer)
 	if err != nil {
 		return "", err
 	}
-	executor, err := alias.Address(signer)
+	exec, err := action.NewExecution(contract.String(), 0, big.NewInt(0), genesis.Default.ActionGasLimit, defaultGasPrice, bytecode)
+	if err != nil {
+		log.L().Error("cannot make an Execution instance", zap.Error(err))
+		return "", err
+	}
+	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
 		return "", err
 	}
-	tx, err := inputToExecution(contract, big.NewInt(0))
-	if err != nil || tx == nil {
-		log.L().Error("cannot make a Execution instance", zap.Error(err))
-		return "", err
+	defer conn.Close()
+	res, err := iotexapi.NewAPIServiceClient(conn).ReadContract(
+		context.Background(),
+		&iotexapi.ReadContractRequest{
+			Execution:     exec.Proto(),
+			CallerAddress: caller,
+		},
+	)
+	if err == nil {
+		return res.Data, nil
 	}
-	return readAction(tx, executor)
+	if sta, ok := status.FromError(err); ok {
+		return "", fmt.Errorf(sta.Message())
+	}
+	return "", err
 }

--- a/cli/ioctl/cmd/action/actionread.go
+++ b/cli/ioctl/cmd/action/actionread.go
@@ -34,7 +34,7 @@ var actionReadCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		contract, err := alias.Address(args[0])
+		contract, err := alias.IOAddress(args[0])
 		if err != nil {
 			return err
 		}
@@ -58,7 +58,7 @@ func init() {
 
 // read reads smart contract on IoTeX blockchain
 func read(contract address.Address, bytecode []byte) (string, error) {
-	signer := signerFlag.Value
+	signer := signerFlag.Value().(string)
 	if len(signer) == 0 {
 		signer = defaultSigner
 	}

--- a/cli/ioctl/cmd/action/actiontransfer.go
+++ b/cli/ioctl/cmd/action/actiontransfer.go
@@ -8,17 +8,13 @@ package action
 
 import (
 	"encoding/hex"
-	"fmt"
-	"math/big"
-
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 // actionTransferCmd represents the action transfer command
@@ -29,68 +25,55 @@ var actionTransferCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(2, 3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := transfer(args)
-		if err == nil {
-			fmt.Println(output)
+		recipient, err := alias.Address(args[0])
+		if err != nil {
+			return err
 		}
-		return err
+		amount, err := util.StringToRau(args[1], util.IotxDecimalNum)
+		if err != nil {
+			return err
+		}
+		var payload []byte
+		if len(args) == 3 {
+			payload, err = hex.DecodeString(args[2])
+			if err != nil {
+				return err
+			}
+		}
+		sender, err := signer()
+		if err != nil {
+			return err
+		}
+		gasLimit := gasLimitFlag.Value
+		if gasLimit == 0 {
+			gasLimit = action.TransferBaseIntrinsicGas +
+				action.TransferPayloadGas*uint64(len(payload))
+		}
+		gasPriceRau, err := gasPriceInRau()
+		if err != nil {
+			return err
+		}
+		nonce, err := nonce(sender)
+		if err != nil {
+			return err
+		}
+		tx, err := action.NewTransfer(nonce, amount,
+			recipient, payload, gasLimit, gasPriceRau)
+		if err != nil {
+			log.L().Error("failed to make a Transfer instance", zap.Error(err))
+			return err
+		}
+		return sendAction(
+			(&action.EnvelopeBuilder{}).
+				SetNonce(nonce).
+				SetGasPrice(gasPriceRau).
+				SetGasLimit(gasLimit).
+				SetAction(tx).Build(),
+			sender,
+		)
 	},
 }
 
-// transfer transfers tokens on IoTeX blockchain
-func transfer(args []string) (string, error) {
-	recipient, err := alias.Address(args[0])
-	if err != nil {
-		return "", err
-	}
-	amount, err := util.StringToRau(args[1], util.IotxDecimalNum)
-	if err != nil {
-		return "", err
-	}
-	var payload []byte
-	if len(args) == 3 {
-		payload, err = hex.DecodeString(args[2])
-		if err != nil {
-			return "", err
-		}
-	}
-	sender, err := alias.Address(signer)
-	if err != nil {
-		return "", err
-	}
-	if gasLimit == 0 {
-		gasLimit = action.TransferBaseIntrinsicGas +
-			action.TransferPayloadGas*uint64(len(payload))
-	}
-	var gasPriceRau *big.Int
-	if len(gasPrice) == 0 {
-		gasPriceRau, err = GetGasPrice()
-		if err != nil {
-			return "", err
-		}
-	} else {
-		gasPriceRau, err = util.StringToRau(gasPrice, util.GasPriceDecimalNum)
-		if err != nil {
-			return "", err
-		}
-	}
-	if nonce == 0 {
-		accountMeta, err := account.GetAccountMeta(sender)
-		if err != nil {
-			return "", err
-		}
-		nonce = accountMeta.PendingNonce
-	}
-	tx, err := action.NewTransfer(nonce, amount,
-		recipient, payload, gasLimit, gasPriceRau)
-	if err != nil {
-		log.L().Error("failed to make a Transfer instance", zap.Error(err))
-		return "", err
-	}
-	bd := &action.EnvelopeBuilder{}
-	elp := bd.SetNonce(nonce).
-		SetGasPrice(gasPriceRau).
-		SetGasLimit(gasLimit).
-		SetAction(tx).Build()
-	return sendAction(elp)
+func init() {
+	registerWriteCommand(actionTransferCmd)
 }

--- a/cli/ioctl/cmd/action/actiontransfer.go
+++ b/cli/ioctl/cmd/action/actiontransfer.go
@@ -44,7 +44,7 @@ var actionTransferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		gasLimit := gasLimitFlag.Value
+		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
 			gasLimit = action.TransferBaseIntrinsicGas +
 				action.TransferPayloadGas*uint64(len(payload))

--- a/cli/ioctl/cmd/action/xrc20.go
+++ b/cli/ioctl/cmd/action/xrc20.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+)
+
+//Xrc20Cmd represent erc20 standard command-line
+var Xrc20Cmd = &cobra.Command{
+	Use:   "xrc20",
+	Short: "Supporting ERC20 standard command-line from ioctl",
+}
+
+var xrc20ContractAddress string
+
+func xrc20Contract() (address.Address, error) {
+	return alias.IOAddress(xrc20ContractAddress)
+}
+
+func init() {
+	Xrc20Cmd.AddCommand(xrc20TotalSupplyCmd)
+	Xrc20Cmd.AddCommand(xrc20BalanceOfCmd)
+	Xrc20Cmd.AddCommand(xrc20TransferCmd)
+	Xrc20Cmd.AddCommand(xrc20TransferFromCmd)
+	Xrc20Cmd.AddCommand(xrc20ApproveCmd)
+	Xrc20Cmd.AddCommand(xrc20AllowanceCmd)
+	Xrc20Cmd.PersistentFlags().StringVarP(&xrc20ContractAddress, "contract-address", "c", "",
+		"set contract address")
+	Xrc20Cmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
+		config.ReadConfig.Endpoint, "set endpoint for once")
+	Xrc20Cmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,
+		"insecure connection for once (default false)")
+	cobra.MarkFlagRequired(Xrc20Cmd.PersistentFlags(), "contract-address")
+}

--- a/cli/ioctl/cmd/action/xrc20allowance.go
+++ b/cli/ioctl/cmd/action/xrc20allowance.go
@@ -8,58 +8,46 @@ package action
 
 import (
 	"fmt"
+	"math/big"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
-// Xrc20AllowanceCmd represents your signer limited amount on target address
-var Xrc20AllowanceCmd = &cobra.Command{
+// xrc20AllowanceCmd represents your signer limited amount on target address
+var xrc20AllowanceCmd = &cobra.Command{
 	Use: "allowance (ALIAS|OWNER_ADDRESS) (ALIAS|SPENDER_ADDRESS) " +
 		" -c ALIAS|CONTRACT_ADDRESS ",
 	Short: "the amount which spender is still allowed to withdraw from owner",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		addr, err := alias.Address(args[0])
+		owner, err := alias.EtherAddress(args[0])
 		if err != nil {
 			return err
 		}
-		xrc20OwnerAddress, err = address.FromString(addr)
+		spender, err := alias.EtherAddress(args[1])
 		if err != nil {
 			return err
 		}
-		addr, err = alias.Address(args[1])
+		bytecode, err := xrc20ABI.Pack("allowance", owner, spender)
+		if err != nil {
+			log.L().Error("cannot generate bytecode from given command", zap.Error(err))
+			return err
+		}
+		contract, err := xrc20Contract()
 		if err != nil {
 			return err
 		}
-		xrc20SpenderAddress, err = address.FromString(addr)
-		if err != nil {
-			return err
-		}
-		output, err := allowance(args)
+		output, err := read(contract, bytecode)
 		if err == nil {
-			fmt.Println(output)
+			fmt.Println("Raw output:", output)
+			decimal, _ := new(big.Int).SetString(output, 16)
+			fmt.Printf("Output in decimal: %d\n", decimal)
 		}
 		return err
 	},
-}
-
-// read reads smart contract on IoTeX blockchain
-func allowance(args []string) (string, error) {
-	var err error
-	args[0] = xrc20ContractAddress
-	gasLimit = 50000
-	signer = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
-	xrc20Bytes, err = xrc20ABI.Pack("allowance", toEthAddr(xrc20OwnerAddress), toEthAddr(xrc20SpenderAddress))
-	if err != nil {
-		log.L().Error("cannot generate bytecode from given command", zap.Error(err))
-		return "", err
-	}
-	return read(args)
-
 }

--- a/cli/ioctl/cmd/action/xrc20balanceof.go
+++ b/cli/ioctl/cmd/action/xrc20balanceof.go
@@ -10,53 +10,36 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 )
 
-// Xrc20BalanceofCmd represents balanceof function
-var Xrc20BalanceofCmd = &cobra.Command{
-	Use: "balanceof (ALIAS|OWNER_ADDRESS)" +
-		" -c ALIAS|CONTRACT_ADDRESS ",
+// xrc20BalanceOfCmd represents balanceOf function
+var xrc20BalanceOfCmd = &cobra.Command{
+	Use:   "balanceOf (ALIAS|OWNER_ADDRESS) -c ALIAS|CONTRACT_ADDRESS ",
 	Short: "Get account balance",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		addr, err := alias.Address(args[0])
+		owner, err := alias.EtherAddress(args[0])
 		if err != nil {
 			return err
 		}
-		xrc20OwnerAddress, err = address.FromString(addr)
+		bytecode, err := xrc20ABI.Pack("balanceOf", owner)
 		if err != nil {
 			return err
 		}
-		output, err := balanceOf(args)
+		contract, err := xrc20Contract()
+		if err != nil {
+			return err
+		}
+		output, err := read(contract, bytecode)
 		if err == nil {
-			fmt.Println(output)
-			result := new(big.Int)
-			result.SetString(output, 16)
-			fmt.Printf("Ouptut in decimal format: %d\n", result)
+			fmt.Println("Raw output:", output)
+			decimal, _ := new(big.Int).SetString(output, 16)
+			fmt.Printf("Output in decimal: %d\n", decimal)
 		}
 		return err
 	},
-}
-
-func toEthAddr(addr address.Address) common.Address {
-	return common.BytesToAddress(addr.Bytes())
-}
-
-// read reads smart contract on IoTeX blockchain
-func balanceOf(args []string) (string, error) {
-	args[0] = xrc20ContractAddress
-	signer = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
-	gasLimit = 50000
-	var err error
-	xrc20Bytes, err = xrc20ABI.Pack("balanceOf", toEthAddr(xrc20OwnerAddress))
-	if err != nil {
-		return "", err
-	}
-	return read(args)
 }

--- a/cli/ioctl/cmd/action/xrc20const.go
+++ b/cli/ioctl/cmd/action/xrc20const.go
@@ -1,5 +1,13 @@
 package action
 
+import (
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"go.uber.org/zap"
+)
+
 const abiConst = `[
 	{
 		"constant": false,
@@ -175,3 +183,13 @@ const abiConst = `[
 		"type": "event"
 	}
 ]`
+
+var xrc20ABI abi.ABI
+
+func init() {
+	var err error
+	xrc20ABI, err = abi.JSON(strings.NewReader(abiConst))
+	if err != nil {
+		log.L().Panic("cannot get abi JSON data", zap.Error(err))
+	}
+}

--- a/cli/ioctl/cmd/action/xrc20totalsupply.go
+++ b/cli/ioctl/cmd/action/xrc20totalsupply.go
@@ -13,34 +13,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Xrc20TotalsupplyCmd represents total supply of the contract
-var Xrc20TotalsupplyCmd = &cobra.Command{
-	Use: "totalsupply" +
-		" -c CONTRACT_ADDRESS",
+// xrc20TotalSupplyCmd represents total supply of the contract
+var xrc20TotalSupplyCmd = &cobra.Command{
+	Use:   "totalSupply -c ALIAS|CONTRACT_ADDRESS",
 	Short: "Get total supply",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := totalSupply(args)
+		bytecode, err := xrc20ABI.Pack("totalSupply")
+		if err != nil {
+			return err
+		}
+		contract, err := xrc20Contract()
+		if err != nil {
+			return err
+		}
+		output, err := read(contract, bytecode)
 		if err == nil {
-			fmt.Println(output)
-			result := new(big.Int)
-			result.SetString(output, 16)
-			fmt.Printf("Ouptut in decimal format: %d\n", result)
+			fmt.Println("Raw output:", output)
+			decimal, _ := new(big.Int).SetString(output, 16)
+			fmt.Printf("Output in decimal: %d\n", decimal)
 		}
 		return err
 	},
-}
-
-// read reads smart contract on IoTeX blockchain
-func totalSupply(args []string) (string, error) {
-	argument := make([]string, 1)
-	argument[0] = xrc20ContractAddress
-	signer = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
-	gasLimit = 50000
-	var err error
-	xrc20Bytes, err = xrc20ABI.Pack("totalSupply")
-	if err != nil {
-		return "", err
-	}
-	return read(argument)
 }

--- a/cli/ioctl/cmd/action/xrc20transfer.go
+++ b/cli/ioctl/cmd/action/xrc20transfer.go
@@ -7,53 +7,42 @@
 package action
 
 import (
-	"fmt"
 	"math/big"
-	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 )
 
-// Xrc20TransferCmd could do transfer action
-var Xrc20TransferCmd = &cobra.Command{
-	Use: "transfer (ALIAS|TARGET_ADDRESS) (AMOUNT)" +
-		" -c ALIAS|CONTRACT_ADDRESS -l GAS_LIMIT -s SIGNER [-p GAS_PRICE]",
+// xrc20TransferCmd could do transfer action
+var xrc20TransferCmd = &cobra.Command{
+	Use: "transfer (ALIAS|TARGET_ADDRESS) AMOUNT" +
+		" -c ALIAS|CONTRACT_ADDRESS [-l GAS_LIMIT] -s SIGNER [-p GAS_PRICE]",
 	Short: "Get account balance",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		addr, err := alias.Address(args[0])
+		recipient, err := alias.EtherAddress(args[0])
 		if err != nil {
 			return err
 		}
-		xrc20TargetAddress, err = address.FromString(addr)
+		amount, ok := new(big.Int).SetString(args[1], 10)
+		if !ok {
+			return errors.Errorf("invalid XRC20 amount format %s", args[1])
+		}
+		bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
 		if err != nil {
 			return err
 		}
-		transfer, err := strconv.ParseInt(args[1], 10, 64)
+		contract, err := xrc20Contract()
 		if err != nil {
 			return err
 		}
-		xrc20TransferAmount = uint64(transfer)
-		output, err := transferTo(args)
-		if err == nil {
-			fmt.Println(output)
-		}
-		return err
+		return execute(contract.String(), big.NewInt(0), bytecode)
 	},
 }
 
-// read reads smart contract on IoTeX blockchain
-func transferTo(args []string) (string, error) {
-	args[0] = xrc20ContractAddress
-	args[1] = "0"
-	var err error
-	xrc20Bytes, err = xrc20ABI.Pack("transfer", toEthAddr(xrc20TargetAddress), new(big.Int).SetUint64(xrc20TransferAmount))
-	if err != nil {
-		return "", err
-	}
-	return invoke(args)
+func init() {
+	registerWriteCommand(xrc20TransferCmd)
 }

--- a/cli/ioctl/cmd/alias/alias.go
+++ b/cli/ioctl/cmd/alias/alias.go
@@ -10,9 +10,12 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/cli/ioctl/validator"
 )
 
@@ -63,6 +66,24 @@ func Address(in string) (string, error) {
 		return addr, nil
 	}
 	return "", fmt.Errorf("cannot find address from " + in)
+}
+
+// IOAddress returns the address in iotex address format
+func IOAddress(in string) (address.Address, error) {
+	addr, err := Address(in)
+	if err != nil {
+		return nil, err
+	}
+	return address.FromString(addr)
+}
+
+// EtherAddress returns the address in ether format
+func EtherAddress(in string) (common.Address, error) {
+	addr, err := Address(in)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return util.IoAddrToEvmAddr(addr)
 }
 
 // Alias returns the alias corresponding to address

--- a/cli/ioctl/flag/flag.go
+++ b/cli/ioctl/flag/flag.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package flag
+
+import "github.com/spf13/cobra"
+
+type (
+	flagBase struct {
+		label       string
+		shortLabel  string
+		description string
+	}
+
+	// Flag defines a cobra command flag
+	Flag interface {
+		Label() string
+		RegisterCommand(*cobra.Command)
+	}
+
+	// StringVarP is a flag of StringVarP type
+	StringVarP struct {
+		flagBase
+		Value        string
+		defaultValue string
+	}
+
+	// Uint64VarP is a flag of Uint64VarP type
+	Uint64VarP struct {
+		flagBase
+		Value        uint64
+		defaultValue uint64
+	}
+)
+
+func (f *flagBase) MarkFlagRequired(cmd *cobra.Command) {
+	cmd.MarkFlagRequired(f.label)
+}
+
+func NewStringVarP(
+	label string,
+	shortLabel string,
+	defaultValue string,
+	description string,
+) *StringVarP {
+	return &StringVarP{
+		flagBase: flagBase{
+			label:       label,
+			shortLabel:  shortLabel,
+			description: description,
+		},
+		defaultValue: defaultValue,
+	}
+}
+
+func (f *StringVarP) RegisterCommand(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.Value, f.label, f.shortLabel, f.defaultValue, f.description)
+}
+
+func NewUint64VarP(
+	label string,
+	shortLabel string,
+	defaultValue uint64,
+	description string,
+) *Uint64VarP {
+	return &Uint64VarP{
+		flagBase: flagBase{
+			label:       label,
+			shortLabel:  shortLabel,
+			description: description,
+		},
+		defaultValue: defaultValue,
+	}
+}
+
+func (f *Uint64VarP) RegisterCommand(cmd *cobra.Command) {
+	cmd.Flags().Uint64VarP(&f.Value, f.label, f.shortLabel, f.defaultValue, f.description)
+}

--- a/cli/ioctl/flag/flag.go
+++ b/cli/ioctl/flag/flag.go
@@ -19,19 +19,19 @@ type (
 	Flag interface {
 		Label() string
 		RegisterCommand(*cobra.Command)
+		Value() interface{}
+		MarkFlagRequired(*cobra.Command)
 	}
 
-	// StringVarP is a flag of StringVarP type
-	StringVarP struct {
+	stringVarP struct {
 		flagBase
-		Value        string
+		value        string
 		defaultValue string
 	}
 
-	// Uint64VarP is a flag of Uint64VarP type
-	Uint64VarP struct {
+	uint64VarP struct {
 		flagBase
-		Value        uint64
+		value        uint64
 		defaultValue uint64
 	}
 )
@@ -40,13 +40,18 @@ func (f *flagBase) MarkFlagRequired(cmd *cobra.Command) {
 	cmd.MarkFlagRequired(f.label)
 }
 
+func (f *flagBase) Label() string {
+	return f.label
+}
+
+// NewStringVarP creates a new stringVarP flag
 func NewStringVarP(
 	label string,
 	shortLabel string,
 	defaultValue string,
 	description string,
-) *StringVarP {
-	return &StringVarP{
+) Flag {
+	return &stringVarP{
 		flagBase: flagBase{
 			label:       label,
 			shortLabel:  shortLabel,
@@ -56,17 +61,22 @@ func NewStringVarP(
 	}
 }
 
-func (f *StringVarP) RegisterCommand(cmd *cobra.Command) {
-	cmd.Flags().StringVarP(&f.Value, f.label, f.shortLabel, f.defaultValue, f.description)
+func (f *stringVarP) Value() interface{} {
+	return f.value
 }
 
+func (f *stringVarP) RegisterCommand(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&f.value, f.label, f.shortLabel, f.defaultValue, f.description)
+}
+
+// NewUint64VarP creates a new uint64VarP flag
 func NewUint64VarP(
 	label string,
 	shortLabel string,
 	defaultValue uint64,
 	description string,
-) *Uint64VarP {
-	return &Uint64VarP{
+) Flag {
+	return &uint64VarP{
 		flagBase: flagBase{
 			label:       label,
 			shortLabel:  shortLabel,
@@ -76,6 +86,10 @@ func NewUint64VarP(
 	}
 }
 
-func (f *Uint64VarP) RegisterCommand(cmd *cobra.Command) {
-	cmd.Flags().Uint64VarP(&f.Value, f.label, f.shortLabel, f.defaultValue, f.description)
+func (f *uint64VarP) RegisterCommand(cmd *cobra.Command) {
+	cmd.Flags().Uint64VarP(&f.value, f.label, f.shortLabel, f.defaultValue, f.description)
+}
+
+func (f *uint64VarP) Value() interface{} {
+	return f.value
 }


### PR DESCRIPTION
1. Introduce Flag to simplify the "set" and "read"
2. Refactor action commands, remove unnecessary returns
3. Add AMOUNT_IN_IOTEX to deploy command for the case that the constructor is payable
4. Add default gas price, gas limit, and nonce
5. Support reading contract as alias