### PR TITLE
deploy command args length error

### DIFF
--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -19,7 +19,7 @@ import (
 var actionDeployCmd = &cobra.Command{
 	Use:   "deploy [AMOUNT_IOTX] [-s SIGNER] -b BYTE_CODE [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
 	Short: "Deploy smart contract on IoTeX blockchain",
-	Args:  cobra.MaximumNArgs(0),
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		err := deploy(args)


### PR DESCRIPTION
The args length should be 0 or 1.