### PR TITLE
Support partitioning db by block height 1395

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -239,6 +239,7 @@ func BoltDBDaoOption() Option {
 			gateway && !cfg.Chain.EnableAsyncIndexWrite,
 			cfg.Chain.CompressBlock,
 			cfg.Chain.MaxCacheSize,
+			cfg.DB,
 		)
 		return nil
 	}
@@ -253,6 +254,7 @@ func InMemDaoOption() Option {
 			gateway && !cfg.Chain.EnableAsyncIndexWrite,
 			cfg.Chain.CompressBlock,
 			cfg.Chain.MaxCacheSize,
+			cfg.DB,
 		)
 
 		return nil

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -8,6 +8,10 @@ package blockchain
 
 import (
 	"context"
+	"fmt"
+	"path"
+	"strings"
+	"sync"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/go-pkgs/hash"
@@ -19,6 +23,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/cache"
 	"github.com/iotexproject/iotex-core/pkg/compress"
@@ -52,6 +57,7 @@ var (
 	heightPrefix             = []byte("he.")
 	actionFromPrefix         = []byte("fr.")
 	actionToPrefix           = []byte("to.")
+	blockHashDBPrefix        = []byte("bhdb.")
 )
 
 var (
@@ -68,19 +74,22 @@ type blockDAO struct {
 	writeIndex    bool
 	compressBlock bool
 	kvstore       db.KVStore
+	kvstores      sync.Map //store like map[index]db.KVStore,index from 1...N
 	timerFactory  *prometheustimer.TimerFactory
 	lifecycle     lifecycle.Lifecycle
 	headerCache   *cache.ThreadSafeLruCache
 	bodyCache     *cache.ThreadSafeLruCache
 	footerCache   *cache.ThreadSafeLruCache
+	cfg           config.DB
 }
 
 // newBlockDAO instantiates a block DAO
-func newBlockDAO(kvstore db.KVStore, writeIndex bool, compressBlock bool, maxCacheSize int) *blockDAO {
+func newBlockDAO(kvstore db.KVStore, writeIndex bool, compressBlock bool, maxCacheSize int, cfg config.DB) *blockDAO {
 	blockDAO := &blockDAO{
 		writeIndex:    writeIndex,
 		compressBlock: compressBlock,
 		kvstore:       kvstore,
+		cfg:           cfg,
 	}
 	if maxCacheSize > 0 {
 		blockDAO.headerCache = cache.NewThreadSafeLruCache(maxCacheSize)
@@ -228,7 +237,7 @@ func (dao *blockDAO) header(h hash.Hash256) (*block.Header, error) {
 		}
 		cacheMtc.WithLabelValues("miss_header").Inc()
 	}
-	value, err := dao.kvstore.Get(blockHeaderNS, h[:])
+	value, err := dao.getBlockValue(blockHeaderNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block header %x", h)
 	}
@@ -268,7 +277,7 @@ func (dao *blockDAO) body(h hash.Hash256) (*block.Body, error) {
 		}
 		cacheMtc.WithLabelValues("miss_body").Inc()
 	}
-	value, err := dao.kvstore.Get(blockBodyNS, h[:])
+	value, err := dao.getBlockValue(blockBodyNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block body %x", h)
 	}
@@ -307,7 +316,7 @@ func (dao *blockDAO) footer(h hash.Hash256) (*block.Footer, error) {
 		}
 		cacheMtc.WithLabelValues("miss_footer").Inc()
 	}
-	value, err := dao.kvstore.Get(blockFooterNS, h[:])
+	value, err := dao.getBlockValue(blockFooterNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block footer %x", h)
 	}
@@ -377,9 +386,13 @@ func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, er
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipt index for action %x", h)
 	}
-	receiptsBytes, err := dao.kvstore.Get(receiptsNS, heightBytes)
+	height := enc.MachineEndian.Uint64(heightBytes)
+	kvstore, err := dao.getDBFromHeight(height)
 	if err != nil {
-		height := enc.MachineEndian.Uint64(heightBytes)
+		return nil, err
+	}
+	receiptsBytes, err := kvstore.Get(receiptsNS, heightBytes)
+	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipts of block %d", height)
 	}
 	receipts := iotextypes.Receipts{}
