### PR TITLE
Add StreamFilterLogs() to enable querying logs by topics

### DIFF
--- a/api/apitestclient.go
+++ b/api/apitestclient.go
@@ -46,4 +46,6 @@ type ServiceClient interface {
 	GetRawBlocks(ctx context.Context, in *iotexapi.GetRawBlocksRequest, opts ...grpc.CallOption) (*iotexapi.GetRawBlocksResponse, error)
 	// get block info in stream
 	StreamBlocks(ctx context.Context, in *iotexapi.StreamBlocksRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamBlocksClient, error)
+	// get filtered logs in stream
+	StreamFilterLogs(ctx context.Context, in *iotexapi.FilterLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamFilterLogsClient, error)
 }

--- a/api/apitestclient.go
+++ b/api/apitestclient.go
@@ -47,5 +47,5 @@ type ServiceClient interface {
 	// get block info in stream
 	StreamBlocks(ctx context.Context, in *iotexapi.StreamBlocksRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamBlocksClient, error)
 	// get filtered logs in stream
-	StreamFilterLogs(ctx context.Context, in *iotexapi.FilterLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamFilterLogsClient, error)
+	StreamLogs(ctx context.Context, in *iotexapi.StreamLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamLogsClient, error)
 }

--- a/api/blocklistener.go
+++ b/api/blocklistener.go
@@ -34,8 +34,7 @@ func (bl *blockListener) Respond(blk *block.Block) error {
 		Receipts: receiptsPb,
 	}
 	// send blockInfo thru streaming API
