### PR TITLE
Fix precommit status

### DIFF
--- a/consensus/consensusfsm/context.go
+++ b/consensus/consensusfsm/context.go
@@ -32,7 +32,7 @@ type Context interface {
 	Prepare() error
 	IsDelegate() bool
 	Proposal() (interface{}, error)
-	WaitUntil() time.Duration
+	WaitUntilRoundStart() time.Duration
 	PreCommitEndorsement() interface{}
 	NewProposalEndorsement(interface{}) (interface{}, error)
 	NewLockEndorsement(interface{}) (interface{}, error)

--- a/consensus/consensusfsm/context.go
+++ b/consensus/consensusfsm/context.go
@@ -29,7 +29,11 @@ type Context interface {
 
 	Broadcast(interface{})
 
-	Prepare() (bool, interface{}, bool, bool, interface{}, time.Duration, error)
+	Prepare() error
+	IsDelegate() bool
+	Proposal() (interface{}, error)
+	WaitUntil() time.Duration
+	PreCommitEndorsement() interface{}
 	NewProposalEndorsement(interface{}) (interface{}, error)
 	NewLockEndorsement(interface{}) (interface{}, error)
 	NewPreCommitEndorsement(interface{}) (interface{}, error)

--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -406,7 +406,7 @@ func (m *ConsensusFSM) prepare(_ fsm.Event) (fsm.State, error) {
 		return m.BackToPrepare(0)
 	}
 	m.ctx.Logger().Info("Start a new round")
-	overtime := m.ctx.WaitUntil()
+	overtime := m.ctx.WaitUntilRoundStart()
 	if proposal != nil {
 		m.ctx.Broadcast(proposal)
 		m.ProduceReceiveBlockEvent(proposal)
@@ -433,6 +433,8 @@ func (m *ConsensusFSM) prepare(_ fsm.Event) (fsm.State, error) {
 	m.produceConsensusEvent(eStopReceivingProposalEndorsement, ttl)
 	ttl += m.cfg.AcceptLockEndorsementTTL
 	m.produceConsensusEvent(eStopReceivingLockEndorsement, ttl)
+	ttl += m.cfg.CommitTTL
+	m.produceConsensusEvent(eStopReceivingPreCommitEndorsement, ttl)
 
 	return sAcceptBlockProposal, nil
 }

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -30,7 +30,7 @@ func TestBackdoorEvt(t *testing.T) {
 	mockCtx.EXPECT().IsFutureEvent(gomock.Any()).Return(false).AnyTimes()
 	mockCtx.EXPECT().IsStaleEvent(gomock.Any()).Return(false).AnyTimes()
 	mockCtx.EXPECT().Logger().Return(log.Logger("consensus")).AnyTimes()
-	mockCtx.EXPECT().Prepare().Return(true, nil, true, false, nil, time.Duration(0), nil).AnyTimes()
+	mockCtx.EXPECT().Prepare().Return(nil).AnyTimes()
 	mockCtx.EXPECT().NewConsensusEvent(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(eventType fsm.EventType, data interface{}) *ConsensusEvent {
 			return &ConsensusEvent{
@@ -91,7 +91,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 
 	t.Run("prepare", func(t *testing.T) {
 		t.Run("with-error", func(t *testing.T) {
-			mockCtx.EXPECT().Prepare().Return(true, nil, false, false, nil, 10*time.Second, errors.New("some error")).Times(1)
+			mockCtx.EXPECT().Prepare().Return(errors.New("some error")).Times(1)
 			state, err := cfsm.prepare(nil)
 			require.NoError(err)
 			require.Equal(sPrepare, state)
@@ -101,7 +101,8 @@ func TestStateTransitionFunctions(t *testing.T) {
 			require.Equal(ePrepare, evt.Type())
 		})
 		t.Run("stand-by-or-is-not-delegate", func(t *testing.T) {
-			mockCtx.EXPECT().Prepare().Return(false, nil, false, false, nil, 10*time.Second, nil).Times(1)
+			mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+			mockCtx.EXPECT().IsDelegate().Return(false).Times(1)
 			state, err := cfsm.prepare(nil)
 			require.NoError(err)
 			require.Equal(sPrepare, state)
@@ -111,20 +112,20 @@ func TestStateTransitionFunctions(t *testing.T) {
 			require.Equal(ePrepare, evt.Type())
 		})
 		t.Run("is-delegate", func(t *testing.T) {
-			t.Run("is-locked", func(t *testing.T) {
-				lockedProposal := NewMockEndorsement(ctrl)
+			mockCtx.EXPECT().IsDelegate().Return(true).AnyTimes()
+			t.Run("not-a-proposer", func(t *testing.T) {
 				t.Run("not-ready-to-commit", func(t *testing.T) {
-					mockCtx.EXPECT().Prepare().Return(true, lockedProposal, false, true, nil, time.Duration(0), nil).Times(1)
+					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+					mockCtx.EXPECT().Proposal().Return(nil, nil).Times(1)
+					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().PreCommitEndorsement().Return(nil).Times(1)
 					state, err := cfsm.prepare(nil)
 					require.NoError(err)
 					require.Equal(sAcceptBlockProposal, state)
-					evt := <-cfsm.evtq
-					require.Equal(eReceiveBlock, evt.Type())
-					require.Equal(lockedProposal, evt.Data())
 					time.Sleep(100 * time.Millisecond)
 					// garbage collection
 					mockClock.Add(cfsm.cfg.AcceptBlockTTL)
-					evt = <-cfsm.evtq
+					evt := <-cfsm.evtq
 					require.Equal(eFailedToReceiveBlock, evt.Type())
 					mockClock.Add(cfsm.cfg.AcceptProposalEndorsementTTL)
 					evt = <-cfsm.evtq
@@ -133,12 +134,13 @@ func TestStateTransitionFunctions(t *testing.T) {
 					evt = <-cfsm.evtq
 					require.Equal(eStopReceivingLockEndorsement, evt.Type())
 					mockClock.Add(cfsm.cfg.CommitTTL)
-					evt = <-cfsm.evtq
-					require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 				})
 				t.Run("ready-to-commit", func(t *testing.T) {
 					mockEndorsement := NewMockEndorsement(ctrl)
-					mockCtx.EXPECT().Prepare().Return(true, lockedProposal, false, true, mockEndorsement, time.Duration(0), nil).Times(1)
+					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+					mockCtx.EXPECT().Proposal().Return(nil, nil).Times(1)
+					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().PreCommitEndorsement().Return(mockEndorsement).Times(1)
 					state, err := cfsm.prepare(nil)
 					require.NoError(err)
 					require.Equal(sAcceptPreCommitEndorsement, state)
@@ -158,56 +160,40 @@ func TestStateTransitionFunctions(t *testing.T) {
 					require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 				})
 			})
-			t.Run("is-not-locked", func(t *testing.T) {
-				mockCtx.EXPECT().Prepare().Return(true, nil, false, false, nil, time.Duration(0), nil).Times(1)
-				state, err := cfsm.prepare(nil)
-				require.NoError(err)
-				require.Equal(sAcceptBlockProposal, state)
-				time.Sleep(100 * time.Millisecond)
-				// garbage collection
-				mockClock.Add(cfsm.cfg.AcceptBlockTTL)
-				evt := <-cfsm.evtq
-				require.Equal(eFailedToReceiveBlock, evt.Type())
-				mockClock.Add(cfsm.cfg.AcceptProposalEndorsementTTL)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingProposalEndorsement, evt.Type())
-				mockClock.Add(cfsm.cfg.AcceptLockEndorsementTTL)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingLockEndorsement, evt.Type())
-				mockClock.Add(cfsm.cfg.CommitTTL)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
-			})
-		})
-		t.Run("is-proposer", func(t *testing.T) {
-			t.Run("fail-to-mint", func(t *testing.T) {
-				mockCtx.EXPECT().Prepare().Return(true, nil, true, false, nil, time.Duration(0), errors.New("some error")).Times(1)
-				state, err := cfsm.prepare(nil)
-				require.NoError(err)
-				require.Equal(sPrepare, state)
-				evt := <-cfsm.evtq
-				require.Equal(ePrepare, evt.Type())
-			})
-			t.Run("success-to-mint", func(t *testing.T) {
-				mockEndorsement := NewMockEndorsement(ctrl)
-				mockCtx.EXPECT().Prepare().Return(true, mockEndorsement, true, false, nil, time.Duration(0), nil).Times(1)
-				mockCtx.EXPECT().Broadcast(gomock.Any()).Return().Times(1)
-				state, err := cfsm.prepare(nil)
-				require.NoError(err)
-				require.Equal(sAcceptBlockProposal, state)
-				evt := <-cfsm.evtq
-				require.Equal(eReceiveBlock, evt.Type())
-				// garbage collection
-				time.Sleep(100 * time.Millisecond)
-				mockClock.Add(4 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eFailedToReceiveBlock, evt.Type())
-				mockClock.Add(2 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingProposalEndorsement, evt.Type())
-				mockClock.Add(2 * time.Second)
-				evt = <-cfsm.evtq
-				require.Equal(eStopReceivingLockEndorsement, evt.Type())
+			t.Run("is-proposer", func(t *testing.T) {
+				t.Run("fail-to-mint", func(t *testing.T) {
+					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+					mockCtx.EXPECT().Proposal().Return(nil, errors.New("some error")).Times(1)
+					state, err := cfsm.prepare(nil)
+					require.NoError(err)
+					require.Equal(sPrepare, state)
+					evt := <-cfsm.evtq
+					require.Equal(ePrepare, evt.Type())
+				})
+				t.Run("success-to-mint", func(t *testing.T) {
+					mockProposal := NewMockEndorsement(ctrl)
+					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+					mockCtx.EXPECT().Proposal().Return(mockProposal, nil).Times(1)
+					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().PreCommitEndorsement().Return(nil).Times(1)
+					mockCtx.EXPECT().Broadcast(gomock.Any()).Return().Times(1)
+					state, err := cfsm.prepare(nil)
+					require.NoError(err)
+					require.Equal(sAcceptBlockProposal, state)
+					evt := <-cfsm.evtq
+					require.Equal(eReceiveBlock, evt.Type())
+					// garbage collection
+					time.Sleep(100 * time.Millisecond)
+					mockClock.Add(4 * time.Second)
+					evt = <-cfsm.evtq
+					require.Equal(eFailedToReceiveBlock, evt.Type())
+					mockClock.Add(2 * time.Second)
+					evt = <-cfsm.evtq
+					require.Equal(eStopReceivingProposalEndorsement, evt.Type())
+					mockClock.Add(2 * time.Second)
+					evt = <-cfsm.evtq
+					require.Equal(eStopReceivingLockEndorsement, evt.Type())
+				})
 			})
 		})
 	})

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -134,7 +134,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 					require.Equal(eStopReceivingLockEndorsement, evt.Type())
 					mockClock.Add(cfsm.cfg.CommitTTL)
 					evt = <-cfsm.evtq
-					require.Equal(ePrepare, evt.Type())
+					require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 				})
 				t.Run("ready-to-commit", func(t *testing.T) {
 					mockEndorsement := NewMockEndorsement(ctrl)
@@ -155,7 +155,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 					require.Equal(eBroadcastPreCommitEndorsement, evt.Type())
 					mockClock.Add(cfsm.cfg.CommitTTL)
 					evt = <-cfsm.evtq
-					require.Equal(ePrepare, evt.Type())
+					require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 				})
 			})
 			t.Run("is-not-locked", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 				require.Equal(eStopReceivingLockEndorsement, evt.Type())
 				mockClock.Add(cfsm.cfg.CommitTTL)
 				evt = <-cfsm.evtq
-				require.Equal(ePrepare, evt.Type())
+				require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 			})
 		})
 		t.Run("is-proposer", func(t *testing.T) {

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -117,7 +117,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 				t.Run("not-ready-to-commit", func(t *testing.T) {
 					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
 					mockCtx.EXPECT().Proposal().Return(nil, nil).Times(1)
-					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().WaitUntilRoundStart().Return(time.Duration(0)).Times(1)
 					mockCtx.EXPECT().PreCommitEndorsement().Return(nil).Times(1)
 					state, err := cfsm.prepare(nil)
 					require.NoError(err)
@@ -134,12 +134,14 @@ func TestStateTransitionFunctions(t *testing.T) {
 					evt = <-cfsm.evtq
 					require.Equal(eStopReceivingLockEndorsement, evt.Type())
 					mockClock.Add(cfsm.cfg.CommitTTL)
+					evt = <-cfsm.evtq
+					require.Equal(eStopReceivingPreCommitEndorsement, evt.Type())
 				})
 				t.Run("ready-to-commit", func(t *testing.T) {
 					mockEndorsement := NewMockEndorsement(ctrl)
 					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
 					mockCtx.EXPECT().Proposal().Return(nil, nil).Times(1)
-					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().WaitUntilRoundStart().Return(time.Duration(0)).Times(1)
 					mockCtx.EXPECT().PreCommitEndorsement().Return(mockEndorsement).Times(1)
 					state, err := cfsm.prepare(nil)
 					require.NoError(err)
@@ -174,7 +176,7 @@ func TestStateTransitionFunctions(t *testing.T) {
 					mockProposal := NewMockEndorsement(ctrl)
 					mockCtx.EXPECT().Prepare().Return(nil).Times(1)
 					mockCtx.EXPECT().Proposal().Return(mockProposal, nil).Times(1)
-					mockCtx.EXPECT().WaitUntil().Return(time.Duration(0)).Times(1)
+					mockCtx.EXPECT().WaitUntilRoundStart().Return(time.Duration(0)).Times(1)
 					mockCtx.EXPECT().PreCommitEndorsement().Return(nil).Times(1)
 					mockCtx.EXPECT().Broadcast(gomock.Any()).Return().Times(1)
 					state, err := cfsm.prepare(nil)

--- a/consensus/consensusfsm/mock_context_test.go
+++ b/consensus/consensusfsm/mock_context_test.go
@@ -214,18 +214,18 @@ func (mr *MockContextMockRecorder) Proposal() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proposal", reflect.TypeOf((*MockContext)(nil).Proposal))
 }
 
-// WaitUntil mocks base method
-func (m *MockContext) WaitUntil() time.Duration {
+// WaitUntilRoundStart mocks base method
+func (m *MockContext) WaitUntilRoundStart() time.Duration {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitUntil")
+	ret := m.ctrl.Call(m, "WaitUntilRoundStart")
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
 }
 
-// WaitUntil indicates an expected call of WaitUntil
-func (mr *MockContextMockRecorder) WaitUntil() *gomock.Call {
+// WaitUntilRoundStart indicates an expected call of WaitUntilRoundStart
+func (mr *MockContextMockRecorder) WaitUntilRoundStart() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntil", reflect.TypeOf((*MockContext)(nil).WaitUntil))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilRoundStart", reflect.TypeOf((*MockContext)(nil).WaitUntilRoundStart))
 }
 
 // PreCommitEndorsement mocks base method

--- a/consensus/consensusfsm/mock_context_test.go
+++ b/consensus/consensusfsm/mock_context_test.go
@@ -37,16 +37,19 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Activate mocks base method
 func (m *MockContext) Activate(arg0 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Activate", arg0)
 }
 
 // Activate indicates an expected call of Activate
 func (mr *MockContextMockRecorder) Activate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Activate", reflect.TypeOf((*MockContext)(nil).Activate), arg0)
 }
 
 // Active mocks base method
 func (m *MockContext) Active() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Active")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -54,11 +57,13 @@ func (m *MockContext) Active() bool {
 
 // Active indicates an expected call of Active
 func (mr *MockContextMockRecorder) Active() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockContext)(nil).Active))
 }
 
 // IsStaleEvent mocks base method
 func (m *MockContext) IsStaleEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsStaleEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -66,11 +71,13 @@ func (m *MockContext) IsStaleEvent(arg0 *ConsensusEvent) bool {
 
 // IsStaleEvent indicates an expected call of IsStaleEvent
 func (mr *MockContextMockRecorder) IsStaleEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStaleEvent", reflect.TypeOf((*MockContext)(nil).IsStaleEvent), arg0)
 }
 
 // IsFutureEvent mocks base method
 func (m *MockContext) IsFutureEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFutureEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -78,11 +85,13 @@ func (m *MockContext) IsFutureEvent(arg0 *ConsensusEvent) bool {
 
 // IsFutureEvent indicates an expected call of IsFutureEvent
 func (mr *MockContextMockRecorder) IsFutureEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFutureEvent", reflect.TypeOf((*MockContext)(nil).IsFutureEvent), arg0)
 }
 
 // IsStaleUnmatchedEvent mocks base method
 func (m *MockContext) IsStaleUnmatchedEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsStaleUnmatchedEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -90,11 +99,13 @@ func (m *MockContext) IsStaleUnmatchedEvent(arg0 *ConsensusEvent) bool {
 
 // IsStaleUnmatchedEvent indicates an expected call of IsStaleUnmatchedEvent
 func (mr *MockContextMockRecorder) IsStaleUnmatchedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStaleUnmatchedEvent", reflect.TypeOf((*MockContext)(nil).IsStaleUnmatchedEvent), arg0)
 }
 
 // Logger mocks base method
 func (m *MockContext) Logger() *zap.Logger {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Logger")
 	ret0, _ := ret[0].(*zap.Logger)
 	return ret0
@@ -102,11 +113,13 @@ func (m *MockContext) Logger() *zap.Logger {
 
 // Logger indicates an expected call of Logger
 func (mr *MockContextMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockContext)(nil).Logger))
 }
 
 // Height mocks base method
 func (m *MockContext) Height() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Height")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -114,11 +127,13 @@ func (m *MockContext) Height() uint64 {
 
 // Height indicates an expected call of Height
 func (mr *MockContextMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContext)(nil).Height))
 }
 
 // NewConsensusEvent mocks base method
 func (m *MockContext) NewConsensusEvent(arg0 go_fsm.EventType, arg1 interface{}) *ConsensusEvent {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewConsensusEvent", arg0, arg1)
 	ret0, _ := ret[0].(*ConsensusEvent)
 	return ret0
@@ -126,11 +141,13 @@ func (m *MockContext) NewConsensusEvent(arg0 go_fsm.EventType, arg1 interface{})
 
 // NewConsensusEvent indicates an expected call of NewConsensusEvent
 func (mr *MockContextMockRecorder) NewConsensusEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewConsensusEvent", reflect.TypeOf((*MockContext)(nil).NewConsensusEvent), arg0, arg1)
 }
 
 // NewBackdoorEvt mocks base method
 func (m *MockContext) NewBackdoorEvt(arg0 go_fsm.State) *ConsensusEvent {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewBackdoorEvt", arg0)
 	ret0, _ := ret[0].(*ConsensusEvent)
 	return ret0
@@ -138,39 +155,96 @@ func (m *MockContext) NewBackdoorEvt(arg0 go_fsm.State) *ConsensusEvent {
 
 // NewBackdoorEvt indicates an expected call of NewBackdoorEvt
 func (mr *MockContextMockRecorder) NewBackdoorEvt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBackdoorEvt", reflect.TypeOf((*MockContext)(nil).NewBackdoorEvt), arg0)
 }
 
 // Broadcast mocks base method
 func (m *MockContext) Broadcast(arg0 interface{}) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Broadcast", arg0)
 }
 
 // Broadcast indicates an expected call of Broadcast
 func (mr *MockContextMockRecorder) Broadcast(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockContext)(nil).Broadcast), arg0)
 }
 
 // Prepare mocks base method
