### PR TITLE
 Refactor error output for ioctl

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -131,8 +131,6 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.10 h1:YecHvKZP1jakkhMUPRfiGEeCNZFyzWA3bVP9mUiPMT0=
 github.com/iotexproject/iotex-election v0.1.10/go.mod h1:kx1vlh018FHFzwLBFynmZCY49sT6r1zIfnsEc6Z8uXY=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27 h1:u/Fk5l75IqKWdu68t7AQz2y4FMHIeJqE2VLq8fmKD0Q=
-github.com/iotexproject/iotex-proto v0.2.1-0.20190711042234-eb3d2a61ab27/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd h1:F24GwzKft8+LJzh2ORDR95PbMKGg9K54+Tsn78UrtJQ=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190717000031-25b6ccc65ebd/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=

--- a/ioctl/cmd/account/accountbalance.go
+++ b/ioctl/cmd/account/accountbalance.go
@@ -24,7 +24,7 @@ var accountBalanceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := balance(args[0])
-		return err
+		return output.PrintError(err)
 	},
 }
 
@@ -37,15 +37,15 @@ type balanceMessage struct {
 func balance(arg string) error {
 	address, err := util.GetAddress(arg)
 	if err != nil {
-		return output.PrintError(output.AddressError, err.Error())
+		return output.NewError(output.AddressError, "", err)
 	}
 	accountMeta, err := GetAccountMeta(address)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.NewError(0, "", err) // TODO: undefined error
 	}
 	balance, ok := big.NewInt(0).SetString(accountMeta.Balance, 10)
 	if !ok {
-		return output.PrintError(output.ConvertError, err.Error())
+		return output.NewError(output.ConvertError, "", err)
 	}
 	message := balanceMessage{
 		Address: address,

--- a/ioctl/cmd/account/accountcreate.go
+++ b/ioctl/cmd/account/accountcreate.go
@@ -28,7 +28,7 @@ var accountCreateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := accountCreate()
-		return err
+		return output.PrintError(err)
 	},
 }
 
@@ -51,11 +51,11 @@ func accountCreate() error {
 	for i := 0; i < int(numAccounts); i++ {
 		private, err := crypto.GenerateKey()
 		if err != nil {
-			return output.PrintError(output.CryptoError, err.Error())
+			return output.NewError(output.CryptoError, "failed to generate new private key", err)
 		}
 		addr, err := address.FromBytes(private.PublicKey().Hash())
 		if err != nil {
-			return output.PrintError(output.ConvertError, err.Error())
+			return output.NewError(output.ConvertError, "failed to convert public key into address", err)
 		}
 		newAccount := generatedAccount{
 			Address:    addr.String(),

--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -27,14 +27,14 @@ var accountCreateAddCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := accountCreateAdd(args)
-		return err
+		return output.PrintError(err)
 	},
 }
 
 func accountCreateAdd(args []string) error {
 	// Validate inputs
 	if err := validator.ValidateAlias(args[0]); err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid alias", err)
 	}
 	alias := args[0]
 	if addr, ok := config.ReadConfig.Aliases[alias]; ok {
@@ -52,16 +52,16 @@ func accountCreateAdd(args []string) error {
 	}
 	addr, err := newAccount(alias, config.ReadConfig.Wallet)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.NewError(0, "", err)
 	}
 	config.ReadConfig.Aliases[alias] = addr
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return output.PrintError(output.SerializationError, err.Error())
+		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
 	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return output.PrintError(output.WriteFileError,
-			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
+		return output.NewError(output.WriteFileError,
+			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}
 	output.PrintResult(fmt.Sprintf("New account \"%s\" is created.\n"+
 		"Please Keep your password, or your will lose your private key.", alias))

--- a/ioctl/cmd/account/accountethaddr.go
+++ b/ioctl/cmd/account/accountethaddr.go
@@ -24,8 +24,8 @@ var accountEthaddrCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountEthaddr(args)
-		return err
+		err := accountEthaddr(args[0])
+		return output.PrintError(err)
 	},
 }
 
@@ -34,24 +34,24 @@ type ethaddrMessage struct {
 	EthAddr string `json:"ethAddr"`
 }
 