-	err := bl.stream.Send(&iotexapi.StreamBlocksResponse{Block: blockInfo})
-	if err != nil {
+	if err := bl.stream.Send(&iotexapi.StreamBlocksResponse{Block: blockInfo}); err != nil {
 		log.L().Info(
 			"Error when streaming the block",
 			zap.Uint64("height", blockInfo.GetBlock().GetHeader().GetCore().GetHeight()),
@@ -43,7 +42,7 @@ func (bl *blockListener) Respond(blk *block.Block) error {
 		)
 		bl.errChan <- err
 	}
-	return err
+	return nil
 }
 
 // Exit send to error channel

--- a/api/blocklistener.go
+++ b/api/blocklistener.go
@@ -1,11 +1,8 @@
 package api
 
 import (
-	"sync"
-
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -14,95 +11,42 @@ import (
 
 // blockListener defines the block listener in subscribed through API
 type blockListener struct {
-	pendingBlks chan *block.Block
-	cancelChan  chan interface{}
-	streamMap   sync.Map
+	stream  iotexapi.APIService_StreamBlocksServer
+	errChan chan error
 }
 
-// Start starts the block listener
-func (bl *blockListener) Start() error {
-	go func() {
-		for {
-			select {
-			case <-bl.cancelChan:
-				bl.streamMap.Range(func(_, value interface{}) bool {
-					errChan, ok := value.(chan error)
-					if !ok {
-						log.S().Panic("streamMap store a value which is not an error channel")
-					}
-					errChan <- nil
-
-					return true
-				})
-				return
-			case blk := <-bl.pendingBlks:
-				var receiptsPb []*iotextypes.Receipt
-				for _, receipt := range blk.Receipts {
-					receiptsPb = append(receiptsPb, receipt.ConvertToReceiptPb())
-				}
-				blockInfo := &iotexapi.BlockInfo{
-					Block:    blk.ConvertToBlockPb(),
-					Receipts: receiptsPb,
-				}
-
-				var wg sync.WaitGroup
-				bl.streamMap.Range(func(key, value interface{}) bool {
-					stream, ok := key.(iotexapi.APIService_StreamBlocksServer)
-					if !ok {
-						log.S().Panic("streamMap stores a key which is not a stream")
-					}
-					errChan, ok := value.(chan error)
-					if !ok {
-						log.S().Panic("streamMap store a value which is not an error channel")
-					}
-					wg.Add(1)
-					go bl.sendBlock(&wg, stream, errChan, blockInfo)
-					return true
-				})
-				wg.Wait()
-			}
-		}
-	}()
-	return nil
-}
-
-// Stop stops the block listener
-func (bl *blockListener) Stop() error {
-	close(bl.cancelChan)
-	return nil
-}
-
-// HandleBlock handles the block
-func (bl *blockListener) HandleBlock(blk *block.Block) error {
-	bl.pendingBlks <- blk
-	return nil
-}
-
-// AddStream adds a new stream into streamMap
-func (bl *blockListener) AddStream(stream iotexapi.APIService_StreamBlocksServer, errChan chan error) error {
-	_, loaded := bl.streamMap.LoadOrStore(stream, errChan)
-	if loaded {
-		return errors.New("stream is already added")
-	}
-	return nil
-}
-
-func newBlockListener() *blockListener {
+// NewBlockListener returns a new block listener
+func NewBlockListener(stream iotexapi.APIService_StreamBlocksServer, errChan chan error) Responder {
 	return &blockListener{
-		pendingBlks: make(chan *block.Block, 64), // Actually 1 should be enough
-		cancelChan:  make(chan interface{}),
+		stream:  stream,
+		errChan: errChan,
 	}
 }
 
-func (bl *blockListener) sendBlock(wg *sync.WaitGroup, stream iotexapi.APIService_StreamBlocksServer, errChan chan error, blockInfo *iotexapi.BlockInfo) {
-	if err := stream.Send(&iotexapi.StreamBlocksResponse{Block: blockInfo}); err != nil {
+// Respond to new block
+func (bl *blockListener) Respond(blk *block.Block) error {
+	var receiptsPb []*iotextypes.Receipt
+	for _, receipt := range blk.Receipts {
+		receiptsPb = append(receiptsPb, receipt.ConvertToReceiptPb())
+	}
+	blockInfo := &iotexapi.BlockInfo{
+		Block:    blk.ConvertToBlockPb(),
+		Receipts: receiptsPb,
+	}
+	// send blockInfo thru streaming API
+	err := bl.stream.Send(&iotexapi.StreamBlocksResponse{Block: blockInfo})
+	if err != nil {
 		log.L().Info(
 			"Error when streaming the block",
 			zap.Uint64("height", blockInfo.GetBlock().GetHeader().GetCore().GetHeight()),
 			zap.Error(err),
 		)
-		bl.streamMap.Delete(stream)
-		errChan <- err
+		bl.errChan <- err
 	}
-	wg.Done()
+	return err
+}
+
+// Exit send to error channel
+func (bl *blockListener) Exit() {
+	bl.errChan <- nil
 }

--- a/api/listener.go
+++ b/api/listener.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"sync"
+
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/blockchain/block"
+)
+
+type (
+	// Responder responds to new block
+	Responder interface {
+		Respond(*block.Block) error
+		Exit()
+	}
+
+	// Listener pass new block to all responders
+	Listener interface {
+		Start() error
+		Stop() error
+		HandleBlock(*block.Block) error
+		AddResponder(Responder) error
+	}
+
+	// chainListener implements the Listener interface
+	chainListener struct {
+		pendingBlks chan *block.Block
+		cancelChan  chan struct{}
+		streamMap   sync.Map // all registered <Responder, chan error>
+	}
+)
+
+// NewChainListener returns a new blockchain chainListener
+func NewChainListener() Listener {
+	return &chainListener{
+		pendingBlks: make(chan *block.Block, 4),
+		cancelChan:  make(chan struct{}),
+	}
+}
+
+// Start starts the chainListener
+func (cl *chainListener) Start() error {
+	go func() {
+		for {
+			select {
+			case <-cl.cancelChan:
+				// notify all responders to exit
+				cl.streamMap.Range(func(key, _ interface{}) bool {
+					r, ok := key.(Responder)
+					if !ok {
+						log.S().Panic("streamMap stores a key which is not a Responder")
+					}
+					r.Exit()
+					cl.streamMap.Delete(key)
+					return true
+				})
+				return
+			case blk := <-cl.pendingBlks:
+				// pass the block to every responder
+				cl.streamMap.Range(func(key, _ interface{}) bool {
+					r, ok := key.(Responder)
+					if !ok {
+						log.S().Panic("streamMap stores a key which is not a Responder")
+					}
+					if err := r.Respond(blk); err != nil {
+						cl.streamMap.Delete(key)
+					}
+					return true
+				})
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop stops the block chainListener
+func (cl *chainListener) Stop() error {
+	close(cl.cancelChan)
+	return nil
+}
+
+// HandleBlock handles the block
+func (cl *chainListener) HandleBlock(blk *block.Block) error {
+	cl.pendingBlks <- blk
+	return nil
+}
+
+// AddResponder adds a new responder
+func (cl *chainListener) AddResponder(r Responder) error {
+	_, loaded := cl.streamMap.LoadOrStore(r, struct{}{})
+	if loaded {
+		return errors.New("Responder already added")
+	}
+	return nil
+}

--- a/api/logfilter.go
+++ b/api/logfilter.go
@@ -104,10 +104,11 @@ func (l *LogFilter) match(log *iotextypes.Log) bool {
 			continue
 		}
 		target := log.Topics[i]
-		var match bool
+		match := false
 		for _, v := range e.Topic {
-			if !match && bytes.Compare(v, target) == 0 {
+			if bytes.Compare(v, target) == 0 {
 				match = true
+				break
 			}
 		}
 		if !match {

--- a/api/logfilter.go
+++ b/api/logfilter.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"bytes"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/pkg/log"
+)
+
+// LogFilter contains options for contract log filtering.
+type LogFilter struct {
+	stream  iotexapi.APIService_StreamFilterLogsServer
+	errChan chan error
+	*iotexapi.FilterLogsRequest
+	// FilterLogsRequest.Topics restricts matches to particular event topics. Each event has a list
+	// of topics. Topics matches a prefix of that list. An empty element slice matches any
+	// topic. Non-empty elements represent an alternative that matches any of the
+	// contained topics.
+	//
+	// Examples:
+	// {} or nil          matches any topic list
+	// {{A}}              matches topic A in first position
+	// {{}, {B}}          matches any topic in first position, B in second position
+	// {{A}, {B}}         matches topic A in first position, B in second position
+	// {{A, B}}, {C, D}}  matches topic (A OR B) in first position, (C OR D) in second position
+}
+
+// NewLogFilter returns a new log filter
+func NewLogFilter(in *iotexapi.FilterLogsRequest, stream iotexapi.APIService_StreamFilterLogsServer, errChan chan error) Responder {
+	return &LogFilter{
+		FilterLogsRequest: in,
+		stream:            stream,
+		errChan:           errChan,
+	}
+}
+
+// Respond to new block
+func (l *LogFilter) Respond(blk *block.Block) error {
+	logs := l.matchBlock(blk)
+	if len(logs) == 0 {
+		return nil
+	}
+	// send matched logs thru streaming API
+	for _, e := range logs {
+		err := l.stream.Send(e)
+		if err != nil {
+			l.errChan <- err
+			log.L().Info("error streaming the log",
+				zap.Uint64("height", e.BlkHeight),
+				zap.Error(err))
+			return err
+		}
+	}
+	return nil
+}
+
+// Exit send to error channel
+func (l *LogFilter) Exit() {
+	l.errChan <- nil
+}
+
+// matchBlock returns matching logs in a given block
+func (l *LogFilter) matchBlock(blk *block.Block) []*iotextypes.Log {
+	var logs []*iotextypes.Log
+	for _, r := range blk.Receipts {
+		for _, v := range r.Logs {
+			log := v.ConvertToLogPb()
+			if l.match(log) {
+				logs = append(logs, log)
+			}
+		}
+	}
+	return logs
+}
+
+// match checks if a given log matches the filter
+func (l *LogFilter) match(log *iotextypes.Log) bool {
+	if l.Address != log.ContractAddress {
+		return false
+	}
+	if len(l.Topics) > len(log.Topics) {
+		// trying to match a prefix of log's topic list, so topics longer than that is consider invalid
+		return false
+	}
+	if len(l.Topics) == 0 {
+		// {} or nil matches any topic list
+		return true
+	}
+	for i, e := range l.Topics {
+		if len(e.Topic) == 0 {
+			continue
+		}
+		target := log.Topics[i]
+		var match bool
+		for _, v := range e.Topic {
+			if !match && bytes.Compare(v, target) == 0 {
+				match = true
+			}
+		}
+		if !match {
+			return false
+		}
+	}
+	return true
+}

--- a/api/logfilter.go
+++ b/api/logfilter.go
@@ -100,7 +100,7 @@ func (l *LogFilter) match(log *iotextypes.Log) bool {
 		return true
 	}
 	for i, e := range l.Topics {
-		if len(e.Topic) == 0 {
+		if e == nil || len(e.Topic) == 0 {
 			continue
 		}
 		target := log.Topics[i]

--- a/api/logfilter_test.go
+++ b/api/logfilter_test.go
@@ -1,0 +1,158 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/action"
+)
+
+var (
+	topic1 = hash.Hash256b([]byte("topic1"))
+	topic2 = hash.Hash256b([]byte("topic2"))
+	topicA = hash.Hash256b([]byte("topicA"))
+	topicB = hash.Hash256b([]byte("topicB"))
+
+	testFilter = []*iotexapi.LogsFilter{
+		&iotexapi.LogsFilter{
+			Address: []string{},
+			Topics:  []*iotexapi.Topics{},
+		},
+		&iotexapi.LogsFilter{
+			Address: []string{"topic1", "topic2", "topicA", "topicB"},
+			Topics:  nil,
+		},
+		&iotexapi.LogsFilter{
+			Address: nil,
+			Topics: []*iotexapi.Topics{
+				&iotexapi.Topics{
+					Topic: [][]byte{
+						topic1[:],
+						topic2[:],
+					},
+				},
+				&iotexapi.Topics{
+					Topic: [][]byte{
+						topicA[:],
+						topicB[:],
+					},
+				},
+			},
+		},
+		&iotexapi.LogsFilter{
+			Address: []string{"topic1", "topic2"},
+			Topics: []*iotexapi.Topics{
+				&iotexapi.Topics{
+					Topic: [][]byte{
+						topic1[:],
+						topic2[:],
+					},
+				},
+				nil,
+			},
+		},
+		&iotexapi.LogsFilter{
+			Address: []string{"topicA", "topicB"},
+			Topics: []*iotexapi.Topics{
+				nil,
+				&iotexapi.Topics{
+					Topic: [][]byte{
+						topicA[:],
+						topicB[:],
+					},
+				},
+			},
+		},
+	}
+
+	data1 = hash.Hash256b([]byte("topic1"))
+	data2 = hash.Hash256b([]byte("topic2"))
+	dataA = hash.Hash256b([]byte("topicA"))
+	dataB = hash.Hash256b([]byte("topicB"))
+	dataN = hash.Hash256b([]byte("topicNotExist"))
+
+	testData = []struct {
+		log   *action.Log
+		match [5]bool
+	}{
+		{
+			&action.Log{
+				Address: "topicN",
+				Topics:  []hash.Hash256{dataN}, // both address and topic not exist
+			},
+			[5]bool{true, false, false, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topicN",
+				Topics:  []hash.Hash256{data1, data2, dataA}, // topic longer than log's topic list
+			},
+			[5]bool{true, false, false, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topicN",
+				Topics:  []hash.Hash256{data1, dataN}, // topic not match
+			},
+			[5]bool{true, false, false, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topic1",
+				Topics:  []hash.Hash256{dataN}, // topic not exist
+			},
+			[5]bool{true, true, false, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topic2",
+				Topics:  []hash.Hash256{dataA, dataB}, // topic not match
+			},
+			[5]bool{true, true, false, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topicN",
+				Topics:  []hash.Hash256{data1, dataB},
+			},
+			[5]bool{true, false, true, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topicN",
+				Topics:  []hash.Hash256{data2, dataA},
+			},
+			[5]bool{true, false, true, false, false},
+		},
+		{
+			&action.Log{
+				Address: "topic1",
+				Topics:  []hash.Hash256{data1, dataN},
+			},
+			[5]bool{true, true, false, true, false},
+		},
+		{
+			&action.Log{
+				Address: "topicB",
+				Topics:  []hash.Hash256{dataN, dataA},
+			},
+			[5]bool{true, true, false, false, true},
+		},
+	}
+)
+
+func TestLogFilter_MatchBlock(t *testing.T) {
+	require := require.New(t)
+
+	for i, q := range testFilter {
+		f, ok := NewLogFilter(q, nil, nil).(*LogFilter)
+		require.True(ok)
+		for _, v := range testData {
+			log := v.log.ConvertToLogPb()
+			require.Equal(f.match(log), v.match[i])
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c
+	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	golang.org/x/tools v0.0.0-20190430194229-2d28432af7a5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.1-0.20190613181553-bd03f6d4187e
 	github.com/iotexproject/iotex-address v0.2.0
 	github.com/iotexproject/iotex-election v0.1.10
-	github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea
+	github.com/iotexproject/iotex-proto v0.2.1-0.20190625001831-d2b1e66ef4cd
 	github.com/ipfs/go-datastore v0.0.5 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/libp2p/go-libp2p v0.0.21 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.1-0.20190613181553-bd03f6d4187e
 	github.com/iotexproject/iotex-address v0.2.0
 	github.com/iotexproject/iotex-election v0.1.10
-	github.com/iotexproject/iotex-proto v0.2.1-0.20190621191822-304e5c94b9b3
+	github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede
 	github.com/ipfs/go-datastore v0.0.5 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/libp2p/go-libp2p v0.0.21 // indirect

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.1-0.20190613181553-bd03f6d4187e
 	github.com/iotexproject/iotex-address v0.2.0
 	github.com/iotexproject/iotex-election v0.1.10
-	github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede
+	github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea
 	github.com/ipfs/go-datastore v0.0.5 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/libp2p/go-libp2p v0.0.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,8 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzWA3bVP9mUiPMT0=
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190621191822-304e5c94b9b3 h1:SW28l6XlI2hlrfpETYbGmuqt5qjIWjjICsk+sjQ1FeM=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190621191822-304e5c94b9b3/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede h1:S3WcVdYDHyo00DBhaPsc4yDb8K9GFBLA2PJUNojEb98=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/go.sum
+++ b/go.sum
@@ -131,15 +131,8 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzWA3bVP9mUiPMT0=
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
-github.com/iotexproject/iotex-proto v0.2.0 h1:N8DW0d63lIsGXEexm8q+jgYElRoFR4/0FOCO/GM5Va8=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede h1:S3WcVdYDHyo00DBhaPsc4yDb8K9GFBLA2PJUNojEb98=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624185717-9774cf69b915 h1:QqNhAznArMMoJO0E46TD316xcQHlwUjJmEJufJrh0k8=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624185717-9774cf69b915/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624205510-00275acd9878 h1:Z9SHiU14qwj2mdJ77OhDB0jsnJBGa/KuiLrFScTyQEw=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624205510-00275acd9878/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea h1:g50s/kxVVsi1h5aXSfd8lDz92CT1UN7JrICv06iWrvY=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190625001831-d2b1e66ef4cd h1:ZX6qdvQZkZrBhEJJ5carPUAJDfTLADREA6YEqLQGGiw=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190625001831-d2b1e66ef4cd/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,15 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzWA3bVP9mUiPMT0=
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
+github.com/iotexproject/iotex-proto v0.2.0 h1:N8DW0d63lIsGXEexm8q+jgYElRoFR4/0FOCO/GM5Va8=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede h1:S3WcVdYDHyo00DBhaPsc4yDb8K9GFBLA2PJUNojEb98=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190621204839-b3fc3c211ede/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624185717-9774cf69b915 h1:QqNhAznArMMoJO0E46TD316xcQHlwUjJmEJufJrh0k8=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624185717-9774cf69b915/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624205510-00275acd9878 h1:Z9SHiU14qwj2mdJ77OhDB0jsnJBGa/KuiLrFScTyQEw=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624205510-00275acd9878/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea h1:g50s/kxVVsi1h5aXSfd8lDz92CT1UN7JrICv06iWrvY=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190624223038-235af0927cea/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
+++ b/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
@@ -287,20 +287,20 @@ func (mr *MockServiceClientMockRecorder) StreamBlocks(ctx, in interface{}, opts 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamBlocks", reflect.TypeOf((*MockServiceClient)(nil).StreamBlocks), varargs...)
 }
 
-// StreamFilterLogs mocks base method
-func (m *MockServiceClient) StreamFilterLogs(ctx context.Context, in *iotexapi.FilterLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamFilterLogsClient, error) {
+// StreamLogs mocks base method
+func (m *MockServiceClient) StreamLogs(ctx context.Context, in *iotexapi.StreamLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamLogsClient, error) {
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "StreamFilterLogs", varargs...)
-	ret0, _ := ret[0].(iotexapi.APIService_StreamFilterLogsClient)
+	ret := m.ctrl.Call(m, "StreamLogs", varargs...)
+	ret0, _ := ret[0].(iotexapi.APIService_StreamLogsClient)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// StreamFilterLogs indicates an expected call of StreamFilterLogs
-func (mr *MockServiceClientMockRecorder) StreamFilterLogs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+// StreamLogs indicates an expected call of StreamLogs
+func (mr *MockServiceClientMockRecorder) StreamLogs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
 	varargs := append([]interface{}{ctx, in}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFilterLogs", reflect.TypeOf((*MockServiceClient)(nil).StreamFilterLogs), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLogs", reflect.TypeOf((*MockServiceClient)(nil).StreamLogs), varargs...)
 }

--- a/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
+++ b/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
@@ -286,3 +286,21 @@ func (mr *MockServiceClientMockRecorder) StreamBlocks(ctx, in interface{}, opts 
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamBlocks", reflect.TypeOf((*MockServiceClient)(nil).StreamBlocks), varargs...)
 }
+
+// StreamFilterLogs mocks base method
+func (m *MockServiceClient) StreamFilterLogs(ctx context.Context, in *iotexapi.FilterLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamFilterLogsClient, error) {
+	varargs := []interface{}{ctx, in}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StreamFilterLogs", varargs...)
+	ret0, _ := ret[0].(iotexapi.APIService_StreamFilterLogsClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StreamFilterLogs indicates an expected call of StreamFilterLogs
+func (mr *MockServiceClientMockRecorder) StreamFilterLogs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	varargs := append([]interface{}{ctx, in}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamFilterLogs", reflect.TypeOf((*MockServiceClient)(nil).StreamFilterLogs), varargs...)
+}

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -6,10 +6,6 @@ package mock_blockchain
 
 import (
 	context "context"
-	big "math/big"
-	reflect "reflect"
-	time "time"
-
 	gomock "github.com/golang/mock/gomock"
 	hash "github.com/iotexproject/go-pkgs/hash"
 	address "github.com/iotexproject/iotex-address/address"
@@ -18,6 +14,9 @@ import (
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
+	big "math/big"
+	reflect "reflect"
+	time "time"
 )
 
 // MockBlockchain is a mock of Blockchain interface
@@ -315,19 +314,6 @@ func (mr *MockBlockchainMockRecorder) GetActionByActionHash(h interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionByActionHash", reflect.TypeOf((*MockBlockchain)(nil).GetActionByActionHash), h)
 }
 
-// GetActionHashFromIndex mocks base method
-func (m *MockBlockchain) GetActionHashFromIndex(index uint64) (hash.Hash256, error) {
-	ret := m.ctrl.Call(m, "GetActionHashFromIndex", index)
-	ret0, _ := ret[0].(hash.Hash256)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActionHashFromIndex indicates an expected call of GetActionHashFromIndex
-func (mr *MockBlockchainMockRecorder) GetActionHashFromIndex(h interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionHashFromIndex", reflect.TypeOf((*MockBlockchain)(nil).GetActionHashFromIndex), h)
-}
-
 // GetBlockHashByActionHash mocks base method
 func (m *MockBlockchain) GetBlockHashByActionHash(h hash.Hash256) (hash.Hash256, error) {
 	ret := m.ctrl.Call(m, "GetBlockHashByActionHash", h)
@@ -546,4 +532,17 @@ func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscribe
 // RemoveSubscriber indicates an expected call of RemoveSubscriber
 func (mr *MockBlockchainMockRecorder) RemoveSubscriber(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubscriber", reflect.TypeOf((*MockBlockchain)(nil).RemoveSubscriber), arg0)
+}
+
+// GetActionHashFromIndex mocks base method
+func (m *MockBlockchain) GetActionHashFromIndex(index uint64) (hash.Hash256, error) {
+	ret := m.ctrl.Call(m, "GetActionHashFromIndex", index)
+	ret0, _ := ret[0].(hash.Hash256)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActionHashFromIndex indicates an expected call of GetActionHashFromIndex
+func (mr *MockBlockchainMockRecorder) GetActionHashFromIndex(index interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionHashFromIndex", reflect.TypeOf((*MockBlockchain)(nil).GetActionHashFromIndex), index)
 }


### PR DESCRIPTION
add a Responder interface to define the actual behavior when a new block arrives, this turns the Listener.Start() into common code. 

the Listener on chain just keep adding Responder -- each implements functionality for different streaming APIs

the original blockListener becomes a Responder, so is log filter added in this PR