### PR TITLE
Make ioctl be aware of current account in context 1295

### DIFF
--- a/cli/ioctl/cmd/account/accountbalance.go
+++ b/cli/ioctl/cmd/account/accountbalance.go
@@ -13,14 +13,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 )
 
 // accountBalanceCmd represents the account balance command
 var accountBalanceCmd = &cobra.Command{
-	Use:   "balance (ALIAS|ADDRESS)",
+	Use:   "balance [ALIAS|ADDRESS]",
 	Short: "Get balance of an account",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := balance(args)
@@ -33,7 +34,11 @@ var accountBalanceCmd = &cobra.Command{
 
 // balance gets balance of an IoTeX blockchain address
 func balance(args []string) (string, error) {
-	address, err := alias.Address(args[0])
+	addr, err := config.GetAddress(args)
+	if err != nil {
+		return "", err
+	}
+	address, err := alias.Address(addr)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/account/accountdelete.go
+++ b/cli/ioctl/cmd/account/accountdelete.go
@@ -13,11 +13,11 @@ import (
 	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -25,9 +25,9 @@ import (
 
 // accountDeleteCmd represents the account delete command
 var accountDeleteCmd = &cobra.Command{
-	Use:   "delete (ALIAS|ADDRESS)",
+	Use:   "delete [ALIAS|ADDRESS]",
 	Short: "Delete an IoTeX account/address from wallet/config",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := accountDelete(args)
@@ -39,7 +39,11 @@ var accountDeleteCmd = &cobra.Command{
 }
 
 func accountDelete(args []string) (string, error) {
-	addr, err := alias.Address(args[0])
+	addr, err := config.GetAddress(args)
+	if err != nil {
+		return "", err
+	}
+	addr, err = alias.Address(addr)
 	if err != nil {
 		return "", err
 	}

--- a/cli/ioctl/cmd/account/accountexport.go
+++ b/cli/ioctl/cmd/account/accountexport.go
@@ -15,14 +15,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // accountExportCmd represents the account export command
 var accountExportCmd = &cobra.Command{
-	Use:   "export (ALIAS|ADDRESS)",
+	Use:   "export [ALIAS|ADDRESS]",
 	Short: "Export IoTeX private key from wallet",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := accountExport(args)
@@ -34,11 +35,15 @@ var accountExportCmd = &cobra.Command{
 }
 
 func accountExport(args []string) (string, error) {
-	addr, err := alias.Address(args[0])
+	addr, err := config.GetAddress(args)
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("Enter password #%s:\n", args[0])
+	addr, err = alias.Address(addr)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Enter password #%s:\n", addr)
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))

--- a/cli/ioctl/cmd/account/accountexportpublic.go
+++ b/cli/ioctl/cmd/account/accountexportpublic.go
@@ -15,14 +15,15 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // accountExportPublicCmd represents the account export public key command
 var accountExportPublicCmd = &cobra.Command{
-	Use:   "exportpublic (ALIAS|ADDRESS)",
+	Use:   "exportpublic [ALIAS|ADDRESS]",
 	Short: "Export IoTeX public key from wallet",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := accountExportPublic(args)
@@ -34,11 +35,15 @@ var accountExportPublicCmd = &cobra.Command{
 }
 
 func accountExportPublic(args []string) (string, error) {
-	addr, err := alias.Address(args[0])
+	addr, err := config.GetAddress(args)
 	if err != nil {
 		return "", err
 	}
-	fmt.Printf("Enter password #%s:\n", args[0])
+	addr, err = alias.Address(addr)
+	if err != nil {
+		return "", err
+	}
+	fmt.Printf("Enter password #%s:\n", addr)
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		log.L().Error("failed to get password", zap.Error(err))

--- a/cli/ioctl/cmd/account/accountnonce.go
+++ b/cli/ioctl/cmd/account/accountnonce.go
@@ -12,13 +12,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 )
 
 // accountNonceCmd represents the account nonce command
 var accountNonceCmd = &cobra.Command{
-	Use:   "nonce (ALIAS|ADDRESS)",
+	Use:   "nonce [ALIAS|ADDRESS]",
 	Short: "Get nonce of an account",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := nonce(args)
@@ -31,14 +32,18 @@ var accountNonceCmd = &cobra.Command{
 
 // nonce gets nonce and pending nonce of an IoTeX blockchain address
 func nonce(args []string) (string, error) {
-	address, err := alias.Address(args[0])
+	addr, err := config.GetAddress(args)
 	if err != nil {
 		return "", err
 	}
-	accountMeta, err := GetAccountMeta(address)
+	addr, err = alias.Address(addr)
+	if err != nil {
+		return "", err
+	}
+	accountMeta, err := GetAccountMeta(addr)
 	if err != nil {
 		return "", err
 	}
 	return fmt.Sprintf("%s:\nNonce: %d, Pending Nonce: %d",
-		address, accountMeta.Nonce, accountMeta.PendingNonce), nil
+		addr, accountMeta.Nonce, accountMeta.PendingNonce), nil
 }

--- a/cli/ioctl/cmd/account/accountupdate.go
+++ b/cli/ioctl/cmd/account/accountupdate.go
@@ -12,12 +12,12 @@ import (
 	"syscall"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -25,9 +25,9 @@ import (
 
 // accountUpdateCmd represents the account update command
 var accountUpdateCmd = &cobra.Command{
-	Use:   "update (ALIAS|ADDRESS)",
+	Use:   "update [ALIAS|ADDRESS]",
 	Short: "Update password for IoTeX account",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		output, err := accountUpdate(args)
@@ -39,12 +39,15 @@ var accountUpdateCmd = &cobra.Command{
 }
 
 func accountUpdate(args []string) (string, error) {
-	account := args[0]
-	addr, err := alias.Address(account)
+	addr, err := config.GetAddress(args)
 	if err != nil {
 		return "", err
 	}
-	address, err := address.FromString(addr)
+	account, err := alias.Address(addr)
+	if err != nil {
+		return "", err
+	}
+	address, err := address.FromString(account)
 	if err != nil {
 		log.L().Error("failed to convert string into address", zap.Error(err))
 		return "", err

--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -15,13 +15,14 @@ import (
 	"syscall"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh/terminal"
 	"google.golang.org/grpc/status"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/cli/ioctl/cmd/alias"
@@ -30,7 +31,6 @@ import (
 	"github.com/iotexproject/iotex-core/cli/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 )
 
 const defaultSigner = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
@@ -68,8 +68,15 @@ func decodeBytecode() ([]byte, error) {
 	return hex.DecodeString(strings.TrimLeft(bytecodeFlag.Value().(string), "0x"))
 }
 
-func signer() (string, error) {
-	return alias.Address(signerFlag.Value().(string))
+func signer() (address string, err error) {
+	address = signerFlag.Value().(string)
+	if strings.EqualFold(address, "") {
+		address, err = config.GetContext()
+		if err != nil {
+			return
+		}
+	}
+	return alias.Address(address)
 }
 
 func nonce(executor string) (uint64, error) {
@@ -89,7 +96,6 @@ func registerWriteCommand(cmd *cobra.Command) {
 	gasPriceFlag.RegisterCommand(cmd)
 	signerFlag.RegisterCommand(cmd)
 	nonceFlag.RegisterCommand(cmd)
-	signerFlag.MarkFlagRequired(cmd)
 }
 
 // gasPriceInRau returns the suggest gas price

--- a/cli/ioctl/cmd/action/actionclaim.go
+++ b/cli/ioctl/cmd/action/actionclaim.go
@@ -15,7 +15,7 @@ import (
 
 // actionClaimCmd represents the action claim command
 var actionClaimCmd = &cobra.Command{
-	Use:   "claim AMOUNT_IOTX [DATA] -s SIGNER [-l GAS_LIMIT] [-p GASPRICE]",
+	Use:   "claim AMOUNT_IOTX [DATA] [-s SIGNER] [-l GAS_LIMIT] [-p GASPRICE]",
 	Short: "Claim rewards from rewarding fund",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/ioctl/cmd/action/actiondeploy.go
+++ b/cli/ioctl/cmd/action/actiondeploy.go
@@ -16,7 +16,7 @@ import (
 
 // actionDeployCmd represents the action deploy command
 var actionDeployCmd = &cobra.Command{
-	Use:   "deploy [AMOUNT_IOTX] -s SIGNER -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE]",
+	Use:   "deploy [AMOUNT_IOTX] [-s SIGNER] -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE]",
 	Short: "Deploy smart contract on IoTeX blockchain",
 	Args:  cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/ioctl/cmd/action/actiondeposit.go
+++ b/cli/ioctl/cmd/action/actiondeposit.go
@@ -15,7 +15,7 @@ import (
 
 // actionDepositCmd represents the action deposit command
 var actionDepositCmd = &cobra.Command{
-	Use:   "deposit AMOUNT_IOTX [DATA] -s SIGNER [-l GAS_LIMIT] [-p GASPRICE]",
+	Use:   "deposit AMOUNT_IOTX [DATA] [-s SIGNER] [-l GAS_LIMIT] [-p GASPRICE]",
 	Short: "Deposit rewards from rewarding fund",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/ioctl/cmd/action/actioninvoke.go
+++ b/cli/ioctl/cmd/action/actioninvoke.go
@@ -18,7 +18,7 @@ import (
 // actionInvokeCmd represents the action invoke command
 var actionInvokeCmd = &cobra.Command{
 	Use: "invoke (ALIAS|CONTRACT_ADDRESS) [AMOUNT_IOTX]" +
-		" -s SIGNER -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE]",
+		" [-s SIGNER] -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE]",
 	Short: "Invoke smart contract on IoTeX blockchain",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/ioctl/cmd/action/actiontransfer.go
+++ b/cli/ioctl/cmd/action/actiontransfer.go
@@ -20,7 +20,7 @@ import (
 // actionTransferCmd represents the action transfer command
 var actionTransferCmd = &cobra.Command{
 	Use: "transfer (ALIAS|RECIPIENT_ADDRESS) AMOUNT_IOTX [DATA]" +
-		" -s SIGNER [-l GAS_LIMIT] [-p GAS_PRICE]",
+		" [-s SIGNER] [-l GAS_LIMIT] [-p GAS_PRICE]",
 	Short: "Transfer tokens on IoTeX blokchain",
 	Args:  cobra.RangeArgs(2, 3),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/ioctl/cmd/alias/aliasremove.go
+++ b/cli/ioctl/cmd/alias/aliasremove.go
@@ -19,12 +19,16 @@ import (
 
 // aliasRemoveCmd represents the alias remove command
 var aliasRemoveCmd = &cobra.Command{
-	Use:   "remove ALIAS",
+	Use:   "remove [ALIAS]",
 	Short: "Remove alias",
-	Args:  cobra.ExactArgs(1),
+	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := remove(args[0])
+		removeAlias, err := config.GetAddress(args)
+		if err != nil {
+			return err
+		}
+		output, err := remove(removeAlias)
 		if err == nil {
 			fmt.Println(output)
 		}

--- a/cli/ioctl/cmd/config/config.go
+++ b/cli/ioctl/cmd/config/config.go
@@ -41,10 +41,11 @@ var ConfigCmd = &cobra.Command{
 
 // Config defines the config schema
 type Config struct {
-	Wallet        string            `yaml:"wallet"`
-	Endpoint      string            `yaml:"endpoint"`
-	SecureConnect bool              `yaml:"secureConnect"`
-	Aliases       map[string]string `yaml:"aliases"`
+	Wallet         string            `yaml:"wallet"`
+	Endpoint       string            `yaml:"endpoint"`
+	SecureConnect  bool              `yaml:"secureConnect"`
+	Aliases        map[string]string `yaml:"aliases"`
+	CurrentContext string            `yaml:"currentcontext"`
 }
 
 var (


### PR DESCRIPTION
work on #1295 

Example:
1、ioctl action transfer aaa 1.5455
Error: use "ioctl config set currentcontext" to config current account first

2、ioctl config set currentcontext aa
currentcontext is set to aa

3、ioctl account balance           
io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg: 88.884722278 IOTX

4、ioctl account sign "12"

Behaior changed ctl:
**account balance
account delete
account export
account exportpublic
account nonce
account update
account sign
action claim
action deploy
action deposit
action invoke
action transfer
alias remove
config set currentcontext
config get currentcontext**