-func accountEthaddr(args []string) error {
+func accountEthaddr(arg string) error {
 	var ethAddress common.Address
-	ioAddr, err := util.Address(args[0])
+	ioAddr, err := util.Address(arg)
 	if err != nil {
-		if ok := common.IsHexAddress(args[0]); !ok {
-			return output.PrintError(output.AddressError, err.Error())
+		if ok := common.IsHexAddress(arg); !ok {
+			return output.NewError(output.AddressError, "", err)
 		}
-		ethAddress = common.HexToAddress(args[0])
+		ethAddress = common.HexToAddress(arg)
 		ioAddress, err := address.FromBytes(ethAddress.Bytes())
 		if err != nil {
-			return output.PrintError(output.AddressError,
-				fmt.Sprintf("failed to form IoTeX address from ETH address"))
+			return output.NewError(output.AddressError,
+				fmt.Sprintf("failed to form IoTeX address from ETH address"), nil)
 		}
 		ioAddr = ioAddress.String()
 	} else {
 		ethAddress, err = util.IoAddrToEvmAddr(ioAddr)
 		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
+			return output.NewError(output.AddressError, "", err)
 		}
 	}
 	message := ethaddrMessage{IOAddr: ioAddr, EthAddr: ethAddress.String()}

--- a/ioctl/cmd/account/accountexport.go
+++ b/ioctl/cmd/account/accountexport.go
@@ -23,23 +23,23 @@ var accountExportCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := accountExport(args[0])
-		return err
+		return output.PrintError(err)
 	},
 }
 
 func accountExport(arg string) error {
 	addr, err := util.GetAddress(arg)
 	if err != nil {
-		return output.PrintError(output.AddressError, err.Error())
+		return output.NewError(output.AddressError, "failed to get address", err)
 	}
-	fmt.Printf("Enter password #%s:\n", addr)
+	output.PrintQuery(fmt.Sprintf("Enter password #%s:\n", addr))
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, "failed to get password")
+		return output.NewError(output.InputError, "failed to get password", nil)
 	}
 	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
-		return output.PrintError(output.KeystoreError, err.Error())
+		return output.NewError(output.KeystoreError, "failed to get private key from keystore", err)
 	}
 	defer prvKey.Zero()
 	output.PrintResult(prvKey.HexString())

--- a/ioctl/cmd/account/accountexportpublic.go
+++ b/ioctl/cmd/account/accountexportpublic.go
@@ -22,24 +22,24 @@ var accountExportPublicCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountExportPublic(args[0])
-		return err
+		err := exportPublic(args[0])
+		return output.PrintError(err)
 	},
 }
 
-func accountExportPublic(arg string) error {
+func exportPublic(arg string) error {
 	addr, err := util.GetAddress(arg)
 	if err != nil {
-		return output.PrintError(output.AddressError, err.Error())
+		return output.NewError(output.AddressError, "failed to get address", err)
 	}
 	fmt.Printf("Enter password #%s:\n", addr)
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, "failed to get password")
+		return output.NewError(output.InputError, "failed to get password", nil)
 	}
 	prvKey, err := KsAccountToPrivateKey(addr, password)
 	if err != nil {
-		return output.PrintError(output.KeystoreError, err.Error())
+		return output.NewError(output.KeystoreError, "failed to get private key from keystore", err)
 	}
 	defer prvKey.Zero()
 	output.PrintResult(prvKey.PublicKey().HexString())

--- a/ioctl/cmd/account/accountimport.go
+++ b/ioctl/cmd/account/accountimport.go
@@ -33,7 +33,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := accountImportKey(args)
-			return err
+			return output.PrintError(err)
 		},
 	}
 	// accountImportKeyCmd represents the account import keystore command
@@ -44,7 +44,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := accountImportKeyStore(args)
-			return err
+			return output.PrintError(err)
 		},
 	}
 )
@@ -66,11 +66,11 @@ func writeToFile(alias, addr string) error {
 	config.ReadConfig.Aliases[alias] = addr
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return output.PrintError(output.SerializationError, err.Error())
+		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
 	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return output.PrintError(output.WriteFileError,
-			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
+		return output.NewError(output.WriteFileError,
+			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}
 	output.PrintResult(fmt.Sprintf("New account #%s is created. Keep your password, "+
 		"or your will lose your private key.", alias))
@@ -88,17 +88,17 @@ func accountImportKey(args []string) error {
 	alias := args[0]
 	err := validataAlias(alias)
 	if err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid alias", err)
 	}
 	output.PrintQuery(fmt.Sprintf("#%s: Enter your private key, "+
 		"which will not be exposed on the screen.", alias))
 	privateKey, err := readPasswordFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, err.Error())
+		return output.NewError(output.InputError, "failed to get password", err)
 	}
 	addr, err := newAccountByKey(alias, privateKey, config.ReadConfig.Wallet)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.NewError(0, "", err)
 	}
 	return writeToFile(alias, addr)
 }
@@ -107,17 +107,17 @@ func accountImportKeyStore(args []string) error {
 	alias := args[0]
 	err := validataAlias(alias)
 	if err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid alias", err)
 	}
 	output.PrintQuery(fmt.Sprintf("#%s: Enter your password of keystore, "+
 		"which will not be exposed on the screen.", alias))
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, err.Error())
+		return output.NewError(output.InputError, "failed to get password", err)
 	}
 	addr, err := newAccountByKeyStore(alias, password, args[1], config.ReadConfig.Wallet)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.NewError(0, "", err) // TODO: undefined error
 	}
 	return writeToFile(alias, addr)
 }

--- a/ioctl/cmd/account/accountlist.go
+++ b/ioctl/cmd/account/accountlist.go
@@ -27,7 +27,7 @@ var accountListCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := accountList()
-		return err
+		return output.PrintError(err)
 	},
 }
 
