### PR TITLE
Small fix on xrc20 decimal issue

### DIFF
--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -23,7 +22,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -198,28 +196,4 @@ func sendAction(elp action.Envelope, signer string) error {
 	fmt.Println("Action has been sent to blockchain.")
 	fmt.Printf("Wait for several seconds and query this action by hash: %s\n", hex.EncodeToString(shash[:]))
 	return nil
-}
-
-func amountTransfer(contract address.Address, amount *big.Int) (*big.Int, error) {
-	decimalBytecode, err := hex.DecodeString("313ce567")
-	if err != nil {
-		return nil, err
-	}
-	output, err := read(contract, decimalBytecode)
-	if err != nil {
-		return nil, err
-	}
-	var decimal int64
-	if output != "" {
-		decimal, err = strconv.ParseInt(output, 16, 8)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		decimal = 0
-	}
-	for index := int64(0); index < decimal; index++ {
-		amount.Mul(amount, big.NewInt(10))
-	}
-	return amount, nil
 }

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -11,6 +11,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -22,6 +23,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -196,4 +198,23 @@ func sendAction(elp action.Envelope, signer string) error {
 	fmt.Println("Action has been sent to blockchain.")
 	fmt.Printf("Wait for several seconds and query this action by hash: %s\n", hex.EncodeToString(shash[:]))
 	return nil
+}
+
+func amountTransfer(contract address.Address, amount *big.Int) (*big.Int, error) {
+	decimalbytecode, err := hex.DecodeString("313ce567")
+	if err != nil {
+		return nil, err
+	}
+	output, err := read(contract, decimalbytecode)
+	if err != nil {
+		return nil, err
+	}
+	decimal, err := strconv.ParseInt(output, 16, 8)
+	if err != nil {
+		return nil, err
+	}
+	for index := int64(0); index < decimal; index++ {
+		amount.Mul(amount, big.NewInt(10))
+	}
+	return amount, nil
 }

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -201,17 +201,22 @@ func sendAction(elp action.Envelope, signer string) error {
 }
 
 func amountTransfer(contract address.Address, amount *big.Int) (*big.Int, error) {
-	decimalbytecode, err := hex.DecodeString("313ce567")
+	decimalBytecode, err := hex.DecodeString("313ce567")
 	if err != nil {
 		return nil, err
 	}
-	output, err := read(contract, decimalbytecode)
+	output, err := read(contract, decimalBytecode)
 	if err != nil {
 		return nil, err
 	}
-	decimal, err := strconv.ParseInt(output, 16, 8)
-	if err != nil {
-		return nil, err
+	var decimal int64
+	if output != "" {
+		decimal, err = strconv.ParseInt(output, 16, 8)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		decimal = 0
 	}
 	for index := int64(0); index < decimal; index++ {
 		amount.Mul(amount, big.NewInt(10))

--- a/cli/ioctl/cmd/action/xrc20approve.go
+++ b/cli/ioctl/cmd/action/xrc20approve.go
@@ -31,11 +31,11 @@ var xrc20ApproveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		amount, ok := new(big.Int).SetString(args[1], 10)
+		rawAmount, ok := new(big.Int).SetString(args[1], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		amount, err = amountTransfer(contract, amount)
+		amount, err := amountTransfer(contract, rawAmount)
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20approve.go
+++ b/cli/ioctl/cmd/action/xrc20approve.go
@@ -9,7 +9,6 @@ package action
 import (
 	"math/big"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -31,11 +30,7 @@ var xrc20ApproveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		rawAmount, ok := new(big.Int).SetString(args[1], 10)
-		if !ok {
-			return errors.Errorf("invalid XRC20 amount format %s", args[1])
-		}
-		amount, err := amountTransfer(contract, rawAmount)
+		amount, err := parseAmount(contract, args[1])
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20approve.go
+++ b/cli/ioctl/cmd/action/xrc20approve.go
@@ -27,15 +27,19 @@ var xrc20ApproveCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		contract, err := xrc20Contract()
+		if err != nil {
+			return err
+		}
 		amount, ok := new(big.Int).SetString(args[1], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		bytecode, err := xrc20ABI.Pack("approve", spender, amount)
+		amount, err = amountTransfer(contract, amount)
 		if err != nil {
 			return err
 		}
-		contract, err := xrc20Contract()
+		bytecode, err := xrc20ABI.Pack("approve", spender, amount)
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transfer.go
+++ b/cli/ioctl/cmd/action/xrc20transfer.go
@@ -9,7 +9,6 @@ package action
 import (
 	"math/big"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -31,11 +30,7 @@ var xrc20TransferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		rawAmount, ok := new(big.Int).SetString(args[1], 10)
-		if !ok {
-			return errors.Errorf("invalid XRC20 amount format %s", args[1])
-		}
-		amount, err := amountTransfer(contract, rawAmount)
+		amount, err := parseAmount(contract, args[1])
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transfer.go
+++ b/cli/ioctl/cmd/action/xrc20transfer.go
@@ -31,11 +31,11 @@ var xrc20TransferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		amount, ok := new(big.Int).SetString(args[1], 10)
+		rawAmount, ok := new(big.Int).SetString(args[1], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		amount, err = amountTransfer(contract, amount)
+		amount, err := amountTransfer(contract, rawAmount)
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transfer.go
+++ b/cli/ioctl/cmd/action/xrc20transfer.go
@@ -27,15 +27,19 @@ var xrc20TransferCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		contract, err := xrc20Contract()
+		if err != nil {
+			return err
+		}
 		amount, ok := new(big.Int).SetString(args[1], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
+		amount, err = amountTransfer(contract, amount)
 		if err != nil {
 			return err
 		}
-		contract, err := xrc20Contract()
+		bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transferfrom.go
+++ b/cli/ioctl/cmd/action/xrc20transferfrom.go
@@ -7,9 +7,6 @@
 package action
 
 import (
-	"math/big"
-
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -35,11 +32,7 @@ var xrc20TransferFromCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		rawAmount, ok := new(big.Int).SetString(args[2], 10)
-		if !ok {
-			return errors.Errorf("invalid XRC20 amount format %s", args[1])
-		}
-		amount, err := amountTransfer(contract, rawAmount)
+		amount, err := parseAmount(contract, args[2])
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transferfrom.go
+++ b/cli/ioctl/cmd/action/xrc20transferfrom.go
@@ -31,15 +31,19 @@ var xrc20TransferFromCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		contract, err := xrc20Contract()
+		if err != nil {
+			return err
+		}
 		amount, ok := new(big.Int).SetString(args[2], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		bytecode, err := xrc20ABI.Pack("transferFrom", owner, recipient, amount)
+		amount, err = amountTransfer(contract, amount)
 		if err != nil {
 			return err
 		}
-		contract, err := xrc20Contract()
+		bytecode, err := xrc20ABI.Pack("transferFrom", owner, recipient, amount)
 		if err != nil {
 			return err
 		}

--- a/cli/ioctl/cmd/action/xrc20transferfrom.go
+++ b/cli/ioctl/cmd/action/xrc20transferfrom.go
@@ -35,11 +35,11 @@ var xrc20TransferFromCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		amount, ok := new(big.Int).SetString(args[2], 10)
+		rawAmount, ok := new(big.Int).SetString(args[2], 10)
 		if !ok {
 			return errors.Errorf("invalid XRC20 amount format %s", args[1])
 		}
-		amount, err = amountTransfer(contract, amount)
+		amount, err := amountTransfer(contract, rawAmount)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously in the xrc20 command line, our amount do not including the decimal attribute. So now I read the decimal information by using contract information and transfer the amount with that value.