### PR TITLE
 Format ouput for Account Cmds in ioctl

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.1-0.20190708233003-85a24189bbd4
 	github.com/iotexproject/iotex-address v0.2.0
 	github.com/iotexproject/iotex-election v0.1.10
-	github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27 // indirect
+	github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27
 	github.com/ipfs/go-datastore v0.0.5 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect
 	github.com/libp2p/go-libp2p v0.0.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzW
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190626221605-1f92737a3f6a h1:eN5zoe19/P+4y4HuvLqSG9HtHTSyK6vcCx8UXVVMuP0=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190626221605-1f92737a3f6a/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27 h1:u/Fk5l75IqKWdu68t7AQz2y4FMHIeJqE2VLq8fmKD0Q=
+github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -24,12 +24,11 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // Errors
@@ -96,8 +95,7 @@ func KsAccountToPrivateKey(signer, password string) (crypto.PrivateKey, error) {
 	}
 	address, err := address.FromString(addr)
 	if err != nil {
-		log.L().Error("failed to convert string into address", zap.Error(err))
-		return nil, err
+		return nil, fmt.Errorf("failed to convert bytes into address")
 	}
 	// find the account in keystore
 	ks := keystore.NewKeyStore(config.ReadConfig.Wallet,
@@ -132,17 +130,15 @@ func GetAccountMeta(addr string) (*iotextypes.AccountMeta, error) {
 }
 
 func newAccount(alias string, walletDir string) (string, error) {
-	fmt.Printf("#%s: Set password\n", alias)
+	output.PrintQuery(fmt.Sprintf("#%s: Set password\n", alias))
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to get password")
 	}
-	fmt.Printf("#%s: Enter password again\n", alias)
+	output.PrintQuery(fmt.Sprintf("#%s: Enter password again\n", alias))
 	passwordAgain, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to get password")
 	}
 	if password != passwordAgain {
 		return "", ErrPasswdNotMatch
@@ -154,24 +150,21 @@ func newAccount(alias string, walletDir string) (string, error) {
 	}
 	addr, err := address.FromBytes(account.Address.Bytes())
 	if err != nil {
-		log.L().Error("failed to convert bytes into address", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to convert bytes into address")
 	}
 	return addr.String(), nil
 }
 
 func newAccountByKey(alias string, privateKey string, walletDir string) (string, error) {
-	fmt.Printf("#%s: Set password\n", alias)
+	output.PrintQuery(fmt.Sprintf("#%s: Set password\n", alias))
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to get password")
 	}
-	fmt.Printf("#%s: Enter password again\n", alias)
+	output.PrintQuery(fmt.Sprintf("#%s: Enter password again\n", alias))
 	passwordAgain, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to get password")
 	}
 	if password != passwordAgain {
 		return "", ErrPasswdNotMatch
@@ -189,8 +182,7 @@ func newAccountByKey(alias string, privateKey string, walletDir string) (string,
 	}
 	addr, err := address.FromBytes(account.Address.Bytes())
 	if err != nil {
-		log.L().Error("failed to convert bytes into address", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to convert bytes into address")
 	}
 	return addr.String(), nil
 }

--- a/ioctl/cmd/account/accountbalance.go
+++ b/ioctl/cmd/account/accountbalance.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
@@ -22,28 +23,41 @@ var accountBalanceCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := balance(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := balance(args)
 		return err
 	},
 }
 
+type balanceMessage struct {
+	Address string `json:"address"`
+	Balance string `json:"balance"`
+}
+
 // balance gets balance of an IoTeX blockchain address