@@ -48,7 +48,7 @@ func accountList() error {
 	for _, v := range ks.Accounts() {
 		address, err := address.FromBytes(v.Address.Bytes())
 		if err != nil {
-			return output.PrintError(output.ConvertError, "failed to convert bytes into address")
+			return output.NewError(output.ConvertError, "failed to convert bytes into address", err)
 		}
 		message.Accounts = append(message.Accounts, account{
 			Address: address.String(),

--- a/ioctl/cmd/account/accountnonce.go
+++ b/ioctl/cmd/account/accountnonce.go
@@ -23,7 +23,7 @@ var accountNonceCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := nonce(args[0])
-		return err
+		return output.PrintError(err)
 	},
 }
 
@@ -37,11 +37,11 @@ type nonceMessage struct {
 func nonce(arg string) error {
 	addr, err := util.GetAddress(arg)
 	if err != nil {
-		return output.PrintError(output.AddressError, err.Error())
+		return output.NewError(output.AddressError, "failed to get address", err)
 	}
 	accountMeta, err := GetAccountMeta(addr)
 	if err != nil {
-		return output.PrintError(0, err.Error()) // TODO: undefined error
+		return output.NewError(0, "", err)
 	}
 	message := nonceMessage{
 		Address:      addr,

--- a/ioctl/cmd/account/accountsign.go
+++ b/ioctl/cmd/account/accountsign.go
@@ -11,51 +11,38 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
+var signer string
+
 // accountSignCmd represents the account sign command
 var accountSignCmd = &cobra.Command{
-	Use:   "sign [ALIAS|ADDRESS] MESSAGE",
+	Use:   "sign MESSAGE [-s SIGNER]",
 	Short: "Sign message with private key from wallet",
-	Args:  cobra.RangeArgs(1, 2),
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountSign(args)
-		return err
+		err := accountSign(args[0])
+		return output.PrintError(err)
 	},
 }
 
-func accountSign(args []string) error {
-	var (
-		address string
-		msg     string
-		err     error
-	)
-	if len(args) == 2 {
-		address = args[0]
-		msg = args[1]
-	} else {
-		msg = args[0]
-		address, err = config.GetContextAddressOrAlias()
-		if err != nil {
-			return output.PrintError(output.ConfigError, err.Error())
-		}
-	}
-	addr, err := util.Address(address)
-	if err != nil {
-		return output.PrintError(output.AddressError, err.Error())
-	}
+func init() {
+	accountSignCmd.Flags().StringVarP(&signer, "signer", "s", "", "choose a signing account")
+}
+
+func accountSign(msg string) error {
+	addr, err := util.GetAddress(signer)
 	fmt.Printf("Enter password #%s:\n", addr)
 	password, err := util.ReadSecretFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, "failed to get password")
+		return output.NewError(output.InputError, "failed to get password", err)
 	}
 	signedMessage, err := Sign(addr, password, msg)
 	if err != nil {
-		return output.PrintError(output.KeystoreError, err.Error())
+		return output.NewError(output.KeystoreError, "failed to sign message", err)
 	}
 	output.PrintResult(signedMessage)
 	return nil

--- a/ioctl/cmd/account/accountverify.go
+++ b/ioctl/cmd/account/accountverify.go
@@ -26,7 +26,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			err := accountVerify()
-			return err
+			return output.PrintError(err)
 		},
 	}
 )
@@ -40,15 +40,15 @@ func accountVerify() error {
 	fmt.Println("Enter private key:")
 	privateKey, err := util.ReadSecretFromStdin()
 	if err != nil {
-		return output.PrintError(output.InputError, err.Error())
+		return output.NewError(output.InputError, "failed to get private key", err)
 	}
 	priKey, err := crypto.HexStringToPrivateKey(privateKey)
 	if err != nil {
-		return output.PrintError(output.CryptoError, err.Error())
+		return output.NewError(output.CryptoError, "failed to generate private key from hex string", err)
 	}
 	addr, err := address.FromBytes(priKey.PublicKey().Hash())
 	if err != nil {
-		return output.PrintError(output.ConvertError, err.Error())
+		return output.NewError(output.ConvertError, "failed to convert public key into address", err)
 	}
 	message := verifyMessage{
 		Address:   addr.String(),

--- a/ioctl/cmd/action/actionclaim.go
+++ b/ioctl/cmd/action/actionclaim.go
@@ -21,39 +21,44 @@ var actionClaimCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
-		if err != nil {
-			return output.PrintError(output.ConvertError, err.Error())
-		}
-		payload := make([]byte, 0)
-		if len(args) == 2 {
-			payload = []byte(args[1])
-		}
-		sender, err := signer()
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		gasLimit := gasLimitFlag.Value().(uint64)
-		if gasLimit == 0 {
-			gasLimit = action.ClaimFromRewardingFundBaseGas +
-				action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))
-		}
-		gasPriceRau, err := gasPriceInRau()
-		nonce, err := nonce(sender)
-		if err != nil {
-			return output.PrintError(0, err.Error()) //TODO: undefined error
-		}
-		act := (&action.ClaimFromRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
-
-		return sendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
-			SetGasPrice(gasPriceRau).
-			SetGasLimit(gasLimit).
-			SetAction(&act).Build(),
-			sender,
-		)
+		err := claim(args)
+		return output.PrintError(err)
 	},
 }
 
 func init() {
 	registerWriteCommand(actionClaimCmd)
+}
+
+func claim(args []string) error {
+	amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
+	if err != nil {
+		return output.NewError(output.ConvertError, "invalid amount", err)
+	}
+	payload := make([]byte, 0)
+	if len(args) == 2 {
+		payload = []byte(args[1])
+	}
+	sender, err := signer()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get signer address", err)
+	}
+	gasLimit := gasLimitFlag.Value().(uint64)
+	if gasLimit == 0 {
+		gasLimit = action.ClaimFromRewardingFundBaseGas +
+			action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))
+	}
+	gasPriceRau, err := gasPriceInRau()
+	nonce, err := nonce(sender)
+	if err != nil {
+		return output.NewError(0, "failed to get nonce", err)
+	}
+	act := (&action.ClaimFromRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
+
+	return SendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
+		SetGasPrice(gasPriceRau).
+		SetGasLimit(gasLimit).
+		SetAction(&act).Build(),
+		sender,
+	)
 }

