### PR TITLE
Make GetBlockMetas API only read block header. #1441

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -282,7 +282,7 @@ var (
 		blkHeight      uint64
 		numActions     int64
 		transferAmount string
-		logsBloom 	   string
+		logsBloom      string
 	}{
 		{
 			2,
@@ -872,11 +872,23 @@ func TestServer_GetBlockMeta(t *testing.T) {
 		require.NoError(err)
 		require.Equal(1, len(res.BlkMetas))
 		blkPb := res.BlkMetas[0]
+		require.Equal(test.blkHeight, blkPb.Height)
 		require.Equal(test.numActions, blkPb.NumActions)
 		require.Equal(test.transferAmount, blkPb.TransferAmount)
 		require.Equal(header.LogsBloomfilter(), nil)
 		require.Equal(test.logsBloom, blkPb.LogsBloom)
 	}
+}
+
+func TestServer_GetBlockMetaUpgrade(t *testing.T) {
+	require := require.New(t)
+	cfg := newConfig()
+
+	svr, err := createServer(cfg, false)
+	require.NoError(err)
+
+	err = svr.getBlockMetaUpgrade(1000)
+	require.Equal(action.ErrNotFound, errors.Cause(err))
 }
 
 func TestServer_GetChainMeta(t *testing.T) {

--- a/blockchain/block/body.go
+++ b/blockchain/block/body.go
@@ -7,6 +7,8 @@
 package block
 
 import (
+	"math/big"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
@@ -62,4 +64,9 @@ func (b *Body) Deserialize(buf []byte) error {
 // CalculateTxRoot returns the Merkle root of all txs and actions in this block.
 func (b *Body) CalculateTxRoot() hash.Hash256 {
 	return calculateTxRoot(b.Actions)
+}
+
+// CalculateTransferAmount returns the calculated transfer amount in this block.
+func (b *Body) CalculateTransferAmount() *big.Int {
+	return calculateTransferAmount(b.Actions)
 }

--- a/blockchain/block/body_test.go
+++ b/blockchain/block/body_test.go
@@ -75,16 +75,34 @@ func TestCalculateTxRoot(t *testing.T) {
 	require.NotEqual(h, hash.ZeroHash256)
 }
 
+func TestCalculateTransferAmount(t *testing.T) {
+	require := require.New(t)
+	body := Body{}
+	i := body.CalculateTransferAmount()
+	require.Equal(i, big.NewInt(0))
+
+	body, err := makeBody()
+	require.NoError(err)
+	i = body.CalculateTransferAmount()
+	require.NotEqual(i, big.NewInt(0))
+	require.Equal(i, big.NewInt(20))
+}
+
 func makeBody() (body Body, err error) {
 	A := make([]action.SealedEnvelope, 0)
 	v, err := action.NewExecution("", 0, big.NewInt(10), uint64(10), big.NewInt(10), []byte("data"))
 	if err != nil {
 		return
 	}
+	t, err := action.NewTransfer(0, big.NewInt(20), "", []byte("payload"), uint64(20), big.NewInt(20))
+	if err != nil {
+		return
+	}
 	bd := &action.EnvelopeBuilder{}
 	elp := bd.SetGasPrice(big.NewInt(10)).
 		SetGasLimit(uint64(100000)).
-		SetAction(v).Build()
+		SetAction(v).
+		SetAction(t).Build()
 
 	selp, err := action.Sign(elp, identityset.PrivateKey(28))
 	if err != nil {

--- a/blockchain/block/utils.go
+++ b/blockchain/block/utils.go
@@ -7,6 +7,8 @@
 package block
 
 import (
+	"math/big"
+
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/crypto"
@@ -21,4 +23,17 @@ func calculateTxRoot(acts []action.SealedEnvelope) hash.Hash256 {
 		return hash.ZeroHash256
 	}
 	return crypto.NewMerkleTree(h).HashTree()
+}
+
+// calculateTransferAmount returns the calculated transfer amount
+func calculateTransferAmount(acts []action.SealedEnvelope) *big.Int {
+	transferAmount := big.NewInt(0)
+	for _, act := range acts {
+		transfer, ok := act.Action().(*action.Transfer)
+		if !ok {
+			continue
+		}
+		transferAmount.Add(transferAmount, transfer.Amount())
+	}
+	return transferAmount
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -96,6 +96,10 @@ type Blockchain interface {
 	BlockFooterByHash(h hash.Hash256) (*block.Footer, error)
 	// GetTotalActions returns the total number of actions
 	GetTotalActions() (uint64, error)
+	// GetNumActions returns the number of actions
+	GetNumActions(height uint64) (uint64, error)
+	// GetTranferAmount returns the transfer amount
+	GetTranferAmount(height uint64) (*big.Int, error)
 	// GetReceiptByActionHash returns the receipt by action hash
 	GetReceiptByActionHash(h hash.Hash256) (*action.Receipt, error)
 	// GetActionsFromAddress returns actions from address
@@ -488,6 +492,16 @@ func (bc *blockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error) {
 // GetTotalActions returns the total number of actions
 func (bc *blockchain) GetTotalActions() (uint64, error) {
 	return bc.dao.getTotalActions()
+}
+
+// GetNumActions returns the number of actions
+func (bc *blockchain) GetNumActions(height uint64) (uint64, error) {
+	return bc.dao.getNumActions(height)
+}
+
+// GetTranferAmount returns the transfer amount
+func (bc *blockchain) GetTranferAmount(height uint64) (*big.Int, error) {
+	return bc.dao.getTranferAmount(height)
 }
 
 // GetReceiptByActionHash returns the receipt by action hash

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -240,6 +240,29 @@ func TestBlockDAO(t *testing.T) {
 		blkHash2 := blks[1].HashBlock()
 		blkHash3 := blks[2].HashBlock()
 
+		blkActions1 := blks[0].Actions
+		blkActions2 := blks[1].Actions
+		blkActions3 := blks[2].Actions
+
+		blkNumActions1 := uint64(len(blkActions1))
+		blkNumActions2 := uint64(len(blkActions2))
+		blkNumActions3 := uint64(len(blkActions3))
+
+		blkTransferAmount1, blkTransferAmount2, blkTransferAmount3 := big.NewInt(0), big.NewInt(0), big.NewInt(0)
+
+		tsfs, _ := action.ClassifyActions(blkActions1)
+		for _, tsf := range tsfs {
+			blkTransferAmount1.Add(blkTransferAmount1, tsf.Amount())
+		}
+		tsfs, _ = action.ClassifyActions(blkActions2)
+		for _, tsf := range tsfs {
+			blkTransferAmount2.Add(blkTransferAmount2, tsf.Amount())
+		}
+		tsfs, _ = action.ClassifyActions(blkActions3)
+		for _, tsf := range tsfs {
+			blkTransferAmount3.Add(blkTransferAmount3, tsf.Amount())
+		}
+
 		// Test getBlockHashByActionHash
 		blkHash, err := getBlockHashByActionHash(dao.kvstore, depositHash1)
 		require.NoError(t, err)
@@ -303,6 +326,28 @@ func TestBlockDAO(t *testing.T) {
 		require.Equal(t, depositHash1, recipientActions[1])
 		require.Equal(t, depositHash2, recipientActions[3])
 		require.Equal(t, depositHash3, recipientActions[5])
+
+		// test getNumActions
+		numActions, err := dao.getNumActions(blks[0].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkNumActions1, numActions)
+		numActions, err = dao.getNumActions(blks[1].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkNumActions2, numActions)
+		numActions, err = dao.getNumActions(blks[2].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkNumActions3, numActions)
+
+		// test getTranferAmount
+		transferAmount, err := dao.getTranferAmount(blks[0].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkTransferAmount1, transferAmount)
+		transferAmount, err = dao.getTranferAmount(blks[1].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkTransferAmount2, transferAmount)
+		transferAmount, err = dao.getTranferAmount(blks[2].Height())
+		require.NoError(t, err)
+		require.Equal(t, blkTransferAmount3, transferAmount)
 	}
 
 	testDeleteDao := func(kvstore db.KVStore, t *testing.T) {

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -44,6 +44,7 @@ func (m *MockBlockchain) EXPECT() *MockBlockchainMockRecorder {
 
 // Start mocks base method
 func (m *MockBlockchain) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -51,11 +52,13 @@ func (m *MockBlockchain) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockBlockchainMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockBlockchain)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockBlockchain) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -63,11 +66,13 @@ func (m *MockBlockchain) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockBlockchainMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockchain)(nil).Stop), arg0)
 }
 
 // Balance mocks base method
 func (m *MockBlockchain) Balance(addr string) (*big.Int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance", addr)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
@@ -76,11 +81,13 @@ func (m *MockBlockchain) Balance(addr string) (*big.Int, error) {
 
 // Balance indicates an expected call of Balance
 func (mr *MockBlockchainMockRecorder) Balance(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Balance", reflect.TypeOf((*MockBlockchain)(nil).Balance), addr)
 }
 
 // Nonce mocks base method
 func (m *MockBlockchain) Nonce(addr string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce", addr)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -89,11 +96,13 @@ func (m *MockBlockchain) Nonce(addr string) (uint64, error) {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockBlockchainMockRecorder) Nonce(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockBlockchain)(nil).Nonce), addr)
 }
 
 // CreateState mocks base method
 func (m *MockBlockchain) CreateState(addr string, init *big.Int) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateState", addr, init)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -102,11 +111,13 @@ func (m *MockBlockchain) CreateState(addr string, init *big.Int) (*state.Account
 
 // CreateState indicates an expected call of CreateState
 func (mr *MockBlockchainMockRecorder) CreateState(addr, init interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateState", reflect.TypeOf((*MockBlockchain)(nil).CreateState), addr, init)
 }
 
 // CandidatesByHeight mocks base method
 func (m *MockBlockchain) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CandidatesByHeight", height)
 	ret0, _ := ret[0].([]*state.Candidate)
 	ret1, _ := ret[1].(error)
@@ -115,11 +126,13 @@ func (m *MockBlockchain) CandidatesByHeight(height uint64) ([]*state.Candidate, 
 
 // CandidatesByHeight indicates an expected call of CandidatesByHeight
 func (mr *MockBlockchainMockRecorder) CandidatesByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockBlockchain)(nil).CandidatesByHeight), height)
 }
 
 // ProductivityByEpoch mocks base method
 func (m *MockBlockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProductivityByEpoch", epochNum)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(map[string]uint64)
@@ -129,11 +142,13 @@ func (m *MockBlockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[strin
 
 // ProductivityByEpoch indicates an expected call of ProductivityByEpoch
 func (mr *MockBlockchainMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockBlockchain)(nil).ProductivityByEpoch), epochNum)
 }
 
 // GetHeightByHash mocks base method
 func (m *MockBlockchain) GetHeightByHash(h hash.Hash256) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeightByHash", h)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -142,11 +157,13 @@ func (m *MockBlockchain) GetHeightByHash(h hash.Hash256) (uint64, error) {
 
 // GetHeightByHash indicates an expected call of GetHeightByHash
 func (mr *MockBlockchainMockRecorder) GetHeightByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeightByHash", reflect.TypeOf((*MockBlockchain)(nil).GetHeightByHash), h)
 }
 
 // GetHashByHeight mocks base method
 func (m *MockBlockchain) GetHashByHeight(height uint64) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHashByHeight", height)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -155,11 +172,13 @@ func (m *MockBlockchain) GetHashByHeight(height uint64) (hash.Hash256, error) {
 
 // GetHashByHeight indicates an expected call of GetHashByHeight
 func (mr *MockBlockchainMockRecorder) GetHashByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHashByHeight", reflect.TypeOf((*MockBlockchain)(nil).GetHashByHeight), height)
 }
 
 // GetBlockByHeight mocks base method
 func (m *MockBlockchain) GetBlockByHeight(height uint64) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockByHeight", height)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -168,11 +187,13 @@ func (m *MockBlockchain) GetBlockByHeight(height uint64) (*block.Block, error) {
 
 // GetBlockByHeight indicates an expected call of GetBlockByHeight
 func (mr *MockBlockchainMockRecorder) GetBlockByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockBlockchain)(nil).GetBlockByHeight), height)
 }
 
 // GetBlockByHash mocks base method
 func (m *MockBlockchain) GetBlockByHash(h hash.Hash256) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockByHash", h)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -181,11 +202,13 @@ func (m *MockBlockchain) GetBlockByHash(h hash.Hash256) (*block.Block, error) {
 
 // GetBlockByHash indicates an expected call of GetBlockByHash
 func (mr *MockBlockchainMockRecorder) GetBlockByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHash", reflect.TypeOf((*MockBlockchain)(nil).GetBlockByHash), h)
 }
 
 // BlockHeaderByHeight mocks base method
 func (m *MockBlockchain) BlockHeaderByHeight(height uint64) (*block.Header, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockHeaderByHeight", height)
 	ret0, _ := ret[0].(*block.Header)
 	ret1, _ := ret[1].(error)
@@ -194,11 +217,13 @@ func (m *MockBlockchain) BlockHeaderByHeight(height uint64) (*block.Header, erro
 
 // BlockHeaderByHeight indicates an expected call of BlockHeaderByHeight
 func (mr *MockBlockchainMockRecorder) BlockHeaderByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHeight), height)
 }
 
 // BlockHeaderByHash mocks base method
 func (m *MockBlockchain) BlockHeaderByHash(h hash.Hash256) (*block.Header, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockHeaderByHash", h)
 	ret0, _ := ret[0].(*block.Header)
 	ret1, _ := ret[1].(error)
@@ -207,11 +232,13 @@ func (m *MockBlockchain) BlockHeaderByHash(h hash.Hash256) (*block.Header, error
 
 // BlockHeaderByHash indicates an expected call of BlockHeaderByHash
 func (mr *MockBlockchainMockRecorder) BlockHeaderByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHash), h)
 }
 
 // BlockFooterByHeight mocks base method
 func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockFooterByHeight", height)
 	ret0, _ := ret[0].(*block.Footer)
 	ret1, _ := ret[1].(error)