-func balance(args []string) (string, error) {
+func balance(args []string) error {
 	address, err := util.GetAddress(args)
 	if err != nil {
-		return "", err
+		return output.PrintError(0, err.Error()) // TODO: undefined error
 	}
 	accountMeta, err := GetAccountMeta(address)
 	if err != nil {
-		return "", err
+		return output.PrintError(0, err.Error()) // TODO: undefined error
 	}
 	balance, ok := big.NewInt(0).SetString(accountMeta.Balance, 10)
 	if !ok {
-		return "", fmt.Errorf("failed to convert balance into big int")
+		return output.PrintError(output.ConvertError, err.Error())
 	}
-	return fmt.Sprintf("%s: %s IOTX", address,
-		util.RauToString(balance, util.IotxDecimalNum)), nil
+	message := balanceMessage{
+		Address: address,
+		Balance: util.RauToString(balance, util.IotxDecimalNum),
+	}
+	fmt.Println((message.String()))
+	return nil
+}
+
+func (m *balanceMessage) String() string {
+	if output.Format == "" {
+		return fmt.Sprintf("%s: %s IOTX", m.Address, m.Balance)
+	}
+	return output.FormatString(output.Result, m)
 }

--- a/ioctl/cmd/account/accountbalance.go
+++ b/ioctl/cmd/account/accountbalance.go
@@ -37,7 +37,7 @@ type balanceMessage struct {
 func balance(args []string) error {
 	address, err := util.GetAddress(args)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.PrintError(output.AddressError, err.Error())
 	}
 	accountMeta, err := GetAccountMeta(address)
 	if err != nil {

--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -46,8 +46,8 @@ func accountCreateAdd(args []string) error {
 		fmt.Println(message.String())
 		fmt.Scanf("%s", &confirm)
 		if !strings.EqualFold(confirm, "yes") {
-			message := output.StringMessage("quit")
-			fmt.Println(message.String())
+			output.PrintResult("quit")
+			return nil
 		}
 	}
 	addr, err := newAccount(alias, config.ReadConfig.Wallet)
@@ -63,8 +63,7 @@ func accountCreateAdd(args []string) error {
 		return output.PrintError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
 	}
-	message := output.StringMessage(fmt.Sprintf("New account \"%s\" is created.\n"+
+	output.PrintResult(fmt.Sprintf("New account \"%s\" is created.\n"+
 		"Please Keep your password, or your will lose your private key.", alias))
-	fmt.Println(message.String())
 	return nil
 }

--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/validator"
 )
 
@@ -25,41 +26,45 @@ var accountCreateAddCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := accountCreateAdd(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := accountCreateAdd(args)
 		return err
 	},
 }
 
-func accountCreateAdd(args []string) (string, error) {
+func accountCreateAdd(args []string) error {
 	// Validate inputs
 	if err := validator.ValidateAlias(args[0]); err != nil {
-		return "", err
+		return output.PrintError(output.ValidationError, err.Error())
 	}
 	alias := args[0]
 	if addr, ok := config.ReadConfig.Aliases[alias]; ok {
 		var confirm string
-		fmt.Printf("** Alias \"%s\" has already used for %s\nOverwriting the account will keep the previous keystore file stay, but bind the alias to the new one.\nType 'YES' to continue, quit for anything else.\n", alias, addr)
+		info := fmt.Sprintf("** Alias \"%s\" has already used for %s\n"+
+			"Overwriting the account will keep the previous keystore file stay, "+
+			"but bind the alias to the new one.\nWould you like to continue?\n", alias, addr)
+		message := output.ComfirmationMessage{Info: info, Options: []string{"yes"}}
+		fmt.Println(message.String())
 		fmt.Scanf("%s", &confirm)
 		if !strings.EqualFold(confirm, "yes") {
-			return "Quit", nil
+			message := output.StringMessage("quit")
+			fmt.Println(message.String())
 		}
 	}
 	addr, err := newAccount(alias, config.ReadConfig.Wallet)
 	if err != nil {
-		return "", err
+		return output.PrintError(0, err.Error()) // TODO: undefined error
 	}
 	config.ReadConfig.Aliases[alias] = addr
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.SerializationError, err.Error())
 	}
 	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return "", fmt.Errorf("failed to write to config file %s", config.DefaultConfigFile)
+		return output.PrintError(output.WriteFileError,
+			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
 	}
-	return fmt.Sprintf(
-		"New account \"%s\" is created.\n"+
-			"Please Keep your password, or your will lose your private key.", alias), nil
+	message := output.StringMessage(fmt.Sprintf("New account \"%s\" is created.\n"+
+		"Please Keep your password, or your will lose your private key.", alias))
+	fmt.Println(message.String())
+	return nil
 }

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -39,7 +39,7 @@ var accountDeleteCmd = &cobra.Command{
 func accountDelete(args []string) error {
 	addr, err := util.GetAddress(args)
 	if err != nil {
-		return output.PrintError(output.UndefinedError, err.Error()) // TODO: undefined error
+		return output.PrintError(output.AddressError, err.Error())
 	}
 	account, err := address.FromString(addr)
 	if err != nil {

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -11,17 +11,17 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // accountDeleteCmd represents the account delete command
@@ -31,52 +31,53 @@ var accountDeleteCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := accountDelete(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := accountDelete(args)
 		return err
 	},
 }
 
-func accountDelete(args []string) (string, error) {
+func accountDelete(args []string) error {
 	addr, err := util.GetAddress(args)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.UndefinedError, err.Error()) // TODO: undefined error
 	}
 	account, err := address.FromString(addr)
 	if err != nil {
-		log.L().Error("failed to convert string into address", zap.Error(err))
-		return "", err
+		return output.PrintError(output.ConvertError, fmt.Sprintf("failed to convert string into address"))
 	}
 	ks := keystore.NewKeyStore(config.ReadConfig.Wallet,
 		keystore.StandardScryptN, keystore.StandardScryptP)
 	for _, v := range ks.Accounts() {
 		if bytes.Equal(account.Bytes(), v.Address.Bytes()) {
 			var confirm string
-			fmt.Println("** This is an irreversible action!\n" +
+			info := fmt.Sprintf("** This is an irreversible action!\n" +
 				"Once an account is deleted, all the assets under this account may be lost!\n" +
 				"Type 'YES' to continue, quit for anything else.")
+			message := output.ComfirmationMessage{Info: info, Options: []string{"yes"}}
+			fmt.Println(message.String())
 			fmt.Scanf("%s", &confirm)
-			if confirm != "YES" && confirm != "yes" {
-				return "Quit", nil
+			if !strings.EqualFold(confirm, "yes") {
+				output.PrintResult("quit")
+				return nil
 			}
 
 			if err := os.Remove(v.URL.Path); err != nil {
-				return "", err
+				return output.PrintError(output.WriteFileError, err.Error())
 			}
 
 			aliases := alias.GetAliasMap()
 			delete(config.ReadConfig.Aliases, aliases[addr])
 			out, err := yaml.Marshal(&config.ReadConfig)
 			if err != nil {
-				log.L().Panic(err.Error())
+				return output.PrintError(output.SerializationError, err.Error())
 			}
 			if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-				log.L().Panic(fmt.Sprintf("Failed to write to config file %s.", config.DefaultConfigFile))
+				return output.PrintError(output.WriteFileError,
+					fmt.Sprintf("Failed to write to config file %s.", config.DefaultConfigFile))
 			}
-			return fmt.Sprintf("Account #%s has been deleted.", addr), nil
+			output.PrintResult(fmt.Sprintf("Account #%s has been deleted.", addr))
+			return nil
 		}
 	}
-	return "", fmt.Errorf("account #%s not found", addr)
+	return output.PrintError(output.ValidationError, fmt.Sprintf("account #%s not found", addr))
 }

--- a/ioctl/cmd/account/accountexport.go
+++ b/ioctl/cmd/account/accountexport.go
@@ -10,10 +10,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // accountExportCmd represents the account export command
@@ -23,29 +22,26 @@ var accountExportCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := accountExport(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := accountExport(args)
 		return err
 	},
 }
 
-func accountExport(args []string) (string, error) {
+func accountExport(args []string) error {
 	addr, err := util.GetAddress(args)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.AddressError, err.Error())
 	}
 	fmt.Printf("Enter password #%s:\n", addr)
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return output.PrintError(output.InputError, "failed to get password")
 	}
 	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.KeystoreError, err.Error())
 	}
 	defer prvKey.Zero()
