### PR TITLE
changed getLogsInBlock

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1145,7 +1145,7 @@ func (api *Server) getLogsInBlock(filter *LogFilter, start, count uint64) ([]*io
 		if err != nil {
 			return logs, status.Error(codes.InvalidArgument, err.Error())
 		}
-		logs = append(logs, filter.MatchBlock(receipts)...)
+		logs = append(logs, filter.MatchLogs(receipts)...)
 	}
 	return logs, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -1141,16 +1141,11 @@ func (api *Server) getLogsInBlock(filter *LogFilter, start, count uint64) ([]*io
 		end = api.bc.TipHeight()
 	}
 	for i := start; i <= end; i++ {
-		blk, err := api.bc.GetBlockByHeight(i)
-		if err != nil {
-			return logs, status.Error(codes.InvalidArgument, err.Error())
-		}
 		receipts, err := api.bc.GetReceiptsByHeight(i)
 		if err != nil {
 			return logs, status.Error(codes.InvalidArgument, err.Error())
 		}
-		blk.Receipts = receipts
-		logs = append(logs, filter.MatchBlock(blk)...)
+		logs = append(logs, filter.MatchBlock(receipts)...)
 	}
 	return logs, nil
 }

--- a/api/api.go
+++ b/api/api.go
@@ -1145,6 +1145,11 @@ func (api *Server) getLogsInBlock(filter *LogFilter, start, count uint64) ([]*io
 		if err != nil {
 			return logs, status.Error(codes.InvalidArgument, err.Error())
 		}
+		receipts, err := api.bc.GetReceiptsByHeight(i)
+		if err != nil {
+			return logs, status.Error(codes.InvalidArgument, err.Error())
+		}
+		blk.Receipts = receipts
 		logs = append(logs, filter.MatchBlock(blk)...)
 	}
 	return logs, nil

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -615,6 +615,24 @@ var (
 			9,
 		},
 	}
+
+	getLogsTest = []struct {
+		// Arguments
+		address   []string
+		topics    []*iotexapi.Topics
+		fromBlock uint64
+		count     uint64
+		// Expected Values
+		numLogs int
+	}{
+		{
+			address:   []string{},
+			topics:    []*iotexapi.Topics{},
+			fromBlock: 1,
+			count:     100,
+			numLogs:   0,
+		},
+	}
 )
 
 func TestServer_GetAccount(t *testing.T) {
@@ -1394,6 +1412,33 @@ func TestServer_GetRawBlocks(t *testing.T) {
 		}
 		require.Equal(test.numActions, numActions)
 		require.Equal(test.numReceipts, numReceipts)
+	}
+}
+
+func TestServer_GetLogs(t *testing.T) {
+	require := require.New(t)
+	cfg := newConfig()
+
+	svr, err := createServer(cfg, false)
+	require.NoError(err)
+
+	for _, test := range getLogsTest {
+		request := &iotexapi.GetLogsRequest{
+			Filter: &iotexapi.LogsFilter{
+				Address: test.address,
+				Topics:  test.topics,
+			},
+			Lookup: &iotexapi.GetLogsRequest_ByRange{
+				ByRange: &iotexapi.GetLogsByRange{
+					FromBlock: test.fromBlock,
+					Count:     test.count,
+				},
+			},
+		}
+		res, err := svr.GetLogs(context.Background(), request)
+		require.NoError(err)
+		logs := res.Logs
+		require.Equal(test.numLogs, len(logs))
 	}
 }
 

--- a/api/logfilter.go
+++ b/api/logfilter.go
@@ -41,7 +41,7 @@ func NewLogFilter(in *iotexapi.LogsFilter, stream iotexapi.APIService_StreamLogs
 
 // Respond to new block
 func (l *LogFilter) Respond(blk *block.Block) error {
-	logs := l.MatchBlock(blk.Receipts)
+	logs := l.MatchLogs(blk.Receipts)
 	if len(logs) == 0 {
 		return nil
 	}
@@ -63,8 +63,8 @@ func (l *LogFilter) Exit() {
 	l.errChan <- nil
 }
 
-// MatchBlock returns matching logs in a given block
-func (l *LogFilter) MatchBlock(receipts []*action.Receipt) []*iotextypes.Log {
+// MatchLogs returns matching logs in a given block
+func (l *LogFilter) MatchLogs(receipts []*action.Receipt) []*iotextypes.Log {
 	var logs []*iotextypes.Log
 	for _, r := range receipts {
 		for _, v := range r.Logs {

--- a/api/logfilter.go
+++ b/api/logfilter.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/pkg/log"
 )
@@ -40,7 +41,7 @@ func NewLogFilter(in *iotexapi.LogsFilter, stream iotexapi.APIService_StreamLogs
 
 // Respond to new block
 func (l *LogFilter) Respond(blk *block.Block) error {
-	logs := l.MatchBlock(blk)
+	logs := l.MatchBlock(blk.Receipts)
 	if len(logs) == 0 {
 		return nil
 	}
@@ -63,9 +64,9 @@ func (l *LogFilter) Exit() {
 }
 
 // MatchBlock returns matching logs in a given block
-func (l *LogFilter) MatchBlock(blk *block.Block) []*iotextypes.Log {
+func (l *LogFilter) MatchBlock(receipts []*action.Receipt) []*iotextypes.Log {
 	var logs []*iotextypes.Log
-	for _, r := range blk.Receipts {
+	for _, r := range receipts {
 		for _, v := range r.Logs {
 			log := v.ConvertToLogPb()
 			if l.match(log) {


### PR DESCRIPTION
works on #1447 
The problem of this issue is not because of filtering logic, but that the receipt field in block struct was empty. 
So I changed getLogsInBlock() to get a receipt by height and put it into the block struct.
But in the test file, the length of logs is still 0 because the block's tipheight is just around 4. 