### PR TITLE
Support partitioning db by block height 1395

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -239,6 +239,7 @@ func BoltDBDaoOption() Option {
 			gateway && !cfg.Chain.EnableAsyncIndexWrite,
 			cfg.Chain.CompressBlock,
 			cfg.Chain.MaxCacheSize,
+			cfg.DB,
 		)
 		return nil
 	}
@@ -253,6 +254,7 @@ func InMemDaoOption() Option {
 			gateway && !cfg.Chain.EnableAsyncIndexWrite,
 			cfg.Chain.CompressBlock,
 			cfg.Chain.MaxCacheSize,
+			cfg.DB,
 		)
 
 		return nil

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1001,7 +1001,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	kv, err := bc.dao.putBlock(blk)
+	err = bc.dao.putBlock(blk)
 	putTimer.End()
 	if err != nil {
 		return err
@@ -1023,7 +1023,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 
 		// write smart contract receipt into DB
 		receiptTimer := bc.timerFactory.NewTimer("putReceipt")
-		err = bc.dao.putReceipts(blk.Height(), blk.Receipts, kv)
+		err = bc.dao.putReceipts(blk.Height(), blk.Receipts)
 		receiptTimer.End()
 		if err != nil {
 			return errors.Wrapf(err, "failed to put smart contract receipts into DB on height %d", blk.Height())

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1001,7 +1001,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	kv, index, err := bc.dao.putBlock(blk)
+	kv, err := bc.dao.putBlock(blk)
 	putTimer.End()
 	if err != nil {
 		return err
@@ -1023,7 +1023,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 
 		// write smart contract receipt into DB
 		receiptTimer := bc.timerFactory.NewTimer("putReceipt")
-		err = bc.dao.putReceipts(blk.Height(), blk.Receipts, kv, index)
+		err = bc.dao.putReceipts(blk.Height(), blk.Receipts, kv)
 		receiptTimer.End()
 		if err != nil {
 			return errors.Wrapf(err, "failed to put smart contract receipts into DB on height %d", blk.Height())

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1001,7 +1001,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	err = bc.dao.putBlock(blk)
+	kv, index, err := bc.dao.putBlock(blk)
 	putTimer.End()
 	if err != nil {
 		return err
@@ -1023,7 +1023,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 
 		// write smart contract receipt into DB
 		receiptTimer := bc.timerFactory.NewTimer("putReceipt")
-		err = bc.dao.putReceipts(blk.Height(), blk.Receipts)
+		err = bc.dao.putReceipts(blk.Height(), blk.Receipts, kv, index)
 		receiptTimer.End()
 		if err != nil {
 			return errors.Wrapf(err, "failed to put smart contract receipts into DB on height %d", blk.Height())

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -8,6 +8,14 @@ package blockchain
 
 import (
 	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/go-pkgs/hash"
@@ -19,6 +27,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/cache"
 	"github.com/iotexproject/iotex-core/pkg/compress"
@@ -52,6 +61,8 @@ var (
 	heightPrefix             = []byte("he.")
 	actionFromPrefix         = []byte("fr.")
 	actionToPrefix           = []byte("to.")
+	blockHeightToFileKey     = []byte("bhf.")
+	receiptHeightToFileKey   = []byte("rhf.")
 )
 
 var (
@@ -68,19 +79,23 @@ type blockDAO struct {
 	writeIndex    bool
 	compressBlock bool
 	kvstore       db.KVStore
+	kvstores      sync.Map //store like map[index]db.KVStore,index from 1...N
+	topIndex      atomic.Value
 	timerFactory  *prometheustimer.TimerFactory
 	lifecycle     lifecycle.Lifecycle
 	headerCache   *cache.ThreadSafeLruCache
 	bodyCache     *cache.ThreadSafeLruCache
 	footerCache   *cache.ThreadSafeLruCache
+	cfg           config.DB
 }
 
 // newBlockDAO instantiates a block DAO
-func newBlockDAO(kvstore db.KVStore, writeIndex bool, compressBlock bool, maxCacheSize int) *blockDAO {
+func newBlockDAO(kvstore db.KVStore, writeIndex bool, compressBlock bool, maxCacheSize int, cfg config.DB) *blockDAO {
 	blockDAO := &blockDAO{
 		writeIndex:    writeIndex,
 		compressBlock: compressBlock,
 		kvstore:       kvstore,
+		cfg:           cfg,
 	}
 	if maxCacheSize > 0 {
 		blockDAO.headerCache = cache.NewThreadSafeLruCache(maxCacheSize)
@@ -123,12 +138,49 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 			return errors.Wrap(err, "failed to write initial value for total actions")
 		}
 	}
+
+	err = dao.initStores()
+	if err != nil {
+		return err
+	}
+
 	value, _ := dao.kvstore.Get(blockNS, totalActionsKey)
 	totalActions := enc.MachineEndian.Uint64(value)
 	if totalActions != 0 {
 		return nil
 	}
+
 	return dao.countActions()
+}
+func (dao *blockDAO) initStores() error {
+	cfg := dao.cfg
+	model, dir := getFileNameAndDir(cfg.DbPath)
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var maxN uint64
+	for _, file := range files {
+		name := file.Name()
+		lens := len(name)
+		if lens < 11 || !strings.Contains(name, model) {
+			continue
+		}
+		num := name[lens-11 : lens-3]
+		n, err := strconv.Atoi(num)
+		if err != nil {
+			continue
+		}
+		dao.openDB(uint64(n))
+		if uint64(n) > maxN {
+			maxN = uint64(n)
+		}
+	}
+	if maxN == 0 {
+		maxN = 1
+	}
+	dao.topIndex.Store(maxN)
+	return nil
 }
 func (dao *blockDAO) countActions() error {
 	totalActions := uint64(0)
@@ -228,7 +280,7 @@ func (dao *blockDAO) header(h hash.Hash256) (*block.Header, error) {
 		}
 		cacheMtc.WithLabelValues("miss_header").Inc()
 	}
-	value, err := dao.kvstore.Get(blockHeaderNS, h[:])
+	value, err := dao.getBlockValue(blockHeaderNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block header %x", h)
 	}
@@ -268,7 +320,7 @@ func (dao *blockDAO) body(h hash.Hash256) (*block.Body, error) {
 		}
 		cacheMtc.WithLabelValues("miss_body").Inc()
 	}
-	value, err := dao.kvstore.Get(blockBodyNS, h[:])
+	value, err := dao.getBlockValue(blockBodyNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block body %x", h)
 	}
@@ -307,7 +359,7 @@ func (dao *blockDAO) footer(h hash.Hash256) (*block.Footer, error) {
 		}
 		cacheMtc.WithLabelValues("miss_footer").Inc()
 	}
-	value, err := dao.kvstore.Get(blockFooterNS, h[:])
+	value, err := dao.getBlockValue(blockFooterNS, h)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block footer %x", h)
 	}
@@ -377,9 +429,13 @@ func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, er
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipt index for action %x", h)
 	}
-	receiptsBytes, err := dao.kvstore.Get(receiptsNS, heightBytes)
+	height := enc.MachineEndian.Uint64(heightBytes)
+	kvstore, _, err := dao.getDBFromHeight(height, receiptHeightToFileKey)
 	if err != nil {
-		height := enc.MachineEndian.Uint64(heightBytes)
+		return nil, err
+	}
+	receiptsBytes, err := kvstore.Get(receiptsNS, heightBytes)
+	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipts of block %d", height)
 	}
 	receipts := iotextypes.Receipts{}
@@ -399,7 +455,7 @@ func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, er
 // putBlock puts a block
 func (dao *blockDAO) putBlock(blk *block.Block) error {
 	batch := db.NewBatch()
-
+	batchForBlock := db.NewBatch()
 	height := byteutil.Uint64ToBytes(blk.Height())
 	hash := blk.HashBlock()
 	serHeader, err := blk.Header.Serialize()
@@ -434,15 +490,28 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 			return errors.Wrapf(err, "error when compressing a block footer")
 		}
 	}
-	batch.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
-	batch.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
-	batch.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
+	batchForBlock.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
+	batchForBlock.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
+	batchForBlock.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
+	kv, fileindex, err := dao.getTopDB(blk.Height())
+	if err != nil {
+		return err
+	}
+
+	err = kv.Commit(batchForBlock)
+	if err != nil {
+		return err
+	}
 
 	hashKey := append(hashPrefix, hash[:]...)
 	batch.Put(blockHashHeightMappingNS, hashKey, height, "failed to put hash -> height mapping")
 
 	heightKey := append(heightPrefix, height...)
 	batch.Put(blockHashHeightMappingNS, heightKey, hash[:], "failed to put height -> hash mapping")
+
+	heightToFile := append(blockHeightToFileKey, height...)
+	fileindexBytes := byteutil.Uint64ToBytes(fileindex)
+	batch.Put(blockNS, heightToFile, fileindexBytes, "failed to put height -> file index mapping")
 
 	value, err := dao.kvstore.Get(blockNS, topHeightKey)
 	if err != nil {
@@ -473,11 +542,16 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 
 // putReceipts store receipt into db
 func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt) error {
+	kvstore, fileindex, err := dao.getTopDB(blkHeight)
+	if err != nil {
+		return err
+	}
 	if blkReceipts == nil {
 		return nil
 	}
 	receipts := iotextypes.Receipts{}
 	batch := db.NewBatch()
+	batchForReceipt := db.NewBatch()
 	var heightBytes [8]byte
 	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
 	for _, r := range blkReceipts {
@@ -497,16 +571,28 @@ func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt
 	if err != nil {
 		return err
 	}
-	batch.Put(receiptsNS, heightBytes[:], receiptsBytes, "Failed to put receipts of block %d", blkHeight)
+	batchForReceipt.Put(receiptsNS, heightBytes[:], receiptsBytes, "Failed to put receipts of block %d", blkHeight)
+	err = kvstore.Commit(batchForReceipt)
+	if err != nil {
+		return err
+	}
+	height := byteutil.Uint64ToBytes(blkHeight)
+	heightToFile := append(receiptHeightToFileKey, height...)
+	fileindexBytes := byteutil.Uint64ToBytes(fileindex)
+	batch.Put(blockNS, heightToFile, fileindexBytes, "failed to put height -> file index mapping")
 	return dao.kvstore.Commit(batch)
 }
 
 // getReceipts gets receipts
 func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
+	kvstore, _, err := dao.getDBFromHeight(blkHeight, receiptHeightToFileKey)
+	if err != nil {
+		return nil, err
+	}
 	var heightBytes [8]byte
 	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
 
-	value, err := dao.kvstore.Get(receiptsNS, heightBytes[:])
+	value, err := kvstore.Get(receiptsNS, heightBytes[:])
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get receipts")
 	}
@@ -529,7 +615,7 @@ func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
 // deleteBlock deletes the tip block
 func (dao *blockDAO) deleteTipBlock() error {
 	batch := db.NewBatch()
-
+	batchForBlock := db.NewBatch()
 	// First obtain tip height from db
 	heightValue, err := dao.kvstore.Get(blockNS, topHeightKey)
 	if err != nil {
@@ -549,17 +635,26 @@ func (dao *blockDAO) deleteTipBlock() error {
 	}
 
 	// Delete hash -> block mapping
-	batch.Delete(blockHeaderNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockHeaderNS, hash[:], "failed to delete block")
 	if dao.headerCache != nil {
 		dao.headerCache.Remove(hash)
 	}
-	batch.Delete(blockBodyNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockBodyNS, hash[:], "failed to delete block")
 	if dao.bodyCache != nil {
 		dao.bodyCache.Remove(hash)
 	}
-	batch.Delete(blockFooterNS, hash[:], "failed to delete block")
+	batchForBlock.Delete(blockFooterNS, hash[:], "failed to delete block")
 	if dao.footerCache != nil {
 		dao.footerCache.Remove(hash)
+	}
+
+	whichDB, _, err := dao.getDBFromHash(hash)
+	if err != nil {
+		return err
+	}
+	err = whichDB.Commit(batchForBlock)
+	if err != nil {
+		return err
 	}
 
 	// Delete hash -> height mapping
@@ -604,6 +699,132 @@ func (dao *blockDAO) deleteTipBlock() error {
 	}
 
 	return dao.kvstore.Commit(batch)
+}
+
+// getDBForHash returns db of this block stored
+func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, uint64, error) {
+	hei, err := dao.getBlockHeight(h)
+	if err != nil {
+		return nil, 0, err
+	}
+	return dao.getDBFromHeight(hei, blockHeightToFileKey)
+}
+
+//getDBFromHeight
+func (dao *blockDAO) getTopDB(blkHeight uint64) (kvstore db.KVStore, index uint64, err error) {
+	if dao.cfg.SplitDBSize == 0 {
+		return dao.kvstore, 0, nil
+	}
+	if blkHeight <= dao.cfg.SplitDBHeight {
+		return dao.kvstore, 0, nil
+	}
+	topIndex := dao.topIndex.Load().(uint64)
+	file, dir := getFileNameAndDir(dao.cfg.DbPath)
+	if err != nil {
+		return
+	}
+	longFileName := dir + "/" + file + fmt.Sprintf("-%08d", topIndex) + ".db"
+	dat, err := os.Stat(longFileName)
+	if err != nil {
+		// db file not exist,this will create
+		return dao.openDB(topIndex)
+	}
+	// dao.cfg.SplitDBSize need conver to M
+	if uint64(dat.Size()) > dao.cfg.SplitDBSize*1024*1024 {
+		kvstore, index, err = dao.openDB(topIndex + 1)
+		dao.topIndex.Store(index)
+		return
+	}
+	kv, ok := dao.kvstores.Load(topIndex)
+	if ok {
+		kvstore, ok = kv.(db.KVStore)
+		if !ok {
+			err = errors.New("db convert error")
+		}
+		index = topIndex
+		return
+	}
+
+	return dao.openDB(topIndex)
+}
+
+//getDBFromHeight
+func (dao *blockDAO) getDBFromHeight(blkHeight uint64, keyPrefix []byte) (kvstore db.KVStore, index uint64, err error) {
+	if dao.cfg.SplitDBSize == 0 {
+		return dao.kvstore, 0, nil
+	}
+	if blkHeight <= dao.cfg.SplitDBHeight {
+		return dao.kvstore, 0, nil
+	}
+	hei := byteutil.Uint64ToBytes(blkHeight)
+	heightToFile := append(keyPrefix, hei...)
+	value, err := dao.kvstore.Get(blockNS, heightToFile[:])
+	if err != nil {
+		return
+	}
+	heiIndex := enc.MachineEndian.Uint64(value)
+	return dao.getDBFromIndex(heiIndex)
+}
+
+// getDBFromIndex
+func (dao *blockDAO) getDBFromIndex(idx uint64) (kvstore db.KVStore, index uint64, err error) {
+	if idx == 0 {
+		return dao.kvstore, 0, nil
+	}
+	kv, ok := dao.kvstores.Load(idx)
+	if ok {
+		kvstore, ok = kv.(db.KVStore)
+		if !ok {
+			err = errors.New("db convert error")
+		}
+		index = idx
+		return
+	}
+	// if user rm some db files manully,then call this method will create new file
+	return dao.openDB(idx)
+}
+
+// getBlockValue get block's data from db,if this db failed,it will try the previous one
+func (dao *blockDAO) getBlockValue(blockNS string, h hash.Hash256) ([]byte, error) {
+	whichDB, index, err := dao.getDBFromHash(h)
+	if err != nil {
+		return nil, err
+	}
+	value, err := whichDB.Get(blockNS, h[:])
+	if errors.Cause(err) == db.ErrNotExist {
+		idx := index - 1
+		if idx < 0 {
+			idx = 0
+		}
+		db, _, err := dao.getDBFromIndex(idx)
+		if err != nil {
+			return nil, err
+		}
+		value, err = db.Get(blockNS, h[:])
+	}
+	return value, err
+}
+
+// open file if exists, or create new file
+func (dao *blockDAO) openDB(idx uint64) (kvstore db.KVStore, index uint64, err error) {
+	if idx == 0 {
+		return dao.kvstore, 0, nil
+	}
+	cfg := dao.cfg
+	model, _ := getFileNameAndDir(cfg.DbPath)
+	name := model + fmt.Sprintf("-%08d", idx) + ".db"
+
+	// open or create this db file
+	cfg.DbPath = path.Dir(cfg.DbPath) + "/" + name
+	kvstore = db.NewBoltDB(cfg)
+	dao.kvstores.Store(idx, kvstore)
+	err = kvstore.Start(context.Background())
+	if err != nil {
+		return
+	}
+	dao.lifecycle.Add(kvstore)
+	index = idx
+	return
 }
 
 // deleteReceipts deletes receipt information from db
@@ -699,4 +920,13 @@ func deleteActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error
 	}
 
 	return nil
+}
+
+func getFileNameAndDir(p string) (fileName, dir string) {
+	var withSuffix, suffix string
+	withSuffix = path.Base(p)
+	suffix = path.Ext(withSuffix)
+	fileName = strings.TrimSuffix(withSuffix, suffix)
+	dir = path.Dir(p)
+	return
 }

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -725,10 +725,10 @@ func (dao *blockDAO) getTopDB(blkHeight uint64) (kvstore db.KVStore, index uint6
 	longFileName := dir + "/" + file + fmt.Sprintf("-%08d", topIndex) + ".db"
 	dat, err := os.Stat(longFileName)
 	if err != nil {
-		// db file not exist,this will create
+		// db file is not exist,this will create
 		return dao.openDB(topIndex)
 	}
-	// dao.cfg.SplitDBSize need conver to M
+	// dao.cfg.SplitDBSize need convert to M
 	if uint64(dat.Size()) > dao.cfg.SplitDBSize*1024*1024 {
 		kvstore, index, err = dao.openDB(topIndex + 1)
 		dao.topIndex.Store(index)

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -61,7 +61,7 @@ var (
 	heightPrefix             = []byte("he.")
 	actionFromPrefix         = []byte("fr.")
 	actionToPrefix           = []byte("to.")
-	blockHeightToFileKey     = []byte("bhf.")
+	heightToFilePrefix       = []byte("hf.")
 )
 
 var (
@@ -72,8 +72,8 @@ var (
 		},
 		[]string{"result"},
 	)
-	modelLen  = len("00000000.db")
-	suffexLen = len(".db")
+	patternLen = len("00000000.db")
+	suffixLen  = len(".db")
 )
 
 type blockDAO struct {
@@ -165,10 +165,10 @@ func (dao *blockDAO) initStores() error {
 	for _, file := range files {
 		name := file.Name()
 		lens := len(name)
-		if lens < modelLen || !strings.Contains(name, model) {
+		if lens < patternLen || !strings.Contains(name, model) {
 			continue
 		}
-		num := name[lens-modelLen : lens-suffexLen]
+		num := name[lens-patternLen : lens-suffixLen]
 		n, err := strconv.Atoi(num)
 		if err != nil {
 			continue
@@ -517,7 +517,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) (kv db.KVStore, err error) {
 	heightKey := append(heightPrefix, height...)
 	batch.Put(blockHashHeightMappingNS, heightKey, hash[:], "failed to put height -> hash mapping")
 
-	heightToFile := append(blockHeightToFileKey, height...)
+	heightToFile := append(heightToFilePrefix, height...)
 	fileindexBytes := byteutil.Uint64ToBytes(index)
 	batch.Put(blockNS, heightToFile, fileindexBytes, "failed to put height -> file index mapping")
 
@@ -763,7 +763,7 @@ func (dao *blockDAO) getDBFromHeight(blkHeight uint64) (kvstore db.KVStore, inde
 		return dao.kvstore, 0, nil
 	}
 	hei := byteutil.Uint64ToBytes(blkHeight)
-	heightToFile := append(blockHeightToFileKey, hei...)
+	heightToFile := append(heightToFilePrefix, hei...)
 	value, err := dao.kvstore.Get(blockNS, heightToFile[:])
 	if err != nil {
 		return

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -612,7 +612,7 @@ func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
 	return blockReceipts, nil
 }
 
-// deleteBlock deletes the tip block
+// deleteTipBlock deletes the tip block
 func (dao *blockDAO) deleteTipBlock() error {
 	batch := db.NewBatch()
 	batchForBlock := db.NewBatch()
@@ -701,7 +701,7 @@ func (dao *blockDAO) deleteTipBlock() error {
 	return dao.kvstore.Commit(batch)
 }
 
-// getDBForHash returns db of this block stored
+// getDBFromHash returns db of this block stored
 func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, uint64, error) {
 	hei, err := dao.getBlockHeight(h)
 	if err != nil {
@@ -710,7 +710,6 @@ func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, uint64, error) {
 	return dao.getDBFromHeight(hei, blockHeightToFileKey)
 }
 
-//getDBFromHeight
 func (dao *blockDAO) getTopDB(blkHeight uint64) (kvstore db.KVStore, index uint64, err error) {
 	if dao.cfg.SplitDBSize == 0 {
 		return dao.kvstore, 0, nil
@@ -748,7 +747,6 @@ func (dao *blockDAO) getTopDB(blkHeight uint64) (kvstore db.KVStore, index uint6
 	return dao.openDB(topIndex)
 }
 
-//getDBFromHeight
 func (dao *blockDAO) getDBFromHeight(blkHeight uint64, keyPrefix []byte) (kvstore db.KVStore, index uint64, err error) {
 	if dao.cfg.SplitDBSize == 0 {
 		return dao.kvstore, 0, nil
@@ -766,7 +764,6 @@ func (dao *blockDAO) getDBFromHeight(blkHeight uint64, keyPrefix []byte) (kvstor
 	return dao.getDBFromIndex(heiIndex)
 }
 
-// getDBFromIndex
 func (dao *blockDAO) getDBFromIndex(idx uint64) (kvstore db.KVStore, index uint64, err error) {
 	if idx == 0 {
 		return dao.kvstore, 0, nil
@@ -805,7 +802,7 @@ func (dao *blockDAO) getBlockValue(blockNS string, h hash.Hash256) ([]byte, erro
 	return value, err
 }
 
-// open file if exists, or create new file
+// openDB open file if exists, or create new file
 func (dao *blockDAO) openDB(idx uint64) (kvstore db.KVStore, index uint64, err error) {
 	if idx == 0 {
 		return dao.kvstore, 0, nil

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -455,7 +455,7 @@ func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, er
 }
 
 // putBlock puts a block
-func (dao *blockDAO) putBlock(blk *block.Block) (kv db.KVStore, index uint64, err error) {
+func (dao *blockDAO) putBlock(blk *block.Block) (kv db.KVStore, err error) {
 	batch := db.NewBatch()
 	batchForBlock := db.NewBatch()
 	height := byteutil.Uint64ToBytes(blk.Height())
@@ -501,7 +501,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) (kv db.KVStore, index uint64, er
 	batchForBlock.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
 	batchForBlock.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
 	batchForBlock.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
-	kv, index, err = dao.getTopDB(blk.Height())
+	kv, index, err := dao.getTopDB(blk.Height())
 	if err != nil {
 		return
 	}
@@ -553,7 +553,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) (kv db.KVStore, index uint64, er
 }
 
 // putReceipts store receipt into db
-func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt, kvstore db.KVStore, fileindex uint64) error {
+func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt, kvstore db.KVStore) error {
 	if blkReceipts == nil {
 		return nil
 	}

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -159,7 +159,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Equal(t, uint64(0), height)
 
 		// block put order is 0 2 1
-		_, err = dao.putBlock(blks[0])
+		err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
 		blk, err := dao.getBlock(blks[0].HashBlock())
 		assert.Nil(t, err)
@@ -169,7 +169,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(1), height)
 
-		_, err = dao.putBlock(blks[2])
+		err = dao.putBlock(blks[2])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[2].HashBlock())
 		assert.Nil(t, err)
@@ -179,7 +179,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(3), height)
 
-		_, err = dao.putBlock(blks[1])
+		err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[1].HashBlock())
 		assert.Nil(t, err)
@@ -226,11 +226,11 @@ func TestBlockDAO(t *testing.T) {
 			assert.Nil(t, err)
 		}()
 
-		_, err = dao.putBlock(blks[0])
+		err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
-		_, err = dao.putBlock(blks[1])
+		err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
-		_, err = dao.putBlock(blks[2])
+		err = dao.putBlock(blks[2])
 
 		depositHash1 := blks[0].Actions[3].Hash()
 		depositHash2 := blks[1].Actions[3].Hash()
@@ -318,11 +318,11 @@ func TestBlockDAO(t *testing.T) {
 		}()
 
 		// Put blocks first
-		_, err = dao.putBlock(blks[0])
+		err = dao.putBlock(blks[0])
 		require.NoError(err)
-		_, err = dao.putBlock(blks[1])
+		err = dao.putBlock(blks[1])
 		require.NoError(err)
-		_, err = dao.putBlock(blks[2])
+		err = dao.putBlock(blks[2])
 		require.NoError(err)
 
 		tipHeight, err := dao.getBlockchainHeight()
@@ -390,7 +390,7 @@ func TestBlockDao_putReceipts(t *testing.T) {
 			Logs:            []*action.Log{},
 		},
 	}
-	require.NoError(t, blkDao.putReceipts(1, receipts, blkDao.kvstore))
+	require.NoError(t, blkDao.putReceipts(1, receipts))
 	for _, receipt := range receipts {
 		r, err := blkDao.getReceiptByActionHash(receipt.ActionHash)
 		require.NoError(t, err)
@@ -444,7 +444,7 @@ func BenchmarkBlockCache(b *testing.B) {
 				AddActions(actions...).
 				SignAndBuild(identityset.PrivateKey(0))
 			require.NoError(b, err)
-			_, err = blkDao.putBlock(&blk)
+			err = blkDao.putBlock(&blk)
 			require.NoError(b, err)
 			prevHash = blk.HashBlock()
 		}

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -159,7 +159,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Equal(t, uint64(0), height)
 
 		// block put order is 0 2 1
-		_, _, err = dao.putBlock(blks[0])
+		_, err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
 		blk, err := dao.getBlock(blks[0].HashBlock())
 		assert.Nil(t, err)
@@ -169,7 +169,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(1), height)
 
-		_, _, err = dao.putBlock(blks[2])
+		_, err = dao.putBlock(blks[2])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[2].HashBlock())
 		assert.Nil(t, err)
@@ -179,7 +179,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(3), height)
 
-		_, _, err = dao.putBlock(blks[1])
+		_, err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[1].HashBlock())
 		assert.Nil(t, err)
@@ -226,11 +226,11 @@ func TestBlockDAO(t *testing.T) {
 			assert.Nil(t, err)
 		}()
 
-		_, _, err = dao.putBlock(blks[0])
+		_, err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
-		_, _, err = dao.putBlock(blks[1])
+		_, err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
-		_, _, err = dao.putBlock(blks[2])
+		_, err = dao.putBlock(blks[2])
 
 		depositHash1 := blks[0].Actions[3].Hash()
 		depositHash2 := blks[1].Actions[3].Hash()
@@ -318,11 +318,11 @@ func TestBlockDAO(t *testing.T) {
 		}()
 
 		// Put blocks first
-		_, _, err = dao.putBlock(blks[0])
+		_, err = dao.putBlock(blks[0])
 		require.NoError(err)
-		_, _, err = dao.putBlock(blks[1])
+		_, err = dao.putBlock(blks[1])
 		require.NoError(err)
-		_, _, err = dao.putBlock(blks[2])
+		_, err = dao.putBlock(blks[2])
 		require.NoError(err)
 
 		tipHeight, err := dao.getBlockchainHeight()
@@ -390,7 +390,7 @@ func TestBlockDao_putReceipts(t *testing.T) {
 			Logs:            []*action.Log{},
 		},
 	}
-	require.NoError(t, blkDao.putReceipts(1, receipts, blkDao.kvstore, 0))
+	require.NoError(t, blkDao.putReceipts(1, receipts, blkDao.kvstore))
 	for _, receipt := range receipts {
 		r, err := blkDao.getReceiptByActionHash(receipt.ActionHash)
 		require.NoError(t, err)
@@ -444,7 +444,7 @@ func BenchmarkBlockCache(b *testing.B) {
 				AddActions(actions...).
 				SignAndBuild(identityset.PrivateKey(0))
 			require.NoError(b, err)
-			_, _, err = blkDao.putBlock(&blk)
+			_, err = blkDao.putBlock(&blk)
 			require.NoError(b, err)
 			prevHash = blk.HashBlock()
 		}

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -159,7 +159,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Equal(t, uint64(0), height)
 
 		// block put order is 0 2 1
-		err = dao.putBlock(blks[0])
+		_, _, err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
 		blk, err := dao.getBlock(blks[0].HashBlock())
 		assert.Nil(t, err)
@@ -169,7 +169,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(1), height)
 
-		err = dao.putBlock(blks[2])
+		_, _, err = dao.putBlock(blks[2])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[2].HashBlock())
 		assert.Nil(t, err)
@@ -179,7 +179,7 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(3), height)
 
-		err = dao.putBlock(blks[1])
+		_, _, err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
 		blk, err = dao.getBlock(blks[1].HashBlock())
 		assert.Nil(t, err)
@@ -226,11 +226,11 @@ func TestBlockDAO(t *testing.T) {
 			assert.Nil(t, err)
 		}()
 
-		err = dao.putBlock(blks[0])
+		_, _, err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
-		err = dao.putBlock(blks[1])
+		_, _, err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
-		err = dao.putBlock(blks[2])
+		_, _, err = dao.putBlock(blks[2])
 
 		depositHash1 := blks[0].Actions[3].Hash()
 		depositHash2 := blks[1].Actions[3].Hash()
@@ -318,11 +318,11 @@ func TestBlockDAO(t *testing.T) {
 		}()
 
 		// Put blocks first
-		err = dao.putBlock(blks[0])
+		_, _, err = dao.putBlock(blks[0])
 		require.NoError(err)
-		err = dao.putBlock(blks[1])
+		_, _, err = dao.putBlock(blks[1])
 		require.NoError(err)
-		err = dao.putBlock(blks[2])
+		_, _, err = dao.putBlock(blks[2])
 		require.NoError(err)
 
 		tipHeight, err := dao.getBlockchainHeight()
@@ -390,7 +390,7 @@ func TestBlockDao_putReceipts(t *testing.T) {
 			Logs:            []*action.Log{},
 		},
 	}
-	require.NoError(t, blkDao.putReceipts(1, receipts))
+	require.NoError(t, blkDao.putReceipts(1, receipts, blkDao.kvstore, 0))
 	for _, receipt := range receipts {
 		r, err := blkDao.getReceiptByActionHash(receipt.ActionHash)
 		require.NoError(t, err)
@@ -444,7 +444,8 @@ func BenchmarkBlockCache(b *testing.B) {
 				AddActions(actions...).
 				SignAndBuild(identityset.PrivateKey(0))
 			require.NoError(b, err)
-			require.NoError(b, blkDao.putBlock(&blk))
+			_, _, err = blkDao.putBlock(&blk)
+			require.NoError(b, err)
 			prevHash = blk.HashBlock()
 		}
 		b.ResetTimer()

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -146,7 +146,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testBlockDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, false, false, 0)
+		dao := newBlockDAO(kvstore, false, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -218,7 +218,7 @@ func TestBlockDAO(t *testing.T) {
 
 	testActionsDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, true, false, 0)
+		dao := newBlockDAO(kvstore, true, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
@@ -309,7 +309,7 @@ func TestBlockDAO(t *testing.T) {
 		require := require.New(t)
 
 		ctx := context.Background()
-		dao := newBlockDAO(kvstore, true, false, 0)
+		dao := newBlockDAO(kvstore, true, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
 		require.NoError(err)
 		defer func() {
@@ -371,7 +371,7 @@ func TestBlockDAO(t *testing.T) {
 }
 
 func TestBlockDao_putReceipts(t *testing.T) {
-	blkDao := newBlockDAO(db.NewMemKVStore(), true, false, 0)
+	blkDao := newBlockDAO(db.NewMemKVStore(), true, false, 0, config.Default.DB)
 	receipts := []*action.Receipt{
 		{
 			BlockHeight:     1,
@@ -414,7 +414,7 @@ func BenchmarkBlockCache(b *testing.B) {
 		}()
 		store := db.NewBoltDB(cfg)
 
-		blkDao := newBlockDAO(store, false, false, cacheSize)
+		blkDao := newBlockDAO(store, false, false, cacheSize, config.Default.DB)
 		require.NoError(b, blkDao.Start(context.Background()))
 		defer func() {
 			require.NoError(b, blkDao.Stop(context.Background()))

--- a/blocksync/buffer.go
+++ b/blocksync/buffer.go
@@ -9,8 +9,7 @@ package blocksync
 import (
 	"sync"
 
-	"github.com/iotexproject/iotex-core/db"
-
+	"github.com/iotexproject/iotex-election/db"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 

--- a/blocksync/buffer.go
+++ b/blocksync/buffer.go
@@ -9,6 +9,8 @@ package blocksync
 import (
 	"sync"
 
+	"github.com/iotexproject/iotex-core/db"
+
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -79,7 +81,7 @@ func (b *blockBuffer) Flush(blk *block.Block) (bool, bCheckinResult) {
 		}
 		delete(b.blocks, heightToSync)
 		if err := commitBlock(b.bc, b.ap, b.cs, blk); err != nil && errors.Cause(err) != blockchain.ErrInvalidTipHeight {
-			if errors.Cause(err) == poll.ErrProposedDelegatesLength || errors.Cause(err) == poll.ErrDelegatesNotAsExpected {
+			if errors.Cause(err) == poll.ErrProposedDelegatesLength || errors.Cause(err) == poll.ErrDelegatesNotAsExpected || errors.Cause(err) == db.ErrNotExist {
 				l.Debug("Failed to commit the block.", zap.Error(err), zap.Uint64("syncHeight", heightToSync))
 			} else {
 				l.Error("Failed to commit the block.", zap.Error(err), zap.Uint64("syncHeight", heightToSync))

--- a/config/config.go
+++ b/config/config.go
@@ -165,7 +165,7 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
-			SplitDBSize: 640,
+			SplitDBSizeMB: 640,
 			SplitDBHeight: 900000,
 		},
 		Genesis: genesis.Default,
@@ -318,7 +318,7 @@ type (
 		SQLITE3 SQLITE3 `yaml:"SQLITE3"`
 
 		// SplitDBSize is the config for DB's split file size
-		SplitDBSize uint64 `yaml:"splitDBSize"`
+		SplitDBSizeMB uint64 `yaml:"splitDBSizeMB"`
 
 		// SplitDBHeight is the config for DB's split start height
 		SplitDBHeight uint64 `yaml:"splitDBHeight"`
@@ -365,6 +365,11 @@ type (
 	// Validate is the interface of validating the config
 	Validate func(Config) error
 )
+
+// SplitDBSize returns the configured SplitDBSizeMB
+func (db DB) SplitDBSize() uint64 {
+	return db.SplitDBSizeMB * 1024 * 1024
+}
 
 // New creates a config instance. It first loads the default configs. If the config path is not empty, it will read from
 // the file and override the default configs. By default, it will apply all validation functions. To bypass validation,

--- a/config/config.go
+++ b/config/config.go
@@ -165,6 +165,8 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
+			SplitDBSize: 640,
+			SplitDBHeight: 900000,
 		},
 		Genesis: genesis.Default,
 		Reindex: false,
@@ -314,6 +316,12 @@ type (
 
 		// SQLite3 is the config for SQLITE3
 		SQLITE3 SQLITE3 `yaml:"SQLITE3"`
+
+		// SplitDBSize is the config for DB's split file size
+		SplitDBSize uint64 `yaml:"splitDBSize"`
+
+		// SplitDBHeight is the config for DB's split start height
+		SplitDBHeight uint64 `yaml:"splitDBHeight"`
 	}
 
 	// RDS is the cloud rds config


### PR DESCRIPTION
work on #1395

Block header,body ,footer and receipt map to different dbs according to block height,
other datas still store in default db：chain.db.
The default split size is 640M，it don't need to split db when it's 0.
The split height config means it will split to diff db since that height.

The new db's name like this:
chain-00000001.db
chain-00000002.db