### PR TITLE
Add format output flag for versionCmd

### DIFF
--- a/ioctl/cmd/root.go
+++ b/ioctl/cmd/root.go
@@ -45,6 +45,6 @@ func init() {
 	RootCmd.AddCommand(update.UpdateCmd)
 	RootCmd.AddCommand(version.VersionCmd)
 	RootCmd.AddCommand(action.Xrc20Cmd)
-	RootCmd.PersistentFlags().StringVarP(&output.OutputFormat, "output-format", "o", "",
+	RootCmd.PersistentFlags().StringVarP(&output.Format, "output-format", "o", "",
 		"output format")
 }

--- a/ioctl/cmd/root.go
+++ b/ioctl/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/cmd/node"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/update"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/version"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -44,4 +45,6 @@ func init() {
 	RootCmd.AddCommand(update.UpdateCmd)
 	RootCmd.AddCommand(version.VersionCmd)
 	RootCmd.AddCommand(action.Xrc20Cmd)
+	RootCmd.PersistentFlags().StringVarP(&output.OutputFormat, "output-format", "o", "",
+		"output format")
 }

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -85,10 +85,10 @@ func version() error {
 }
 
 func printVersion(message versionMessage) {
-	switch {
+	switch output.Format {
 	default:
 		fmt.Printf("%s:\n%+v\n\n", message.Object, message.VersionInfo)
-	case output.OutputFormat == "json":
+	case "json":
 		out := output.Output{MessageType: output.Result, Message: message}
 		byteAsJSON, err := json.MarshalIndent(out, "", "  ")
 		if err != nil {

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -30,8 +30,8 @@ var VersionCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		version()
-		return nil
+		err := version()
+		return err
 	},
 }
 

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -69,7 +69,7 @@ func version() output.Error {
 	message = versionMessage{Type: output.Result, Object: config.ReadConfig.Endpoint}
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		oErr = output.Error{Code: output.Network_Error, Info: err.Error()}
+		oErr = output.Error{Code: output.NetworkError, Info: err.Error()}
 		printVersion(message, oErr)
 		return oErr
 	}
@@ -84,7 +84,7 @@ func version() output.Error {
 			oErr = output.Error{Code: 1, Info: sta.Message()}
 		} else {
 			oErr = output.Error{
-				Code: output.API_Error,
+				Code: output.APIError,
 				Info: "failed to get version from server: " + err.Error(),
 			}
 		}

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -6,15 +6,21 @@
 
 package output
 
+// OutputFormat is the target of output-format flag
 var OutputFormat string
 
+// ErrorCode is the code of error
 type ErrorCode int
 
 const (
+	// NoError used when no error is happened
 	NoError ErrorCode = iota
-	Undefined_Error
-	Network_Error
-	API_Error
+	// UndefinedError used when an error cat't be classified 
+	UndefinedError
+	// NetworkError used when an network error is happened
+	NetworkError
+	// APIError used when an API error is happened
+	APIError
 )
 
 // MessageType marks the type of output message
@@ -29,15 +35,18 @@ const (
 	Query
 )
 
+// Output is used for format output
 type Output struct {
 	Error   Error   `json:"error"`
 	Message Message `json:"message"`
 }
 
+// Error is the error part of Output
 type Error struct {
 	Code ErrorCode `json:"code"`
 	Info string    `json:"info"`
 }
 
+// Message is the message part of Output
 type Message interface {
 }

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -61,7 +61,7 @@ type ErrorMessage struct {
 func PrintError(code ErrorCode, info string) error {
 	switch {
 	default:
-		return fmt.Errorf("%d,%s", code, info)
+		return fmt.Errorf("%d, %s", code, info)
 	case OutputFormat == "json":
 		out := Output{
 			MessageType: Error,

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -61,7 +61,7 @@ type ErrorMessage struct {
 func PrintError(code ErrorCode, info string) error {
 	switch {
 	default:
-		return fmt.Errorf("Error%d:%s", code, info)
+		return fmt.Errorf("%d,%s", code, info)
 	case OutputFormat == "json":
 		out := Output{
 			MessageType: Error,

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -12,8 +12,8 @@ import (
 	"log"
 )
 
-// OutputFormat is the target of output-format flag
-var OutputFormat string
+// Format is the target of output-format flag
+var Format string
 
 // ErrorCode is the code of error
 type ErrorCode int
@@ -59,10 +59,10 @@ type ErrorMessage struct {
 
 // PrintError prints error message in format, and returns golang error when using default output
 func PrintError(code ErrorCode, info string) error {
-	switch {
+	switch Format {
 	default:
 		return fmt.Errorf("%d, %s", code, info)
-	case OutputFormat == "json":
+	case "json":
 		out := Output{
 			MessageType: Error,
 			Message:     ErrorMessage{Code: code, Info: info},

--- a/ioctl/output/json.go
+++ b/ioctl/output/json.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package output
+
+var OutputFormat string
+
+type ErrorCode int
+
+const (
+	NoError ErrorCode = iota
+	Undefined_Error
+	Network_Error
+	API_Error
+)
+
+// MessageType marks the type of output message
+type MessageType int
+
+const (
+	// Result represents the result of a command
+	Result MessageType = iota
+	// Confirmation represents request for confirmation
+	Confirmation
+	// Query represents request for answer of certain question
+	Query
+)
+
+type Output struct {
+	Error   Error   `json:"error"`
+	Message Message `json:"message"`
+}
+
+type Error struct {
+	Code ErrorCode `json:"code"`
+	Info string    `json:"info"`
+}
+
+type Message interface {
+}


### PR DESCRIPTION
I take the version command as an example of format output refactoring. #935 
In new versionCmd, by default, result is printed through stdout and error is printed throught stderr.
When using the flag output-format(eg. `-o json`), output(contains error) will be printed through stdout.

Tested on windows and centos

```
// success case
-> ioctl version -o json                                      
{
  "messageType": 0,
  "message": {
    "object": "Client",
    "versionInfo": {
      "packageVersion": "v0.8.0-13-gfa27c17",
      "packageCommitID": "fa27c17a0c286d6df5f3c35ad9ae2c2b38e450a7",
      "gitStatus": "clean",
      "goVersion": "go version go1.12.6 linux/amd64",
      "buildTime": "2019-07-08-CST/13:12:02"
    }
  }
}
{
  "messageType": 0,
  "message": {
    "object": "api.iotex.one:443",
    "versionInfo": {
      "packageVersion": "v0.6.2",
      "packageCommitID": "2df78e9460dee3bd3d96526468472409ac36d615",
      "gitStatus": "clean",
      "goVersion": "go version go1.12.5 linux/amd64",
      "buildTime": "2019-05-29-UTC/21:33:14"
    }
  }
}


// failure case
-> ioctl version -o json
{
  "messageType": 0,
  "message": {
    "object": "Client",
    "versionInfo": {
      "packageVersion": "v0.8.0-13-gfa27c17",
      "packageCommitID": "fa27c17a0c286d6df5f3c35ad9ae2c2b38e450a7",
      "gitStatus": "clean",
      "goVersion": "go version go1.12.6 linux/amd64",
      "buildTime": "2019-07-08-CST/13:12:02"
    }
  }
}
{
  "messageType": 3,
  "message": {
    "code": 1,
    "info": "all SubConns are in TransientFailure, latest connection error: conn                                                                                        ection error: desc = \"transport: Error while dialing dial tcp: address baidu.co                                                                                        m: missing port in address\""
  }
}

```