-func (m *MockContext) Prepare() (bool, interface{}, bool, bool, interface{}, time.Duration, error) {
+func (m *MockContext) Prepare() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare")
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(interface{})
-	ret2, _ := ret[2].(bool)
-	ret3, _ := ret[3].(bool)
-	ret4, _ := ret[4].(interface{})
-	ret5, _ := ret[5].(time.Duration)
-	ret6, _ := ret[6].(error)
-	return ret0, ret1, ret2, ret3, ret4, ret5, ret6
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockContextMockRecorder) Prepare() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockContext)(nil).Prepare))
+}
+
+// IsDelegate mocks base method
+func (m *MockContext) IsDelegate() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsDelegate")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsDelegate indicates an expected call of IsDelegate
+func (mr *MockContextMockRecorder) IsDelegate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDelegate", reflect.TypeOf((*MockContext)(nil).IsDelegate))
+}
+
+// Proposal mocks base method
+func (m *MockContext) Proposal() (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Proposal")
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Proposal indicates an expected call of Proposal
+func (mr *MockContextMockRecorder) Proposal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proposal", reflect.TypeOf((*MockContext)(nil).Proposal))
+}
+
+// WaitUntil mocks base method
+func (m *MockContext) WaitUntil() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntil")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// WaitUntil indicates an expected call of WaitUntil
+func (mr *MockContextMockRecorder) WaitUntil() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntil", reflect.TypeOf((*MockContext)(nil).WaitUntil))
+}
+
+// PreCommitEndorsement mocks base method
+func (m *MockContext) PreCommitEndorsement() interface{} {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PreCommitEndorsement")
+	ret0, _ := ret[0].(interface{})
+	return ret0
+}
+
+// PreCommitEndorsement indicates an expected call of PreCommitEndorsement
+func (mr *MockContextMockRecorder) PreCommitEndorsement() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreCommitEndorsement", reflect.TypeOf((*MockContext)(nil).PreCommitEndorsement))
 }
 
 // NewProposalEndorsement mocks base method
 func (m *MockContext) NewProposalEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewProposalEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -179,11 +253,13 @@ func (m *MockContext) NewProposalEndorsement(arg0 interface{}) (interface{}, err
 
 // NewProposalEndorsement indicates an expected call of NewProposalEndorsement
 func (mr *MockContextMockRecorder) NewProposalEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProposalEndorsement", reflect.TypeOf((*MockContext)(nil).NewProposalEndorsement), arg0)
 }
 
 // NewLockEndorsement mocks base method
 func (m *MockContext) NewLockEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewLockEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -192,11 +268,13 @@ func (m *MockContext) NewLockEndorsement(arg0 interface{}) (interface{}, error) 
 
 // NewLockEndorsement indicates an expected call of NewLockEndorsement
 func (mr *MockContextMockRecorder) NewLockEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLockEndorsement", reflect.TypeOf((*MockContext)(nil).NewLockEndorsement), arg0)
 }
 
 // NewPreCommitEndorsement mocks base method
 func (m *MockContext) NewPreCommitEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewPreCommitEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -205,11 +283,13 @@ func (m *MockContext) NewPreCommitEndorsement(arg0 interface{}) (interface{}, er
 
 // NewPreCommitEndorsement indicates an expected call of NewPreCommitEndorsement
 func (mr *MockContextMockRecorder) NewPreCommitEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewPreCommitEndorsement", reflect.TypeOf((*MockContext)(nil).NewPreCommitEndorsement), arg0)
 }
 
 // Commit mocks base method
 func (m *MockContext) Commit(arg0 interface{}) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -218,5 +298,6 @@ func (m *MockContext) Commit(arg0 interface{}) (bool, error) {
 
 // Commit indicates an expected call of Commit
 func (mr *MockContextMockRecorder) Commit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockContext)(nil).Commit), arg0)
 }

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -176,7 +176,7 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 		LatestEpoch:         round.EpochNum(),
 		LatestHeight:        height,
 		LatestDelegates:     round.Delegates(),