-	return prvKey.HexString(), nil
+	output.PrintResult(prvKey.HexString())
+	return nil
 }

--- a/ioctl/cmd/account/accountexportpublic.go
+++ b/ioctl/cmd/account/accountexportpublic.go
@@ -10,10 +10,9 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // accountExportPublicCmd represents the account export public key command
@@ -23,29 +22,26 @@ var accountExportPublicCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := accountExportPublic(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := accountExportPublic(args)
 		return err
 	},
 }
 
-func accountExportPublic(args []string) (string, error) {
+func accountExportPublic(args []string) error {
 	addr, err := util.GetAddress(args)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.AddressError, err.Error())
 	}
 	fmt.Printf("Enter password #%s:\n", addr)
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		log.L().Error("failed to get password", zap.Error(err))
-		return "", err
+		return output.PrintError(output.InputError, "failed to get password")
 	}
 	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.KeystoreError, err.Error())
 	}
 	defer prvKey.Zero()
-	return prvKey.PublicKey().HexString(), nil
+	output.PrintResult(prvKey.PublicKey().HexString())
+	return nil
 }

--- a/ioctl/cmd/alias/aliasremove.go
+++ b/ioctl/cmd/alias/aliasremove.go
@@ -45,7 +45,6 @@ func remove(arg string) error {
 		return output.PrintError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
 	}
-	message := output.StringMessage(alias + " is removed")
-	fmt.Println(message.String())
+	output.PrintResult(alias + " is removed")
 	return nil
 }