@@ -399,7 +412,7 @@ func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, er
 // putBlock puts a block
 func (dao *blockDAO) putBlock(blk *block.Block) error {
 	batch := db.NewBatch()
-
+	batchForBlock := db.NewBatch()
 	height := byteutil.Uint64ToBytes(blk.Height())
 	hash := blk.HashBlock()
 	serHeader, err := blk.Header.Serialize()
@@ -434,9 +447,20 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 			return errors.Wrapf(err, "error when compressing a block footer")
 		}
 	}
-	batch.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
-	batch.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
-	batch.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
+	batchForBlock.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
+	batchForBlock.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
+	batchForBlock.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
+	whichDB := getDBIndex(blk.Height(), dao.cfg.SplitDBLength)
+	kv, err := dao.getDBFromIndex(whichDB)
+	if err != nil {
+		return err
+	}
+	err = kv.Commit(batchForBlock)
+	if err != nil {
+		return err
+	}
+	blockHashDBKey := append(blockHashDBPrefix, hash[:]...)
+	batch.Put(blockNS, blockHashDBKey, byteutil.Uint64ToBytes(uint64(whichDB)), "failed to put block hash -> db mapping")
 
 	hashKey := append(hashPrefix, hash[:]...)
 	batch.Put(blockHashHeightMappingNS, hashKey, height, "failed to put hash -> height mapping")
@@ -473,11 +497,16 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 
 // putReceipts store receipt into db
 func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt) error {
+	kvstore, err := dao.getDBFromHeight(blkHeight)
+	if err != nil {
+		return err
+	}
 	if blkReceipts == nil {
 		return nil
 	}
 	receipts := iotextypes.Receipts{}
 	batch := db.NewBatch()
+	batchForReceipt := db.NewBatch()
 	var heightBytes [8]byte
 	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
 	for _, r := range blkReceipts {
@@ -497,16 +526,24 @@ func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt
 	if err != nil {
 		return err
 	}
-	batch.Put(receiptsNS, heightBytes[:], receiptsBytes, "Failed to put receipts of block %d", blkHeight)
+	batchForReceipt.Put(receiptsNS, heightBytes[:], receiptsBytes, "Failed to put receipts of block %d", blkHeight)
+	err = kvstore.Commit(batchForReceipt)
+	if err != nil {
+		return err
+	}
 	return dao.kvstore.Commit(batch)
 }
 
 // getReceipts gets receipts
 func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
+	kvstore, err := dao.getDBFromHeight(blkHeight)
+	if err != nil {
+		return nil, err
+	}
 	var heightBytes [8]byte
 	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
 
-	value, err := dao.kvstore.Get(receiptsNS, heightBytes[:])
+	value, err := kvstore.Get(receiptsNS, heightBytes[:])
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get receipts")
 	}