@@ -220,11 +247,13 @@ func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, erro
 
 // BlockFooterByHeight indicates an expected call of BlockFooterByHeight
 func (mr *MockBlockchainMockRecorder) BlockFooterByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHeight), height)
 }
 
 // BlockFooterByHash mocks base method
 func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockFooterByHash", h)
 	ret0, _ := ret[0].(*block.Footer)
 	ret1, _ := ret[1].(error)
@@ -233,11 +262,13 @@ func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error
 
 // BlockFooterByHash indicates an expected call of BlockFooterByHash
 func (mr *MockBlockchainMockRecorder) BlockFooterByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHash), h)
 }
 
 // GetTotalActions mocks base method
 func (m *MockBlockchain) GetTotalActions() (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetTotalActions")
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -246,11 +277,57 @@ func (m *MockBlockchain) GetTotalActions() (uint64, error) {
 
 // GetTotalActions indicates an expected call of GetTotalActions
 func (mr *MockBlockchainMockRecorder) GetTotalActions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTotalActions", reflect.TypeOf((*MockBlockchain)(nil).GetTotalActions))
+}
+
+// GetNumActions mocks base method
+func (m *MockBlockchain) GetNumActions(height uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNumActions", height)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetNumActions indicates an expected call of GetNumActions
+func (mr *MockBlockchainMockRecorder) GetNumActions(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumActions", reflect.TypeOf((*MockBlockchain)(nil).GetNumActions), height)
+}
+
+// GetTranferAmount mocks base method
+func (m *MockBlockchain) GetTranferAmount(height uint64) (*big.Int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTranferAmount", height)
+	ret0, _ := ret[0].(*big.Int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTranferAmount indicates an expected call of GetTranferAmount
+func (mr *MockBlockchainMockRecorder) GetTranferAmount(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTranferAmount", reflect.TypeOf((*MockBlockchain)(nil).GetTranferAmount), height)
+}
+
+// CalculateTransferAmount mocks base method
+func (m *MockBlockchain) CalculateTransferAmount(blkActions []action.SealedEnvelope) *big.Int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CalculateTransferAmount", blkActions)
+	ret0, _ := ret[0].(*big.Int)
+	return ret0
+}
+
+// CalculateTransferAmount indicates an expected call of CalculateTransferAmount
+func (mr *MockBlockchainMockRecorder) CalculateTransferAmount(blkActions interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CalculateTransferAmount", reflect.TypeOf((*MockBlockchain)(nil).CalculateTransferAmount), blkActions)
 }
 
 // GetReceiptByActionHash mocks base method
 func (m *MockBlockchain) GetReceiptByActionHash(h hash.Hash256) (*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReceiptByActionHash", h)
 	ret0, _ := ret[0].(*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -259,11 +336,13 @@ func (m *MockBlockchain) GetReceiptByActionHash(h hash.Hash256) (*action.Receipt
 
 // GetReceiptByActionHash indicates an expected call of GetReceiptByActionHash
 func (mr *MockBlockchainMockRecorder) GetReceiptByActionHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptByActionHash", reflect.TypeOf((*MockBlockchain)(nil).GetReceiptByActionHash), h)
 }
 
 // GetActionsFromAddress mocks base method
 func (m *MockBlockchain) GetActionsFromAddress(address string) ([]hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionsFromAddress", address)
 	ret0, _ := ret[0].([]hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -272,11 +351,13 @@ func (m *MockBlockchain) GetActionsFromAddress(address string) ([]hash.Hash256, 
 
 // GetActionsFromAddress indicates an expected call of GetActionsFromAddress
 func (mr *MockBlockchainMockRecorder) GetActionsFromAddress(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsFromAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionsFromAddress), address)
 }
 
 // GetActionsToAddress mocks base method
 func (m *MockBlockchain) GetActionsToAddress(address string) ([]hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionsToAddress", address)
 	ret0, _ := ret[0].([]hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -285,11 +366,13 @@ func (m *MockBlockchain) GetActionsToAddress(address string) ([]hash.Hash256, er
 
 // GetActionsToAddress indicates an expected call of GetActionsToAddress
 func (mr *MockBlockchainMockRecorder) GetActionsToAddress(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsToAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionsToAddress), address)
 }
 
 // GetActionCountByAddress mocks base method
 func (m *MockBlockchain) GetActionCountByAddress(address string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionCountByAddress", address)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -298,11 +381,13 @@ func (m *MockBlockchain) GetActionCountByAddress(address string) (uint64, error)
 
 // GetActionCountByAddress indicates an expected call of GetActionCountByAddress
 func (mr *MockBlockchainMockRecorder) GetActionCountByAddress(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionCountByAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionCountByAddress), address)
 }
 
 // GetActionByActionHash mocks base method
 func (m *MockBlockchain) GetActionByActionHash(h hash.Hash256) (action.SealedEnvelope, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionByActionHash", h)
 	ret0, _ := ret[0].(action.SealedEnvelope)
 	ret1, _ := ret[1].(error)
@@ -311,11 +396,13 @@ func (m *MockBlockchain) GetActionByActionHash(h hash.Hash256) (action.SealedEnv
 
 // GetActionByActionHash indicates an expected call of GetActionByActionHash
 func (mr *MockBlockchainMockRecorder) GetActionByActionHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionByActionHash", reflect.TypeOf((*MockBlockchain)(nil).GetActionByActionHash), h)
 }
 
 // GetBlockHashByActionHash mocks base method
 func (m *MockBlockchain) GetBlockHashByActionHash(h hash.Hash256) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockHashByActionHash", h)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -324,11 +411,13 @@ func (m *MockBlockchain) GetBlockHashByActionHash(h hash.Hash256) (hash.Hash256,
 
 // GetBlockHashByActionHash indicates an expected call of GetBlockHashByActionHash
 func (mr *MockBlockchainMockRecorder) GetBlockHashByActionHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockHashByActionHash", reflect.TypeOf((*MockBlockchain)(nil).GetBlockHashByActionHash), h)
 }
 
 // GetReceiptsByHeight mocks base method
 func (m *MockBlockchain) GetReceiptsByHeight(height uint64) ([]*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReceiptsByHeight", height)
 	ret0, _ := ret[0].([]*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -337,11 +426,13 @@ func (m *MockBlockchain) GetReceiptsByHeight(height uint64) ([]*action.Receipt, 
 
 // GetReceiptsByHeight indicates an expected call of GetReceiptsByHeight
 func (mr *MockBlockchainMockRecorder) GetReceiptsByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptsByHeight", reflect.TypeOf((*MockBlockchain)(nil).GetReceiptsByHeight), height)
 }
 
 // GetFactory mocks base method
 func (m *MockBlockchain) GetFactory() factory.Factory {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFactory")
 	ret0, _ := ret[0].(factory.Factory)
 	return ret0
@@ -349,11 +440,13 @@ func (m *MockBlockchain) GetFactory() factory.Factory {
 
 // GetFactory indicates an expected call of GetFactory
 func (mr *MockBlockchainMockRecorder) GetFactory() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFactory", reflect.TypeOf((*MockBlockchain)(nil).GetFactory))
 }
 
 // ChainID mocks base method
 func (m *MockBlockchain) ChainID() uint32 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainID")
 	ret0, _ := ret[0].(uint32)
 	return ret0
@@ -361,11 +454,13 @@ func (m *MockBlockchain) ChainID() uint32 {
 
 // ChainID indicates an expected call of ChainID
 func (mr *MockBlockchainMockRecorder) ChainID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockBlockchain)(nil).ChainID))
 }
 
 // ChainAddress mocks base method
 func (m *MockBlockchain) ChainAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -373,11 +468,13 @@ func (m *MockBlockchain) ChainAddress() string {
 
 // ChainAddress indicates an expected call of ChainAddress
 func (mr *MockBlockchainMockRecorder) ChainAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainAddress", reflect.TypeOf((*MockBlockchain)(nil).ChainAddress))
 }
 
 // TipHash mocks base method
 func (m *MockBlockchain) TipHash() hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TipHash")
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -385,11 +482,13 @@ func (m *MockBlockchain) TipHash() hash.Hash256 {
 
 // TipHash indicates an expected call of TipHash
 func (mr *MockBlockchainMockRecorder) TipHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipHash", reflect.TypeOf((*MockBlockchain)(nil).TipHash))
 }
 
 // TipHeight mocks base method
 func (m *MockBlockchain) TipHeight() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TipHeight")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -397,11 +496,13 @@ func (m *MockBlockchain) TipHeight() uint64 {
 
 // TipHeight indicates an expected call of TipHeight
 func (mr *MockBlockchainMockRecorder) TipHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipHeight", reflect.TypeOf((*MockBlockchain)(nil).TipHeight))
 }
 
 // StateByAddr mocks base method
 func (m *MockBlockchain) StateByAddr(address string) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateByAddr", address)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -410,11 +511,13 @@ func (m *MockBlockchain) StateByAddr(address string) (*state.Account, error) {
 
 // StateByAddr indicates an expected call of StateByAddr
 func (mr *MockBlockchainMockRecorder) StateByAddr(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateByAddr", reflect.TypeOf((*MockBlockchain)(nil).StateByAddr), address)
 }
 
 // RecoverChainAndState mocks base method
 func (m *MockBlockchain) RecoverChainAndState(targetHeight uint64) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecoverChainAndState", targetHeight)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -422,11 +525,13 @@ func (m *MockBlockchain) RecoverChainAndState(targetHeight uint64) error {
 
 // RecoverChainAndState indicates an expected call of RecoverChainAndState
 func (mr *MockBlockchainMockRecorder) RecoverChainAndState(targetHeight interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverChainAndState", reflect.TypeOf((*MockBlockchain)(nil).RecoverChainAndState), targetHeight)
 }
 
 // GenesisTimestamp mocks base method
 func (m *MockBlockchain) GenesisTimestamp() int64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenesisTimestamp")
 	ret0, _ := ret[0].(int64)
 	return ret0
@@ -434,11 +539,13 @@ func (m *MockBlockchain) GenesisTimestamp() int64 {
 
 // GenesisTimestamp indicates an expected call of GenesisTimestamp
 func (mr *MockBlockchainMockRecorder) GenesisTimestamp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenesisTimestamp", reflect.TypeOf((*MockBlockchain)(nil).GenesisTimestamp))
 }
 
 // MintNewBlock mocks base method
 func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, timestamp time.Time) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, timestamp)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -447,11 +554,13 @@ func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelo
 
 // MintNewBlock indicates an expected call of MintNewBlock
 func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, timestamp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, timestamp)
 }
 
 // CommitBlock mocks base method
 func (m *MockBlockchain) CommitBlock(blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitBlock", blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -459,11 +568,13 @@ func (m *MockBlockchain) CommitBlock(blk *block.Block) error {
 
 // CommitBlock indicates an expected call of CommitBlock
 func (mr *MockBlockchainMockRecorder) CommitBlock(blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitBlock", reflect.TypeOf((*MockBlockchain)(nil).CommitBlock), blk)
 }
 
 // ValidateBlock mocks base method
 func (m *MockBlockchain) ValidateBlock(blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateBlock", blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -471,11 +582,13 @@ func (m *MockBlockchain) ValidateBlock(blk *block.Block) error {
 
 // ValidateBlock indicates an expected call of ValidateBlock
 func (mr *MockBlockchainMockRecorder) ValidateBlock(blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateBlock", reflect.TypeOf((*MockBlockchain)(nil).ValidateBlock), blk)
 }
 
 // Validator mocks base method
 func (m *MockBlockchain) Validator() blockchain.Validator {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validator")
 	ret0, _ := ret[0].(blockchain.Validator)
 	return ret0
@@ -483,21 +596,25 @@ func (m *MockBlockchain) Validator() blockchain.Validator {
 
 // Validator indicates an expected call of Validator
 func (mr *MockBlockchainMockRecorder) Validator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validator", reflect.TypeOf((*MockBlockchain)(nil).Validator))
 }
 
 // SetValidator mocks base method
 func (m *MockBlockchain) SetValidator(val blockchain.Validator) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValidator", val)
 }
 
 // SetValidator indicates an expected call of SetValidator
 func (mr *MockBlockchainMockRecorder) SetValidator(val interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidator", reflect.TypeOf((*MockBlockchain)(nil).SetValidator), val)
 }
 
 // ExecuteContractRead mocks base method
 func (m *MockBlockchain) ExecuteContractRead(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteContractRead", caller, ex)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(*action.Receipt)
@@ -507,11 +624,13 @@ func (m *MockBlockchain) ExecuteContractRead(caller address.Address, ex *action.
 
 // ExecuteContractRead indicates an expected call of ExecuteContractRead
 func (mr *MockBlockchainMockRecorder) ExecuteContractRead(caller, ex interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteContractRead", reflect.TypeOf((*MockBlockchain)(nil).ExecuteContractRead), caller, ex)
 }
 
 // AddSubscriber mocks base method
 func (m *MockBlockchain) AddSubscriber(arg0 blockchain.BlockCreationSubscriber) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSubscriber", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -519,11 +638,13 @@ func (m *MockBlockchain) AddSubscriber(arg0 blockchain.BlockCreationSubscriber) 
 
 // AddSubscriber indicates an expected call of AddSubscriber
 func (mr *MockBlockchainMockRecorder) AddSubscriber(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSubscriber", reflect.TypeOf((*MockBlockchain)(nil).AddSubscriber), arg0)
 }
 
 // RemoveSubscriber mocks base method
 func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscriber) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSubscriber", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -531,11 +652,13 @@ func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscribe
 
 // RemoveSubscriber indicates an expected call of RemoveSubscriber
 func (mr *MockBlockchainMockRecorder) RemoveSubscriber(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubscriber", reflect.TypeOf((*MockBlockchain)(nil).RemoveSubscriber), arg0)
 }
 
 // GetActionHashFromIndex mocks base method
 func (m *MockBlockchain) GetActionHashFromIndex(index uint64) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionHashFromIndex", index)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -544,5 +667,6 @@ func (m *MockBlockchain) GetActionHashFromIndex(index uint64) (hash.Hash256, err
 
 // GetActionHashFromIndex indicates an expected call of GetActionHashFromIndex
 func (mr *MockBlockchainMockRecorder) GetActionHashFromIndex(index interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionHashFromIndex", reflect.TypeOf((*MockBlockchain)(nil).GetActionHashFromIndex), index)
 }


### PR DESCRIPTION
Related to issue #1441.
From my understanding, the number of all transactions are even with the block height.
