### PR TITLE
improve evmadaptor and contract test coverage

### DIFF
--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -14,15 +14,14 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
-	"github.com/iotexproject/iotex-core/db/trie"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -40,28 +39,23 @@ func TestCreateContract(t *testing.T) {
 	require.Nil(err)
 	require.Nil(sf.Start(context.Background()))
 
-	code := []byte("test contract creation")
 	addr := identityset.Address(28)
 	ws, err := sf.NewWorkingSet()
 	require.Nil(err)
 	_, err = accountutil.LoadOrCreateAccount(ws, addr.String(), big.NewInt(0))
 	require.Nil(err)
-	stateDB := StateDBAdapter{
-		sm:             ws,
-		cachedContract: make(map[hash.Hash160]Contract),
-		dao:            ws.GetDB(),
-		cb:             ws.GetCachedBatch(),
-	}
+	hu := config.NewHeightUpgrade(cfg)
+	stateDB := NewStateDBAdapter(nil, ws, hu, 0, hash.ZeroHash256)
 	contract := addr.Bytes()
 	var evmContract common.Address
 	copy(evmContract[:], contract[:])
-	stateDB.SetCode(evmContract, code)
+	stateDB.SetCode(evmContract, bytecode)
 	// contract exist
 	codeHash := stateDB.GetCodeHash(evmContract)
 	var emptyEVMHash common.Hash
 	require.NotEqual(emptyEVMHash, codeHash)
 	v := stateDB.GetCode(evmContract)
-	require.Equal(code, v)
+	require.Equal(bytecode, v)
 	// non-existing contract
 	addr1 := hash.Hash160b([]byte("random"))
 	var evmAddr1 common.Address
@@ -97,131 +91,143 @@ func TestCreateContract(t *testing.T) {
 	contract1, err = accountutil.LoadOrCreateAccount(ws, addr.String(), big.NewInt(0))
 	require.Nil(err)
 	require.Equal(codeHash[:], contract1.CodeHash)
-	stateDB = StateDBAdapter{
-		sm:             ws,
-		cachedContract: make(map[hash.Hash160]Contract),
-		dao:            ws.GetDB(),
-		cb:             ws.GetCachedBatch(),
-	}
+	stateDB = NewStateDBAdapter(nil, ws, hu, 0, hash.ZeroHash256)
 	// contract already exist
 	h = stateDB.GetCodeHash(evmContract)
 	require.Equal(codeHash, h)
 	v = stateDB.GetCode(evmContract)
-	require.Equal(code, v)
+	require.Equal(bytecode, v)
 	require.Nil(sf.Stop(context.Background()))
 }
 
-func TestLoadStoreContract(t *testing.T) {
-	require := require.New(t)
+func TestLoadStoreCommit(t *testing.T) {
+	testLoadStoreCommit := func(cfg config.Config, t *testing.T) {
+		require := require.New(t)
+
+		var sf factory.Factory
+		if cfg.Chain.EnableTrielessStateDB {
+			sf, _ = factory.NewStateDB(cfg, factory.DefaultStateDBOption())
+		} else {
+			sf, _ = factory.NewFactory(cfg, factory.DefaultTrieOption())
+		}
+		require.NoError(sf.Start(context.Background()))
+
+		ws, err := sf.NewWorkingSet()
+		require.NoError(err)
+		cntr1, err := newContract(hash.BytesToHash160(c1[:]), &state.Account{}, ws.GetDB(), ws.GetCachedBatch())
+		require.NoError(err)
+
+		tests := []cntrTest{
+			{
+				cntr1,
+				[]code{
+					{c1, []byte("2nd contract creation")},
+				},
+				[]set{
+					{k1b, v1b[:], nil},
+					{k2b, v2b[:], nil},
+				},
+			},
+			{
+				cntr1,
+				[]code{
+					{c2, bytecode},
+				},
+				[]set{
+					{k1b, v4b[:], nil},
+					{k2b, v3b[:], nil},
+					{k3b, v2b[:], nil},
+					{k4b, v1b[:], nil},
+				},
+			},
+			{
+				cntr1,
+				nil,
+				[]set{
+					{k1b, v2b[:], nil},
+					{k2b, v1b[:], nil},
+					{k3b, v4b[:], nil},
+					{k4b, nil, nil},
+				},
+			},
+		}
+
+		for _, test := range tests {
+			c := test.contract
+			// set code
+			for _, e := range test.codes {
+				c.SetCode(hash.Hash256b(e.v), e.v)
+			}
+			// set states
+			for _, e := range test.states {
+				require.NoError(c.SetState(e.k, e.v))
+				v, err := c.GetState(e.k)
+				require.NoError(err)
+				require.Equal(e.v, v)
+			}
+			require.NoError(c.Commit())
+		}
+
+		checks := []cntrTest{
+			{
+				cntr1,
+				[]code{
+					{c1, bytecode},
+				},
+				[]set{
+					{k1b, v2b[:], nil},
+					{k2b, v1b[:], nil},
+					{k3b, v4b[:], nil},
+					{k4b, nil, nil},
+				},
+			},
+		}
+
+		for _, test := range checks {
+			c := test.contract
+			// check code
+			for _, e := range test.codes {
+				v, err := c.GetCode()
+				require.NoError(err)
+				require.Equal(e.v, v)
+				chash := hash.Hash256b(e.v)
+				require.Equal(chash[:], c.SelfState().CodeHash)
+				require.NotEqual(hash.ZeroHash256, hash.BytesToHash256(chash[:]))
+			}
+			// check states
+			for _, e := range test.states {
+				v, err := c.GetState(e.k)
+				require.Equal(e.v, v)
+				if err != nil {
+					require.Equal(e.cause, errors.Cause(err))
+				}
+			}
+		}
+	}
+
 	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
 	testTriePath := testTrieFile.Name()
+	defer func() {
+		testutil.CleanupPath(t, testTriePath)
+	}()
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
-	sf, err := factory.NewFactory(cfg, factory.DefaultTrieOption())
-	require.Nil(err)
-	require.Nil(sf.Start(context.Background()))
+	t.Run("contract load/store with stateDB", func(t *testing.T) {
+		testLoadStoreCommit(cfg, t)
+	})
 
-	code := []byte("test contract creation")
-	addr := identityset.Address(28)
-	ws, err := sf.NewWorkingSet()
-	require.Nil(err)
-	_, err = accountutil.LoadOrCreateAccount(ws, addr.String(), big.NewInt(0))
-	require.Nil(err)
-	stateDB := StateDBAdapter{
-		sm:             ws,
-		cachedContract: make(map[hash.Hash160]Contract),
-		dao:            ws.GetDB(),
-		cb:             ws.GetCachedBatch(),
-	}
-	contract := addr.Bytes()
-	var evmContract common.Address
-	copy(evmContract[:], contract[:])
-	stateDB.SetCode(evmContract, code)
-	codeHash := stateDB.GetCodeHash(evmContract)
-	var emptyEVMHash common.Hash
-	require.NotEqual(emptyEVMHash, codeHash)
+	testTrieFile, _ = ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath2 := testTrieFile.Name()
+	defer func() {
+		testutil.CleanupPath(t, testTriePath2)
+	}()
+	cfg.Chain.EnableTrielessStateDB = false
+	cfg.Chain.TrieDBPath = testTriePath2
 
-	v := stateDB.GetCode(evmContract)
-	require.Equal(code, v)
-	// insert entries into storage
-	k1 := hash.Hash256b([]byte("cat"))
-	v1 := hash.Hash256b([]byte("cat"))
-	k2 := hash.Hash256b([]byte("dog"))
-	v2 := hash.Hash256b([]byte("dog"))
-	require.Nil(stateDB.setContractState(hash.BytesToHash160(contract), k1, v1))
-	require.Nil(stateDB.setContractState(hash.BytesToHash160(contract), k2, v2))
-
-	code1 := []byte("2nd contract creation")
-	addr1 := identityset.Address(29)
-	_, err = accountutil.LoadOrCreateAccount(ws, addr1.String(), big.NewInt(0))
-	require.Nil(err)
-	contract1 := addr1.Bytes()
-	var evmContract1 common.Address
-	copy(evmContract1[:], contract1[:])
-	stateDB.SetCode(evmContract1, code1)
-	codeHash1 := stateDB.GetCodeHash(evmContract1)
-	require.NotEqual(emptyEVMHash, codeHash1)
-	v = stateDB.GetCode(evmContract1)
-	require.Equal(code1, v)
-	// insert entries into storage
-	k3 := hash.Hash256b([]byte("egg"))
-	v3 := hash.Hash256b([]byte("egg"))
-	k4 := hash.Hash256b([]byte("hen"))
-	v4 := hash.Hash256b([]byte("hen"))
-	require.Nil(stateDB.setContractState(hash.BytesToHash160(contract1), k3, v3))
-	require.Nil(stateDB.setContractState(hash.BytesToHash160(contract1), k4, v4))
-	require.NoError(stateDB.CommitContracts())
-	stateDB.clear()
-
-	gasLimit := testutil.TestGasLimit
-	ctx := protocol.WithRunActionsCtx(context.Background(),
-		protocol.RunActionsCtx{
-			Producer: identityset.Address(27),
-			GasLimit: gasLimit,
-		})
-	_, err = ws.RunActions(ctx, 0, nil)
-	require.Nil(err)
-	require.Nil(sf.Commit(ws))
-	require.Nil(sf.Stop(context.Background()))
-
-	// re-open the StateFactory
-	cfg.DB.DbPath = testTriePath
-	sf, err = factory.NewFactory(cfg, factory.PrecreatedTrieDBOption(db.NewOnDiskDB(cfg.DB)))
-	require.Nil(err)
-	require.Nil(sf.Start(context.Background()))
-	// query first contract
-	ws, err = sf.NewWorkingSet()
-	require.Nil(err)
-	stateDB = StateDBAdapter{
-		sm:             ws,
-		cachedContract: make(map[hash.Hash160]Contract),
-		dao:            ws.GetDB(),
-		cb:             ws.GetCachedBatch(),
-	}
-
-	w, err := stateDB.getContractState(hash.BytesToHash160(contract), k1)
-	require.Nil(err)
-	require.Equal(v1, w)
-	w, err = stateDB.getContractState(hash.BytesToHash160(contract), k2)
-	require.Nil(err)
-	require.Equal(v2, w)
-	_, err = stateDB.getContractState(hash.BytesToHash160(contract), k3)
-	require.Equal(trie.ErrNotExist, errors.Cause(err))
-	_, err = stateDB.getContractState(hash.BytesToHash160(contract), k4)
-	require.Equal(trie.ErrNotExist, errors.Cause(err))
-	// query second contract
-	w, err = stateDB.getContractState(hash.BytesToHash160(contract1), k3)
-	require.Nil(err)
-	require.Equal(v3, w)
-	w, err = stateDB.getContractState(hash.BytesToHash160(contract1), k4)
-	require.Nil(err)
-	require.Equal(v4, w)
-	_, err = stateDB.getContractState(hash.BytesToHash160(contract1), k1)
-	require.Equal(trie.ErrNotExist, errors.Cause(err))
-	_, err = stateDB.getContractState(hash.BytesToHash160(contract1), k2)
-	require.Equal(trie.ErrNotExist, errors.Cause(err))
-	require.Nil(sf.Stop(context.Background()))
+	t.Run("contract load/store with trie", func(t *testing.T) {
+		testLoadStoreCommit(cfg, t)
+	})
 }
 
 func TestSnapshot(t *testing.T) {
@@ -230,11 +236,6 @@ func TestSnapshot(t *testing.T) {
 	s := &state.Account{
 		Balance: big.NewInt(5),
 	}
-	k1 := hash.Hash256b([]byte("cat"))
-	v1 := hash.Hash256b([]byte("cat"))
-	k2 := hash.Hash256b([]byte("dog"))
-	v2 := hash.Hash256b([]byte("dog"))
-
 	c1, err := newContract(
 		hash.BytesToHash160(identityset.Address(28).Bytes()),
 		s,
@@ -242,10 +243,10 @@ func TestSnapshot(t *testing.T) {
 		db.NewCachedBatch(),
 	)
 	require.NoError(err)
-	require.NoError(c1.SetState(k2, v2[:]))
+	require.NoError(c1.SetState(k2b, v2[:]))
 	c2 := c1.Snapshot()
 	require.NoError(c1.SelfState().AddBalance(big.NewInt(7)))
-	require.NoError(c1.SetState(k1, v1[:]))
+	require.NoError(c1.SetState(k1b, v1[:]))
 	require.Equal(big.NewInt(12), c1.SelfState().Balance)
 	require.Equal(big.NewInt(5), c2.SelfState().Balance)
 	require.NotEqual(c1.RootHash(), c2.RootHash())

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -9,20 +9,26 @@ package evm
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
 	"math/big"
+	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
+	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestAddBalance(t *testing.T) {
@@ -163,174 +169,279 @@ func TestNonce(t *testing.T) {
 	require.Equal(uint64(1), stateDB.GetNonce(addr))
 }
 
-func TestSnapshotAndRevert(t *testing.T) {
-	require := require.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+func TestSnapshotRevertAndCommit(t *testing.T) {
+	testSnapshotAndRevert := func(cfg config.Config, t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
 
-	ctx := context.Background()
-	cfg := config.Default
-	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
-	require.NoError(err)
-	require.NoError(sf.Start(ctx))
-	defer func() {
+		ctx := context.Background()
+		var sf factory.Factory
+		if cfg.Chain.EnableTrielessStateDB {
+			sf, _ = factory.NewStateDB(cfg, factory.DefaultStateDBOption())
+		} else {
+			sf, _ = factory.NewFactory(cfg, factory.DefaultTrieOption())
+		}
+		require.NoError(sf.Start(ctx))
+		ws, err := sf.NewWorkingSet()
+		require.NoError(err)
+		mcm := mock_chainmanager.NewMockChainManager(ctrl)
+		mcm.EXPECT().ChainID().AnyTimes().Return(uint32(1))
+		stateDB := NewStateDBAdapter(mcm, ws, config.NewHeightUpgrade(cfg), 1, hash.ZeroHash256)
+
+		tests := []stateDBTest{
+			{
+				[]bal{
+					{addr1, big.NewInt(40000)},
+				},
+				[]code{
+					{c1, bytecode},
+				},
+				[]evmSet{
+					{c1, k1, v1},
+					{c1, k2, v2},
+					{c3, k3, v4},
+				},
+				[]sui{
+					{c2, false, false},
+					{C4, false, false},
+				},
+				[]image{
+					{common.BytesToHash(v1[:]), []byte("cat")},
+					{common.BytesToHash(v2[:]), []byte("dog")},
+				},
+			},
+			{
+				[]bal{
+					{addr1, big.NewInt(40000)},
+				},
+				[]code{
+					{c2, bytecode},
+				},
+				[]evmSet{
+					{c1, k1, v3},
+					{c1, k2, v4},
+					{c2, k3, v3},
+					{c2, k4, v4},
+				},
+				[]sui{
+					{c1, true, true},
+					{c3, true, true},
+				},
+				[]image{
+					{common.BytesToHash(v3[:]), []byte("hen")},
+				},
+			},
+			{
+				nil,
+				nil,
+				[]evmSet{
+					{c2, k3, v1},
+					{c2, k4, v2},
+				},
+				[]sui{
+					{addr1, true, true},
+				},
+				[]image{
+					{common.BytesToHash(v4[:]), []byte("fox")},
+				},
+			},
+		}
+
+		for i, test := range tests {
+			// add balance
+			for _, e := range test.balance {
+				stateDB.AddBalance(e.addr, e.v)
+			}
+			// set code
+			for _, e := range test.codes {
+				stateDB.SetCode(e.addr, e.v)
+				v := stateDB.GetCode(e.addr)
+				require.Equal(e.v, v)
+			}
+			// set states
+			for _, e := range test.states {
+				stateDB.SetState(e.addr, e.k, e.v)
+			}
+			// set suicide
+			for _, e := range test.suicide {
+				require.Equal(e.suicide, stateDB.Suicide(e.addr))
+				require.Equal(e.exist, stateDB.Exist(e.addr))
+			}
+			// set preimage
+			for _, e := range test.preimage {
+				stateDB.AddPreimage(e.hash, e.v)
+			}
+			require.Equal(i, stateDB.Snapshot())
+		}
+
+		reverts := []stateDBTest{
+			{
+				[]bal{
+					{addr1, big.NewInt(0)},
+				},
+				[]code{},
+				[]evmSet{
+					{c1, k1, v3},
+					{c1, k2, v4},
+					{c2, k3, v1},
+					{c2, k4, v2},
+				},
+				[]sui{
+					{c1, true, true},
+					{c3, true, true},
+					{c2, false, true},
+					{C4, false, false},
+					{addr1, true, true},
+				},
+				[]image{
+					{common.BytesToHash(v1[:]), []byte("cat")},
+					{common.BytesToHash(v2[:]), []byte("dog")},
+					{common.BytesToHash(v3[:]), []byte("hen")},
+					{common.BytesToHash(v4[:]), []byte("fox")},
+				},
+			},
+			{
+				[]bal{
+					{addr1, big.NewInt(80000)},
+				},
+				[]code{},
+				tests[1].states,
+				[]sui{
+					{c1, true, true},
+					{c3, true, true},
+					{c2, false, true},
+					{C4, false, false},
+					{addr1, false, true},
+				},
+				[]image{
+					{common.BytesToHash(v1[:]), []byte("cat")},
+					{common.BytesToHash(v2[:]), []byte("dog")},
+					{common.BytesToHash(v3[:]), []byte("hen")},
+					{common.BytesToHash(v4[:]), []byte(nil)},
+				},
+			},
+			{
+				[]bal{
+					{addr1, big.NewInt(40000)},
+				},
+				[]code{},
+				[]evmSet{
+					{c1, k1, v1},
+					{c1, k2, v2},
+					{c3, k3, v4},
+				},
+				[]sui{
+					{c1, false, true},
+					{c3, false, true},
+					{c2, false, false},
+					{C4, false, false},
+					{addr1, false, true},
+				},
+				[]image{
+					{common.BytesToHash(v1[:]), []byte("cat")},
+					{common.BytesToHash(v2[:]), []byte("dog")},
+					{common.BytesToHash(v3[:]), []byte(nil)},
+					{common.BytesToHash(v4[:]), []byte(nil)},
+				},
+			},
+		}
+
+		// test revert
+		for i, test := range reverts {
+			stateDB.RevertToSnapshot(len(reverts) - 1 - i)
+
+			// test balance
+			for _, e := range test.balance {
+				amount := stateDB.GetBalance(e.addr)
+				require.Equal(e.v, amount)
+			}
+			// test states
+			for _, e := range test.states {
+				require.Equal(e.v, stateDB.GetState(e.addr, e.k))
+			}
+			// test suicide/exist
+			for _, e := range test.suicide {
+				require.Equal(e.suicide, stateDB.HasSuicided(e.addr))
+				require.Equal(e.exist, stateDB.Exist(e.addr))
+			}
+			// test preimage
+			for _, e := range test.preimage {
+				v, _ := stateDB.preimages[e.hash]
+				require.Equal(e.v, v)
+			}
+		}
+
+		// commit snapshot 0's state
+		require.NoError(stateDB.CommitContracts())
+		stateDB.clear()
+		gasLimit := testutil.TestGasLimit
+		ctx = protocol.WithRunActionsCtx(ctx,
+			protocol.RunActionsCtx{
+				Producer: identityset.Address(27),
+				GasLimit: gasLimit,
+			})
+		_, err = ws.RunActions(ctx, 0, nil)
+		require.NoError(err)
+		require.NoError(sf.Commit(ws))
 		require.NoError(sf.Stop(ctx))
+
+		// re-open the StateFactory
+		cfg.DB.DbPath = cfg.Chain.TrieDBPath
+		if cfg.Chain.EnableTrielessStateDB {
+			sf, err = factory.NewStateDB(cfg, factory.PrecreatedStateDBOption(db.NewOnDiskDB(cfg.DB)))
+		} else {
+			sf, err = factory.NewFactory(cfg, factory.PrecreatedTrieDBOption(db.NewOnDiskDB(cfg.DB)))
+		}
+		require.NoError(err)
+		require.NoError(sf.Start(ctx))
+		defer func() {
+			require.NoError(sf.Stop(ctx))
+		}()
+
+		ws, err = sf.NewWorkingSet()
+		require.NoError(err)
+		stateDB = NewStateDBAdapter(mcm, ws, config.NewHeightUpgrade(cfg), 1, hash.ZeroHash256)
+
+		// state factory should have snapshot 0's state
+		snapshot0 := reverts[len(reverts)-1]
+		// test balance
+		for _, e := range snapshot0.balance {
+			amount := stateDB.GetBalance(e.addr)
+			require.Equal(e.v, amount)
+		}
+		// test states
+		for _, e := range snapshot0.states {
+			require.Equal(e.v, stateDB.GetState(e.addr, e.k))
+		}
+		// test suicide/exist
+		for _, e := range snapshot0.suicide {
+			require.Equal(e.suicide, stateDB.HasSuicided(e.addr))
+			require.Equal(e.exist, stateDB.Exist(e.addr))
+		}
+	}
+
+	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath := testTrieFile.Name()
+	defer func() {
+		testutil.CleanupPath(t, testTriePath)
 	}()
-	ws, err := sf.NewWorkingSet()
-	require.NoError(err)
-	mcm := mock_chainmanager.NewMockChainManager(ctrl)
-	mcm.EXPECT().ChainID().AnyTimes().Return(uint32(1))
-	stateDB := NewStateDBAdapter(mcm, ws, config.NewHeightUpgrade(cfg), 1, hash.ZeroHash256)
+	cfg := config.Default
+	cfg.Chain.TrieDBPath = testTriePath
+	t.Run("contract snapshot/revert/commit with stateDB", func(t *testing.T) {
+		testSnapshotAndRevert(cfg, t)
+	})
 
-	code := []byte("test contract creation")
-	addr1 := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
-	cntr1 := common.HexToAddress("01fc246633470cf62ae2a956d21e8d481c3a69e1")
-	cntr3 := common.HexToAddress("956d21e8d481c3a6901fc246633470cf62ae2ae1")
-	cntr2 := common.HexToAddress("3470cf62ae2a956d38d481c3a69e121e01fc2466")
-	cntr4 := common.HexToAddress("121e01fc24663470cf62ae2a956d38d481c3a69e")
-	k1 := hash.Hash256b([]byte("cat"))
-	v1 := hash.Hash256b([]byte("cat"))
-	k2 := hash.Hash256b([]byte("dog"))
-	v2 := hash.Hash256b([]byte("dog"))
-	k3 := hash.Hash256b([]byte("hen"))
-	v3 := hash.Hash256b([]byte("hen"))
-	k4 := hash.Hash256b([]byte("fox"))
-	v4 := hash.Hash256b([]byte("fox"))
-
-	addAmount := big.NewInt(40000)
-	stateDB.AddBalance(addr1, addAmount)
-	stateDB.SetCode(cntr1, code)
-	v := stateDB.GetCode(cntr1)
-	require.Equal(code, v)
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr1[:]), k1, v1))
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr1[:]), k2, v2))
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr3[:]), k3, v4))
-	require.False(stateDB.Suicide(cntr2))
-	require.False(stateDB.Exist(cntr2))
-	require.False(stateDB.Suicide(cntr4))
-	require.False(stateDB.Exist(cntr4))
-	stateDB.AddPreimage(common.BytesToHash(v1[:]), []byte("cat"))
-	stateDB.AddPreimage(common.BytesToHash(v2[:]), []byte("dog"))
-	require.Equal(0, stateDB.Snapshot())
-
-	stateDB.AddBalance(addr1, addAmount)
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr1[:]), k1, v3))
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr1[:]), k2, v4))
-	stateDB.SetCode(cntr2, code)
-	v = stateDB.GetCode(cntr2)
-	require.Equal(code, v)
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr2[:]), k3, v3))
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr2[:]), k4, v4))
-	// kill contract 1 and 3
-	require.True(stateDB.Suicide(cntr1))
-	require.True(stateDB.Exist(cntr1))
-	require.True(stateDB.Suicide(cntr3))
-	require.True(stateDB.Exist(cntr3))
-	stateDB.AddPreimage(common.BytesToHash(v3[:]), []byte("hen"))
-	require.Equal(1, stateDB.Snapshot())
-
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr2[:]), k3, v1))
-	require.NoError(stateDB.setContractState(hash.BytesToHash160(cntr2[:]), k4, v2))
-	require.True(stateDB.Suicide(addr1))
-	require.True(stateDB.Exist(addr1))
-	stateDB.AddPreimage(common.BytesToHash(v4[:]), []byte("fox"))
-	require.Equal(2, stateDB.Snapshot())
-
-	stateDB.RevertToSnapshot(2)
-	// cntr1 and 3 killed, but still exists before commit
-	require.True(stateDB.HasSuicided(cntr1))
-	require.True(stateDB.Exist(cntr1))
-	require.True(stateDB.HasSuicided(cntr3))
-	require.True(stateDB.Exist(cntr3))
-	w, _ := stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k1)
-	require.Equal(v3, w)
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k2)
-	require.Equal(v4, w)
-	// cntr2 still normal
-	require.False(stateDB.HasSuicided(cntr2))
-	require.True(stateDB.Exist(cntr2))
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr2[:]), k3)
-	require.Equal(v1, w)
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr2[:]), k4)
-	require.Equal(v2, w)
-	// addr1 also killed
-	require.True(stateDB.HasSuicided(addr1))
-	require.True(stateDB.Exist(addr1))
-	amount := stateDB.GetBalance(addr1)
-	require.Equal(0, amount.Cmp(big.NewInt(0)))
-	v, _ = stateDB.preimages[common.BytesToHash(v1[:])]
-	require.Equal([]byte("cat"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v2[:])]
-	require.Equal([]byte("dog"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v3[:])]
-	require.Equal([]byte("hen"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v4[:])]
-	require.Equal([]byte("fox"), v)
-
-	stateDB.RevertToSnapshot(1)
-	// cntr1 and 3 killed, but still exists before commit
-	require.True(stateDB.HasSuicided(cntr1))
-	require.True(stateDB.Exist(cntr1))
-	require.True(stateDB.HasSuicided(cntr3))
-	require.True(stateDB.Exist(cntr3))
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k1)
-	require.Equal(v3, w)
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k2)
-	require.Equal(v4, w)
-	// cntr2 is normal
-	require.False(stateDB.HasSuicided(cntr2))
-	require.True(stateDB.Exist(cntr2))
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr2[:]), k3)
-	require.Equal(v3, w)
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr2[:]), k4)
-	require.Equal(v4, w)
-	// addr1 has balance 80000
-	require.False(stateDB.HasSuicided(addr1))
-	require.True(stateDB.Exist(addr1))
-	amount = stateDB.GetBalance(addr1)
-	require.Equal(0, amount.Cmp(big.NewInt(80000)))
-	v, _ = stateDB.preimages[common.BytesToHash(v1[:])]
-	require.Equal([]byte("cat"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v2[:])]
-	require.Equal([]byte("dog"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v3[:])]
-	require.Equal([]byte("hen"), v)
-	_, ok := stateDB.preimages[common.BytesToHash(v4[:])]
-	require.False(ok)
-
-	stateDB.RevertToSnapshot(0)
-	// cntr1 and 3 is normal
-	require.False(stateDB.HasSuicided(cntr1))
-	require.True(stateDB.Exist(cntr1))
-	require.False(stateDB.HasSuicided(cntr3))
-	require.True(stateDB.Exist(cntr3))
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k1)
-	require.Equal(v1, w)
-	w, _ = stateDB.getContractState(hash.BytesToHash160(cntr1[:]), k2)
-	require.Equal(v2, w)
-	// cntr2 and 4 does not exist
-	require.False(stateDB.Exist(cntr2))
-	require.False(stateDB.Exist(cntr4))
-	// addr1 has balance 40000
-	require.False(stateDB.HasSuicided(addr1))
-	require.True(stateDB.Exist(addr1))
-	amount = stateDB.GetBalance(addr1)
-	require.Equal(0, amount.Cmp(addAmount))
-	v, _ = stateDB.preimages[common.BytesToHash(v1[:])]
-	require.Equal([]byte("cat"), v)
-	v, _ = stateDB.preimages[common.BytesToHash(v2[:])]
-	require.Equal([]byte("dog"), v)
-	_, ok = stateDB.preimages[common.BytesToHash(v3[:])]
-	require.False(ok)
-	_, ok = stateDB.preimages[common.BytesToHash(v4[:])]
-	require.False(ok)
-
-	require.NoError(stateDB.CommitContracts())
-	stateDB.clear()
-	require.True(stateDB.Exist(addr1))
-	require.True(stateDB.Exist(cntr1))
-	require.False(stateDB.Exist(cntr2))
-	require.False(stateDB.Exist(cntr4))
+	testTrieFile, _ = ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath2 := testTrieFile.Name()
+	defer func() {
+		testutil.CleanupPath(t, testTriePath2)
+	}()
+	cfg.Chain.EnableTrielessStateDB = false
+	cfg.Chain.TrieDBPath = testTriePath2
+	t.Run("contract snapshot/revert/commit with trie", func(t *testing.T) {
+		testSnapshotAndRevert(cfg, t)
+	})
 }
 
 func TestGetBalanceOnError(t *testing.T) {
@@ -375,9 +486,6 @@ func TestPreimage(t *testing.T) {
 	mcm.EXPECT().ChainID().AnyTimes().Return(uint32(1))
 	stateDB := NewStateDBAdapter(mcm, ws, config.NewHeightUpgrade(cfg), 1, hash.ZeroHash256)
 
-	v1 := hash.Hash256b([]byte("cat"))
-	v2 := hash.Hash256b([]byte("dog"))
-	v3 := hash.Hash256b([]byte("hen"))
 	stateDB.AddPreimage(common.BytesToHash(v1[:]), []byte("cat"))
 	stateDB.AddPreimage(common.BytesToHash(v2[:]), []byte("dog"))
 	stateDB.AddPreimage(common.BytesToHash(v3[:]), []byte("hen"))

--- a/action/protocol/execution/evm/testdata_test.go
+++ b/action/protocol/execution/evm/testdata_test.go
@@ -1,0 +1,78 @@
+package evm
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/go-pkgs/hash"
+	"math/big"
+)
+
+type (
+	// test vector for Contract
+	set struct {
+		k     hash.Hash256
+		v     []byte
+		cause error
+	}
+	cntrTest struct {
+		contract Contract
+		codes    []code
+		states   []set
+	}
+	// test vector for StateDBAdapter
+	bal struct {
+		addr common.Address
+		v    *big.Int
+	}
+	code struct {
+		addr common.Address
+		v    []byte
+	}
+	evmSet struct {
+		addr common.Address
+		k    common.Hash
+		v    common.Hash
+	}
+	sui struct {
+		addr    common.Address
+		suicide bool
+		exist   bool
+	}
+	image struct {
+		hash common.Hash
+		v    []byte
+	}
+	stateDBTest struct {
+		balance  []bal
+		codes    []code
+		states   []evmSet
+		suicide  []sui
+		preimage []image
+	}
+)
+
+var (
+	bytecode = []byte("test contract creation")
+
+	addr1 = common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
+	c1    = common.HexToAddress("01fc246633470cf62ae2a956d21e8d481c3a69e1")
+	c2    = common.HexToAddress("3470cf62ae2a956d38d481c3a69e121e01fc2466")
+	c3    = common.HexToAddress("956d21e8d481c3a6901fc246633470cf62ae2ae1")
+	C4    = common.HexToAddress("121e01fc24663470cf62ae2a956d38d481c3a69e")
+
+	k1b = hash.Hash256b([]byte("cat"))
+	v1b = hash.Hash256b([]byte("cat"))
+	k2b = hash.Hash256b([]byte("dog"))
+	v2b = hash.Hash256b([]byte("dog"))
+	k3b = hash.Hash256b([]byte("hen"))
+	v3b = hash.Hash256b([]byte("hen"))
+	k4b = hash.Hash256b([]byte("fox"))
+	v4b = hash.Hash256b([]byte("fox"))
+	k1  = common.BytesToHash(k1b[:])
+	v1  = common.BytesToHash(v1b[:])
+	k2  = common.BytesToHash(k2b[:])
+	v2  = common.BytesToHash(v2b[:])
+	k3  = common.BytesToHash(k3b[:])
+	v3  = common.BytesToHash(v3b[:])
+	k4  = common.BytesToHash(k4b[:])
+	v4  = common.BytesToHash(v4b[:])
+)

--- a/api/api.go
+++ b/api/api.go
@@ -53,7 +53,7 @@ var (
 	// ErrReceipt indicates the error of receipt
 	ErrReceipt = errors.New("invalid receipt")
 	// ErrAction indicates the error of action
-	ErrAction = errors.New("invalid action")
+	ErrAction        = errors.New("invalid action")
 	candidateNameLen = 12
 )
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.1-0.20190708233003-85a24189bbd4
 	github.com/iotexproject/iotex-address v0.2.0
 	github.com/iotexproject/iotex-election v0.1.10
-	github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd // indirect
+	github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd
 	github.com/ipfs/go-datastore v0.0.5 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/libp2p/go-libp2p v0.0.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzW
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27 h1:u/Fk5l75IqKWdu68t7AQz2y4FMHIeJqE2VLq8fmKD0Q=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd h1:F24GwzKft8+LJzh2ORDR95PbMKGg9K54+Tsn78UrtJQ=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -40,9 +40,20 @@ type stateDB struct {
 // StateDBOption sets stateDB construction parameter
 type StateDBOption func(*stateDB, config.Config) error
 
-// DefaultStateDBOption creates trie from config for state db
+// PrecreatedStateDBOption uses pre-created state db
+func PrecreatedStateDBOption(kv db.KVStore) StateDBOption {
+	return func(sdb *stateDB, cfg config.Config) error {
+		if kv == nil {
+			return errors.New("Invalid state db")
+		}
+		sdb.dao = kv
+		return nil
+	}
+}
+
+// DefaultStateDBOption creates default state db from config
 func DefaultStateDBOption() StateDBOption {
-	return func(sdb *stateDB, cfg config.Config) (err error) {
+	return func(sdb *stateDB, cfg config.Config) error {
 		dbPath := cfg.Chain.TrieDBPath
 		if len(dbPath) == 0 {
 			return errors.New("Invalid empty trie db path")
@@ -53,9 +64,9 @@ func DefaultStateDBOption() StateDBOption {
 	}
 }
 
-// InMemStateDBOption creates in memory trie for state db
+// InMemStateDBOption creates in memory state db
 func InMemStateDBOption() StateDBOption {
-	return func(sdb *stateDB, cfg config.Config) (err error) {
+	return func(sdb *stateDB, cfg config.Config) error {
 		sdb.dao = db.NewMemKVStore()
 		return nil
 	}


### PR DESCRIPTION
This would enable solidity 0.5.1

Please focus on 2nd commit, which adds the 2 new interfaces. It also refactors the implementation of SetCode/State, GetState

The 1st commit is just to make the test code more readable by adding test vector, and also improve test coverage by testing both Trie and Trieless DB