### PR TITLE
Fix one bug after system interrupt during typing password

### DIFF
--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -134,13 +134,13 @@ func GetAccountMeta(addr string) (*iotextypes.AccountMeta, error) {
 
 func newAccount(alias string, walletDir string) (string, error) {
 	fmt.Printf("#%s: Set password\n", alias)
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
 	fmt.Printf("#%s: Enter password again\n", alias)
-	passwordAgain, err := util.TypePassword()
+	passwordAgain, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
@@ -163,13 +163,13 @@ func newAccount(alias string, walletDir string) (string, error) {
 
 func newAccountByKey(alias string, privateKey string, walletDir string) (string, error) {
 	fmt.Printf("#%s: Set password\n", alias)
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
 	fmt.Printf("#%s: Enter password again\n", alias)
-	passwordAgain, err := util.TypePassword()
+	passwordAgain, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err

--- a/cli/ioctl/cmd/account/account.go
+++ b/cli/ioctl/cmd/account/account.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
-	"syscall"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
@@ -26,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -136,19 +134,18 @@ func GetAccountMeta(addr string) (*iotextypes.AccountMeta, error) {
 
 func newAccount(alias string, walletDir string) (string, error) {
 	fmt.Printf("#%s: Set password\n", alias)
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	password := string(bytePassword)
 	fmt.Printf("#%s: Enter password again\n", alias)
-	bytePassword, err = terminal.ReadPassword(int(syscall.Stdin))
+	passwordAgain, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	if password != string(bytePassword) {
+	if password != passwordAgain {
 		return "", ErrPasswdNotMatch
 	}
 	ks := keystore.NewKeyStore(walletDir, keystore.StandardScryptN, keystore.StandardScryptP)
@@ -166,19 +163,18 @@ func newAccount(alias string, walletDir string) (string, error) {
 
 func newAccountByKey(alias string, privateKey string, walletDir string) (string, error) {
 	fmt.Printf("#%s: Set password\n", alias)
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	password := string(bytePassword)
 	fmt.Printf("#%s: Enter password again\n", alias)
-	bytePassword, err = terminal.ReadPassword(int(syscall.Stdin))
+	passwordAgain, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	if password != string(bytePassword) {
+	if password != passwordAgain {
 		return "", ErrPasswdNotMatch
 	}
 	ks := keystore.NewKeyStore(walletDir, keystore.StandardScryptN, keystore.StandardScryptP)

--- a/cli/ioctl/cmd/account/accountexport.go
+++ b/cli/ioctl/cmd/account/accountexport.go
@@ -9,12 +9,11 @@ package account
 import (
 	"fmt"
 
-	"github.com/iotexproject/iotex-core/cli/ioctl/util"
-
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 

--- a/cli/ioctl/cmd/account/accountexport.go
+++ b/cli/ioctl/cmd/account/accountexport.go
@@ -38,7 +38,7 @@ func accountExport(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err

--- a/cli/ioctl/cmd/account/accountexport.go
+++ b/cli/ioctl/cmd/account/accountexport.go
@@ -8,11 +8,11 @@ package account
 
 import (
 	"fmt"
-	"syscall"
+
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -39,12 +39,12 @@ func accountExport(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	prvKey, err := KsAccountToPrivateKey(addr, string(bytePassword))
+	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/account/accountexportpublic.go
+++ b/cli/ioctl/cmd/account/accountexportpublic.go
@@ -38,7 +38,7 @@ func accountExportPublic(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err

--- a/cli/ioctl/cmd/account/accountexportpublic.go
+++ b/cli/ioctl/cmd/account/accountexportpublic.go
@@ -8,13 +8,12 @@ package account
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
@@ -39,12 +38,12 @@ func accountExportPublic(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	prvKey, err := KsAccountToPrivateKey(addr, string(bytePassword))
+	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -10,14 +10,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 	"gopkg.in/yaml.v2"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/cli/ioctl/validator"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
@@ -85,15 +84,12 @@ func writeToFile(alias, addr string) (string, error) {
 		alias), nil
 }
 func readPasswordFromStdin() (string, error) {
-	passwordBytes, err := terminal.ReadPassword(int(syscall.Stdin))
+	Password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	password := strings.TrimSpace(string(passwordBytes))
-	for i := 0; i < len(passwordBytes); i++ {
-		passwordBytes[i] = 0
-	}
+	password := strings.TrimSpace(Password)
 	return password, nil
 }
 func accountImportKey(args []string) (string, error) {

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -9,7 +9,6 @@ package account
 import (
 	"fmt"
 	"io/ioutil"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -84,12 +83,11 @@ func writeToFile(alias, addr string) (string, error) {
 		alias), nil
 }
 func readPasswordFromStdin() (string, error) {
-	Password, err := util.TypePassword()
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	password := strings.TrimSpace(Password)
 	return password, nil
 }
 func accountImportKey(args []string) (string, error) {

--- a/cli/ioctl/cmd/account/accountimport.go
+++ b/cli/ioctl/cmd/account/accountimport.go
@@ -83,7 +83,7 @@ func writeToFile(alias, addr string) (string, error) {
 		alias), nil
 }
 func readPasswordFromStdin() (string, error) {
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
@@ -116,7 +116,7 @@ func accountImportKeyStore(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("#%s: Enter your password of keystore, which will not be exposed on the screen.\n", alias)
-	password, err := readPasswordFromStdin()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		return "", nil
 	}

--- a/cli/ioctl/cmd/account/accountupdate.go
+++ b/cli/ioctl/cmd/account/accountupdate.go
@@ -54,7 +54,7 @@ func accountUpdate(args []string) (string, error) {
 	for _, v := range ks.Accounts() {
 		if bytes.Equal(address.Bytes(), v.Address.Bytes()) {
 			fmt.Printf("#%s: Enter current password\n", account)
-			currentPassword, err := util.TypePassword()
+			currentPassword, err := util.ReadSecretFromStdin()
 			if err != nil {
 				log.L().Error("failed to get current password", zap.Error(err))
 				return "", err
@@ -64,13 +64,13 @@ func accountUpdate(args []string) (string, error) {
 				return "", err
 			}
 			fmt.Printf("#%s: Enter new password\n", account)
-			password, err := util.TypePassword()
+			password, err := util.ReadSecretFromStdin()
 			if err != nil {
 				log.L().Error("failed to get password", zap.Error(err))
 				return "", err
 			}
 			fmt.Printf("#%s: Enter new password again\n", account)
-			passwordAgain, err := util.TypePassword()
+			passwordAgain, err := util.ReadSecretFromStdin()
 			if err != nil {
 				log.L().Error("failed to get password", zap.Error(err))
 				return "", err

--- a/cli/ioctl/cmd/account/accountupdate.go
+++ b/cli/ioctl/cmd/account/accountupdate.go
@@ -9,17 +9,16 @@ package account
 import (
 	"bytes"
 	"fmt"
-	"syscall"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
@@ -55,30 +54,28 @@ func accountUpdate(args []string) (string, error) {
 	for _, v := range ks.Accounts() {
 		if bytes.Equal(address.Bytes(), v.Address.Bytes()) {
 			fmt.Printf("#%s: Enter current password\n", account)
-			byteCurrentPassword, err := terminal.ReadPassword(int(syscall.Stdin))
+			currentPassword, err := util.TypePassword()
 			if err != nil {
 				log.L().Error("failed to get current password", zap.Error(err))
 				return "", err
 			}
-			currentPassword := string(byteCurrentPassword)
 			_, err = ks.SignHashWithPassphrase(v, currentPassword, hash.ZeroHash256[:])
 			if err != nil {
 				return "", err
 			}
 			fmt.Printf("#%s: Enter new password\n", account)
-			bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+			password, err := util.TypePassword()
 			if err != nil {
 				log.L().Error("failed to get password", zap.Error(err))
 				return "", err
 			}
-			password := string(bytePassword)
 			fmt.Printf("#%s: Enter new password again\n", account)
-			bytePassword, err = terminal.ReadPassword(int(syscall.Stdin))
+			passwordAgain, err := util.TypePassword()
 			if err != nil {
 				log.L().Error("failed to get password", zap.Error(err))
 				return "", err
 			}
-			if password != string(bytePassword) {
+			if password != passwordAgain {
 				return "", ErrPasswdNotMatch
 			}
 			if err := ks.Update(v, currentPassword, password); err != nil {

--- a/cli/ioctl/cmd/account/sign.go
+++ b/cli/ioctl/cmd/account/sign.go
@@ -8,13 +8,12 @@ package account
 
 import (
 	"fmt"
-	"syscall"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
@@ -39,10 +38,10 @@ func accountSign(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	password, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err
 	}
-	return Sign(addr, string(bytePassword), args[1])
+	return Sign(addr, password, args[1])
 }

--- a/cli/ioctl/cmd/account/sign.go
+++ b/cli/ioctl/cmd/account/sign.go
@@ -38,7 +38,7 @@ func accountSign(args []string) (string, error) {
 		return "", err
 	}
 	fmt.Printf("Enter password #%s:\n", args[0])
-	password, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return "", err

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -143,12 +143,12 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 
 func sendAction(elp action.Envelope, signer string) error {
 	fmt.Printf("Enter password #%s:\n", signer)
-	bytePassword, err := util.TypePassword()
+	password, err := util.ReadSecretFromStdin()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return err
 	}
-	prvKey, err := account.KsAccountToPrivateKey(signer, bytePassword)
+	prvKey, err := account.KsAccountToPrivateKey(signer, password)
 	if err != nil {
 		return err
 	}

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -12,13 +12,11 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
-	"syscall"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
-	"golang.org/x/crypto/ssh/terminal"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -145,12 +143,12 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 
 func sendAction(elp action.Envelope, signer string) error {
 	fmt.Printf("Enter password #%s:\n", signer)
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
+	bytePassword, err := util.TypePassword()
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))
 		return err
 	}
-	prvKey, err := account.KsAccountToPrivateKey(signer, string(bytePassword))
+	prvKey, err := account.KsAccountToPrivateKey(signer, bytePassword)
 	if err != nil {
 		return err
 	}

--- a/cli/ioctl/util/util.go
+++ b/cli/ioctl/util/util.go
@@ -116,8 +116,8 @@ func StringToIOTX(amount string) (iotx string, err error) {
 	return
 }
 
-//TypePassword used to safely get password input
-func TypePassword() (string, error) {
+// ReadSecretFromStdin used to safely get password input
+func ReadSecretFromStdin() (string, error) {
 	signalListener := make(chan os.Signal, 1)
 	signal.Notify(signalListener, os.Interrupt)
 	routineTerminate := make(chan struct{})


### PR DESCRIPTION
During user should typing the password, if there is a system interrupt like CTRL+C will cause terminal remain in hidden input status. So I create a listener to reset the terminal status when system interrupt approach.