### PR TITLE
 Add account verify cmd for ioctl

### DIFF
--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -54,6 +54,7 @@ func init() {
 	AccountCmd.AddCommand(accountListCmd)
 	AccountCmd.AddCommand(accountNonceCmd)
 	AccountCmd.AddCommand(accountUpdateCmd)
+	AccountCmd.AddCommand(accountVerifyCmd)
 	AccountCmd.AddCommand(accountSignCmd)
 	AccountCmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
 		config.ReadConfig.Endpoint, "set endpoint for once")

--- a/ioctl/cmd/account/accountverify.go
+++ b/ioctl/cmd/account/accountverify.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package account
+
+import (
+	"fmt"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+var (
+	// accountVerifyCmd represents the account verify command
+	accountVerifyCmd = &cobra.Command{
+		Use:   "verify",
+		Short: "Verify IoTeX public key and address by private key",
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			err := accountVerify()
+			return err
+		},
+	}
+)
+
+type verifyMessage struct {
+	Address   string `json:"address"`
+	PublicKey string `json:"publicKey"`
+}
+
+func accountVerify() error {
+	fmt.Println("Enter private key:\n")
+	privateKey, err := util.ReadSecretFromStdin()
+	if err != nil {
+		return output.PrintError(output.InputError, err.Error())
+	}
+	priKey, err := crypto.HexStringToPrivateKey(privateKey)
+	if err != nil {
+		return output.PrintError(output.CryptoError, err.Error())
+	}
+	addr, err := address.FromBytes(priKey.PublicKey().Hash())
+	if err != nil {
+		return output.PrintError(output.ConvertError, err.Error())
+	}
+	message := verifyMessage{
+		Address:   addr.String(),
+		PublicKey: fmt.Sprintf("%x", priKey.PublicKey().Bytes()),
+	}
+	priKey.Zero()
+	fmt.Println(message.String())
+	return nil
+}
+
+func (m *verifyMessage) String() string {
+	if output.Format == "" {
+		fmt.Sprintf("Address: %s\nPublic Key:%s", m.Address, m.PublicKey)
+	}
+	return output.FormatString(output.Result, m)
+}

--- a/ioctl/cmd/account/accountverify.go
+++ b/ioctl/cmd/account/accountverify.go
@@ -37,7 +37,7 @@ type verifyMessage struct {
 }
 
 func accountVerify() error {
-	fmt.Println("Enter private key:\n")
+	fmt.Println("Enter private key:")
 	privateKey, err := util.ReadSecretFromStdin()
 	if err != nil {
 		return output.PrintError(output.InputError, err.Error())
@@ -61,7 +61,7 @@ func accountVerify() error {
 
 func (m *verifyMessage) String() string {
 	if output.Format == "" {
-		fmt.Sprintf("Address: %s\nPublic Key:%s", m.Address, m.PublicKey)
+		return fmt.Sprintf("Address: %s\nPublic Key:%s", m.Address, m.PublicKey)
 	}
 	return output.FormatString(output.Result, m)
 }

--- a/ioctl/cmd/account/accountverify.go
+++ b/ioctl/cmd/account/accountverify.go
@@ -61,7 +61,7 @@ func accountVerify() error {
 
 func (m *verifyMessage) String() string {
 	if output.Format == "" {
-		return fmt.Sprintf("Address: %s\nPublic Key:%s", m.Address, m.PublicKey)
+		return fmt.Sprintf("Address:\t%s\nPublic Key:\t%s", m.Address, m.PublicKey)
 	}
 	return output.FormatString(output.Result, m)
 }


### PR DESCRIPTION
Tested on centos #1372 
```
->  ioctl account verify       
Enter private key:
Address:        io1jd7z68w3v350hk45kwhuqac9m8kdmkndsk6w7m
Public Key:     048787f3fb838b2eec8c43d51a6f2343b750c7c5246245b6d7d32c4c5911266bff5d2ad6a9f9045a2aadf3bc763e131825aa557f87d9cc8093b7b07fb47be4eefa

->  ioctl account verify -o json                        
Enter private key:
{
  "messageType": 0,
  "message": {
    "address": "io1jd7z68w3v350hk45kwhuqac9m8kdmkndsk6w7m",
    "publicKey": "048787f3fb838b2eec8c43d51a6f2343b750c7c5246245b6d7d32c4c5911266bff5d2ad6a9f9045a2aadf3bc763e131825aa557f87d9cc8093b7b07fb47be4eefa"
  }
}
```