--- a/ioctl/cmd/alias/aliasset.go
+++ b/ioctl/cmd/alias/aliasset.go
@@ -54,7 +54,6 @@ func set(args []string) error {
 		return output.PrintError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
 	}
-	message := output.StringMessage("set")
-	fmt.Println(message.String())
+	output.PrintResult("set")
 	return nil
 }

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -35,6 +35,11 @@ const (
 	WriteFileError
 	// FlagError used when invalid flag is set
 	FlagError
+	// ConvertError used when fail to converting data
+	ConvertError
+	// CryptoError used when crypto error occurs
+	CryptoError
+	// InputError used when error occurs during reading from stdin
 )
 
 // MessageType marks the type of output message
@@ -62,6 +67,24 @@ type Message interface {
 	String() string
 }
 
+// ComfirmationMessage is the struct of an Confirmation output
+type ComfirmationMessage struct {
+	Info    string   `json:"info"`
+	Options []string `json:"options"`
+}
+
+func (m *ComfirmationMessage) String() string {
+	if Format == "" {
+		line := fmt.Sprintf("%s\nOptions:", m.Info)
+		for _, option := range m.Options {
+			line += " " + option
+		}
+		line += "\nQuit for anything else."
+		return line
+	}
+	return FormatString(Confirmation, m)
+}
+
 // ErrorMessage is the struct of an Error output
 type ErrorMessage struct {
 	Code ErrorCode `json:"code"`
@@ -75,7 +98,7 @@ func (m *ErrorMessage) String() string {
 	return FormatString(Error, m)
 }
 
-// StringMessage is for implementing string as interface Message
+// StringMessage is the Result Message for string
 type StringMessage string
 
 func (m StringMessage) String() string {
@@ -97,11 +120,11 @@ func FormatString(t MessageType, m Message) string {
 		if err != nil {
 			log.Panic(err)
 		}
-		return fmt.Sprintln(string(byteAsJSON))
+		return fmt.Sprint(string(byteAsJSON))
 	}
 }
 
-// PrintError prints error message in format, and returns golang error when using default output
+// PrintError sprints error message in format, and returns golang error when using default output
 func PrintError(code ErrorCode, info string) error {
 	errMessage := ErrorMessage{Code: code, Info: info}
 	if Format == "" {
@@ -109,4 +132,10 @@ func PrintError(code ErrorCode, info string) error {
 	}
 	fmt.Println(errMessage.String())
 	return nil
+}
+
+// PrintQuery prints query message in format
+func PrintQuery(query string) {
+	message := StringMessage(query)
+	fmt.Println(message.String())
 }

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -98,7 +98,7 @@ func (m *ErrorMessage) String() string {
 	return FormatString(Error, m)
 }
 
-// StringMessage is the Result Message for string
+// StringMessage is the Message for string
 type StringMessage string
 
 func (m StringMessage) String() string {
@@ -106,6 +106,14 @@ func (m StringMessage) String() string {
 		return string(m)
 	}
 	return FormatString(Result, m)
+}
+
+// Query prints query message
+func (m StringMessage) Query() string {
+	if Format == "" {
+		return string(m)
+	}
+	return FormatString(Query, m)
 }
 
 // FormatString returns Output as string in certain format
@@ -137,5 +145,5 @@ func PrintError(code ErrorCode, info string) error {
 // PrintQuery prints query message in format
 func PrintQuery(query string) {
 	message := StringMessage(query)
-	fmt.Println(message.String())
+	fmt.Println(message.Query())
 }

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -39,7 +39,14 @@ const (
 	ConvertError
 	// CryptoError used when crypto error occurs
 	CryptoError
-	// InputError used when error occurs during reading from stdin
+	// AddressError used if an error is related to address
+	AddressError
+	// InputError used when error about input occurs
+	InputError
+	// KeystoreError used when an error related to keystore
+	KeystoreError
+	// ConfigError used when an error about config occurs
+	ConfigError
 )
 
 // MessageType marks the type of output message
@@ -140,6 +147,12 @@ func PrintError(code ErrorCode, info string) error {
 	}
 	fmt.Println(errMessage.String())
 	return nil
+}
+
+// PrintResult prints result message in format
+func PrintResult(result string) {
+	message := StringMessage(result)
+	fmt.Println(message.String())
 }
 
 // PrintQuery prints query message in format


### PR DESCRIPTION
This is a rough implementation of format output for Account Cmds. I don't match all the errors with the error code. There are still some undefined errors and we may need to integrate them after all clusters of Cmds are changed into format output.

There is also a concern about safety when using struct to wrap private key or signed message and marshal them into json format to print. I don't know whether some of the messages will be left in memory.