### PR TITLE
Format output for action cmds and xrc20 cmds

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,6 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzWA3bVP9mUiPMT0=
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190626221605-1f92737a3f6a h1:eN5zoe19/P+4y4HuvLqSG9HtHTSyK6vcCx8UXVVMuP0=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190626221605-1f92737a3f6a/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27 h1:u/Fk5l75IqKWdu68t7AQz2y4FMHIeJqE2VLq8fmKD0Q=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=

--- a/ioctl/cmd/account/accountbalance.go
+++ b/ioctl/cmd/account/accountbalance.go
@@ -23,7 +23,7 @@ var accountBalanceCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := balance(args)
+		err := balance(args[0])
 		return err
 	},
 }
@@ -34,8 +34,8 @@ type balanceMessage struct {
 }
 
 // balance gets balance of an IoTeX blockchain address
-func balance(args []string) error {
-	address, err := util.GetAddress(args)
+func balance(arg string) error {
+	address, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -42,7 +42,7 @@ func accountCreateAdd(args []string) error {
 		info := fmt.Sprintf("** Alias \"%s\" has already used for %s\n"+
 			"Overwriting the account will keep the previous keystore file stay, "+
 			"but bind the alias to the new one.\nWould you like to continue?\n", alias, addr)
-		message := output.ComfirmationMessage{Info: info, Options: []string{"yes"}}
+		message := output.ConfirmationMessage{Info: info, Options: []string{"yes"}}
 		fmt.Println(message.String())
 		fmt.Scanf("%s", &confirm)
 		if !strings.EqualFold(confirm, "yes") {

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -53,7 +53,7 @@ func accountDelete(args []string) error {
 			info := fmt.Sprintf("** This is an irreversible action!\n" +
 				"Once an account is deleted, all the assets under this account may be lost!\n" +
 				"Type 'YES' to continue, quit for anything else.")
-			message := output.ComfirmationMessage{Info: info, Options: []string{"yes"}}
+			message := output.ConfirmationMessage{Info: info, Options: []string{"yes"}}
 			fmt.Println(message.String())
 			fmt.Scanf("%s", &confirm)
 			if !strings.EqualFold(confirm, "yes") {

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -31,13 +31,13 @@ var accountDeleteCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountDelete(args)
+		err := accountDelete(args[0])
 		return err
 	},
 }
 
-func accountDelete(args []string) error {
-	addr, err := util.GetAddress(args)
+func accountDelete(arg string) error {
+	addr, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/account/accountexport.go
+++ b/ioctl/cmd/account/accountexport.go
@@ -22,13 +22,13 @@ var accountExportCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountExport(args)
+		err := accountExport(args[0])
 		return err
 	},
 }
 
-func accountExport(args []string) error {
-	addr, err := util.GetAddress(args)
+func accountExport(arg string) error {
+	addr, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/account/accountexportpublic.go
+++ b/ioctl/cmd/account/accountexportpublic.go
@@ -22,13 +22,13 @@ var accountExportPublicCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountExportPublic(args)
+		err := accountExportPublic(args[0])
 		return err
 	},
 }
 
-func accountExportPublic(args []string) error {
-	addr, err := util.GetAddress(args)
+func accountExportPublic(arg string) error {
+	addr, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/account/accountnonce.go
+++ b/ioctl/cmd/account/accountnonce.go
@@ -22,7 +22,7 @@ var accountNonceCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := nonce(args)
+		err := nonce(args[0])
 		return err
 	},
 }
@@ -34,8 +34,8 @@ type nonceMessage struct {
 }
 
 // nonce gets nonce and pending nonce of an IoTeX blockchain address
-func nonce(args []string) error {
-	addr, err := util.GetAddress(args)
+func nonce(arg string) error {
+	addr, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/account/accountupdate.go
+++ b/ioctl/cmd/account/accountupdate.go
@@ -27,13 +27,13 @@ var accountUpdateCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountUpdate(args)
+		err := accountUpdate(args[0])
 		return err
 	},
 }
 
-func accountUpdate(args []string) error {
-	account, err := util.GetAddress(args)
+func accountUpdate(arg string) error {
+	account, err := util.GetAddress(arg)
 	if err != nil {
 		return output.PrintError(output.AddressError, err.Error())
 	}

--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -82,7 +82,7 @@ func decodeBytecode() ([]byte, error) {
 }
 
 func signer() (address string, err error) {
-	return util.GetAddress([]string{signerFlag.Value().(string)})
+	return util.GetAddress(signerFlag.Value().(string))
 }
 
 func nonce(executor string) (uint64, error) {

--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -20,17 +20,15 @@ import (
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/account"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/flag"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
@@ -49,6 +47,19 @@ var (
 var ActionCmd = &cobra.Command{
 	Use:   "action",
 	Short: "Manage actions of IoTeX blockchain",
+}
+
+type sendMessage struct {
+	Info   string `json:"info"`
+	TxHash string `json:"txHash"`
+	URL    string `json:"url"`
+}
+
+func (m *sendMessage) String() string {
+	if output.Format == "" {
+		return fmt.Sprintf("%s\nWait for several seconds and query this action by hash:%s", m.Info, m.URL)
+	}
+	return output.FormatString(output.Result, m)
 }
 
 func init() {
@@ -116,25 +127,24 @@ func gasPriceInRau() (*big.Int, error) {
 	return new(big.Int).SetUint64(response.GasPrice), nil
 }
 
-func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
+// execute must be used at the end of a command
+func execute(contract string, amount *big.Int, bytecode []byte) error {
 	gasPriceRau, err := gasPriceInRau()
 	if err != nil {
-		return
+		return output.PrintError(output.ConvertError, err.Error())
 	}
 	signer, err := signer()
 	if err != nil {
-		return err
+		return output.PrintError(output.AddressError, err.Error())
 	}
 	nonce, err := nonce(signer)
 	if err != nil {
-		return
+		return output.PrintError(0, err.Error()) // TODO: undefined error
 	}
 	gasLimit := gasLimitFlag.Value().(uint64)
 	tx, err := action.NewExecution(contract, nonce, amount, gasLimit, gasPriceRau, bytecode)
 	if err != nil || tx == nil {
-		err = errors.Wrap(err, "cannot make a Execution instance")
-		log.L().Error("error when invoke an execution", zap.Error(err))
-		return
+		return output.PrintError(0, "cannot make a Execution instance"+err.Error()) // TODO: undefined error
 	}
 	return sendAction(
 		(&action.EnvelopeBuilder{}).
@@ -146,10 +156,11 @@ func execute(contract string, amount *big.Int, bytecode []byte) (err error) {
 	)
 }
 
+// sendRaw must be used at the end of a command
 func sendRaw(selp *iotextypes.Action) error {
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return err
+		return output.PrintError(output.NetworkError, err.Error())
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -158,25 +169,26 @@ func sendRaw(selp *iotextypes.Action) error {
 	request := &iotexapi.SendActionRequest{Action: selp}
 	if _, err = cli.SendAction(ctx, request); err != nil {
 		if sta, ok := status.FromError(err); ok {
-			return fmt.Errorf(sta.Message())
+			return output.PrintError(output.APIError, sta.Message())
 		}
-		return err
+		return output.PrintError(output.NetworkError, err.Error())
 	}
 	shash := hash.Hash256b(byteutil.Must(proto.Marshal(selp)))
 	txhash := hex.EncodeToString(shash[:])
-	fmt.Println("Action has been sent to blockchain.")
-	fmt.Println("Wait for several seconds and query this action by hash:")
+	message := sendMessage{Info: "Action has been sent to blockchain.", TxHash: txhash}
 	switch config.ReadConfig.Explorer {
 	case "iotexscan":
-		fmt.Printf("iotexscan.io/action/%s\n", txhash)
+		message.URL = "iotexscan.io/action/" + txhash
 	case "iotxplorer":
-		fmt.Printf("iotxplorer.io/actions/%s\n", txhash)
+		message.URL = "iotxplorer.io/actions/" + txhash
 	default:
-		fmt.Println(config.ReadConfig.Explorer + txhash)
+		message.URL = config.ReadConfig.Explorer + txhash
 	}
+	fmt.Println(message.String())
 	return nil
 }
 
+// sendAction must be used at the end of a command
 func sendAction(elp action.Envelope, signer string) error {
 	var (
 		prvKey           crypto.PrivateKey
@@ -184,55 +196,51 @@ func sendAction(elp action.Envelope, signer string) error {
 		prvKeyOrPassword string
 	)
 	if !signerIsExist(signer) {
-		fmt.Printf("Enter private key #%s:\n", signer)
+		output.PrintQuery(fmt.Sprintf("Enter private key #%s:", signer))
 		prvKeyOrPassword, err = util.ReadSecretFromStdin()
 		if err != nil {
-			log.L().Error("failed to get private key", zap.Error(err))
-			return err
+			return output.PrintError(output.InputError, err.Error())
 		}
 		prvKey, err = crypto.HexStringToPrivateKey(prvKeyOrPassword)
 	} else if passwordFlag.Value() == "" {
-		fmt.Printf("Enter password #%s:\n", signer)
+		output.PrintQuery(fmt.Sprintf("Enter password #%s:\n", signer))
 		prvKeyOrPassword, err = util.ReadSecretFromStdin()
 		if err != nil {
-			log.L().Error("failed to get password", zap.Error(err))
-			return err
+			return output.PrintError(output.InputError, err.Error())
 		}
 	} else {
 		prvKeyOrPassword = passwordFlag.Value().(string)
 	}
 	prvKey, err = account.KsAccountToPrivateKey(signer, prvKeyOrPassword)
-
 	if err != nil {
-		return err
+		return output.PrintError(output.KeystoreError, err.Error())
 	}
 	defer prvKey.Zero()
 	sealed, err := action.Sign(elp, prvKey)
 	prvKey.Zero()
 	if err != nil {
-		log.L().Error("failed to sign action", zap.Error(err))
-		return err
+		return output.PrintError(output.CryptoError, "failed to sign action"+err.Error())
 	}
 	if err := isBalanceEnough(signer, sealed); err != nil {
-		return err
+		return output.PrintError(0, err.Error()) // TODO: undefined error
 	}
 	selp := sealed.Proto()
 
 	actionInfo, err := printActionProto(selp)
 	if err != nil {
-		return err
+		return output.PrintError(output.ConvertError, err.Error())
 	}
 	if yesFlag.Value() == false {
 		var confirm string
-		fmt.Println("\n" + actionInfo + "\n" +
-			"Please confirm your action.\n" +
-			"Type 'YES' to continue, quit for anything else.")
+		info := fmt.Sprintln(actionInfo + "\nPlease confirm your action.\n")
+		message := output.ConfirmationMessage{Info: info, Options: []string{"yes"}}
+		fmt.Println(message.String())
 		fmt.Scanf("%s", &confirm)
-		if confirm != "YES" && confirm != "yes" {
+		if !strings.EqualFold(confirm, "yes") {
+			output.PrintResult("quit")
 			return nil
 		}
 	}
-	fmt.Println()
 	return sendRaw(selp)
 }
 
@@ -262,8 +270,8 @@ func signerIsExist(signer string) bool {
 	// find the account in keystore
 	ks := keystore.NewKeyStore(config.ReadConfig.Wallet,
 		keystore.StandardScryptN, keystore.StandardScryptP)
-	for _, account := range ks.Accounts() {
-		if address.Equal(addr, account.Address) {
+	for _, ksAccount := range ks.Accounts() {
+		if address.Equal(addr, ksAccount.Address) {
 			return true
 		}
 	}

--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -146,7 +146,7 @@ func fixGasLimit(signer string, execution *action.Execution) (*action.Execution,
 	}
 	res, err := cli.EstimateActionGasConsumption(context.Background(), request)
 	if err != nil {
-		return nil, errors.New("error when invoke EstimateActionGasConsumption api")
+		return nil, fmt.Errorf("error when invoke EstimateActionGasConsumption api")
 	}
 	return action.NewExecution(execution.Contract(), execution.Nonce(), execution.Amount(), res.Gas, execution.GasPrice(), execution.Data())
 }
@@ -173,7 +173,7 @@ func execute(contract string, amount *big.Int, bytecode []byte) error {
 	if gasLimit == 0 {
 		tx, err = fixGasLimit(signer, tx)
 		if err != nil || tx == nil {
-      return output.PrintError(0, "cannot fix Execution gaslimit"+err.Error()) // TODO: undefined error
+			return output.PrintError(0, "cannot fix Execution gaslimit"+err.Error()) // TODO: undefined error
 		}
 		gasLimit = tx.GasLimit()
 	}

--- a/ioctl/cmd/action/actionclaim.go
+++ b/ioctl/cmd/action/actionclaim.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
@@ -22,7 +23,7 @@ var actionClaimCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
 		payload := make([]byte, 0)
 		if len(args) == 2 {
@@ -30,7 +31,7 @@ var actionClaimCmd = &cobra.Command{
 		}
 		sender, err := signer()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
@@ -40,7 +41,7 @@ var actionClaimCmd = &cobra.Command{
 		gasPriceRau, err := gasPriceInRau()
 		nonce, err := nonce(sender)
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) //TODO: undefined error
 		}
 		act := (&action.ClaimFromRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
 

--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -9,9 +9,10 @@ package action
 import (
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
 // actionDeployCmd represents the action deploy command
@@ -23,13 +24,13 @@ var actionDeployCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		bytecode, err := decodeBytecode()
 		if err != nil {
-			return err
+			return output.PrintError(output.FlagError, "Invalid bytecode flag:"+err.Error())
 		}
 		amount := big.NewInt(0)
 		if len(args) == 1 {
 			amount, err = util.StringToRau(args[0], util.IotxDecimalNum)
 			if err != nil {
-				return errors.Wrapf(err, "Invalid amount format %s", args[0])
+				return output.PrintError(output.ConvertError, "Invalid amount:"+err.Error())
 			}
 		}
 		return execute("", amount, bytecode)

--- a/ioctl/cmd/action/actiondeposit.go
+++ b/ioctl/cmd/action/actiondeposit.go
@@ -7,6 +7,7 @@
 package action
 
 import (
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/action"
@@ -22,7 +23,7 @@ var actionDepositCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, "Invalid amount:"+err.Error())
 		}
 		payload := make([]byte, 0)
 		if len(args) == 2 {
@@ -30,7 +31,7 @@ var actionDepositCmd = &cobra.Command{
 		}
 		sender, err := signer()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
@@ -40,7 +41,7 @@ var actionDepositCmd = &cobra.Command{
 		gasPriceRau, err := gasPriceInRau()
 		nonce, err := nonce(sender)
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
 		act := (&action.DepositToRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
 

--- a/ioctl/cmd/action/actionhash.go
+++ b/ioctl/cmd/action/actionhash.go
@@ -9,8 +9,11 @@ package action
 import (
 	"context"
 	"fmt"
+	"log"
 	"math/big"
 	"strconv"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
@@ -19,14 +22,12 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // actionHashCmd represents the action hash command
@@ -36,66 +37,90 @@ var actionHashCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := getActionByHash(args)
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := getActionByHash(args)
 		return err
 	},
 }
 
+type actionState int
+
+const (
+	// Pending action is in the action pool but not executed by blockchain
+	Pending actionState = iota
+	// Executed action has been run and recorded on blockchain
+	Executed
+)
+
+type actionMessage struct {
+	State   actionState          `json:"state"`
+	Proto   *iotexapi.ActionInfo `json:"proto"`
+	Receipt *iotextypes.Receipt  `json:"receipt"`
+}
+
+func (m *actionMessage) String() string {
+	if output.Format == "" {
+		message, err := printAction(m.Proto)
+		if err != nil {
+			log.Panic(err.Error())
+		}
+		if m.State == Pending {
+			message += "\n#This action is pending"
+		} else {
+			message += "\n#This action has been written on blockchain\n\n" + printReceiptProto(m.Receipt)
+		}
+		return message
+	}
+	return output.FormatString(output.Result, m)
+}
+
 // getActionByHash gets action of IoTeX Blockchain by hash
-func getActionByHash(args []string) (string, error) {
+func getActionByHash(args []string) error {
 	hash := args[0]
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return "", err
+		return output.PrintError(output.NetworkError, err.Error())
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
 	ctx := context.Background()
 
 	// search action on blockchain
-	requestGetActionByHash := &iotexapi.GetActionByHashRequest{
-		ActionHash:   hash,
-		CheckPending: false,
-	}
 	requestGetAction := iotexapi.GetActionsRequest{
 		Lookup: &iotexapi.GetActionsRequest_ByHash{
-			ByHash: requestGetActionByHash,
+			ByHash: &iotexapi.GetActionByHashRequest{
+				ActionHash:   hash,
+				CheckPending: false,
+			},
 		},
 	}
 	response, err := cli.GetActions(ctx, &requestGetAction)
 	if err != nil {
-		// search action in action pool
-		requestGetActionByHash.CheckPending = true
-		response, err = cli.GetActions(ctx, &requestGetAction)
-		if err != nil {
-			return "", err
+		sta, ok := status.FromError(err)
+		if ok {
+			return output.PrintError(output.APIError, sta.Message())
 		}
+		return output.PrintError(output.NetworkError, err.Error())
 	}
 	if len(response.ActionInfo) == 0 {
-		return "", fmt.Errorf("No action info returned")
+		return output.PrintError(output.APIError, "No action info returned")
 	}
-	output, err := printAction(response.ActionInfo[0])
-	if err != nil {
-		return "", err
-	}
-	fmt.Println(output)
+	message := actionMessage{Proto: response.ActionInfo[0]}
 
 	requestGetReceipt := &iotexapi.GetReceiptByActionRequest{ActionHash: hash}
 	responseReceipt, err := cli.GetReceiptByAction(ctx, requestGetReceipt)
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok && sta.Code() == codes.NotFound {
-			return "\n#This action is pending", nil
+			message.State = Pending
 		} else if ok {
-			return "", fmt.Errorf(sta.Message())
+			return output.PrintError(output.APIError, sta.Message())
 		}
-		return "", err
+		return output.PrintError(output.NetworkError, err.Error())
 	}
-	return "\n#This action has been written on blockchain\n" +
-		printReceiptProto(responseReceipt.ReceiptInfo.Receipt), nil
+	message.State = Executed
+	message.Receipt = responseReceipt.ReceiptInfo.Receipt
+	fmt.Println(message.String())
+	return nil
 }
 
 func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
@@ -118,13 +143,11 @@ func printAction(actionInfo *iotexapi.ActionInfo) (string, error) {
 func printActionProto(action *iotextypes.Action) (string, error) {
 	pubKey, err := crypto.BytesToPublicKey(action.SenderPubKey)
 	if err != nil {
-		log.L().Error("failed to convert pubkey", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to convert pubkey:" + err.Error())
 	}
 	senderAddress, err := address.FromBytes(pubKey.Hash())
 	if err != nil {
-		log.L().Error("failed to convert bytes into address", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("failed to convert bytes into address" + err.Error())
 	}
 	output := fmt.Sprintf("\nversion: %d  ", action.Core.GetVersion()) +
 		fmt.Sprintf("nonce: %d  ", action.Core.GetNonce()) +

--- a/ioctl/cmd/action/actionhash.go
+++ b/ioctl/cmd/action/actionhash.go
@@ -13,8 +13,6 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/iotexproject/go-pkgs/crypto"
@@ -27,6 +25,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 

--- a/ioctl/cmd/action/actioninvoke.go
+++ b/ioctl/cmd/action/actioninvoke.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
@@ -24,18 +25,18 @@ var actionInvokeCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		contract, err := util.Address(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		amount := big.NewInt(0)
 		if len(args) == 2 {
 			amount, err = util.StringToRau(args[1], util.IotxDecimalNum)
 			if err != nil {
-				return err
+				return output.PrintError(output.ConvertError, err.Error())
 			}
 		}
 		bytecode, err := decodeBytecode()
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
 		return execute(contract, amount, bytecode)
 	},

--- a/ioctl/cmd/action/actionread.go
+++ b/ioctl/cmd/action/actionread.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/spf13/cobra"
@@ -21,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 )

--- a/ioctl/cmd/action/actionread.go
+++ b/ioctl/cmd/action/actionread.go
@@ -11,17 +11,17 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 )
 
@@ -38,16 +38,17 @@ var actionReadCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		contract, err := alias.IOAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		bytecode, err := decodeBytecode()
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
-		output, err := read(contract, bytecode)
-		if err == nil {
-			fmt.Println(output)
+		result, err := read(contract, bytecode)
+		if err != nil {
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
+		output.PrintResult(result)
 		return err
 	},
 }
@@ -66,8 +67,7 @@ func read(contract address.Address, bytecode []byte) (string, error) {
 	}
 	exec, err := action.NewExecution(contract.String(), 0, big.NewInt(0), defaultGasLimit, defaultGasPrice, bytecode)
 	if err != nil {
-		log.L().Error("cannot make an Execution instance", zap.Error(err))
-		return "", err
+		return "", fmt.Errorf("cannot make an Execution instance" + err.Error())
 	}
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {

--- a/ioctl/cmd/action/actionsendraw.go
+++ b/ioctl/cmd/action/actionsendraw.go
@@ -9,11 +9,11 @@ package action
 import (
 	"encoding/hex"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // actionSendRawCmd represents the action send raw transaction command

--- a/ioctl/cmd/action/actionsendraw.go
+++ b/ioctl/cmd/action/actionsendraw.go
@@ -9,6 +9,8 @@ package action
 import (
 	"encoding/hex"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/spf13/cobra"
@@ -23,11 +25,11 @@ var actionSendRawCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		actBytes, err := hex.DecodeString(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
 		act := &iotextypes.Action{}
 		if err := proto.Unmarshal(actBytes, act); err != nil {
-			return err
+			return output.PrintError(output.SerializationError, err.Error())
 		}
 		return sendRaw(act)
 	},

--- a/ioctl/cmd/action/actiontransfer.go
+++ b/ioctl/cmd/action/actiontransfer.go
@@ -9,12 +9,11 @@ package action
 import (
 	"encoding/hex"
 
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/spf13/cobra"
 )
 
 // actionTransferCmd represents the action transfer command
@@ -27,22 +26,22 @@ var actionTransferCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		recipient, err := util.Address(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		amount, err := util.StringToRau(args[1], util.IotxDecimalNum)
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
 		var payload []byte
 		if len(args) == 3 {
 			payload, err = hex.DecodeString(args[2])
 			if err != nil {
-				return err
+				return output.PrintError(output.ConvertError, err.Error())
 			}
 		}
 		sender, err := signer()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		gasLimit := gasLimitFlag.Value().(uint64)
 		if gasLimit == 0 {
@@ -51,17 +50,16 @@ var actionTransferCmd = &cobra.Command{
 		}
 		gasPriceRau, err := gasPriceInRau()
 		if err != nil {
-			return err
+			return output.PrintError(output.ConvertError, err.Error())
 		}
 		nonce, err := nonce(sender)
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) //TODO: undefined error
 		}
 		tx, err := action.NewTransfer(nonce, amount,
 			recipient, payload, gasLimit, gasPriceRau)
 		if err != nil {
-			log.L().Error("failed to make a Transfer instance", zap.Error(err))
-			return err
+			return output.PrintError(0, "failed to make a Transfer instance"+err.Error()) // TODO: undefined error
 		}
 		return sendAction(
 			(&action.EnvelopeBuilder{}).

--- a/ioctl/cmd/action/actiontransfer.go
+++ b/ioctl/cmd/action/actiontransfer.go
@@ -9,11 +9,11 @@ package action
 import (
 	"encoding/hex"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // actionTransferCmd represents the action transfer command

--- a/ioctl/cmd/action/actiontransfer.go
+++ b/ioctl/cmd/action/actiontransfer.go
@@ -9,11 +9,11 @@ package action
 import (
 	"encoding/hex"
 
-	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
 // actionTransferCmd represents the action transfer command

--- a/ioctl/cmd/action/xrc20.go
+++ b/ioctl/cmd/action/xrc20.go
@@ -12,12 +12,12 @@ import (
 	"math/big"
 	"strconv"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 //Xrc20Cmd represent erc20 standard command-line
@@ -30,6 +30,18 @@ var xrc20ContractAddress string
 
 func xrc20Contract() (address.Address, error) {
 	return alias.IOAddress(xrc20ContractAddress)
+}
+
+type amountMessage struct {
+	RawData string `json"rawData"`
+	Decimal string `json:"decimal"`
+}
+
+func (m *amountMessage) String() string {
+	if output.Format == "" {
+		return fmt.Sprintf("Raw output: %d\nOutput in decimal: %d\n", m.RawData, m.Decimal)
+	}
+	return output.FormatString(output.Result, m)
 }
 
 func init() {
@@ -72,8 +84,7 @@ func parseAmount(contract address.Address, amount string) (*big.Int, error) {
 	}
 	amountResultFloat := amountFloat.Mul(amountFloat, new(big.Float).SetInt(new(big.Int).Exp(big.NewInt(10), big.NewInt(decimal), nil)))
 	if !amountResultFloat.IsInt() {
-		fmt.Println("Please enter appropriate amount")
-		return nil, errors.Wrap(err, "Unappropriate amount")
+		return nil, fmt.Errorf("Unappropriate amount")
 	}
 	var amountResultInt *big.Int
 	amountResultInt, _ = amountResultFloat.Int(amountResultInt)

--- a/ioctl/cmd/action/xrc20.go
+++ b/ioctl/cmd/action/xrc20.go
@@ -39,7 +39,7 @@ type amountMessage struct {
 
 func (m *amountMessage) String() string {
 	if output.Format == "" {
-		return fmt.Sprintf("Raw output: %d\nOutput in decimal: %d\n", m.RawData, m.Decimal)
+		return fmt.Sprintf("Raw output: %s\nOutput in decimal: %s", m.RawData, m.Decimal)
 	}
 	return output.FormatString(output.Result, m)
 }

--- a/ioctl/cmd/action/xrc20allowance.go
+++ b/ioctl/cmd/action/xrc20allowance.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
-	"github.com/spf13/cobra"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20AllowanceCmd represents your signer limited amount on target address

--- a/ioctl/cmd/action/xrc20allowance.go
+++ b/ioctl/cmd/action/xrc20allowance.go
@@ -10,11 +10,10 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
-	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/spf13/cobra"
 )
 
 // xrc20AllowanceCmd represents your signer limited amount on target address
@@ -27,31 +26,31 @@ var xrc20AllowanceCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		caller, err := signer()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		owner, err := alias.EtherAddress(caller)
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		spender, err := alias.EtherAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		bytecode, err := xrc20ABI.Pack("allowance", owner, spender)
 		if err != nil {
-			log.L().Error("cannot generate bytecode from given command", zap.Error(err))
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
-		output, err := read(contract, bytecode)
-		if err == nil {
-			fmt.Println("Raw output:", output)
-			decimal, _ := new(big.Int).SetString(output, 16)
-			fmt.Printf("Output in decimal: %d\n", decimal)
+		result, err := read(contract, bytecode)
+		if err != nil {
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
+		decimal, _ := new(big.Int).SetString(result, 16)
+		message := amountMessage{RawData: result, Decimal: decimal.String()}
+		fmt.Println(message.String())
 		return err
 	},
 }

--- a/ioctl/cmd/action/xrc20approve.go
+++ b/ioctl/cmd/action/xrc20approve.go
@@ -9,6 +9,8 @@ package action
 import (
 	"math/big"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
@@ -24,19 +26,19 @@ var xrc20ApproveCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		spender, err := alias.EtherAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		amount, err := parseAmount(contract, args[1])
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) // TODO:undefined error
 		}
 		bytecode, err := xrc20ABI.Pack("approve", spender, amount)
 		if err != nil {
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		return execute(contract.String(), big.NewInt(0), bytecode)
 	},

--- a/ioctl/cmd/action/xrc20approve.go
+++ b/ioctl/cmd/action/xrc20approve.go
@@ -9,11 +9,10 @@ package action
 import (
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20ApproveCmd could config target address limited amount

--- a/ioctl/cmd/action/xrc20balanceof.go
+++ b/ioctl/cmd/action/xrc20balanceof.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20BalanceOfCmd represents balanceOf function
@@ -24,22 +25,23 @@ var xrc20BalanceOfCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		owner, err := alias.EtherAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		bytecode, err := xrc20ABI.Pack("balanceOf", owner)
 		if err != nil {
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
-		output, err := read(contract, bytecode)
-		if err == nil {
-			fmt.Println("Raw output:", output)
-			decimal, _ := new(big.Int).SetString(output, 16)
-			fmt.Printf("Output in decimal: %d\n", decimal)
+		result, err := read(contract, bytecode)
+		if err != nil {
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
+		decimal, _ := new(big.Int).SetString(result, 16)
+		message := amountMessage{RawData: result, Decimal: decimal.String()}
+		fmt.Println(message.String())
 		return err
 	},
 }

--- a/ioctl/cmd/action/xrc20totalsupply.go
+++ b/ioctl/cmd/action/xrc20totalsupply.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/spf13/cobra"
 )
 
@@ -21,18 +22,19 @@ var xrc20TotalSupplyCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		bytecode, err := xrc20ABI.Pack("totalSupply")
 		if err != nil {
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
-		output, err := read(contract, bytecode)
-		if err == nil {
-			fmt.Println("Raw output:", output)
-			decimal, _ := new(big.Int).SetString(output, 16)
-			fmt.Printf("Output in decimal: %d\n", decimal)
+		result, err := read(contract, bytecode)
+		if err != nil {
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
+		decimal, _ := new(big.Int).SetString(result, 16)
+		message := amountMessage{RawData: result, Decimal: decimal.String()}
+		fmt.Println(message.String())
 		return err
 	},
 }

--- a/ioctl/cmd/action/xrc20totalsupply.go
+++ b/ioctl/cmd/action/xrc20totalsupply.go
@@ -10,8 +10,9 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20TotalSupplyCmd represents total supply of the contract

--- a/ioctl/cmd/action/xrc20transfer.go
+++ b/ioctl/cmd/action/xrc20transfer.go
@@ -9,11 +9,10 @@ package action
 import (
 	"math/big"
 
-	"github.com/iotexproject/iotex-core/ioctl/output"
-
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20TransferCmd could do transfer action

--- a/ioctl/cmd/action/xrc20transfer.go
+++ b/ioctl/cmd/action/xrc20transfer.go
@@ -9,6 +9,8 @@ package action
 import (
 	"math/big"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
@@ -24,19 +26,19 @@ var xrc20TransferCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		recipient, err := alias.EtherAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		amount, err := parseAmount(contract, args[1])
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
 		bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
 		if err != nil {
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		return execute(contract.String(), big.NewInt(0), bytecode)
 	},

--- a/ioctl/cmd/action/xrc20transferfrom.go
+++ b/ioctl/cmd/action/xrc20transferfrom.go
@@ -7,10 +7,10 @@
 package action
 
 import (
-	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // xrc20TransferFromCmd could transfer from owner address to target address

--- a/ioctl/cmd/action/xrc20transferfrom.go
+++ b/ioctl/cmd/action/xrc20transferfrom.go
@@ -7,6 +7,7 @@
 package action
 
 import (
+	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
@@ -22,23 +23,23 @@ var xrc20TransferFromCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		owner, err := alias.EtherAddress(args[0])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		recipient, err := alias.EtherAddress(args[1])
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		contract, err := xrc20Contract()
 		if err != nil {
-			return err
+			return output.PrintError(output.AddressError, err.Error())
 		}
 		amount, err := parseAmount(contract, args[2])
 		if err != nil {
-			return err
+			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
 		bytecode, err := xrc20ABI.Pack("transferFrom", owner, recipient, amount)
 		if err != nil {
-			return err
+			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
 		}
 		return execute(contract.String(), nil, bytecode)
 	},

--- a/ioctl/cmd/alias/alias.go
+++ b/ioctl/cmd/alias/alias.go
@@ -52,7 +52,7 @@ func init() {
 	AliasCmd.AddCommand(aliasExportCmd)
 }
 
-// IOAddress returns the address in iotex address format
+// IOAddress returns the address in IoTeX address format
 func IOAddress(in string) (address.Address, error) {
 	addr, err := util.Address(in)
 	if err != nil {

--- a/ioctl/cmd/config/configsetget.go
+++ b/ioctl/cmd/config/configsetget.go
@@ -133,9 +133,9 @@ func GetContextAddressOrAlias() (string, error) {
 }
 
 // GetAddressOrAlias gets address from args or context
-func GetAddressOrAlias(args []string) (address string, err error) {
-	if len(args) == 1 && !strings.EqualFold(args[0], "") {
-		address = args[0]
+func GetAddressOrAlias(in string) (address string, err error) {
+	if !strings.EqualFold(in, "") {
+		address = in
 	} else {
 		address, err = GetContextAddressOrAlias()
 	}

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -71,9 +71,9 @@ func version() error {
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok {
-			return output.PrintError(output.NetworkError, sta.Message())
+			return output.PrintError(output.APIError, sta.Message())
 		}
-		return output.PrintError(output.APIError,
+		return output.PrintError(output.NetworkError,
 			"failed to get version from server: "+err.Error())
 	}
 

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -74,13 +74,13 @@ type Message interface {
 	String() string
 }
 
-// ComfirmationMessage is the struct of an Confirmation output
-type ComfirmationMessage struct {
+// ConfirmationMessage is the struct of an Confirmation output
+type ConfirmationMessage struct {
 	Info    string   `json:"info"`
 	Options []string `json:"options"`
 }
 
-func (m *ComfirmationMessage) String() string {
+func (m *ConfirmationMessage) String() string {
 	if Format == "" {
 		line := fmt.Sprintf("%s\nOptions:", m.Info)
 		for _, option := range m.Options {

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -150,9 +150,9 @@ func ReadSecretFromStdin() (string, error) {
 	return string(bytePass), nil
 }
 
-// GetAddress get address from address or alias
-func GetAddress(args []string) (addr string, err error) {
-	addr, err = config.GetAddressOrAlias(args)
+// GetAddress get address from address or alias or context
+func GetAddress(in string) (addr string, err error) {
+	addr, err = config.GetAddressOrAlias(in)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Refactoring action&xrc20 cmds for format output and leaving many undefined errors, which I will resolve when finishing refactoring all clusters of ioctl cmds.

I don't quite understand the output of xrc20's read command so I followed the origin code to design the amountMessage struct.

#935 