--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -22,18 +22,8 @@ var actionDeployCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		bytecode, err := decodeBytecode()
-		if err != nil {
-			return output.PrintError(output.FlagError, "Invalid bytecode flag:"+err.Error())
-		}
-		amount := big.NewInt(0)
-		if len(args) == 1 {
-			amount, err = util.StringToRau(args[0], util.IotxDecimalNum)
-			if err != nil {
-				return output.PrintError(output.ConvertError, "Invalid amount:"+err.Error())
-			}
-		}
-		return execute("", amount, bytecode)
+		err := deploy(args)
+		return output.PrintError(err)
 	},
 }
 
@@ -41,4 +31,19 @@ func init() {
 	registerWriteCommand(actionDeployCmd)
 	bytecodeFlag.RegisterCommand(actionDeployCmd)
 	bytecodeFlag.MarkFlagRequired(actionDeployCmd)
+}
+
+func deploy(args []string) error {
+	bytecode, err := decodeBytecode()
+	if err != nil {
+		return output.NewError(output.FlagError, "invalid bytecode flag", err)
+	}
+	amount := big.NewInt(0)
+	if len(args) == 1 {
+		amount, err = util.StringToRau(args[0], util.IotxDecimalNum)
+		if err != nil {
+			return output.NewError(output.ConvertError, "invalid amount", err)
+		}
+	}
+	return Execute("", amount, bytecode)
 }

--- a/ioctl/cmd/action/actiondeposit.go
+++ b/ioctl/cmd/action/actiondeposit.go
@@ -21,39 +21,44 @@ var actionDepositCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
-		if err != nil {
-			return output.PrintError(output.ConvertError, "Invalid amount:"+err.Error())
-		}
-		payload := make([]byte, 0)
-		if len(args) == 2 {
-			payload = []byte(args[1])
-		}
-		sender, err := signer()
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		gasLimit := gasLimitFlag.Value().(uint64)
-		if gasLimit == 0 {
-			gasLimit = action.DepositToRewardingFundBaseGas +
-				action.DepositToRewardingFundGasPerByte*uint64(len(payload))
-		}
-		gasPriceRau, err := gasPriceInRau()
-		nonce, err := nonce(sender)
-		if err != nil {
-			return output.PrintError(0, err.Error()) // TODO: undefined error
-		}
-		act := (&action.DepositToRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
-
-		return sendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
-			SetGasPrice(gasPriceRau).
-			SetGasLimit(gasLimit).
-			SetAction(&act).Build(),
-			sender,
-		)
+		err := deposit(args)
+		return output.PrintError(err)
 	},
 }
 
 func init() {
 	registerWriteCommand(actionDepositCmd)
+}
+
+func deposit(args []string) error {
+	amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
+	if err != nil {
+		return output.NewError(output.ConvertError, "invalid amount", err)
+	}
+	payload := make([]byte, 0)
+	if len(args) == 2 {
+		payload = []byte(args[1])
+	}
+	sender, err := signer()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get signer address", err)
+	}
+	gasLimit := gasLimitFlag.Value().(uint64)
+	if gasLimit == 0 {
+		gasLimit = action.DepositToRewardingFundBaseGas +
+			action.DepositToRewardingFundGasPerByte*uint64(len(payload))
+	}
+	gasPriceRau, err := gasPriceInRau()
+	nonce, err := nonce(sender)
+	if err != nil {
+		return output.NewError(0, "failed to get nonce", err)
+	}
+	act := (&action.DepositToRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
+
+	return SendAction((&action.EnvelopeBuilder{}).SetNonce(nonce).
+		SetGasPrice(gasPriceRau).
+		SetGasLimit(gasLimit).
+		SetAction(&act).Build(),
+		sender,
+	)
 }

