### PR TITLE
Add transfer log in stateDB for evm transfer tracking

### DIFF
--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -41,6 +41,9 @@ const (
 	CurrentHeightKey = "currentHeight"
 	// AccountTrieRootKey indicates the key of accountTrie root hash in underlying DB
 	AccountTrieRootKey = "accountTrieRoot"
+
+	// TransferLog is the bucket name for transfer log storage
+	TransferLog = "transferLog"
 )
 
 type (

--- a/state/transferlog.go
+++ b/state/transferlog.go
@@ -15,7 +15,7 @@ type TransferLogs struct {
 	Transfers []TransferLog `json:"transfers"`
 }
 
-// TransferLogs represents one evm transfer trace
+// TransferLog represents one evm transfer trace
 type TransferLog struct {
 	From   string `json:"from"`
 	To     string `json:"to"`

--- a/state/transferlog.go
+++ b/state/transferlog.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2018 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package state
+
+import (
+	"encoding/json"
+)
+
+// TransferLogs represents a group of evm transfer traces
+type TransferLogs struct {
+	Transfers []TransferLog `json:"transfers"`
+}
+
+// TransferLogs represents one evm transfer trace
+type TransferLog struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Amount string `json:"amount"`
+}
+
+// NewTransferLogs news a TransferLogs state
+func NewTransferLogs(from, to, amount string) TransferLogs {
+	return TransferLogs{Transfers: []TransferLog{TransferLog{
+		From:   from,
+		To:     to,
+		Amount: amount,
+	}}}
+}
+
+// AddLog adds new transfer log into TransferLogs state
+func (t *TransferLogs) AddLog(from, to, amount string) {
+	t.Transfers = append(t.Transfers, TransferLog{
+		From:   from,
+		To:     to,
+		Amount: amount,
+	})
+}
+
+// Serialize serializes TransferLogs state into bytes
+func (st TransferLogs) Serialize() ([]byte, error) {
+	return json.Marshal(st)
+}
+
+// Deserialize deserializes bytes into TransferLogs state
+func (st *TransferLogs) Deserialize(buf []byte) error {
+	if err := json.Unmarshal(buf, st); err != nil {
+		return err
+	}
+	return nil
+}

--- a/state/transferlog.go
+++ b/state/transferlog.go
@@ -41,13 +41,13 @@ func (t *TransferLogs) AddLog(from, to, amount string) {
 }
 
 // Serialize serializes TransferLogs state into bytes
-func (st TransferLogs) Serialize() ([]byte, error) {
-	return json.Marshal(st)
+func (t TransferLogs) Serialize() ([]byte, error) {
+	return json.Marshal(t)
 }
 
 // Deserialize deserializes bytes into TransferLogs state
-func (st *TransferLogs) Deserialize(buf []byte) error {
-	if err := json.Unmarshal(buf, st); err != nil {
+func (t *TransferLogs) Deserialize(buf []byte) error {
+	if err := json.Unmarshal(buf, t); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
One solution of evm transfer tracking. #1346 
I define a new stateDB namespace "transferLog" to storage transfer logs. The key is execution hash and the value is a set of transfer logs that records all transfers happened in this execution.