### PR TITLE
Fix TestBatchRollback for windows

### DIFF
--- a/db/db_test.go
+++ b/db/db_test.go
@@ -125,8 +125,6 @@ func TestBatchRollback(t *testing.T) {
 	testPath := testFile.Name()
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
-		testutil.CleanupPath(t, testPath)
-		defer testutil.CleanupPath(t, testPath)
 		testBatchRollback(NewOnDiskDB(cfg), t)
 	})
 


### PR DESCRIPTION
The testutil.CleanupPath(t, testPath) meets error in TestBatchRollback on windows
`The process cannot access the file because it is being used by another process.`

This test case uses os.TempDir, so we can remove those CleanupPath()

Tested on windows and centos