--- a/ioctl/cmd/action/actioninvoke.go
+++ b/ioctl/cmd/action/actioninvoke.go
@@ -23,22 +23,8 @@ var actionInvokeCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		contract, err := util.Address(args[0])
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		amount := big.NewInt(0)
-		if len(args) == 2 {
-			amount, err = util.StringToRau(args[1], util.IotxDecimalNum)
-			if err != nil {
-				return output.PrintError(output.ConvertError, err.Error())
-			}
-		}
-		bytecode, err := decodeBytecode()
-		if err != nil {
-			return output.PrintError(output.ConvertError, err.Error())
-		}
-		return execute(contract, amount, bytecode)
+		err := invoke(args)
+		return output.PrintError(err)
 	},
 }
 
@@ -46,4 +32,23 @@ func init() {
 	registerWriteCommand(actionInvokeCmd)
 	bytecodeFlag.RegisterCommand(actionInvokeCmd)
 	bytecodeFlag.MarkFlagRequired(actionInvokeCmd)
+}
+
+func invoke(args []string) error {
+	contract, err := util.Address(args[0])
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get contract address", err)
+	}
+	amount := big.NewInt(0)
+	if len(args) == 2 {
+		amount, err = util.StringToRau(args[1], util.IotxDecimalNum)
+		if err != nil {
+			return output.NewError(output.ConvertError, "invalid amount", err)
+		}
+	}
+	bytecode, err := decodeBytecode()
+	if err != nil {
+		return output.NewError(output.ConvertError, "invalid bytecode", err)
+	}
+	return Execute(contract, amount, bytecode)
 }

--- a/ioctl/cmd/action/actionsendraw.go
+++ b/ioctl/cmd/action/actionsendraw.go
@@ -23,18 +23,23 @@ var actionSendRawCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		actBytes, err := hex.DecodeString(args[0])
-		if err != nil {
-			return output.PrintError(output.ConvertError, err.Error())
-		}
-		act := &iotextypes.Action{}
-		if err := proto.Unmarshal(actBytes, act); err != nil {
-			return output.PrintError(output.SerializationError, err.Error())
-		}
-		return sendRaw(act)
+		err := sendRaw(args[0])
+		return output.PrintError(err)
 	},
 }
 
 func init() {
 	registerWriteCommand(actionSendRawCmd)
+}
+
+func sendRaw(arg string) error {
+	actBytes, err := hex.DecodeString(arg)
+	if err != nil {
+		return output.NewError(output.ConvertError, "failed to decode data", err)
+	}
+	act := &iotextypes.Action{}
+	if err := proto.Unmarshal(actBytes, act); err != nil {
+		return output.NewError(output.SerializationError, "failed to unmarshal data bytes", err)
+	}
+	return SendRaw(act)
 }

--- a/ioctl/cmd/action/xrc20totalsupply.go
+++ b/ioctl/cmd/action/xrc20totalsupply.go
@@ -21,21 +21,26 @@ var xrc20TotalSupplyCmd = &cobra.Command{
 	Short: "Get total supply",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		bytecode, err := xrc20ABI.Pack("totalSupply")
-		if err != nil {
-			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
-		}
-		contract, err := xrc20Contract()
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		result, err := read(contract, bytecode)
-		if err != nil {
-			return output.PrintError(0, err.Error()) // TODO: undefined error
-		}
-		decimal, _ := new(big.Int).SetString(result, 16)
-		message := amountMessage{RawData: result, Decimal: decimal.String()}
-		fmt.Println(message.String())
-		return err
+		err := totalSupply()
+		return output.PrintError(err)
 	},
+}
+
+func totalSupply() error {
+	bytecode, err := xrc20ABI.Pack("totalSupply")
+	if err != nil {
+		return output.NewError(output.ConvertError, "cannot generate bytecode from given command", err)
+	}
+	contract, err := xrc20Contract()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get contract address", err)
+	}
+	result, err := Read(contract, bytecode)
+	if err != nil {
+		return output.NewError(0, "failed to read contract", err)
+	}
+	decimal, _ := new(big.Int).SetString(result, 16)
+	message := amountMessage{RawData: result, Decimal: decimal.String()}
+	fmt.Println(message.String())
+	return err
 }

--- a/ioctl/cmd/action/xrc20transfer.go
+++ b/ioctl/cmd/action/xrc20transfer.go
@@ -23,26 +23,31 @@ var xrc20TransferCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		recipient, err := alias.EtherAddress(args[0])
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		contract, err := xrc20Contract()
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		amount, err := parseAmount(contract, args[1])
-		if err != nil {
-			return output.PrintError(0, err.Error()) // TODO: undefined error
-		}
-		bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
-		if err != nil {
-			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
-		}
-		return execute(contract.String(), big.NewInt(0), bytecode)
+		err := xrc20Transfer(args)
+		return output.PrintError(err)
 	},
 }
 
 func init() {
 	registerWriteCommand(xrc20TransferCmd)
+}
+
+func xrc20Transfer(args []string) error {
+	recipient, err := alias.EtherAddress(args[0])
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get recipient address", err)
+	}
+	contract, err := xrc20Contract()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get contract address", err)
+	}
+	amount, err := parseAmount(contract, args[1])
+	if err != nil {
+		return output.NewError(0, "failed to parse amount", err)
+	}
+	bytecode, err := xrc20ABI.Pack("transfer", recipient, amount)
+	if err != nil {
+		return output.NewError(output.ConvertError, "cannot generate bytecode from given command", err)
+	}
+	return Execute(contract.String(), big.NewInt(0), bytecode)
 }

