### PR TITLE
Make ioctl be able to send raw transaction bytes 1319

### DIFF
--- a/cli/ioctl/cmd/action/action.go
+++ b/cli/ioctl/cmd/action/action.go
@@ -29,6 +29,7 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 const defaultSigner = "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7"
@@ -56,6 +57,7 @@ func init() {
 	ActionCmd.AddCommand(actionReadCmd)
 	ActionCmd.AddCommand(actionClaimCmd)
 	ActionCmd.AddCommand(actionDepositCmd)
+	ActionCmd.AddCommand(actionSendRawCmd)
 	ActionCmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
 		config.ReadConfig.Endpoint, "set endpoint for once")
 	ActionCmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,
@@ -87,7 +89,6 @@ func registerWriteCommand(cmd *cobra.Command) {
 	gasPriceFlag.RegisterCommand(cmd)
 	signerFlag.RegisterCommand(cmd)
 	nonceFlag.RegisterCommand(cmd)
-	signerFlag.MarkFlagRequired(cmd)
 }
 
 // gasPriceInRau returns the suggest gas price
@@ -140,7 +141,27 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 		signer,
 	)
 }
+func sendRaw(selp *iotextypes.Action) error {
+	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	cli := iotexapi.NewAPIServiceClient(conn)
+	ctx := context.Background()
 
+	request := &iotexapi.SendActionRequest{Action: selp}
+	if _, err = cli.SendAction(ctx, request); err != nil {
+		if sta, ok := status.FromError(err); ok {
+			return fmt.Errorf(sta.Message())
+		}
+		return err
+	}
+	shash := hash.Hash256b(byteutil.Must(proto.Marshal(selp)))
+	fmt.Println("Action has been sent to blockchain.")
+	fmt.Printf("Wait for several seconds and query this action by hash: %s\n", hex.EncodeToString(shash[:]))
+	return nil
+}
 func sendAction(elp action.Envelope, signer string) error {
 	fmt.Printf("Enter password #%s:\n", signer)
 	password, err := util.ReadSecretFromStdin()
@@ -177,26 +198,7 @@ func sendAction(elp action.Envelope, signer string) error {
 		return nil
 	}
 	fmt.Println()
-
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
-	if err != nil {
-		return err
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	request := &iotexapi.SendActionRequest{Action: selp}
-	if _, err = cli.SendAction(ctx, request); err != nil {
-		if sta, ok := status.FromError(err); ok {
-			return fmt.Errorf(sta.Message())
-		}
-		return err
-	}
-	shash := hash.Hash256b(byteutil.Must(proto.Marshal(selp)))
-	fmt.Println("Action has been sent to blockchain.")
-	fmt.Printf("Wait for several seconds and query this action by hash: %s\n", hex.EncodeToString(shash[:]))
-	return nil
+	return sendRaw(selp)
 }
 func isBalanceEnough(address string, act action.SealedEnvelope) (err error) {
 	accountMeta, err := account.GetAccountMeta(address)

--- a/cli/ioctl/cmd/action/actionsendraw.go
+++ b/cli/ioctl/cmd/action/actionsendraw.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"encoding/hex"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/spf13/cobra"
+)
+
+// actionSendRawCmd represents the action send raw transaction command
+var actionSendRawCmd = &cobra.Command{
+	Use:   "sendraw DATA",
+	Short: "Send raw action on IoTeX blokchain",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		act := &iotextypes.Action{}
+		actByte, err := hex.DecodeString(args[0])
+		if err != nil {
+			return err
+		}
+		if err := proto.Unmarshal(actByte, act); err != nil {
+			return err
+		}
+		return sendRaw(act)
+	},
+}
+
+func init() {
+	registerWriteCommand(actionSendRawCmd)
+}

--- a/cli/ioctl/cmd/action/actionsendraw.go
+++ b/cli/ioctl/cmd/action/actionsendraw.go
@@ -21,12 +21,12 @@ var actionSendRawCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		act := &iotextypes.Action{}
-		actByte, err := hex.DecodeString(args[0])
+		actBytes, err := hex.DecodeString(args[0])
 		if err != nil {
 			return err
 		}
-		if err := proto.Unmarshal(actByte, act); err != nil {
+		act := &iotextypes.Action{}
+		if err := proto.Unmarshal(actBytes, act); err != nil {
 			return err
 		}
 		return sendRaw(act)


### PR DESCRIPTION
work on #1319

use:
ioctl action sendraw 0a590801101518e0a712220d3130303030303030303030303052400a13313534353530303030303030303030303030301229696f3165796e39746336743738327a78347a677933686774333268707a36743876377067663532347a124104ea8046cf8dc5bc9cda5f2e83e5d2d61932ad7e0e402b4f4cb65b58e9618891f54cba5cfcda873351ad9da1f5a819f54bba9e8343f2edd1ad34dcf7f35de552f31a41eb9037e0d5c71c48acf114b2e3d68fb5313873e73e02ce30eff8ace0e6f879ca36c6ed806bacc34aeef40aab4a8629e4acc7784f94fa4eda3bbed375abf183d400