@@ -529,7 +566,7 @@ func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
 // deleteBlock deletes the tip block
 func (dao *blockDAO) deleteTipBlock() error {
 	batch := db.NewBatch()
-
+	batchForBlock := db.NewBatch()
 	// First obtain tip height from db
 	heightValue, err := dao.kvstore.Get(blockNS, topHeightKey)
 	if err != nil {
@@ -549,17 +586,26 @@ func (dao *blockDAO) deleteTipBlock() error {
 	}
 
 	// Delete hash -> block mapping
-	batch.Delete(blockHeaderNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockHeaderNS, hash[:], "failed to delete block")
 	if dao.headerCache != nil {
 		dao.headerCache.Remove(hash)
 	}
-	batch.Delete(blockBodyNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockBodyNS, hash[:], "failed to delete block")
 	if dao.bodyCache != nil {
 		dao.bodyCache.Remove(hash)
 	}
-	batch.Delete(blockFooterNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockFooterNS, hash[:], "failed to delete block")
 	if dao.footerCache != nil {
 		dao.footerCache.Remove(hash)
+	}
+
+	whichDB, _, err := dao.getDBFromHash(hash)
+	if err != nil {
+		return err
+	}
+	err = whichDB.Commit(batchForBlock)
+	if err != nil {
+		return err
 	}
 
 	// Delete hash -> height mapping
@@ -604,6 +650,82 @@ func (dao *blockDAO) deleteTipBlock() error {
 	}
 
 	return dao.kvstore.Commit(batch)
+}
+
+// getDBForHash returns db of this block stored
+func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, int, error) {
+	blockHashDBKey := append(blockHashDBPrefix, h[:]...)
+	whichDBValue, err := dao.kvstore.Get(blockNS, blockHashDBKey)
+	if err != nil {
+		return dao.kvstore, 0, nil
+	}
+	index := int(enc.MachineEndian.Uint64(whichDBValue))
+
+	db, err := dao.getDBFromIndex(index)
+	if err != nil {
+		return nil, 0, err
+	}
+	return db, index, nil
+}
+
+// getDB get db if exists,or will create new db and return
+func (dao *blockDAO) getDBFromIndex(index int) (kvstore db.KVStore, err error) {
+	if index == 0 {
+		return dao.kvstore, nil
+	}
+	kv, ok := dao.kvstores.Load(index)
+	if ok {
+		kvstore, ok = kv.(db.KVStore)
+		if !ok {
+			err = errors.New("db convert error")
+		}
+		return
+	}
+
+	// create new db according to cfg's file name
+	var withSuffix, suffix, name string
+	cfg := dao.cfg
+	withSuffix = path.Base(cfg.DbPath)
+	suffix = path.Ext(withSuffix)
+	name = strings.TrimSuffix(withSuffix, suffix)
+	name += fmt.Sprintf("-%d", index) + ".db"
+	cfg.DbPath = path.Dir(cfg.DbPath) + "/" + name
+
+	kvstore = db.NewBoltDB(cfg)
+	dao.kvstores.Store(index, kvstore)
+	err = kvstore.Start(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	dao.lifecycle.Add(kv)
+	return
+}
+
+//getDBFromHeight
+func (dao *blockDAO) getDBFromHeight(blkHeight uint64) (kvstore db.KVStore, err error) {
+	index := getDBIndex(blkHeight, dao.cfg.SplitDBLength)
+	return dao.getDBFromIndex(index)
+}
+
+// getBlockValue get block's data from db,if this db failed,it will try the previous one
+func (dao *blockDAO) getBlockValue(blockNS string, h hash.Hash256) ([]byte, error) {
+	whichDB, index, err := dao.getDBFromHash(h)
+	if err != nil {
+		return nil, err
+	}
+	value, err := whichDB.Get(blockNS, h[:])
+	if errors.Cause(err) == db.ErrNotExist {
+		idx := index - 1
+		if idx < 0 {
+			idx = 0
+		}
+		db, err := dao.getDBFromIndex(idx)
+		if err != nil {
+			return nil, err
+		}
+		value, err = db.Get(blockNS, h[:])
+	}
+	return value, err
 }
 
 // deleteReceipts deletes receipt information from db
@@ -699,4 +821,12 @@ func deleteActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error
 	}
 
 	return nil
+}
+
+// getDBIndex get db index from block height
+func getDBIndex(hei uint64, split uint64) int {
+	if split == 0 {
+		return 0
+	}
+	return int(hei / split)
 }

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -658,7 +658,7 @@ func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, int, error) {
 	if err != nil {
 		return nil, 0, err
 	}
-	index := getDBIndex(hei, dao.cfg.SplitDBLength)
+	index := getDBIndex(hei, dao.cfg.SplitDBLength, dao.cfg.SplitDBHeight)
 	return db, index, nil
 }
 