--- a/ioctl/cmd/action/xrc20transferfrom.go
+++ b/ioctl/cmd/action/xrc20transferfrom.go
@@ -23,30 +23,35 @@ var xrc20TransferFromCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		owner, err := alias.EtherAddress(args[0])
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		recipient, err := alias.EtherAddress(args[1])
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		contract, err := xrc20Contract()
-		if err != nil {
-			return output.PrintError(output.AddressError, err.Error())
-		}
-		amount, err := parseAmount(contract, args[2])
-		if err != nil {
-			return output.PrintError(0, err.Error()) // TODO: undefined error
-		}
-		bytecode, err := xrc20ABI.Pack("transferFrom", owner, recipient, amount)
-		if err != nil {
-			return output.PrintError(0, "cannot generate bytecode from given command"+err.Error()) // TODO: undefined error
-		}
-		return execute(contract.String(), big.NewInt(0), bytecode)
+		err := transferFrom(args)
+		return output.PrintError(err)
 	},
 }
 
 func init() {
 	registerWriteCommand(xrc20TransferFromCmd)
+}
+
+func transferFrom(args []string) error {
+	owner, err := alias.EtherAddress(args[0])
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get owner address", err)
+	}
+	recipient, err := alias.EtherAddress(args[1])
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get recipient address", err)
+	}
+	contract, err := xrc20Contract()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get contract address", err)
+	}
+	amount, err := parseAmount(contract, args[2])
+	if err != nil {
+		return output.NewError(0, "failed to parse amount", err)
+	}
+	bytecode, err := xrc20ABI.Pack("transferFrom", owner, recipient, amount)
+	if err != nil {
+		return output.NewError(output.ConvertError, "cannot generate bytecode from given command", err)
+	}
+	return Execute(contract.String(), big.NewInt(0), bytecode)
 }