-		LatestBlockProducer: r.ctx.round.proposer,
+		LatestBlockProducer: round.proposer,
 		Candidates:          candidateAddresses,
 	}, nil
 }

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -148,6 +148,8 @@ func (ctx *rollDPoSCtx) CheckVoteEndorser(
 	vote *ConsensusVote,
 	en *endorsement.Endorsement,
 ) error {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
 	endorserAddr, err := address.FromBytes(en.Endorser().Hash())
 	if err != nil {
 		return err
@@ -164,6 +166,8 @@ func (ctx *rollDPoSCtx) CheckBlockProposer(
 	proposal *blockProposal,
 	en *endorsement.Endorsement,
 ) error {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
 	if height != proposal.block.Height() {
 		return errors.Errorf(
 			"block height %d different from expected %d",
@@ -253,21 +257,13 @@ func (ctx *rollDPoSCtx) Logger() *zap.Logger {
 	return ctx.logger()
 }
 
-func (ctx *rollDPoSCtx) Prepare() (
-	isDelegate bool,
-	proposal interface{},
-	isProposer bool,
-	locked bool,
-	precommitEndorsement interface{},
-	delay time.Duration,
-	err error,
-) {
+func (ctx *rollDPoSCtx) Prepare() error {
 	ctx.mutex.Lock()
 	defer ctx.mutex.Unlock()
 	height := ctx.chain.TipHeight() + 1
 	newRound, err := ctx.roundCalc.UpdateRound(ctx.round, height, ctx.clock.Now())
 	if err != nil {
-		return
+		return err
 	}
 	ctx.logger().Debug(
 		"new round",
@@ -279,41 +275,57 @@ func (ctx *rollDPoSCtx) Prepare() (
 		zap.String("roundStartTime", newRound.roundStartTime.String()),
 	)
 	ctx.round = newRound
-	if active := ctx.active; !active {
-		ctx.logger().Info("current node is in standby mode")
-		delay = ctx.round.NextRoundStartTime().Sub(ctx.clock.Now())
-		isDelegate = false
-		return
-	}
-	if isDelegate = ctx.round.IsDelegate(ctx.encodedAddr); !isDelegate {
-		ctx.logger().Info("current node is not an active consensus delegate")
-		delay = ctx.round.NextRoundStartTime().Sub(ctx.clock.Now())
-		return
-	}
-	if locked = ctx.round.IsLocked(); locked {
-		if proposal, err = ctx.endorseBlockProposal(newBlockProposal(
-			ctx.round.Block(ctx.round.HashOfBlockInLock()),
-			ctx.round.ProofOfLock(),
-		)); err != nil {
-			return
-		}
-		precommitEndorsement = ctx.round.ReadyToCommit(ctx.encodedAddr)
-	}
-	if isProposer = ctx.round.Proposer() == ctx.encodedAddr; isProposer {
-		ctx.logger().Info("current node is a proposer")
-		if proposal == nil {
-			if proposal, err = ctx.mintNewBlock(); err != nil {
-				return
-			}
-		}
-	} else {
-		ctx.logger().Info("current node is an active consensus delegate")
-	}
-	delay = ctx.round.StartTime().Sub(ctx.clock.Now())
-
 	consensusHeightMtc.WithLabelValues().Set(float64(ctx.round.height))
 	timeSlotMtc.WithLabelValues().Set(float64(ctx.round.roundNum))
-	return
+	return nil
+}
+
+func (ctx *rollDPoSCtx) IsDelegate() bool {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	if active := ctx.active; !active {
+		ctx.logger().Info("current node is in standby mode")
+		return false
+	}
+	return ctx.round.IsDelegate(ctx.encodedAddr)
+}
+
+func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	if ctx.round.Proposer() != ctx.encodedAddr {
+		return nil, nil
+	}
+	if ctx.round.IsLocked() {
+		return ctx.endorseBlockProposal(newBlockProposal(
+			ctx.round.Block(ctx.round.HashOfBlockInLock()),
+			ctx.round.ProofOfLock(),
+		))
+	}
+	return ctx.mintNewBlock()
+}
+
+func (ctx *rollDPoSCtx) WaitUntil() time.Duration {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	now := ctx.clock.Now()
+	startTime := ctx.round.StartTime()
+	if now.Before(startTime) {
+		time.Sleep(startTime.Sub(now))
+		return 0
+	}
+	return now.Sub(startTime)
+}
+
+func (ctx *rollDPoSCtx) PreCommitEndorsement() interface{} {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	endorsement := ctx.round.ReadyToCommit(ctx.encodedAddr)
+	if endorsement == nil {
+		// DON'T CHANGE, this is on purpose, because endorsement as nil won't result in a nil interface
+		return nil
+	}
+	return endorsement
 }
 
 func (ctx *rollDPoSCtx) NewProposalEndorsement(msg interface{}) (interface{}, error) {

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -305,7 +305,7 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	return ctx.mintNewBlock()
 }
 
-func (ctx *rollDPoSCtx) WaitUntil() time.Duration {
+func (ctx *rollDPoSCtx) WaitUntilRoudnStart() time.Duration {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
 	now := ctx.clock.Now()
@@ -322,7 +322,7 @@ func (ctx *rollDPoSCtx) PreCommitEndorsement() interface{} {
 	defer ctx.mutex.RUnlock()
 	endorsement := ctx.round.ReadyToCommit(ctx.encodedAddr)
 	if endorsement == nil {
-		// DON'T CHANGE, this is on purpose, because endorsement as nil won't result in a nil interface
+		// DON'T CHANGE, this is on purpose, because endorsement as nil won't result in a nil "interface {}"
 		return nil
 	}
 	return endorsement

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -305,7 +305,7 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	return ctx.mintNewBlock()
 }
 
-func (ctx *rollDPoSCtx) WaitUntilRoudnStart() time.Duration {
+func (ctx *rollDPoSCtx) WaitUntilRoundStart() time.Duration {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
 	now := ctx.clock.Now()

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -134,7 +134,7 @@ func (ctx *roundCtx) ReadyToCommit(addr string) *EndorsedConsensusMessage {
 	if blk == nil {
 		return nil
 	}
-	blkHash := c.Block().HashBlock()
+	blkHash := blk.HashBlock()
 	return NewEndorsedConsensusMessage(
 		blk.Height(),
 		NewConsensusVote(blkHash[:], COMMIT),

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -121,13 +121,25 @@ func (ctx *roundCtx) IsUnlocked() bool {
 	return ctx.status == unlocked
 }
 
-func (ctx *roundCtx) ReadyToCommit(addr string) *endorsement.Endorsement {
+func (ctx *roundCtx) ReadyToCommit(addr string) *EndorsedConsensusMessage {
 	c := ctx.eManager.CollectionByBlockHash(ctx.blockInLock)
 	if c == nil {
 		return nil
 	}
-
-	return c.Endorsement(addr, COMMIT)
+	en := c.Endorsement(addr, COMMIT)
+	if en == nil {
+		return nil
+	}
+	blk := c.Block()
+	if blk == nil {
+		return nil
+	}
+	blkHash := c.Block().HashBlock()
+	return NewEndorsedConsensusMessage(
+		blk.Height(),
+		NewConsensusVote(blkHash[:], COMMIT),
+		en,
+	)
 }
 
 func (ctx *roundCtx) HashOfBlockInLock() []byte {

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,7 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-address v0.2.1-0.20190725020429-99e5492ea0c3 h1:ZEXJTkZzwS+Itc2QfRXUnsPx/2fJStCsQvhCMoZ4tKE=
 github.com/iotexproject/iotex-address v0.2.1-0.20190725020429-99e5492ea0c3/go.mod h1:ias6axlk8TFocZ2stKY7L0k5hnrLq6q/2qeCNJ1K8uA=
 github.com/iotexproject/iotex-antenna-go/v2 v2.2.0/go.mod h1:sDCcRI0VQnF2jAB2bCzbyPpraRtVKtefbUI+JYBvU3g=
+github.com/iotexproject/iotex-antenna-go/v2 v2.3.0/go.mod h1:sDCcRI0VQnF2jAB2bCzbyPpraRtVKtefbUI+JYBvU3g=
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.18-0.20190720010220-fddc58c26ff5 h1:Bpk7xStlPYjyAipRt7hNffHdIxhhXxdGhrBirqYN+Cw=
 github.com/iotexproject/iotex-election v0.1.18-0.20190720010220-fddc58c26ff5/go.mod h1:sddJsiho4QO02JtKiZgBl/pn0o+3Nm9DxcnIUKHVG4E=

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/graph-gophers/graphql-go v0.0.0-20190610161739-8f92f34fc598 h1:XLoCW/kXxbvPvp216Kq/c+TtwWYHy9sjeDidFcG45g0=
 github.com/graph-gophers/graphql-go v0.0.0-20190610161739-8f92f34fc598/go.mod h1:Au3iQ8DvDis8hZ4q2OzRcaKYlAsPt+fYvib5q4nIqu4=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -156,6 +157,7 @@ github.com/iotexproject/iotex-address v0.2.0/go.mod h1:ias6axlk8TFocZ2stKY7L0k5h
 github.com/iotexproject/iotex-address v0.2.1-0.20190725020429-99e5492ea0c3 h1:ZEXJTkZzwS+Itc2QfRXUnsPx/2fJStCsQvhCMoZ4tKE=
 github.com/iotexproject/iotex-address v0.2.1-0.20190725020429-99e5492ea0c3/go.mod h1:ias6axlk8TFocZ2stKY7L0k5hnrLq6q/2qeCNJ1K8uA=
 github.com/iotexproject/iotex-antenna-go/v2 v2.2.0/go.mod h1:sDCcRI0VQnF2jAB2bCzbyPpraRtVKtefbUI+JYBvU3g=
+github.com/iotexproject/iotex-antenna-go/v2 v2.3.0 h1:iGrQBmqafiqYCNkvF42EIkYdds2ovzN8MXFnwF0DXR4=
 github.com/iotexproject/iotex-antenna-go/v2 v2.3.0/go.mod h1:sDCcRI0VQnF2jAB2bCzbyPpraRtVKtefbUI+JYBvU3g=
 github.com/iotexproject/iotex-core v0.5.1/go.mod h1:8nEaqyRRzZK6IAH8H/bB/hUCz2jpTsQ0DBuhSm+nBEk=
 github.com/iotexproject/iotex-election v0.1.18-0.20190720010220-fddc58c26ff5 h1:Bpk7xStlPYjyAipRt7hNffHdIxhhXxdGhrBirqYN+Cw=


### PR DESCRIPTION
Three issues in previous implementation:
1. If overtime, the initial ttl was calculated wrongly (should be +=, not -=)
2. m.produceConsensusEvent(ePrepare, ttl) won't kick the node in pre-commit status back to sPrepare status
3. interface{} with type specified won't be nil

Test with minicluster, and nightly-cluster-0