@@ -697,7 +697,7 @@ func (dao *blockDAO) getDBFromIndex(index int) (kvstore db.KVStore, err error) {
 
 //getDBFromHeight
 func (dao *blockDAO) getDBFromHeight(blkHeight uint64) (kvstore db.KVStore, err error) {
-	index := getDBIndex(blkHeight, dao.cfg.SplitDBLength)
+	index := getDBIndex(blkHeight, dao.cfg.SplitDBLength, dao.cfg.SplitDBHeight)
 	return dao.getDBFromIndex(index)
 }
 
@@ -818,9 +818,12 @@ func deleteActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error
 }
 
 // getDBIndex get db index from block height
-func getDBIndex(hei uint64, split uint64) int {
+func getDBIndex(hei, split, splitStartHeight uint64) int {
 	if split == 0 {
 		return 0
 	}
-	return int(hei / split)
+	if hei <= splitStartHeight {
+		return 0
+	}
+	return int((hei-splitStartHeight)/split) + 1 //from 1....N
 }

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -146,7 +146,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testBlockDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, false, false, 0)
+		dao := newBlockDAO(kvstore, false, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -218,7 +218,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testActionsDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, true, false, 0)
+		dao := newBlockDAO(kvstore, true, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -309,7 +309,7 @@ func TestBlockDAO(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, true, false, 0)
+		dao := newBlockDAO(kvstore, true, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		require.NoError(err)
 		defer func() {
@@ -371,7 +371,7 @@ func TestBlockDAO(t *testing.T) {
 }
 
 func TestBlockDao_putReceipts(t *testing.T) {
-	blkDao := newBlockDAO(db.NewMemKVStore(), true, false, 0)
+	blkDao := newBlockDAO(db.NewMemKVStore(), true, false, 0, config.Default.DB)
 	receipts := []*action.Receipt{
 		{
 			BlockHeight:     1,
@@ -414,7 +414,7 @@ func BenchmarkBlockCache(b *testing.B) {
 		}()
 		store := db.NewBoltDB(cfg)
 
-		blkDao := newBlockDAO(store, false, false, cacheSize)
+		blkDao := newBlockDAO(store, false, false, cacheSize, config.Default.DB)
 		require.NoError(b, blkDao.Start(context.Background()))
 		defer func() {
 			require.NoError(b, blkDao.Stop(context.Background()))

--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,7 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
+			SplitDBLength: 100000,
 		},
 		Genesis: genesis.Default,
 		Reindex: false,
@@ -314,6 +315,9 @@ type (
 
 		// SQLite3 is the config for SQLITE3
 		SQLITE3 SQLITE3 `yaml:"SQLITE3"`
+
+		// SplitDBLength is the config for DB's split length
+		SplitDBLength uint64 `yaml:"splitDBLength"`
 	}
 
 	// RDS is the cloud rds config

--- a/config/config.go
+++ b/config/config.go
@@ -166,6 +166,7 @@ var (
 				SQLite3File: "./explorer.db",
 			},
 			SplitDBLength: 0,
+			SplitDBHeight: 900000,
 		},
 		Genesis: genesis.Default,
 		Reindex: false,
@@ -318,6 +319,9 @@ type (
 
 		// SplitDBLength is the config for DB's split length
 		SplitDBLength uint64 `yaml:"splitDBLength"`
+
+		// SplitDBHeight is the config for DB's split start height
+		SplitDBHeight uint64 `yaml:"splitDBHeight"`
 	}
 
 	// RDS is the cloud rds config

--- a/config/config.go
+++ b/config/config.go
@@ -165,7 +165,7 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
-			SplitDBLength: 100000,
+			SplitDBLength: 0,
 		},
 		Genesis: genesis.Default,
 		Reindex: false,


### PR DESCRIPTION
work on #1395

Block header,body ,footer and receipt map to different dbs according to block height,
other datas still store in default db,chain.db.
The default split length is 0，it means don't need to split db.
The split height config means it will split to diff db since that height.

If split length is 100000,every db's size is about 400M.
The new db's name like this:
chain-1.db
chain-2.db