--- a/ioctl/cmd/alias/alias.go
+++ b/ioctl/cmd/alias/alias.go
@@ -9,6 +9,8 @@ package alias
 import (
 	"errors"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
 
@@ -56,7 +58,7 @@ func init() {
 func IOAddress(in string) (address.Address, error) {
 	addr, err := util.Address(in)
 	if err != nil {
-		return nil, err
+		return nil, output.NewError(output.AddressError, "", err)
 	}
 	return address.FromString(addr)
 }
@@ -65,7 +67,7 @@ func IOAddress(in string) (address.Address, error) {
 func EtherAddress(in string) (common.Address, error) {
 	addr, err := util.Address(in)
 	if err != nil {
-		return common.Address{}, err
+		return common.Address{}, output.NewError(output.AddressError, "", err)
 	}
 	return util.IoAddrToEvmAddr(addr)
 }
@@ -73,14 +75,14 @@ func EtherAddress(in string) (common.Address, error) {
 // Alias returns the alias corresponding to address
 func Alias(address string) (string, error) {
 	if err := validator.ValidateAddress(address); err != nil {
-		return "", err
+		return "", output.NewError(output.ValidationError, "", err)
 	}
 	for alias, addr := range config.ReadConfig.Aliases {
 		if addr == address {
 			return alias, nil
 		}
 	}
-	return "", ErrNoAliasFound
+	return "", output.NewError(output.AddressError, ErrNoAliasFound.Error(), nil)
 }
 
 // GetAliasMap gets the map from address to alias

--- a/ioctl/cmd/alias/aliasremove.go
+++ b/ioctl/cmd/alias/aliasremove.go
@@ -26,24 +26,24 @@ var aliasRemoveCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := remove(args[0])
-		return err
+		return output.PrintError(err)
 	},
 }
 
 // remove removes alias
 func remove(arg string) error {
 	if err := validator.ValidateAlias(arg); err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid alias", err)
 	}
 	alias := arg
 	delete(config.ReadConfig.Aliases, alias)
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return output.PrintError(output.SerializationError, err.Error())
+		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
 	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return output.PrintError(output.WriteFileError,
-			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
+		return output.NewError(output.WriteFileError,
+			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}
 	output.PrintResult(alias + " is removed")
 	return nil

--- a/ioctl/cmd/alias/aliasset.go
+++ b/ioctl/cmd/alias/aliasset.go
@@ -26,18 +26,18 @@ var aliasSetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := set(args)
-		return err
+		return output.PrintError(err)
 	},
 }
 
 // set sets alias
 func set(args []string) error {
 	if err := validator.ValidateAlias(args[0]); err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid alias", err)
 	}
 	alias := args[0]
 	if err := validator.ValidateAddress(args[1]); err != nil {
-		return output.PrintError(output.ValidationError, err.Error())
+		return output.NewError(output.ValidationError, "invalid address", err)
 	}
 	addr := args[1]
 	aliases := GetAliasMap()
@@ -48,11 +48,11 @@ func set(args []string) error {
 	config.ReadConfig.Aliases[alias] = addr
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return output.PrintError(output.SerializationError, err.Error())
+		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
 	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return output.PrintError(output.WriteFileError,
-			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
+		return output.NewError(output.WriteFileError,
+			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}
 	output.PrintResult("set")
 	return nil

--- a/ioctl/cmd/bc/bc.go
+++ b/ioctl/cmd/bc/bc.go
@@ -8,7 +8,8 @@ package bc
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/iotexproject/iotex-core/ioctl/output"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
@@ -38,7 +39,7 @@ func init() {
 func GetChainMeta() (*iotextypes.ChainMeta, error) {
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -48,9 +49,9 @@ func GetChainMeta() (*iotextypes.ChainMeta, error) {
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok {
-			return nil, fmt.Errorf(sta.Message())
+			return nil, output.NewError(output.APIError, sta.Message(), nil)
 		}
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to invoke GetChainMeta api", err)
 	}
 	return response.ChainMeta, nil
 }

--- a/ioctl/cmd/bc/bcblock.go
+++ b/ioctl/cmd/bc/bcblock.go
@@ -85,7 +85,7 @@ func getBlock(args []string) error {
 func GetBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -102,12 +102,12 @@ func GetBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok {
-			return nil, fmt.Errorf(sta.Message())
+			return nil, output.NewError(output.APIError, sta.Message(), err)
 		}
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to invoke GetBlockMetas api", err)
 	}
 	if len(response.BlkMetas) == 0 {
-		return nil, fmt.Errorf("no block returned")
+		return nil, output.NewError(output.APIError, "no block returned", err)
 	}
 	return response.BlkMetas[0], nil
 }
@@ -116,7 +116,7 @@ func GetBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
 func GetBlockMetaByHash(hash string) (*iotextypes.BlockMeta, error) {
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -130,12 +130,12 @@ func GetBlockMetaByHash(hash string) (*iotextypes.BlockMeta, error) {
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok {
-			return nil, fmt.Errorf(sta.Message())
+			return nil, output.NewError(output.APIError, sta.Message(), err)
 		}
-		return nil, err
+		return nil, output.NewError(output.NetworkError, "failed to invoke GetBlockMetas api", err)
 	}
 	if len(response.BlkMetas) == 0 {
-		return nil, fmt.Errorf("no block returned")
+		return nil, output.NewError(output.APIError, "no block returned", err)
 	}
 	return response.BlkMetas[0], nil
 }

--- a/ioctl/cmd/bc/bcinfo.go
+++ b/ioctl/cmd/bc/bcinfo.go
@@ -9,7 +9,11 @@ package bc
 import (
 	"fmt"
 
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
 )
 
 // bcInfoCmd represents the bc info command
@@ -19,21 +23,31 @@ var bcInfoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := bcInfo()
-		if err == nil {
-			fmt.Println(output)
-		}
-		return err
+		err := bcInfo()
+		return output.PrintError(err)
 	},
 }
 
+type infoMessage struct {
+	Node string                `json:"node"`
+	Info *iotextypes.ChainMeta `json:"info"`
+}
+
+func (m *infoMessage) String() string {
+	if output.Format == "" {
+		message := fmt.Sprintf("Blockchain Node: %s\n%s", m.Node, output.JSONString(m.Info))
+		return message
+	}
+	return output.FormatString(output.Result, m)
+}
+
 // bcInfo get current information of block chain from server
-func bcInfo() (string, error) {
+func bcInfo() error {
 	chainMeta, err := GetChainMeta()
 	if err != nil {
-		return "", err
+		return output.NewError(0, "failed to get chain meta", err)
 	}
-	return fmt.Sprintf("height:%d  numActions:%d  tps:%3f\nepochNum:%d  epochStartHeight:%d"+
-		"  gravityChainStartHeight:%d", chainMeta.Height, chainMeta.NumActions, chainMeta.TpsFloat,
-		chainMeta.Epoch.Num, chainMeta.Epoch.Height, chainMeta.Epoch.GravityChainStartHeight), nil
+	message := infoMessage{Node: config.ReadConfig.Endpoint, Info: chainMeta}
+	fmt.Println(message.String())
+	return nil
 }

--- a/ioctl/cmd/update/update.go
+++ b/ioctl/cmd/update/update.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/iotexproject/iotex-core/ioctl/output"
+
 	"github.com/spf13/cobra"
 )
 
@@ -24,10 +26,7 @@ var UpdateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		output, err := update()
-		if err == nil {
-			fmt.Println(output)
-		}
+		err := update()
 		return err
 	},
 }
@@ -37,11 +36,11 @@ func init() {
 		`set version type, "stable" or "unstable"`)
 }
 
