### PR TITLE
Add more friendly message to ioctl.

### DIFF
--- a/ioctl/cmd/account/accountbalance.go
+++ b/ioctl/cmd/account/accountbalance.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
@@ -23,7 +24,15 @@ var accountBalanceCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := balance(args[0])
+		if len(args) == 1 {
+			err := balance(args[0])
+			return err
+		}
+		if config.ReadConfig.DefaultAccount.AddressOrAlias == "" {
+			fmt.Println("Please specify a account to query balance")
+			return nil
+		}
+		err := balance(config.ReadConfig.DefaultAccount.AddressOrAlias)
 		return err
 	},
 }

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -31,7 +31,15 @@ var accountDeleteCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountDelete(args[0])
+		if len(args) == 1 {
+			err := accountDelete(args[0])
+			return err
+		}
+		if config.ReadConfig.DefaultAccount.AddressOrAlias == "" {
+			fmt.Println("Please specify a account to delete")
+			return nil
+		}
+		err := accountDelete(config.ReadConfig.DefaultAccount.AddressOrAlias)
 		return err
 	},
 }

--- a/ioctl/cmd/account/accountexport.go
+++ b/ioctl/cmd/account/accountexport.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
@@ -22,7 +23,15 @@ var accountExportCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountExport(args[0])
+		if len(args) == 1 {
+			err := accountExport(args[0])
+			return err
+		}
+		if config.ReadConfig.DefaultAccount.AddressOrAlias == "" {
+			fmt.Println("Please specify a account to export")
+			return nil
+		}
+		err := accountExport(config.ReadConfig.DefaultAccount.AddressOrAlias)
 		return err
 	},
 }

--- a/ioctl/cmd/account/accountnonce.go
+++ b/ioctl/cmd/account/accountnonce.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/iotexproject/iotex-core/ioctl/cmd/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
@@ -22,7 +23,15 @@ var accountNonceCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := nonce(args[0])
+		if len(args) == 1 {
+			err := nonce(args[0])
+			return err
+		}
+		if config.ReadConfig.DefaultAccount.AddressOrAlias == "" {
+			fmt.Println("Please specify a account to query nonce")
+			return nil
+		}
+		err := nonce(config.ReadConfig.DefaultAccount.AddressOrAlias)
 		return err
 	},
 }

--- a/ioctl/cmd/account/accountupdate.go
+++ b/ioctl/cmd/account/accountupdate.go
@@ -27,7 +27,15 @@ var accountUpdateCmd = &cobra.Command{
 	Args:  cobra.RangeArgs(0, 1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		err := accountUpdate(args[0])
+		if len(args) == 1 {
+			err := accountUpdate(args[0])
+			return err
+		}
+		if config.ReadConfig.DefaultAccount.AddressOrAlias == "" {
+			fmt.Println("Please specify a account to update")
+			return nil
+		}
+		err := accountUpdate(config.ReadConfig.DefaultAccount.AddressOrAlias)
 		return err
 	},
 }

--- a/ioctl/cmd/action/xrc20balanceof.go
+++ b/ioctl/cmd/action/xrc20balanceof.go
@@ -40,6 +40,12 @@ var xrc20BalanceOfCmd = &cobra.Command{
 			return output.PrintError(0, err.Error()) // TODO: undefined error
 		}
 		decimal, _ := new(big.Int).SetString(result, 16)
+		if result == "" {
+			result = "0"
+		}
+		if decimal == nil {
+			decimal = big.NewInt(0)
+		}
 		message := amountMessage{RawData: result, Decimal: decimal.String()}
 		fmt.Println(message.String())
 		return err

--- a/ioctl/cmd/alias/aliasset.go
+++ b/ioctl/cmd/alias/aliasset.go
@@ -54,6 +54,6 @@ func set(args []string) error {
 		return output.PrintError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile))
 	}
-	output.PrintResult("set")
+	output.PrintResult(args[0] + " has been set!")
 	return nil
 }

--- a/ioctl/cmd/config/configsetget.go
+++ b/ioctl/cmd/config/configsetget.go
@@ -114,6 +114,10 @@ func Get(arg string) (string, error) {
 	case "wallet":
 		return ReadConfig.Wallet, nil
 	case "defaultacc":
+		configRes := ReadConfig.DefaultAccount
+		if configRes.AddressOrAlias == "" {
+			return fmt.Sprintf("Default account did not set"), nil
+		}
 		return fmt.Sprint(ReadConfig.DefaultAccount), nil
 	case "explorer":
 		return ReadConfig.Explorer, nil


### PR DESCRIPTION
working on #1285 

Things have been modified:
1.Some command in account.go it shows could receive zero argument in our documentation and actually they will run into index out of range error with zero argument. So I just use default account in config to be the default argument in these account commands.
2. modified alias set output message.

3.modify get output of config default account to be more friendly.

4.modified xrc20 balanceOf output when they have no balance in current contract.