-func update() (string, error) {
+func update() error {
 	var cmdString string
 	switch versionType {
 	default:
-		return "", fmt.Errorf("invalid flag %s", versionType)
+		return output.NewError(output.FlagError, "invalid version-type flag: "+versionType, nil)
 	case "stable":
 		cmdString = "curl --silent https://raw.githubusercontent.com/iotexproject/" +
 			"iotex-core/master/install-cli.sh | sh"
@@ -51,10 +50,11 @@ func update() (string, error) {
 
 	}
 	cmd := exec.Command("bash", "-c", cmdString)
-	fmt.Printf("Downloading the latest %s version ...\n", versionType)
+	output.PrintResult(fmt.Sprintf("Downloading the latest %s version ...\n", versionType))
 	err := cmd.Run()
 	if err != nil {
-		return "", fmt.Errorf("failed to update ioctl")
+		return output.NewError(output.UpdateError, "failed to update ioctl", nil)
 	}
-	return "ioctl is up-to-date now.", nil
+	output.PrintResult("ioctl is up-to-date now.")
+	return nil
 }

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -61,7 +61,7 @@ func version() error {
 	message = versionMessage{Object: config.ReadConfig.Endpoint}
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
-		return output.PrintError(output.NetworkError, err.Error())
+		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
 	}
 	defer conn.Close()
 	cli := iotexapi.NewAPIServiceClient(conn)
@@ -71,10 +71,10 @@ func version() error {
 	if err != nil {
 		sta, ok := status.FromError(err)
 		if ok {
-			return output.PrintError(output.APIError, sta.Message())
+			return output.NewError(output.APIError, sta.Message(), nil)
 		}
-		return output.PrintError(output.NetworkError,
-			"failed to get version from server: "+err.Error())
+		return output.NewError(output.NetworkError,
+			"failed to get version from server", err)
 	}
 
 	message.VersionInfo = response.ServerMeta

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -182,7 +182,7 @@ func newError(code ErrorCode, info string, pre error) ErrorMessage {
 // NewError and returns golang error that contains Error Message
 func NewError(code ErrorCode, newInfo string, pre error) error {
 	message := newError(code, newInfo, pre)
-	return fmt.Errorf(message.String())
+	return fmt.Errorf(fmt.Sprintf("%d, %s", message.Code, message.Info))
 }
 
 // PrintError prints Error Message in format

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -154,7 +154,7 @@ func JSONString(out interface{}) string {
 }
 
 func newError(code ErrorCode, info string, pre error) ErrorMessage {
-	// find out previous ErrorMessage and recompose it
+	// find out format Error message and recompose it
 	if pre != nil {
 		errParts := strings.Split(pre.Error(), ", ")
 		if len(errParts) >= 2 {
@@ -163,6 +163,7 @@ func newError(code ErrorCode, info string, pre error) ErrorMessage {
 				preCode, err := strconv.Atoi(errParts[0])
 				if err == nil {
 					if code == 0 {
+						// override error code
 						code = ErrorCode(preCode)
 					}
 					pre = fmt.Errorf(strings.Join(errParts[1:], ", "))
@@ -179,12 +180,16 @@ func newError(code ErrorCode, info string, pre error) ErrorMessage {
 }
 
 // NewError and returns golang error that contains Error Message
+// ErrorCode can pass zero only when previous error is always a format error
+// that contains non-zero error code. ErrorCode passes 0 means that I want to
+// use previous error's code rather than override it.
+// If there is no previous error, newInfo should not be empty.
 func NewError(code ErrorCode, newInfo string, pre error) error {
 	message := newError(code, newInfo, pre)
 	return fmt.Errorf(fmt.Sprintf("%d, %s", message.Code, message.Info))
 }
 
-// PrintError prints Error Message in format
+// PrintError prints Error Message in format, only used at top layer of a command
 func PrintError(err error) error {
 	if err == nil {
 		return nil

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -158,18 +158,17 @@ func newError(code ErrorCode, info string, pre error) ErrorMessage {
 	if pre != nil {
 		errParts := strings.Split(pre.Error(), ", ")
 		if len(errParts) >= 2 {
-			if !strings.Contains(errParts[0], " ") {
-				ok, _ := regexp.MatchString(`^[1-9]\d|0$`, errParts[0])
-				if ok {
-					preCode, err := strconv.Atoi(errParts[0])
-					if err == nil {
-						if code == 0 {
-							code = ErrorCode(preCode)
-						}
-						pre = fmt.Errorf(strings.Join(errParts[1:], ", "))
+			ok, _ := regexp.MatchString(`^[1-9]\d*$`, errParts[0]) // errParts[0] shouldn't be 0
+			if ok {
+				preCode, err := strconv.Atoi(errParts[0])
+				if err == nil {
+					if code == 0 {
+						code = ErrorCode(preCode)
 					}
+					pre = fmt.Errorf(strings.Join(errParts[1:], ", "))
 				}
 			}
+
 		}
 		if len(info) != 0 {
 			info += ": "


### PR DESCRIPTION
Using `output.NewError()` instead of `output.PrintError()` to deliver error message among functions.
```
func NewError(code ErrorCode, newInfo string, pre error)
```
`pre` error will be parsed and recomposed with `newInfo`. In this way, we can retain low layer function error message and deliver upper layer function the same time.

At the top layer of a command, new `output.PrintError()` is used to print error message in format.

This PR also fixes some minor problems that has not been merged into master branch (#1381) and refactor some ioctl command to adapt new error output mode.

After merging this PR, most clusters of ioctl command except `node` and `config` commands support format output (json).

Part of commands has been tested on CentOS and worked well.

#935 