### PR TITLE
 improve address action index

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -525,10 +525,12 @@ func TestProtocol_Handle(t *testing.T) {
 		require.Nil(err)
 		require.Equal(eHash, exe.Hash())
 
-		exes, err := bc.GetActionsFromAddress(identityset.Address(27).String())
+		total, err := bc.GetActionCountByAddress(identityset.Address(27).String())
+		require.NoError(err)
+		exes, err := bc.GetActionsByAddress(identityset.Address(27).String(), 0, total)
 		require.Nil(err)
 		require.Equal(1, len(exes))
-		require.Equal(eHash, exes[0])
+		require.Equal(eHash[:], exes[0])
 
 		blkHash, err := bc.GetBlockHashByActionHash(eHash)
 		require.Nil(err)

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -38,9 +38,9 @@ func NewStakingCommittee(
 		}
 	}
 	return &stakingCommittee{
-		hu: hu,
+		hu:                hu,
 		governanceStaking: gs,
-		nativeStaking: ns,
+		nativeStaking:     ns,
 	}, nil
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -681,6 +681,10 @@ func TestServer_GetActions(t *testing.T) {
 		res, err := svr.GetActions(context.Background(), request)
 		require.NoError(err)
 		require.Equal(test.numActions, len(res.ActionInfo))
+		if test.numActions == 0 {
+			// returns empty response body in case of no result
+			require.Equal(&iotexapi.GetActionsResponse{}, res)
+		}
 	}
 }
 
@@ -742,6 +746,10 @@ func TestServer_GetActionsByAddress(t *testing.T) {
 		res, err := svr.GetActions(context.Background(), request)
 		require.NoError(err)
 		require.Equal(test.numActions, len(res.ActionInfo))
+		if test.numActions == 0 {
+			// returns empty response body in case of no result
+			require.Equal(&iotexapi.GetActionsResponse{}, res)
+		}
 		var prevAct *iotexapi.ActionInfo
 		for _, act := range res.ActionInfo {
 			if prevAct != nil {
@@ -788,6 +796,10 @@ func TestServer_GetUnconfirmedActionsByAddress(t *testing.T) {
 		require.Equal(test.numActions, len(res.ActionInfo))
 		if test.numActions > 0 {
 			require.Equal(test.address, res.ActionInfo[0].Sender)
+		} else {
+			// returns empty response body in case of no result
+			res.Total = 0
+			require.Equal(&iotexapi.GetActionsResponse{}, res)
 		}
 	}
 }
@@ -817,6 +829,10 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 		require.Equal(test.numActions, len(res.ActionInfo))
 		if test.numActions > 0 {
 			require.Equal(test.blkHeight, res.ActionInfo[0].BlkHeight)
+		} else {
+			// returns empty response body in case of no result
+			res.Total = 0
+			require.Equal(&iotexapi.GetActionsResponse{}, res)
 		}
 	}
 }

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -21,10 +21,8 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -36,36 +34,31 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
 	"github.com/iotexproject/iotex-core/pkg/prometheustimer"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 const (
-	blockNS                          = "blk"
-	blockHashHeightMappingNS         = "h2h"
-	blockActionBlockMappingNS        = "a2b"
-	blockActionReceiptMappingNS      = "a2r"
-	blockAddressActionMappingNS      = "a2a"
-	blockAddressActionCountMappingNS = "a2c"
-	blockHeaderNS                    = "bhr"
-	blockBodyNS                      = "bbd"
-	blockFooterNS                    = "bfr"
-	receiptsNS                       = "rpt"
-	numActionsNS                     = "nac"
-	transferAmountNS                 = "tfa"
+	blockNS                   = "blk"
+	blockHashHeightMappingNS  = "h2h"
+	blockActionBlockMappingNS = "a2b"
+	blockHeaderNS             = "bhr"
+	blockBodyNS               = "bbd"
+	blockFooterNS             = "bfr"
+	receiptsNS                = "rpt"
+	numActionsNS              = "nac"
+	transferAmountNS          = "tfa"
 
 	hashOffset = 12
 )
 
 var (
-	topHeightKey             = []byte("th")
-	topHashKey               = []byte("ts")
-	totalActionsKey          = []byte("ta")
-	indexActionsTipIndexKey  = []byte("iati")
-	indexActionsTipHeightKey = []byte("iath")
-	hashPrefix               = []byte("ha.")
-	heightPrefix             = []byte("he.")
-	actionFromPrefix         = []byte("fr.")
-	actionToPrefix           = []byte("to.")
-	heightToFilePrefix       = []byte("hf.")
+	topHeightKey        = []byte("th")
+	topHashKey          = []byte("ts")
+	totalActionsKey     = []byte("ta")
+	topIndexedHeightKey = []byte("ti")
+	hashPrefix          = []byte("ha.")
+	heightPrefix        = []byte("he.")
+	heightToFilePrefix  = []byte("hf.")
 )
 
 var (
@@ -138,28 +131,9 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 			return errors.Wrap(err, "failed to write initial value for top height")
 		}
 	}
-
-	// set init total actions to be 0
-	if _, err := dao.kvstore.Get(blockNS, totalActionsKey); err != nil &&
-		errors.Cause(err) == db.ErrNotExist {
-		if err = dao.kvstore.Put(blockNS, totalActionsKey, make([]byte, 8)); err != nil {
-			return errors.Wrap(err, "failed to write initial value for total actions")
-		}
-	}
-
-	err = dao.initStores()
-	if err != nil {
-		return err
-	}
-
-	value, _ := dao.kvstore.Get(blockNS, totalActionsKey)
-	totalActions := enc.MachineEndian.Uint64(value)
-	if totalActions != 0 {
-		return nil
-	}
-
-	return dao.countActions()
+	return dao.initStores()
 }
+
 func (dao *blockDAO) initStores() error {
 	cfg := dao.cfg
 	model, dir := getFileNameAndDir(cfg.DbPath)
@@ -188,34 +162,6 @@ func (dao *blockDAO) initStores() error {
 		maxN = 1
 	}
 	dao.topIndex.Store(maxN)
-	return nil
-}
-func (dao *blockDAO) countActions() error {
-	totalActions := uint64(0)
-	tipHeight, err := dao.getBlockchainHeight()
-	if err != nil {
-		return err
-	}
-	for i := uint64(1); i <= tipHeight; i++ {
-		hash, err := dao.getBlockHash(i)
-		if err != nil {
-			return err
-		}
-		body, err := dao.body(hash)
-		if err != nil {
-			return err
-		}
-		totalActions += uint64(len(body.Actions))
-		if i%1000 == 0 {
-			zap.L().Info("Counting number of actions", zap.Uint64("height", i))
-		}
-	}
-	totalActionsBytes := byteutil.Uint64ToBytes(totalActions)
-	batch := db.NewBatch()
-	batch.Put(blockNS, totalActionsKey, totalActionsBytes, "failed to put total actions")
-	if err := dao.kvstore.Commit(batch); err != nil {
-		return err
-	}
 	return nil
 }
 
@@ -310,7 +256,6 @@ func (dao *blockDAO) header(h hash.Hash256) (*block.Header, error) {
 	if dao.headerCache != nil {
 		dao.headerCache.Add(h, header)
 	}
-
 	return header, nil
 }
 
@@ -392,21 +337,6 @@ func (dao *blockDAO) footer(h hash.Hash256) (*block.Footer, error) {
 	return footer, nil
 }
 
-// getActionHashFromIndex returns the action hash from index
-func (dao *blockDAO) getActionHashFromIndex(index uint64) (hash.Hash256, error) {
-	hash := hash.ZeroHash256
-	indexActionsBytes := byteutil.Uint64ToBytes(index)
-	value, err := dao.kvstore.Get(blockActionBlockMappingNS, indexActionsBytes)
-	if err != nil {
-		return hash, errors.Wrap(err, "failed to get action hash")
-	}
-	if len(hash) != len(value) {
-		return hash, errors.Wrap(err, "action hash is broken")
-	}
-	copy(hash[:], value)
-	return hash, nil
-}
-
 // getBlockchainHeight returns the blockchain height
 func (dao *blockDAO) getBlockchainHeight() (uint64, error) {
 	value, err := dao.kvstore.Get(blockNS, topHeightKey)
@@ -430,28 +360,70 @@ func (dao *blockDAO) getTipHash() (hash.Hash256, error) {
 
 // getTotalActions returns the total number of actions
 func (dao *blockDAO) getTotalActions() (uint64, error) {
-	value, err := dao.kvstore.Get(blockNS, totalActionsKey)
+	indexer, err := dao.kvstore.CountingIndex(totalActionsKey)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to get total actions")
+		return 0, err
 	}
-	if len(value) == 0 {
-		return 0, errors.Wrap(db.ErrNotExist, "total actions missing")
+	return indexer.Size(), nil
+}
+
+// getActionHashFromIndex returns the action hash from index
+func (dao *blockDAO) getActionHashFromIndex(start, count uint64) ([][]byte, error) {
+	indexer, err := dao.kvstore.CountingIndex(totalActionsKey)
+	if err != nil {
+		return nil, err
 	}
-	return enc.MachineEndian.Uint64(value), nil
+	return indexer.Range(start, count)
+}
+
+// getBlockHashByActionHash returns block hash of the action
+func (dao *blockDAO) getBlockHashByActionHash(h hash.Hash256) (hash.Hash256, error) {
+	hashAndHeight, err := dao.kvstore.Get(blockActionBlockMappingNS, h[hashOffset:])
+	if err != nil {
+		return hash.ZeroHash256, errors.Wrapf(err, "failed to get action %x", h)
+	}
+	if len(hashAndHeight) == 0 {
+		return hash.ZeroHash256, errors.Wrapf(db.ErrNotExist, "action %x missing", h)
+	}
+	// hash is the front 32-byte
+	return hash.BytesToHash256(hashAndHeight[:32]), nil
+}
+
+// getActionCountByAddress returns action count by address
+func (dao *blockDAO) getActionCountByAddress(addrBytes hash.Hash160) (uint64, error) {
+	address, err := dao.kvstore.CountingIndex(addrBytes[:])
+	if err != nil {
+		return 0, nil
+	}
+	return address.Size(), nil
+}
+
+// getActionsByAddress returns actions by address
+func (dao *blockDAO) getActionsByAddress(addrBytes hash.Hash160, start, count uint64) ([][]byte, error) {
+	address, err := dao.kvstore.CountingIndex(addrBytes[:])
+	if err != nil {
+		return nil, err
+	}
+	total := address.Size()
+	if start+count > total {
+		count = total - start
+	}
+	return address.Range(start, count)
 }
 
 // getReceiptByActionHash returns the receipt by execution hash
 func (dao *blockDAO) getReceiptByActionHash(h hash.Hash256) (*action.Receipt, error) {
-	heightBytes, err := dao.kvstore.Get(blockActionReceiptMappingNS, h[hashOffset:])
+	hashAndHeight, err := dao.kvstore.Get(blockActionBlockMappingNS, h[hashOffset:])
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipt index for action %x", h)
 	}
-	height := enc.MachineEndian.Uint64(heightBytes)
+	// height is the last 8-byte
+	height := enc.MachineEndian.Uint64(hashAndHeight[32:])
 	kvstore, _, err := dao.getDBFromHeight(height)
 	if err != nil {
 		return nil, err
 	}
-	receiptsBytes, err := kvstore.Get(receiptsNS, heightBytes)
+	receiptsBytes, err := kvstore.Get(receiptsNS, hashAndHeight[32:])
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipts of block %d", height)
 	}
@@ -514,9 +486,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 	if err != nil {
 		return err
 	}
-
-	err = kv.Commit(batchForBlock)
-	if err != nil {
+	if err = kv.Commit(batchForBlock); err != nil {
 		return err
 	}
 
@@ -540,17 +510,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 		batch.Put(blockNS, topHashKey, hash[:], "failed to put top hash")
 	}
 
-	value, err = dao.kvstore.Get(blockNS, totalActionsKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to get total actions")
-	}
-	totalActions := enc.MachineEndian.Uint64(value)
-	numActions := uint64(len(blk.Actions))
-	totalActions += numActions
-	totalActionsBytes := byteutil.Uint64ToBytes(totalActions)
-	batch.Put(blockNS, totalActionsKey, totalActionsBytes, "failed to put total actions")
-
-	numActionsBytes := byteutil.Uint64ToBytes(numActions)
+	numActionsBytes := byteutil.Uint64ToBytes(uint64(len(blk.Actions)))
 	batch.Put(numActionsNS, heightKey, numActionsBytes, "Failed to put num actions of block %d", blk.Height())
 
 	transferAmount := blk.CalculateTransferAmount()
@@ -560,7 +520,7 @@ func (dao *blockDAO) putBlock(blk *block.Block) error {
 	if !dao.writeIndex {
 		return dao.kvstore.Commit(batch)
 	}
-	if err := indexBlock(dao.kvstore, blk, batch); err != nil {
+	if err := indexBlock(dao.kvstore, hash, blk.Height(), blk.Actions, batch, nil); err != nil {
 		return err
 	}
 	return dao.kvstore.Commit(batch)
@@ -610,33 +570,14 @@ func (dao *blockDAO) putReceipts(blkHeight uint64, blkReceipts []*action.Receipt
 		return nil
 	}
 	receipts := iotextypes.Receipts{}
-	batch := db.NewBatch()
-	batchForReceipt := db.NewBatch()
-	var heightBytes [8]byte
-	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
 	for _, r := range blkReceipts {
 		receipts.Receipts = append(receipts.Receipts, r.ConvertToReceiptPb())
-		if !dao.writeIndex {
-			continue
-		}
-		batch.Put(
-			blockActionReceiptMappingNS,
-			r.ActionHash[hashOffset:],
-			heightBytes[:],
-			"Failed to put receipt index for action %x",
-			r.ActionHash[:],
-		)
 	}
 	receiptsBytes, err := proto.Marshal(&receipts)
 	if err != nil {
 		return err
 	}
-	batchForReceipt.Put(receiptsNS, heightBytes[:], receiptsBytes, "Failed to put receipts of block %d", blkHeight)
-	err = kvstore.Commit(batchForReceipt)
-	if err != nil {
-		return err
-	}
-	return dao.kvstore.Commit(batch)
+	return kvstore.Put(receiptsNS, byteutil.Uint64ToBytes(blkHeight), receiptsBytes)
 }
 
 // getReceipts gets receipts
@@ -645,10 +586,7 @@ func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
 	if err != nil {
 		return nil, err
 	}
-	var heightBytes [8]byte
-	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
-
-	value, err := kvstore.Get(receiptsNS, heightBytes[:])
+	value, err := kvstore.Get(receiptsNS, byteutil.Uint64ToBytes(blkHeight))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get receipts")
 	}
@@ -677,9 +615,13 @@ func (dao *blockDAO) deleteTipBlock() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to get tip height")
 	}
-
+	height := enc.MachineEndian.Uint64(heightValue)
+	if height == 0 {
+		// should not delete genesis block
+		return errors.New("cannot delete genesis block")
+	}
 	// Obtain tip block hash
-	hash, err := dao.getBlockHash(enc.MachineEndian.Uint64(heightValue))
+	hash, err := dao.getBlockHash(height)
 	if err != nil {
 		return errors.Wrap(err, "failed to get tip block hash")
 	}
@@ -722,39 +664,71 @@ func (dao *blockDAO) deleteTipBlock() error {
 	batch.Delete(blockHashHeightMappingNS, heightKey, "failed to delete height -> hash mapping")
 
 	// Update tip height
-	topHeight := enc.MachineEndian.Uint64(heightValue) - 1
-	topHeightValue := byteutil.Uint64ToBytes(topHeight)
-	batch.Put(blockNS, topHeightKey, topHeightValue, "failed to put top height")
+	batch.Put(blockNS, topHeightKey, byteutil.Uint64ToBytes(height-1), "failed to put top height")
 
 	if !dao.writeIndex {
 		return dao.kvstore.Commit(batch)
 	}
-
-	// update total action count
-	value, err := dao.kvstore.Get(blockNS, totalActionsKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to get total actions")
+	if err := dao.deleteBlock(blk, batch); err != nil {
+		return err
 	}
-	totalActions := enc.MachineEndian.Uint64(value)
-	totalActions -= uint64(len(blk.Actions))
-	totalActionsBytes := byteutil.Uint64ToBytes(totalActions)
-	batch.Put(blockNS, totalActionsKey, totalActionsBytes, "failed to put total actions")
+	return dao.kvstore.Commit(batch)
+}
 
+func (dao *blockDAO) deleteBlock(blk *block.Block, batch db.KVStoreBatch) error {
+	if len(blk.Actions) == 0 {
+		return nil
+	}
 	// Delete action hash -> block hash mapping
 	for _, selp := range blk.Actions {
 		actHash := selp.Hash()
-		batch.Delete(blockActionBlockMappingNS, actHash[hashOffset:], "failed to delete actions f")
-	}
+		batch.Delete(blockActionBlockMappingNS, actHash[hashOffset:], "failed to delete action hash %x", actHash)
 
-	if err = deleteActions(dao, blk, batch); err != nil {
+		if err := dao.deleteAction(selp); err != nil {
+			return err
+		}
+	}
+	// rollback total action index
+	indexer, err := dao.kvstore.CountingIndex(totalActionsKey)
+	if err != nil {
+		return err
+	}
+	return indexer.Revert(uint64(len(blk.Actions)))
+}
+
+// deleteActions deletes action information from db
+func (dao *blockDAO) deleteAction(selp action.SealedEnvelope) error {
+	callerAddrBytes := hash.BytesToHash160(selp.SrcPubkey().Hash())
+	sender, err := dao.kvstore.CountingIndex(callerAddrBytes[:])
+	if err != nil {
+		return err
+	}
+	// rollback sender index
+	if err := sender.Revert(1); err != nil {
 		return err
 	}
 
-	if err = deleteReceipts(blk, batch); err != nil {
+	dst, ok := selp.Destination()
+	if !ok || dst == "" {
+		return nil
+	}
+	dstAddr, err := address.FromString(dst)
+	if err != nil {
 		return err
 	}
+	dstAddrBytes := hash.BytesToHash160(dstAddr.Bytes())
 
-	return dao.kvstore.Commit(batch)
+	if dstAddrBytes == callerAddrBytes {
+		// recipient is same as sender
+		return nil
+	}
+
+	recipient, err := dao.kvstore.CountingIndex(dstAddrBytes[:])
+	if err != nil {
+		return err
+	}
+	// rollback recipient index
+	return recipient.Revert(1)
 }
 
 // getDBFromHash returns db of this block stored
@@ -807,6 +781,7 @@ func (dao *blockDAO) getTopDB(blkHeight uint64) (kvstore db.KVStore, index uint6
 	// file exists,but not opened
 	return dao.openDB(topIndex)
 }
+
 func (dao *blockDAO) getTopDBOfOpened(blkHeight uint64) (kvstore db.KVStore, err error) {
 	if dao.cfg.SplitDBSizeMB == 0 {
 		return dao.kvstore, nil
@@ -826,6 +801,7 @@ func (dao *blockDAO) getTopDBOfOpened(blkHeight uint64) (kvstore db.KVStore, err
 	err = ErrNotOpened
 	return
 }
+
 func (dao *blockDAO) getDBFromHeight(blkHeight uint64) (kvstore db.KVStore, index uint64, err error) {
 	if dao.cfg.SplitDBSizeMB == 0 {
 		return dao.kvstore, 0, nil
@@ -903,101 +879,6 @@ func (dao *blockDAO) openDB(idx uint64) (kvstore db.KVStore, index uint64, err e
 	dao.lifecycle.Add(kvstore)
 	index = idx
 	return
-}
-
-// deleteReceipts deletes receipt information from db
-func deleteReceipts(blk *block.Block, batch db.KVStoreBatch) error {
-	for _, r := range blk.Receipts {
-		batch.Delete(blockActionReceiptMappingNS, r.ActionHash[hashOffset:], "failed to delete receipt for action %x", r.ActionHash[:])
-	}
-	return nil
-}
-
-// deleteActions deletes action information from db
-func deleteActions(dao *blockDAO, blk *block.Block, batch db.KVStoreBatch) error {
-	// Firt get the total count of actions by sender and recipient respectively in the block
-	senderCount := make(map[hash.Hash160]uint64)
-	recipientCount := make(map[hash.Hash160]uint64)
-	for _, selp := range blk.Actions {
-		callerAddrBytes := hash.BytesToHash160(selp.SrcPubkey().Hash())
-		senderCount[callerAddrBytes]++
-		if dst, ok := selp.Destination(); ok && dst != "" {
-			dstAddr, err := address.FromString(dst)
-			if err != nil {
-				return err
-			}
-			dstAddrBytes := hash.BytesToHash160(dstAddr.Bytes())
-			recipientCount[dstAddrBytes]++
-		}
-	}
-	// Roll back the status of address -> actionCount mapping to the preivous block
-	for sender, count := range senderCount {
-		senderActionCount, err := getActionCountBySenderAddress(dao.kvstore, sender)
-		if err != nil {
-			return errors.Wrapf(err, "for sender %x", sender)
-		}
-		senderActionCountKey := append(actionFromPrefix, sender[:]...)
-		senderCount[sender] = senderActionCount - count
-		batch.Put(blockAddressActionCountMappingNS, senderActionCountKey, byteutil.Uint64ToBytes(senderCount[sender]),
-			"failed to update action count for sender %x", sender)
-	}
-	for recipient, count := range recipientCount {
-		recipientActionCount, err := getActionCountByRecipientAddress(dao.kvstore, recipient)
-		if err != nil {
-			return errors.Wrapf(err, "for recipient %x", recipient)
-		}
-		recipientActionCountKey := append(actionToPrefix, recipient[:]...)
-		recipientCount[recipient] = recipientActionCount - count
-		batch.Put(blockAddressActionCountMappingNS, recipientActionCountKey,
-			byteutil.Uint64ToBytes(recipientCount[recipient]), "failed to update action count for recipient %x",
-			recipient)
-
-	}
-
-	senderDelta := map[hash.Hash160]uint64{}
-	recipientDelta := map[hash.Hash160]uint64{}
-
-	for _, selp := range blk.Actions {
-		actHash := selp.Hash()
-		callerAddrBytes := hash.BytesToHash160(selp.SrcPubkey().Hash())
-
-		if delta, ok := senderDelta[callerAddrBytes]; ok {
-			senderCount[callerAddrBytes] += delta
-			senderDelta[callerAddrBytes]++
-		} else {
-			senderDelta[callerAddrBytes] = 1
-		}
-
-		// Delete new action from sender
-		senderKey := append(actionFromPrefix, callerAddrBytes[:]...)
-		senderKey = append(senderKey, byteutil.Uint64ToBytes(senderCount[callerAddrBytes])...)
-		batch.Delete(blockAddressActionMappingNS, senderKey, "failed to delete action hash %x for sender %x",
-			actHash, callerAddrBytes)
-
-		dst, ok := selp.Destination()
-		if !ok || dst == "" {
-			continue
-		}
-		dstAddr, err := address.FromString(dst)
-		if err != nil {
-			return err
-		}
-		dstAddrBytes := hash.BytesToHash160(dstAddr.Bytes())
-		if delta, ok := recipientDelta[dstAddrBytes]; ok {
-			recipientCount[dstAddrBytes] += delta
-			recipientDelta[dstAddrBytes]++
-		} else {
-			recipientDelta[dstAddrBytes] = 1
-		}
-
-		// Delete new action to recipient
-		recipientKey := append(actionToPrefix, dstAddrBytes[:]...)
-		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientCount[dstAddrBytes])...)
-		batch.Delete(blockAddressActionMappingNS, recipientKey, "failed to delete action hash %x for recipient %x",
-			actHash, dstAddrBytes)
-	}
-
-	return nil
 }
 
 func getFileNameAndDir(p string) (fileName, dir string) {

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -351,6 +351,13 @@ func TestBlockDAO(t *testing.T) {
 			tipHeight, err := dao.getBlockchainHeight()
 			require.NoError(err)
 			require.EqualValues(uint64(3-i), tipHeight)
+			h, err := dao.getTipHash()
+			require.NoError(err)
+			if i <= 2 {
+				require.Equal(blks[2-i].HashBlock(), h)
+			} else {
+				require.Equal(hash.ZeroHash256, h)
+			}
 			total, err := dao.getTotalActions()
 			require.NoError(err)
 			require.EqualValues(daoTests[i].total, total)

--- a/blockchain/blockdao_test.go
+++ b/blockchain/blockdao_test.go
@@ -33,70 +33,140 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
+func getTestBlocks(t *testing.T) []*block.Block {
+	amount := uint64(50 << 22)
+	tsf1, err := testutil.SignedTransfer(identityset.Address(28).String(), identityset.PrivateKey(28), 1, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	tsf2, err := testutil.SignedTransfer(identityset.Address(29).String(), identityset.PrivateKey(29), 2, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	tsf3, err := testutil.SignedTransfer(identityset.Address(30).String(), identityset.PrivateKey(30), 3, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	tsf4, err := testutil.SignedTransfer(identityset.Address(29).String(), identityset.PrivateKey(28), 2, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	tsf5, err := testutil.SignedTransfer(identityset.Address(30).String(), identityset.PrivateKey(29), 3, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	tsf6, err := testutil.SignedTransfer(identityset.Address(28).String(), identityset.PrivateKey(30), 4, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
+	require.NoError(t, err)
+
+	// create testing executions
+	execution1, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(28), 1, big.NewInt(1), 0, big.NewInt(0), nil)
+	require.NoError(t, err)
+	execution2, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(29), 2, big.NewInt(0), 0, big.NewInt(0), nil)
+	require.NoError(t, err)
+	execution3, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(30), 3, big.NewInt(2), 0, big.NewInt(0), nil)
+	require.NoError(t, err)
+
+	hash1 := hash.Hash256{}
+	fnv.New32().Sum(hash1[:])
+	blk1, err := block.NewTestingBuilder().
+		SetHeight(1).
+		SetPrevBlockHash(hash1).
+		SetTimeStamp(testutil.TimestampNow()).
+		AddActions(tsf1, tsf4, execution1).
+		SignAndBuild(identityset.PrivateKey(27))
+	require.NoError(t, err)
+
+	hash2 := hash.Hash256{}
+	fnv.New32().Sum(hash2[:])
+	blk2, err := block.NewTestingBuilder().
+		SetHeight(2).
+		SetPrevBlockHash(hash2).
+		SetTimeStamp(testutil.TimestampNow()).
+		AddActions(tsf2, tsf5, execution2).
+		SignAndBuild(identityset.PrivateKey(27))
+	require.NoError(t, err)
+
+	hash3 := hash.Hash256{}
+	fnv.New32().Sum(hash3[:])
+	blk3, err := block.NewTestingBuilder().
+		SetHeight(3).
+		SetPrevBlockHash(hash3).
+		SetTimeStamp(testutil.TimestampNow()).
+		AddActions(tsf3, tsf6, execution3).
+		SignAndBuild(identityset.PrivateKey(27))
+	require.NoError(t, err)
+	return []*block.Block{&blk1, &blk2, &blk3}
+}
+
 func TestBlockDAO(t *testing.T) {
 
-	getBlocks := func() []*block.Block {
-		amount := uint64(50 << 22)
-		tsf1, err := testutil.SignedTransfer(identityset.Address(28).String(), identityset.PrivateKey(28), 1, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		tsf2, err := testutil.SignedTransfer(identityset.Address(29).String(), identityset.PrivateKey(29), 2, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		tsf3, err := testutil.SignedTransfer(identityset.Address(30).String(), identityset.PrivateKey(30), 3, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		tsf4, err := testutil.SignedTransfer(identityset.Address(29).String(), identityset.PrivateKey(28), 2, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		tsf5, err := testutil.SignedTransfer(identityset.Address(30).String(), identityset.PrivateKey(29), 3, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		tsf6, err := testutil.SignedTransfer(identityset.Address(28).String(), identityset.PrivateKey(30), 4, big.NewInt(int64(amount)), nil, testutil.TestGasLimit, big.NewInt(0))
-		require.NoError(t, err)
-
-		// create testing executions
-		execution1, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(28), 1, big.NewInt(1), 0, big.NewInt(0), nil)
-		require.NoError(t, err)
-		execution2, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(29), 2, big.NewInt(0), 0, big.NewInt(0), nil)
-		require.NoError(t, err)
-		execution3, err := testutil.SignedExecution(identityset.Address(31).String(), identityset.PrivateKey(30), 3, big.NewInt(2), 0, big.NewInt(0), nil)
-		require.NoError(t, err)
-
-		hash1 := hash.Hash256{}
-		fnv.New32().Sum(hash1[:])
-		blk1, err := block.NewTestingBuilder().
-			SetHeight(1).
-			SetPrevBlockHash(hash1).
-			SetTimeStamp(testutil.TimestampNow()).
-			AddActions(tsf1, tsf4, execution1).
-			SignAndBuild(identityset.PrivateKey(27))
-		require.NoError(t, err)
-
-		hash2 := hash.Hash256{}
-		fnv.New32().Sum(hash2[:])
-		blk2, err := block.NewTestingBuilder().
-			SetHeight(2).
-			SetPrevBlockHash(hash2).
-			SetTimeStamp(testutil.TimestampNow()).
-			AddActions(tsf2, tsf5, execution2).
-			SignAndBuild(identityset.PrivateKey(27))
-		require.NoError(t, err)
-
-		hash3 := hash.Hash256{}
-		fnv.New32().Sum(hash3[:])
-		blk3, err := block.NewTestingBuilder().
-			SetHeight(3).
-			SetPrevBlockHash(hash3).
-			SetTimeStamp(testutil.TimestampNow()).
-			AddActions(tsf3, tsf6, execution3).
-			SignAndBuild(identityset.PrivateKey(27))
-		require.NoError(t, err)
-		return []*block.Block{&blk1, &blk2, &blk3}
+	blks := getTestBlocks(t)
+	assert.Equal(t, 3, len(blks))
+	blkHash := []hash.Hash256{
+		blks[0].HashBlock(), blks[1].HashBlock(), blks[2].HashBlock(),
 	}
 
-	blks := getBlocks()
-	assert.Equal(t, 3, len(blks))
+	t1Hash := blks[0].Actions[0].Hash()
+	t4Hash := blks[0].Actions[1].Hash()
+	e1Hash := blks[0].Actions[2].Hash()
+	t2Hash := blks[1].Actions[0].Hash()
+	t5Hash := blks[1].Actions[1].Hash()
+	e2Hash := blks[1].Actions[2].Hash()
+	t3Hash := blks[2].Actions[0].Hash()
+	t6Hash := blks[2].Actions[1].Hash()
+	e3Hash := blks[2].Actions[2].Hash()
+
+	addr28 := hash.BytesToHash160(identityset.Address(28).Bytes())
+	addr29 := hash.BytesToHash160(identityset.Address(29).Bytes())
+	addr30 := hash.BytesToHash160(identityset.Address(30).Bytes())
+	addr31 := hash.BytesToHash160(identityset.Address(31).Bytes())
+
+	type index struct {
+		addr   hash.Hash160
+		hashes [][]byte
+	}
+
+	daoTests := []struct {
+		total     uint64
+		hashTotal [][]byte
+		actions   [4]index
+	}{
+		{
+			9,
+			[][]byte{t1Hash[:], t4Hash[:], e1Hash[:], t2Hash[:], t5Hash[:], e2Hash[:], t3Hash[:], t6Hash[:], e3Hash[:]},
+			[4]index{
+				{addr28, [][]byte{t1Hash[:], t4Hash[:], e1Hash[:], t6Hash[:]}},
+				{addr29, [][]byte{t4Hash[:], t2Hash[:], t5Hash[:], e2Hash[:]}},
+				{addr30, [][]byte{t5Hash[:], t3Hash[:], t6Hash[:], e3Hash[:]}},
+				{addr31, [][]byte{e1Hash[:], e2Hash[:], e3Hash[:]}},
+			},
+		},
+		{
+			6,
+			[][]byte{t1Hash[:], t4Hash[:], e1Hash[:], t2Hash[:], t5Hash[:], e2Hash[:]},
+			[4]index{
+				{addr28, [][]byte{t1Hash[:], t4Hash[:], e1Hash[:]}},
+				{addr29, [][]byte{t4Hash[:], t2Hash[:], t5Hash[:], e2Hash[:]}},
+				{addr30, [][]byte{t5Hash[:]}},
+				{addr31, [][]byte{e1Hash[:], e2Hash[:]}},
+			},
+		},
+		{
+			3,
+			[][]byte{t1Hash[:], t4Hash[:], e1Hash[:]},
+			[4]index{
+				{addr28, [][]byte{t1Hash[:], t4Hash[:], e1Hash[:]}},
+				{addr29, [][]byte{t4Hash[:]}},
+				{addr30, nil},
+				{addr31, [][]byte{e1Hash[:]}},
+			},
+		},
+		{
+			0,
+			nil,
+			[4]index{
+				{addr28, nil},
+				{addr29, nil},
+				{addr30, nil},
+				{addr31, nil},
+			},
+		},
+	}
 
 	testBlockDao := func(kvstore db.KVStore, t *testing.T) {
 		ctx := context.Background()
@@ -104,8 +174,7 @@ func TestBlockDAO(t *testing.T) {
 		err := dao.Start(ctx)
 		assert.Nil(t, err)
 		defer func() {
-			err = dao.Stop(ctx)
-			assert.Nil(t, err)
+			require.NoError(t, dao.Stop(ctx))
 		}()
 
 		height, err := dao.getBlockchainHeight()
@@ -115,7 +184,7 @@ func TestBlockDAO(t *testing.T) {
 		// block put order is 0 2 1
 		err = dao.putBlock(blks[0])
 		assert.Nil(t, err)
-		blk, err := dao.getBlock(blks[0].HashBlock())
+		blk, err := dao.getBlock(blkHash[0])
 		assert.Nil(t, err)
 		require.NotNil(t, blk)
 		assert.Equal(t, blks[0].Actions[0].Hash(), blk.Actions[0].Hash())
@@ -125,7 +194,7 @@ func TestBlockDAO(t *testing.T) {
 
 		err = dao.putBlock(blks[2])
 		assert.Nil(t, err)
-		blk, err = dao.getBlock(blks[2].HashBlock())
+		blk, err = dao.getBlock(blkHash[2])
 		assert.Nil(t, err)
 		assert.NotNil(t, blk)
 		assert.Equal(t, blks[2].Actions[0].Hash(), blk.Actions[0].Hash())
@@ -135,7 +204,7 @@ func TestBlockDAO(t *testing.T) {
 
 		err = dao.putBlock(blks[1])
 		assert.Nil(t, err)
-		blk, err = dao.getBlock(blks[1].HashBlock())
+		blk, err = dao.getBlock(blkHash[1])
 		assert.Nil(t, err)
 		assert.NotNil(t, blk)
 		assert.Equal(t, blks[1].Actions[0].Hash(), blk.Actions[0].Hash())
@@ -143,34 +212,18 @@ func TestBlockDAO(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, uint64(3), height)
 
-		// test getting hash by height
-		hash, err := dao.getBlockHash(1)
-		assert.Nil(t, err)
-		assert.Equal(t, blks[0].HashBlock(), hash)
-
-		hash, err = dao.getBlockHash(2)
-		assert.Nil(t, err)
-		assert.Equal(t, blks[1].HashBlock(), hash)
-
-		hash, err = dao.getBlockHash(3)
-		assert.Nil(t, err)
-		assert.Equal(t, blks[2].HashBlock(), hash)
-
-		// test getting height by hash
-		height, err = dao.getBlockHeight(blks[0].HashBlock())
-		assert.Nil(t, err)
-		assert.Equal(t, blks[0].Height(), height)
-
-		height, err = dao.getBlockHeight(blks[1].HashBlock())
-		assert.Nil(t, err)
-		assert.Equal(t, blks[1].Height(), height)
-
-		height, err = dao.getBlockHeight(blks[2].HashBlock())
-		assert.Nil(t, err)
-		assert.Equal(t, blks[2].Height(), height)
+		// test hash <--> height mapping
+		for i := uint64(0); i < 3; i++ {
+			hash, err := dao.getBlockHash(blks[i].Height())
+			assert.NoError(t, err)
+			assert.Equal(t, blkHash[i], hash)
+			height, err = dao.getBlockHeight(hash)
+			assert.Nil(t, err)
+			assert.Equal(t, blks[i].Height(), height)
+		}
 
 		// test getTipHash
-		hash, err = dao.getTipHash()
+		hash, err := dao.getTipHash()
 		assert.Nil(t, err)
 		assert.Equal(t, blks[2].HashBlock(), hash)
 	}
@@ -179,109 +232,96 @@ func TestBlockDAO(t *testing.T) {
 		ctx := context.Background()
 		dao := newBlockDAO(kvstore, true, false, 0, config.Default.DB)
 		err := dao.Start(ctx)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		defer func() {
-			err = dao.Stop(ctx)
-			assert.Nil(t, err)
+			require.NoError(t, dao.Stop(ctx))
 		}()
 
-		err = dao.putBlock(blks[0])
-		assert.Nil(t, err)
-		err = dao.putBlock(blks[1])
-		assert.Nil(t, err)
-		err = dao.putBlock(blks[2])
-
-		blkActions1 := blks[0].Actions
-		blkActions2 := blks[1].Actions
-		blkActions3 := blks[2].Actions
-
-		blkNumActions1 := uint64(len(blkActions1))
-		blkNumActions2 := uint64(len(blkActions2))
-		blkNumActions3 := uint64(len(blkActions3))
-
-		blkTransferAmount1, blkTransferAmount2, blkTransferAmount3 := big.NewInt(0), big.NewInt(0), big.NewInt(0)
-
-		tsfs, _ := action.ClassifyActions(blkActions1)
-		for _, tsf := range tsfs {
-			blkTransferAmount1.Add(blkTransferAmount1, tsf.Amount())
+		// receipts for the 3 blocks
+		receipts := [][]*action.Receipt{
+			{
+				{1, 1, t1Hash, 15, "1", []*action.Log{}},
+				{0, 1, t4Hash, 216, "2", []*action.Log{}},
+				{2, 1, e1Hash, 6, "3", []*action.Log{}},
+			},
+			{
+				{3, 2, t2Hash, 1500, "1", []*action.Log{}},
+				{5, 2, t5Hash, 34, "2", []*action.Log{}},
+				{9, 2, e2Hash, 655, "3", []*action.Log{}},
+			},
+			{
+				{7, 3, t3Hash, 488, "1", []*action.Log{}},
+				{6, 3, t6Hash, 2, "2", []*action.Log{}},
+				{2, 3, e3Hash, 1099, "3", []*action.Log{}},
+			},
 		}
-		tsfs, _ = action.ClassifyActions(blkActions2)
-		for _, tsf := range tsfs {
-			blkTransferAmount2.Add(blkTransferAmount2, tsf.Amount())
+
+		for i := uint64(0); i < 3; i++ {
+			require.NoError(t, dao.putBlock(blks[i]))
+			require.NoError(t, dao.putReceipts(i+1, receipts[i]))
 		}
-		tsfs, _ = action.ClassifyActions(blkActions3)
-		for _, tsf := range tsfs {
-			blkTransferAmount3.Add(blkTransferAmount3, tsf.Amount())
+
+		// Test getBlockHashByActionHash
+		h, err := dao.getBlockHashByActionHash(t1Hash)
+		require.NoError(t, err)
+		require.Equal(t, blkHash[0], h)
+		h, err = dao.getBlockHashByActionHash(t2Hash)
+		require.NoError(t, err)
+		require.Equal(t, blkHash[1], h)
+		h, err = dao.getBlockHashByActionHash(t3Hash)
+		require.NoError(t, err)
+		require.Equal(t, blkHash[2], h)
+
+		// Test getReceiptByActionHash
+		for j := range daoTests[0].hashTotal {
+			h := hash.BytesToHash256(daoTests[0].hashTotal[j])
+			receipt, err := dao.getReceiptByActionHash(h)
+			require.NoError(t, err)
+			require.Equal(t, receipts[j/3][j%3], receipt)
 		}
 
 		// Test get actions
-		senderActionCount, err := getActionCountBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(28).Bytes()))
+		total, err := dao.getTotalActions()
 		require.NoError(t, err)
-		require.Equal(t, uint64(3), senderActionCount)
-		senderActions, err := getActionsBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(28).Bytes()))
+		require.EqualValues(t, daoTests[0].total, total)
+		_, err = dao.getActionHashFromIndex(1, total)
+		require.Equal(t, db.ErrInvalid, errors.Cause(err))
+		actions, err := dao.getActionHashFromIndex(0, total)
 		require.NoError(t, err)
-		require.Equal(t, 3, len(senderActions))
-		recipientActionCount, err := getActionCountByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(28).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), recipientActionCount)
-		recipientActions, err := getActionsByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(28).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 1, len(recipientActions))
+		require.Equal(t, actions, daoTests[0].hashTotal)
+		for j := range daoTests[0].actions {
+			actionCount, err := dao.getActionCountByAddress(daoTests[0].actions[j].addr)
+			require.NoError(t, err)
+			require.EqualValues(t, len(daoTests[0].actions[j].hashes), actionCount)
+			if actionCount > 0 {
+				actions, err := dao.getActionsByAddress(daoTests[0].actions[j].addr, 0, actionCount)
+				require.NoError(t, err)
+				require.Equal(t, actions, daoTests[0].actions[j].hashes)
+			}
+		}
 
-		senderActionCount, err = getActionCountBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(29).Bytes()))
+		// non-existing address has 0 actions
+		actionCount, err := dao.getActionCountByAddress(hash.BytesToHash160(identityset.Address(13).Bytes()))
 		require.NoError(t, err)
-		require.Equal(t, uint64(3), senderActionCount)
-		senderActions, err = getActionsBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(29).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 3, len(senderActions))
-		recipientActionCount, err = getActionCountByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(29).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), recipientActionCount)
-		recipientActions, err = getActionsByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(29).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 1, len(recipientActions))
+		require.EqualValues(t, 0, actionCount)
 
-		senderActionCount, err = getActionCountBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(30).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, uint64(3), senderActionCount)
-		senderActions, err = getActionsBySenderAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(30).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 3, len(senderActions))
-		recipientActionCount, err = getActionCountByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(30).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, uint64(1), recipientActionCount)
-		recipientActions, err = getActionsByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(30).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 1, len(recipientActions))
+		for i := 0; i < 3; i++ {
+			amount := big.NewInt(0)
+			tsfs, _ := action.ClassifyActions(blks[i].Actions)
+			for _, tsf := range tsfs {
+				amount.Add(amount, tsf.Amount())
+			}
 
-		recipientActionCount, err = getActionCountByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(31).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, uint64(3), recipientActionCount)
-		recipientActions, err = getActionsByRecipientAddress(dao.kvstore, hash.BytesToHash160(identityset.Address(31).Bytes()))
-		require.NoError(t, err)
-		require.Equal(t, 3, len(recipientActions))
+			// test getNumActions
+			numActions, err := dao.getNumActions(blks[i].Height())
+			require.NoError(t, err)
+			require.EqualValues(t, len(blks[i].Actions), numActions)
 
-		// test getNumActions
-		numActions, err := dao.getNumActions(blks[0].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkNumActions1, numActions)
-		numActions, err = dao.getNumActions(blks[1].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkNumActions2, numActions)
-		numActions, err = dao.getNumActions(blks[2].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkNumActions3, numActions)
-
-		// test getTranferAmount
-		transferAmount, err := dao.getTranferAmount(blks[0].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkTransferAmount1, transferAmount)
-		transferAmount, err = dao.getTranferAmount(blks[1].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkTransferAmount2, transferAmount)
-		transferAmount, err = dao.getTranferAmount(blks[2].Height())
-		require.NoError(t, err)
-		require.Equal(t, blkTransferAmount3, transferAmount)
+			// test getTranferAmount
+			transferAmount, err := dao.getTranferAmount(blks[i].Height())
+			require.NoError(t, err)
+			require.Equal(t, amount, transferAmount)
+		}
 	}
 
 	testDeleteDao := func(kvstore db.KVStore, t *testing.T) {
@@ -292,89 +332,81 @@ func TestBlockDAO(t *testing.T) {
 		err := dao.Start(ctx)
 		require.NoError(err)
 		defer func() {
-			err = dao.Stop(ctx)
-			assert.Nil(t, err)
+			require.NoError(dao.Stop(ctx))
 		}()
 
 		// Put blocks first
-		err = dao.putBlock(blks[0])
-		require.NoError(err)
-		err = dao.putBlock(blks[1])
-		require.NoError(err)
-		err = dao.putBlock(blks[2])
-		require.NoError(err)
+		require.NoError(dao.putBlock(blks[0]))
+		require.NoError(dao.putBlock(blks[1]))
+		require.NoError(dao.putBlock(blks[2]))
 
-		tipHeight, err := dao.getBlockchainHeight()
-		require.NoError(err)
-		require.Equal(uint64(3), tipHeight)
-		blk, err := dao.getBlock(blks[2].HashBlock())
-		require.NoError(err)
-		require.NotNil(blk)
-
-		// Delete tip block
-		err = dao.deleteTipBlock()
-		require.NoError(err)
-		tipHeight, err = dao.getBlockchainHeight()
-		require.NoError(err)
-		require.Equal(uint64(2), tipHeight)
-		blk, err = dao.getBlock(blks[2].HashBlock())
-		require.Equal(db.ErrNotExist, errors.Cause(err))
-		require.Nil(blk)
+		// delete tip block one by one, verify address/action after each deletion
+		for i := range daoTests {
+			if i == 0 {
+				// tests[0] is the whole address/action data at block height 3
+				continue
+			}
+			err = dao.deleteTipBlock()
+			require.NoError(err)
+			tipHeight, err := dao.getBlockchainHeight()
+			require.NoError(err)
+			require.EqualValues(uint64(3-i), tipHeight)
+			total, err := dao.getTotalActions()
+			require.NoError(err)
+			require.EqualValues(daoTests[i].total, total)
+			if total > 0 {
+				_, err = dao.getActionHashFromIndex(1, total)
+				require.Equal(db.ErrInvalid, errors.Cause(err))
+				actions, err := dao.getActionHashFromIndex(0, total)
+				require.NoError(err)
+				require.Equal(actions, daoTests[i].hashTotal)
+			}
+			for j := range daoTests[i].actions {
+				actionCount, err := dao.getActionCountByAddress(daoTests[i].actions[j].addr)
+				require.NoError(err)
+				require.EqualValues(len(daoTests[i].actions[j].hashes), actionCount)
+				if actionCount > 0 {
+					actions, err := dao.getActionsByAddress(daoTests[i].actions[j].addr, 0, actionCount)
+					require.NoError(err)
+					require.Equal(actions, daoTests[i].actions[j].hashes)
+				}
+			}
+		}
+		// cannot delete genesis block
+		require.Equal("cannot delete genesis block", dao.deleteTipBlock().Error())
 	}
 
 	t.Run("In-memory KV Store for blocks", func(t *testing.T) {
 		testBlockDao(db.NewMemKVStore(), t)
 	})
-
 	path := "test-kv-store"
 	testFile, _ := ioutil.TempFile(os.TempDir(), path)
 	testPath := testFile.Name()
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 	t.Run("Bolt DB for blocks", func(t *testing.T) {
+		testutil.CleanupPath(t, testPath)
+		defer testutil.CleanupPath(t, testPath)
 		testBlockDao(db.NewBoltDB(cfg), t)
 	})
+
 	t.Run("In-memory KV Store for actions", func(t *testing.T) {
 		testActionsDao(db.NewMemKVStore(), t)
 	})
 	t.Run("Bolt DB for actions", func(t *testing.T) {
+		testutil.CleanupPath(t, testPath)
+		defer testutil.CleanupPath(t, testPath)
 		testActionsDao(db.NewBoltDB(cfg), t)
 	})
+
 	t.Run("In-memory KV Store deletions", func(t *testing.T) {
 		testDeleteDao(db.NewMemKVStore(), t)
 	})
-
 	t.Run("Bolt DB deletions", func(t *testing.T) {
+		testutil.CleanupPath(t, testPath)
+		defer testutil.CleanupPath(t, testPath)
 		testDeleteDao(db.NewBoltDB(cfg), t)
 	})
-}
-
-func TestBlockDao_putReceipts(t *testing.T) {
-	blkDao := newBlockDAO(db.NewMemKVStore(), true, false, 0, config.Default.DB)
-	receipts := []*action.Receipt{
-		{
-			BlockHeight:     1,
-			ActionHash:      hash.Hash256b([]byte("1")),
-			Status:          1,
-			GasConsumed:     1,
-			ContractAddress: "1",
-			Logs:            []*action.Log{},
-		},
-		{
-			BlockHeight:     1,
-			ActionHash:      hash.Hash256b([]byte("1")),
-			Status:          2,
-			GasConsumed:     2,
-			ContractAddress: "2",
-			Logs:            []*action.Log{},
-		},
-	}
-	require.NoError(t, blkDao.putReceipts(1, receipts))
-	for _, receipt := range receipts {
-		r, err := blkDao.getReceiptByActionHash(receipt.ActionHash)
-		require.NoError(t, err)
-		assert.Equal(t, receipt.ActionHash, r.ActionHash)
-	}
 }
 
 func BenchmarkBlockCache(b *testing.B) {

--- a/blockchain/indexbuilder.go
+++ b/blockchain/indexbuilder.go
@@ -7,6 +7,7 @@
 package blockchain
 
 import (
+	"bytes"
 	"strconv"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -25,6 +26,12 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
+const (
+	blockAddressActionMappingNS      = "a2a"
+	blockAddressActionCountMappingNS = "a2c"
+	blockActionReceiptMappingNS      = "a2r"
+)
+
 var batchSizeMtc = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Name: "iotex_indexer_batch_size",
@@ -37,6 +44,8 @@ func init() {
 	prometheus.MustRegister(batchSizeMtc)
 }
 
+type addrIndex map[hash.Hash160]db.CountingIndex
+
 // IndexBuilder defines the index builder
 type IndexBuilder struct {
 	store        db.KVStore
@@ -45,11 +54,7 @@ type IndexBuilder struct {
 	timerFactory *prometheustimer.TimerFactory
 	dao          *blockDAO
 	reindex      bool
-}
-
-type actionDelta struct {
-	senderDelta    map[hash.Hash160]uint64
-	recipientDelta map[hash.Hash160]uint64
+	dirtyAddr    addrIndex
 }
 
 // NewIndexBuilder instantiates an index builder
@@ -74,12 +79,13 @@ func NewIndexBuilder(chain Blockchain, reindex bool) (*IndexBuilder, error) {
 		timerFactory: timerFactory,
 		dao:          bc.dao,
 		reindex:      reindex,
+		dirtyAddr:    make(addrIndex),
 	}, nil
 }
 
 // Start starts the index builder
 func (ib *IndexBuilder) Start(_ context.Context) error {
-	if err := ib.initAndLoadActions(); err != nil {
+	if err := ib.init(); err != nil {
 		return err
 	}
 	go func() {
@@ -90,18 +96,15 @@ func (ib *IndexBuilder) Start(_ context.Context) error {
 			case blk := <-ib.pendingBlks:
 				timer := ib.timerFactory.NewTimer("indexBlock")
 				batch := db.NewBatch()
-				if err := indexBlock(ib.store, blk, batch); err != nil {
-					log.L().Info(
+				if err := indexBlock(ib.store, blk.HashBlock(), blk.Height(), blk.Actions, batch, nil); err != nil {
+					log.L().Error(
 						"Error when indexing the block",
 						zap.Uint64("height", blk.Height()),
 						zap.Error(err),
 					)
 				}
-				// index receipts
-				putReceipts(blk.Height(), blk.Receipts, batch)
-				batchSizeMtc.WithLabelValues().Set(float64(batch.Size()))
 				if err := ib.store.Commit(batch); err != nil {
-					log.L().Info(
+					log.L().Error(
 						"Error when indexing the block",
 						zap.Uint64("height", blk.Height()),
 						zap.Error(err),
@@ -125,78 +128,28 @@ func (ib *IndexBuilder) HandleBlock(blk *block.Block) error {
 	ib.pendingBlks <- blk
 	return nil
 }
-func initIndexActionsKey(store db.KVStore) error {
-	_, err := store.Get(blockActionBlockMappingNS, indexActionsTipIndexKey)
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		if err = store.Put(blockActionBlockMappingNS, indexActionsTipIndexKey, make([]byte, 8)); err != nil {
-			return errors.Wrap(err, "failed to write initial value for tip index of index actions")
-		}
-	}
 
-	_, err = store.Get(blockActionBlockMappingNS, indexActionsTipHeightKey)
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		if err = store.Put(blockActionBlockMappingNS, indexActionsTipHeightKey, make([]byte, 8)); err != nil {
-			return errors.Wrap(err, "failed to write initial value for tip height of index actions")
-		}
-	}
-	return err
-}
-func (ib *IndexBuilder) getStartHeightAndIndex() (startHeight, startIndex uint64, err error) {
-	// get index that already builded
-	startIndex, err = getNextIndex(ib.store)
-	if err != nil {
-		return
-	}
-	// get height that already builded
-	startHeight, err = getNextHeight(ib.store)
-	if err != nil {
-		return
-	}
-	return
-}
-func (ib *IndexBuilder) commitBatchAndClear(tipIndex, tipHeight uint64, batch db.KVStoreBatch, actDelta *actionDelta) error {
-	tipIndexBytes := byteutil.Uint64ToBytes(tipIndex)
-	batch.Put(blockActionBlockMappingNS, indexActionsTipIndexKey, tipIndexBytes, "failed to put tip index of actions")
-	tipHeightBytes := byteutil.Uint64ToBytes(tipHeight)
-	batch.Put(blockActionBlockMappingNS, indexActionsTipHeightKey, tipHeightBytes, "failed to put tip height")
-	if err := ib.store.Commit(batch); err != nil {
-		return err
-	}
-	actDelta.senderDelta = make(map[hash.Hash160]uint64)
-	actDelta.recipientDelta = make(map[hash.Hash160]uint64)
-	return nil
-}
-func (ib *IndexBuilder) initAndLoadActions() error {
-	err := initIndexActionsKey(ib.store)
-	if err != nil {
-		return err
-	}
+func (ib *IndexBuilder) init() error {
 	tipHeight, err := ib.dao.getBlockchainHeight()
 	if err != nil {
 		return err
 	}
-	startHeight, startIndex := uint64(1), uint64(0)
+	// check if we need to re-index
+	if err := ib.checkReindex(); err != nil {
+		return err
+	}
+
+	startHeight := uint64(1)
 	if !ib.reindex {
-		startHeight, startIndex, err = ib.getStartHeightAndIndex()
+		startHeight, err = ib.getNextHeight()
 		if err != nil {
 			return err
 		}
-	} else {
-		if err = ib.dao.kvstore.Delete(blockAddressActionMappingNS, nil); err != nil {
-			return err
-		}
-		if err = ib.dao.kvstore.Delete(blockAddressActionCountMappingNS, nil); err != nil {
-			return err
-		}
 	}
-	zap.L().Info("Loading actions", zap.Uint64("startHeight", startHeight), zap.Uint64("startIndex", startIndex))
+	// update index to latest block
+	zap.L().Info("Loading blocks", zap.Uint64("startHeight", startHeight))
 	batch := db.NewBatch()
-	actDelta := &actionDelta{
-		senderDelta:    make(map[hash.Hash160]uint64),
-		recipientDelta: make(map[hash.Hash160]uint64),
-	}
-	i := startHeight
-	for ; i <= tipHeight; i++ {
+	for i := startHeight; i <= tipHeight; i++ {
 		hash, err := ib.dao.getBlockHash(i)
 		if err != nil {
 			return err
@@ -208,261 +161,161 @@ func (ib *IndexBuilder) initAndLoadActions() error {
 		blk := &block.Block{
 			Body: *body,
 		}
-		err = indexBlockHash(startIndex, hash, ib.store, blk, batch, actDelta)
+		err = indexBlock(ib.store, hash, i, blk.Actions, batch, ib.dirtyAddr)
 		if err != nil {
 			return err
 		}
-		receipts, err := ib.dao.getReceipts(i)
-		// if receipts are not available,this error will be ignored
-		if err != nil && errors.Cause(err) != db.ErrNotExist {
+		// commit once every 10000 blocks
+		if i%10000 == 0 || i == tipHeight {
+			if err := ib.commitBatchAndClear(i, batch); err != nil {
+				return err
+			}
+			zap.L().Info("Finished indexing blocks", zap.Uint64("height", i))
+		}
+	}
+	return nil
+}
+
+func (ib *IndexBuilder) checkReindex() error {
+	if _, err := ib.store.CountingIndex(totalActionsKey); err != nil && errors.Cause(err) == db.ErrBucketNotExist {
+		// counting index does not exist, need to re-index
+		ib.reindex = true
+	}
+	if ib.reindex {
+		return ib.purgeObsoleteIndex()
+	}
+	return nil
+}
+
+func (ib *IndexBuilder) purgeObsoleteIndex() error {
+	if err := ib.dao.kvstore.Delete(blockAddressActionMappingNS, nil); err != nil {
+		return err
+	}
+	if err := ib.dao.kvstore.Delete(blockAddressActionCountMappingNS, nil); err != nil {
+		return err
+	}
+	if err := ib.dao.kvstore.Delete(blockActionBlockMappingNS, nil); err != nil {
+		return err
+	}
+	if err := ib.dao.kvstore.Delete(blockActionReceiptMappingNS, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (ib *IndexBuilder) commitBatchAndClear(tipHeight uint64, batch db.KVStoreBatch) error {
+	for _, v := range ib.dirtyAddr {
+		if err := v.Commit(); err != nil {
 			return err
 		}
-		putReceipts(i, receipts, batch)
-		startIndex += uint64(len(blk.Actions))
-		// commit once every 10000 heights
-		if i%10000 == 0 || i == tipHeight {
-			if err := ib.commitBatchAndClear(startIndex, i, batch, actDelta); err != nil {
+	}
+	ib.dirtyAddr = nil
+	ib.dirtyAddr = make(addrIndex)
+	// update indexed height
+	batch.Put(blockNS, topIndexedHeightKey, byteutil.Uint64ToBytes(tipHeight), "failed to put indexed height")
+	return ib.store.Commit(batch)
+}
+
+func (ib *IndexBuilder) getNextHeight() (uint64, error) {
+	value, err := ib.store.Get(blockNS, topIndexedHeightKey)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get indexed height")
+	}
+	nextHeight := enc.MachineEndian.Uint64(value)
+	return nextHeight + 1, nil
+}
+
+// getIndexerForAddr returns the indexer for an address
+// if indexer does not exist, one will be created and added to dirtyAddr
+func getIndexerForAddr(kvstore db.KVStore, addr []byte, dirtyAddr addrIndex) (db.CountingIndex, error) {
+	if dirtyAddr == nil {
+		return nil, errors.New("empty dirtyAddr map")
+	}
+
+	address := hash.BytesToHash160(addr)
+	indexer, ok := dirtyAddr[address]
+	if !ok {
+		// create indexer for addr if not exist
+		var err error
+		indexer, err = kvstore.CreateCountingIndexNX(addr)
+		if err != nil {
+			return nil, err
+		}
+		dirtyAddr[address] = indexer
+	}
+	return indexer, nil
+}
+
+// indexBlock builds index for the block
+func indexBlock(kvstore db.KVStore, blkHash hash.Hash256, height uint64, actions []action.SealedEnvelope, batch db.KVStoreBatch, dirtyAddr addrIndex) error {
+	localDirtyMap := dirtyAddr == nil
+	if localDirtyMap {
+		// use local dirtyAddr map if no external is provided
+		dirtyAddr = make(addrIndex)
+	}
+	// get indexer for total actions
+	total, err := getIndexerForAddr(kvstore, totalActionsKey, dirtyAddr)
+	if err != nil {
+		return err
+	}
+
+	// store 32-byte hash + 8-byte height, so getReceiptByActionHash() can use last 8-byte to directly pull receipts
+	hashAndHeight := append(blkHash[:], byteutil.Uint64ToBytes(height)...)
+	for _, elp := range actions {
+		actHash := elp.Hash()
+		batch.Put(blockActionBlockMappingNS, actHash[hashOffset:], hashAndHeight, "failed to put action hash %x", actHash)
+		// add to total account index
+		if err := total.Add(actHash[:], true); err != nil {
+			return err
+		}
+		if err := indexAction(kvstore, actHash, elp, dirtyAddr); err != nil {
+			return err
+		}
+	}
+	if localDirtyMap {
+		// commit local dirtyAddr map
+		for k := range dirtyAddr {
+			if err := dirtyAddr[k].Commit(); err != nil {
 				return err
 			}
 		}
-		if i%1000 == 0 {
-			zap.L().Info("committing actions", zap.Uint64("height", i), zap.Uint64("index", startIndex))
-		}
-	}
-	return nil
-}
-func getNextIndex(store db.KVStore) (uint64, error) {
-	value, err := store.Get(blockActionBlockMappingNS, indexActionsTipIndexKey)
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		return 0, initIndexActionsKey(store)
-	}
-	nextIndex := enc.MachineEndian.Uint64(value)
-	return nextIndex, nil
-}
-func getNextHeight(store db.KVStore) (uint64, error) {
-	value, err := store.Get(blockActionBlockMappingNS, indexActionsTipHeightKey)
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		return 0, initIndexActionsKey(store)
-	}
-	nextHeight := enc.MachineEndian.Uint64(value)
-	nextHeight++
-	return nextHeight, nil
-}
-func indexBlock(store db.KVStore, blk *block.Block, batch db.KVStoreBatch) error {
-	hashBlock := blk.HashBlock()
-	// get index that already builded
-	startIndex, err := getNextIndex(store)
-	if err != nil {
-		return err
-	}
-	// get height that already builded
-	startHeight, err := getNextHeight(store)
-	if err != nil {
-		return err
-	}
-	actDelta := &actionDelta{
-		senderDelta:    make(map[hash.Hash160]uint64),
-		recipientDelta: make(map[hash.Hash160]uint64),
-	}
-	if err = indexBlockHash(startIndex, hashBlock, store, blk, batch, actDelta); err != nil {
-		return err
-	}
-	tipIndexBytes := byteutil.Uint64ToBytes(startIndex + uint64(len(blk.Actions)))
-	batch.Put(blockActionBlockMappingNS, indexActionsTipIndexKey, tipIndexBytes, "failed to put index actions")
-	tipHeightBytes := byteutil.Uint64ToBytes(startHeight)
-	batch.Put(blockActionBlockMappingNS, indexActionsTipHeightKey, tipHeightBytes, "failed to put tip height")
-	return nil
-}
-func indexBlockHash(startActionsNum uint64, blkHash hash.Hash256, store db.KVStore, blk *block.Block, batch db.KVStoreBatch, actDelta *actionDelta) error {
-	for i, elp := range blk.Actions {
-		actHash := elp.Hash()
-		batch.Put(blockActionBlockMappingNS, actHash[hashOffset:], blkHash[:], "failed to put action hash %x", actHash)
-		indexActionsBytes := byteutil.Uint64ToBytes(startActionsNum + uint64(i))
-		batch.Put(blockActionBlockMappingNS, indexActionsBytes, actHash[:], "failed to put index of actions %x", actHash)
-	}
-
-	return putActions(store, blk, batch, actDelta)
-}
-
-func putActions(store db.KVStore, blk *block.Block, batch db.KVStoreBatch, actDelta *actionDelta) error {
-	senderDelta := actDelta.senderDelta
-	recipientDelta := actDelta.recipientDelta
-	for _, selp := range blk.Actions {
-		actHash := selp.Hash()
-		callerAddrBytes := hash.BytesToHash160(selp.SrcPubkey().Hash())
-
-		// get action count for sender
-		senderActionCount, err := getActionCountBySenderAddress(store, callerAddrBytes)
-		if err != nil {
-			return errors.Wrapf(err, "for sender %x", callerAddrBytes)
-		}
-		if delta, ok := senderDelta[callerAddrBytes]; ok {
-			senderActionCount += delta
-			senderDelta[callerAddrBytes]++
-		} else {
-			senderDelta[callerAddrBytes] = 1
-		}
-
-		// put new action to sender
-		senderKey := append(actionFromPrefix, callerAddrBytes[:]...)
-		senderKey = append(senderKey, byteutil.Uint64ToBytes(senderActionCount)...)
-		batch.Put(blockAddressActionMappingNS, senderKey, actHash[:],
-			"failed to put action hash %x for sender %x", actHash, callerAddrBytes)
-
-		// update sender action count
-		senderActionCountKey := append(actionFromPrefix, callerAddrBytes[:]...)
-		batch.Put(blockAddressActionCountMappingNS, senderActionCountKey,
-			byteutil.Uint64ToBytes(senderActionCount+1),
-			"failed to bump action count %x for sender %x", actHash, callerAddrBytes)
-
-		dst, ok := selp.Destination()
-		if !ok || dst == "" {
-			continue
-		}
-		dstAddr, err := address.FromString(dst)
-		if err != nil {
-			return err
-		}
-		dstAddrBytes := hash.BytesToHash160(dstAddr.Bytes())
-
-		if dstAddrBytes == callerAddrBytes {
-			// recipient is same as sender
-			continue
-		}
-
-		// get action count for recipient
-		recipientActionCount, err := getActionCountByRecipientAddress(store, dstAddrBytes)
-		if err != nil {
-			return errors.Wrapf(err, "for recipient %x", dstAddrBytes)
-		}
-		if delta, ok := recipientDelta[dstAddrBytes]; ok {
-			recipientActionCount += delta
-			recipientDelta[dstAddrBytes]++
-		} else {
-			recipientDelta[dstAddrBytes] = 1
-		}
-
-		// put new action to recipient
-		recipientKey := append(actionToPrefix, dstAddrBytes[:]...)
-		recipientKey = append(recipientKey, byteutil.Uint64ToBytes(recipientActionCount)...)
-		batch.Put(blockAddressActionMappingNS, recipientKey, actHash[:],
-			"failed to put action hash %x for recipient %x", actHash, dstAddrBytes)
-
-		// update recipient action count
-		recipientActionCountKey := append(actionToPrefix, dstAddrBytes[:]...)
-		batch.Put(blockAddressActionCountMappingNS, recipientActionCountKey,
-			byteutil.Uint64ToBytes(recipientActionCount+1), "failed to bump action count %x for recipient %x",
-			actHash, dstAddrBytes)
+		// update indexed height
+		batch.Put(blockNS, topIndexedHeightKey, byteutil.Uint64ToBytes(height), "failed to put indexed height")
 	}
 	return nil
 }
 
-// putReceipts store receipt into db
-func putReceipts(blkHeight uint64, blkReceipts []*action.Receipt, batch db.KVStoreBatch) {
-	if blkReceipts == nil {
-		zap.L().Info("Block contains no receipt", zap.Uint64("height", blkHeight))
-		return
-	}
-	var heightBytes [8]byte
-	enc.MachineEndian.PutUint64(heightBytes[:], blkHeight)
-	for _, r := range blkReceipts {
-		batch.Put(
-			blockActionReceiptMappingNS,
-			r.ActionHash[hashOffset:],
-			heightBytes[:],
-			"Failed to put receipt index for action %x",
-			r.ActionHash[:],
-		)
-	}
-}
-
-func getBlockHashByActionHash(store db.KVStore, h hash.Hash256) (hash.Hash256, error) {
-	var blkHash hash.Hash256
-	value, err := store.Get(blockActionBlockMappingNS, h[hashOffset:])
+// indexAction builds index for an action
+func indexAction(kvstore db.KVStore, actHash hash.Hash256, elp action.SealedEnvelope, dirtyAddr addrIndex) error {
+	// add to sender's index
+	callerAddrBytes := elp.SrcPubkey().Hash()
+	sender, err := getIndexerForAddr(kvstore, callerAddrBytes, dirtyAddr)
 	if err != nil {
-		return blkHash, errors.Wrapf(err, "failed to get action %x", h)
+		return err
 	}
-	if len(value) == 0 {
-		return blkHash, errors.Wrapf(db.ErrNotExist, "action %x missing", h)
+	if err := sender.Add(actHash[:], true); err != nil {
+		return err
 	}
-	copy(blkHash[:], value)
-	return blkHash, nil
-}
 
-// getActionCountBySenderAddress returns action count by sender address
-func getActionCountBySenderAddress(store db.KVStore, addrBytes hash.Hash160) (uint64, error) {
-	senderActionCountKey := append(actionFromPrefix, addrBytes[:]...)
-	value, err := store.Get(blockAddressActionCountMappingNS, senderActionCountKey)
+	dst, ok := elp.Destination()
+	if !ok || dst == "" {
+		return nil
+	}
+	dstAddr, err := address.FromString(dst)
 	if err != nil {
-		return 0, nil
+		return err
 	}
-	if len(value) == 0 {
-		return 0, errors.New("count of actions by sender is broken")
-	}
-	return enc.MachineEndian.Uint64(value), nil
-}
+	dstAddrBytes := dstAddr.Bytes()
 
-// getActionsBySenderAddress returns actions for sender
-func getActionsBySenderAddress(store db.KVStore, addrBytes hash.Hash160) ([]hash.Hash256, error) {
-	// get action count for sender
-	senderActionCount, err := getActionCountBySenderAddress(store, addrBytes)
+	if bytes.Compare(dstAddrBytes, callerAddrBytes) == 0 {
+		// recipient is same as sender
+		return nil
+	}
+
+	// add to recipient's index
+	recipient, err := getIndexerForAddr(kvstore, dstAddrBytes, dirtyAddr)
 	if err != nil {
-		return nil, errors.Wrapf(err, "for sender %x", addrBytes)
+		return err
 	}
-
-	res, err := getActionsByAddress(store, addrBytes, senderActionCount, actionFromPrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
-// getActionsByRecipientAddress returns actions for recipient
-func getActionsByRecipientAddress(store db.KVStore, addrBytes hash.Hash160) ([]hash.Hash256, error) {
-	// get action count for recipient
-	recipientActionCount, getCountErr := getActionCountByRecipientAddress(store, addrBytes)
-	if getCountErr != nil {
-		return nil, errors.Wrapf(getCountErr, "for recipient %x", addrBytes)
-	}
-
-	res, err := getActionsByAddress(store, addrBytes, recipientActionCount, actionToPrefix)
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
-}
-
-// getActionCountByRecipientAddress returns action count by recipient address
-func getActionCountByRecipientAddress(store db.KVStore, addrBytes hash.Hash160) (uint64, error) {
-	recipientActionCountKey := append(actionToPrefix, addrBytes[:]...)
-	value, err := store.Get(blockAddressActionCountMappingNS, recipientActionCountKey)
-	if err != nil {
-		return 0, nil
-	}
-	if len(value) == 0 {
-		return 0, errors.New("count of actions by recipient is broken")
-	}
-	return enc.MachineEndian.Uint64(value), nil
-}
-
-// getActionsByAddress returns actions by address
-func getActionsByAddress(store db.KVStore, addrBytes hash.Hash160, count uint64, keyPrefix []byte) ([]hash.Hash256, error) {
-	var res []hash.Hash256
-
-	for i := uint64(0); i < count; i++ {
-		key := append(keyPrefix, addrBytes[:]...)
-		key = append(key, byteutil.Uint64ToBytes(i)...)
-		value, err := store.Get(blockAddressActionMappingNS, key)
-		if err != nil {
-			return res, errors.Wrapf(err, "failed to get action for index %d", i)
-		}
-		if len(value) == 0 {
-			return res, errors.Wrapf(db.ErrNotExist, "action for index %d missing", i)
-		}
-		res = append(res, hash.BytesToHash256(value))
-	}
-
-	return res, nil
+	return recipient.Add(actHash[:], true)
 }

--- a/blockchain/indexbuilder_test.go
+++ b/blockchain/indexbuilder_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"context"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/testutil"
+)
+
+func TestIndexer(t *testing.T) {
+
+	blks := getTestBlocks(t)
+	require.Equal(t, 3, len(blks))
+	blkHash1 := blks[0].HashBlock()
+	blkHash2 := blks[1].HashBlock()
+	blkHash3 := blks[2].HashBlock()
+
+	t1Hash := blks[0].Actions[0].Hash()
+	t4Hash := blks[0].Actions[1].Hash()
+	e1Hash := blks[0].Actions[2].Hash()
+	t2Hash := blks[1].Actions[0].Hash()
+	t5Hash := blks[1].Actions[1].Hash()
+	e2Hash := blks[1].Actions[2].Hash()
+	t3Hash := blks[2].Actions[0].Hash()
+	t6Hash := blks[2].Actions[1].Hash()
+	e3Hash := blks[2].Actions[2].Hash()
+
+	type index struct {
+		addr   hash.Hash160
+		hashes [][]byte
+	}
+
+	indexTests := struct {
+		total     uint64
+		hashTotal [][]byte
+		actions   [4]index
+	}{
+		9,
+		[][]byte{t1Hash[:], t4Hash[:], e1Hash[:], t2Hash[:], t5Hash[:], e2Hash[:], t3Hash[:], t6Hash[:], e3Hash[:]},
+		[4]index{
+			{hash.BytesToHash160(identityset.Address(28).Bytes()),
+				[][]byte{t1Hash[:], t4Hash[:], e1Hash[:], t6Hash[:]}},
+			{hash.BytesToHash160(identityset.Address(29).Bytes()),
+				[][]byte{t4Hash[:], t2Hash[:], t5Hash[:], e2Hash[:]}},
+			{hash.BytesToHash160(identityset.Address(30).Bytes()),
+				[][]byte{t5Hash[:], t3Hash[:], t6Hash[:], e3Hash[:]}},
+			{hash.BytesToHash160(identityset.Address(31).Bytes()),
+				[][]byte{e1Hash[:], e2Hash[:], e3Hash[:]}},
+		},
+	}
+
+	testIndexer := func(kvstore db.KVStore, t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		dao := newBlockDAO(kvstore, false, false, 0, config.Default.DB)
+		require.NoError(dao.Start(ctx))
+		defer func() {
+			require.NoError(dao.Stop(ctx))
+		}()
+
+		zero := make([]byte, 8)
+		require.NoError(dao.kvstore.Put(blockNS, totalActionsKey, zero))
+		v, _ := dao.kvstore.Get(blockNS, totalActionsKey)
+		require.Equal(zero, v)
+		require.NoError(dao.putBlock(blks[0]))
+		require.NoError(dao.putBlock(blks[1]))
+
+		ib := &IndexBuilder{
+			store:       dao.kvstore,
+			pendingBlks: make(chan *block.Block, 64),
+			cancelChan:  make(chan interface{}),
+			dao:         dao,
+			reindex:     false,
+			dirtyAddr:   make(map[hash.Hash160]db.CountingIndex),
+		}
+		require.NoError(ib.Start(context.Background()))
+		defer ib.Stop(context.Background())
+		require.True(ib.reindex)
+		height, err := ib.getNextHeight()
+		require.NoError(err)
+		require.EqualValues(3, height)
+
+		// test handle new block
+		require.NoError(dao.putBlock(blks[2]))
+		ib.pendingBlks <- blks[2]
+		time.Sleep(500 * time.Millisecond)
+
+		height, err = ib.getNextHeight()
+		require.NoError(err)
+		require.EqualValues(4, height)
+
+		// Test getBlockHashByActionHash
+		blkHash, err := dao.getBlockHashByActionHash(t1Hash)
+		require.NoError(err)
+		require.Equal(blkHash1, blkHash)
+		blkHash, err = dao.getBlockHashByActionHash(t2Hash)
+		require.NoError(err)
+		require.Equal(blkHash2, blkHash)
+		blkHash, err = dao.getBlockHashByActionHash(t3Hash)
+		require.NoError(err)
+		require.Equal(blkHash3, blkHash)
+
+		// Test get actions
+		total, err := dao.getTotalActions()
+		require.NoError(err)
+		require.EqualValues(indexTests.total, total)
+		_, err = dao.getActionHashFromIndex(1, total)
+		require.Equal(db.ErrInvalid, errors.Cause(err))
+		actions, err := dao.getActionHashFromIndex(0, total)
+		require.NoError(err)
+		require.Equal(actions, indexTests.hashTotal)
+		for j := range indexTests.actions {
+			actionCount, err := dao.getActionCountByAddress(indexTests.actions[j].addr)
+			require.NoError(err)
+			require.EqualValues(len(indexTests.actions[j].hashes), actionCount)
+			if actionCount > 0 {
+				actions, err := dao.getActionsByAddress(indexTests.actions[j].addr, 0, actionCount)
+				require.NoError(err)
+				require.Equal(actions, indexTests.actions[j].hashes)
+			}
+		}
+
+		for i := 0; i < 3; i++ {
+			amount := big.NewInt(0)
+			tsfs, _ := action.ClassifyActions(blks[i].Actions)
+			for _, tsf := range tsfs {
+				amount.Add(amount, tsf.Amount())
+			}
+
+			// test getNumActions
+			numActions, err := dao.getNumActions(blks[i].Height())
+			require.NoError(err)
+			require.EqualValues(len(blks[i].Actions), numActions)
+
+			// test getTranferAmount
+			transferAmount, err := dao.getTranferAmount(blks[i].Height())
+			require.NoError(err)
+			require.Equal(amount, transferAmount)
+		}
+	}
+
+	t.Run("In-memory KV indexer", func(t *testing.T) {
+		testIndexer(db.NewMemKVStore(), t)
+	})
+	path := "test-indexer"
+	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testPath := testFile.Name()
+	cfg := config.Default.DB
+	cfg.DbPath = testPath
+
+	t.Run("Bolt DB indexer", func(t *testing.T) {
+		testutil.CleanupPath(t, testPath)
+		defer testutil.CleanupPath(t, testPath)
+		testIndexer(db.NewBoltDB(cfg), t)
+	})
+}

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -176,7 +176,7 @@ func New(
 
 	var indexBuilder *blockchain.IndexBuilder
 	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok && cfg.Chain.EnableAsyncIndexWrite {
-		if indexBuilder, err = blockchain.NewIndexBuilder(chain, cfg.Reindex); err != nil {
+		if indexBuilder, err = blockchain.NewIndexBuilder(chain, cfg.DB.Reindex); err != nil {
 			return nil, errors.Wrap(err, "failed to create index builder")
 		}
 		if err := chain.AddSubscriber(indexBuilder); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -167,9 +167,9 @@ var (
 			},
 			SplitDBSizeMB: 0,
 			SplitDBHeight: 900000,
+			Reindex:       false,
 		},
 		Genesis: genesis.Default,
-		Reindex: false,
 	}
 
 	// ErrInvalidCfg indicates the invalid config value
@@ -309,18 +309,16 @@ type (
 		DbPath string `yaml:"dbPath"`
 		// NumRetries is the number of retries
 		NumRetries uint8 `yaml:"numRetries"`
-
 		// RDS is the config for rds
 		RDS RDS `yaml:"RDS"`
-
 		// SQLite3 is the config for SQLITE3
 		SQLITE3 SQLITE3 `yaml:"SQLITE3"`
-
 		// SplitDBSize is the config for DB's split file size
 		SplitDBSizeMB uint64 `yaml:"splitDBSizeMB"`
-
 		// SplitDBHeight is the config for DB's split start height
 		SplitDBHeight uint64 `yaml:"splitDBHeight"`
+		// Reindex will rebuild index if set to true
+		Reindex bool `yaml:"reindex"`
 	}
 
 	// RDS is the cloud rds config
@@ -358,7 +356,6 @@ type (
 		Log        log.GlobalConfig            `yaml:"log"`
 		SubLogs    map[string]log.GlobalConfig `yaml:"subLogs"`
 		Genesis    genesis.Genesis             `yaml:"genesis"`
-		Reindex    bool                        `yaml:"reindex"`
 	}
 
 	// Validate is the interface of validating the config
@@ -392,7 +389,7 @@ func New(validates ...Validate) (Config, error) {
 	if err := yaml.Get(uconfig.Root).Populate(&cfg); err != nil {
 		return Config{}, errors.Wrap(err, "failed to unmarshal YAML config to struct")
 	}
-	cfg.Reindex = _reindex
+	cfg.DB.Reindex = _reindex
 	// set network master key to private key
 	if cfg.Network.MasterKey == "" {
 		cfg.Network.MasterKey = cfg.Chain.ProducerPrivKey

--- a/db/counting_index.go
+++ b/db/counting_index.go
@@ -1,0 +1,431 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package db
+
+import (
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+)
+
+var (
+	// ZeroIndex is 8-byte of 0
+	ZeroIndex = byteutil.Uint64ToBytesBigEndian(0)
+	// ErrInvalid indicates an invalid input
+	ErrInvalid = errors.New("invalid input")
+)
+
+type (
+	// CountingIndex is a bucket of <k, v> where
+	// k consists of 8-byte whose value increments (0, 1, 2 ... n) upon each insertion
+	// position 0 (k = 0x0000000000000000) stores the total number of items in bucket so far
+	CountingIndex interface {
+		// Size returns the total number of keys so far
+		Size() uint64
+		// Add inserts a value into the index
+		Add([]byte, bool) error
+		// Get return value of key[slot]
+		Get(uint64) ([]byte, error)
+		// Range return value of keys [start, start+count)
+		Range(uint64, uint64) ([][]byte, error)
+		// Revert removes entries from end
+		Revert(uint64) error
+		// Close makes the index not usable
+		Close()
+		// Commit commits the batch
+		Commit() error
+	}
+
+	// countingIndex is CountingIndex implementation based on bolt DB
+	countingIndex struct {
+		db         *bolt.DB
+		numRetries uint8
+		bucket     []byte
+		size       uint64 // total number of keys
+		batch      KVStoreBatch
+	}
+
+	// memCountingIndex is the in-memory implementation of CountingIndex
+	memCountingIndex struct {
+		kvstore *memKVStore
+		bucket  []byte
+		size    uint64 // total number of keys
+		batch   KVStoreBatch
+	}
+)
+
+// NewCountingIndex creates a new instance of countingIndex
+func NewCountingIndex(db *bolt.DB, retry uint8, name []byte, size uint64) (CountingIndex, error) {
+	if db == nil {
+		return nil, errors.Wrap(ErrInvalid, "db object is nil")
+	}
+
+	if len(name) == 0 {
+		return nil, errors.Wrap(ErrInvalid, "bucket name is nil")
+	}
+
+	bucket := make([]byte, len(name))
+	copy(bucket, name)
+	return &countingIndex{
+		db:         db,
+		numRetries: retry,
+		bucket:     bucket,
+		size:       size,
+	}, nil
+}
+
+// Size returns the total number of keys so far
+func (c *countingIndex) Size() uint64 {
+	return c.size
+}
+
+// Add inserts a value into the index
+func (c *countingIndex) Add(value []byte, batch bool) error {
+	if batch {
+		return c.addBatch(value)
+	}
+	if c.batch != nil {
+		return errors.Wrap(ErrInvalid, "cannot call Add in batch mode, call Commit() first to exit batch mode")
+	}
+	var err error
+	for i := uint8(0); i < c.numRetries; i++ {
+		if err = c.db.Update(func(tx *bolt.Tx) error {
+			bucket := tx.Bucket(c.bucket)
+			if bucket == nil {
+				return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", c.bucket)
+			}
+			last := byteutil.Uint64ToBytesBigEndian(c.size + 1)
+			if err := bucket.Put(last, value); err != nil {
+				return err
+			}
+			// update the total amount
+			return bucket.Put(ZeroIndex, last)
+		}); err == nil {
+			break
+		}
+	}
+	if err != nil {
+		err = errors.Wrap(ErrIO, err.Error())
+	}
+	c.size++
+	return nil
+}
+
+// addBatch inserts a value into the index in batch mode
+func (c *countingIndex) addBatch(value []byte) error {
+	if c.batch == nil {
+		c.batch = NewBatch()
+	}
+	c.batch.Put("", byteutil.Uint64ToBytesBigEndian(c.size+1), value, "failed to put")
+	c.size++
+	return nil
+}
+
+// Get return value of key[slot]
+func (c *countingIndex) Get(slot uint64) ([]byte, error) {
+	if slot >= c.size {
+		return nil, errors.Wrapf(ErrNotExist, "slot: %d", slot)
+	}
+
+	var value []byte
+	err := c.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(c.bucket)
+		if bucket == nil {
+			return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", c.bucket)
+		}
+		// seek to start
+		cur := bucket.Cursor()
+		k, v := cur.Seek(byteutil.Uint64ToBytesBigEndian(slot + 1))
+		if k == nil {
+			return errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", slot)
+		}
+		value = make([]byte, len(v))
+		copy(value, v)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+// Range return value of keys [start, start+count)
+func (c *countingIndex) Range(start, count uint64) ([][]byte, error) {
+	if start+count > c.size || count == 0 {
+		return nil, errors.Wrapf(ErrInvalid, "start: %d, count: %d", start, count)
+	}
+
+	value := make([][]byte, count)
+	err := c.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(c.bucket)
+		if bucket == nil {
+			return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", c.bucket)
+		}
+		// seek to start
+		cur := bucket.Cursor()
+		k, v := cur.Seek(byteutil.Uint64ToBytesBigEndian(start + 1))
+		if k == nil {
+			return errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", start)
+		}
+
+		// retrieve 'count' items
+		for i := uint64(0); i < count; k, v = cur.Next() {
+			if k == nil {
+				return errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", start+1+i)
+			}
+			value[i] = make([]byte, len(v))
+			copy(value[i], v)
+			i++
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return value, nil
+}
+
+// Revert removes entries from end
+func (c *countingIndex) Revert(count uint64) error {
+	if c.batch != nil {
+		return errors.Wrap(ErrInvalid, "cannot call Revert in batch mode, call Commit() first to exit batch mode")
+	}
+	if count == 0 || count > c.size {
+		return errors.Wrapf(ErrInvalid, "count: %d", count)
+	}
+
+	return c.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(c.bucket)
+		if bucket == nil {
+			return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", c.bucket)
+		}
+
+		start := c.size - count
+		// seek to start
+		cur := bucket.Cursor()
+		k, _ := cur.Seek(byteutil.Uint64ToBytesBigEndian(start + 1))
+		if k == nil {
+			return errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", start)
+		}
+
+		// delete 'count' items
+		for i := uint64(0); i < count; k, _ = cur.Next() {
+			if k == nil {
+				return errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", start+i)
+			}
+			if err := bucket.Delete(k); err != nil {
+				return errors.Wrapf(ErrNotExist, "failed to delete entry at %d", start+i)
+			}
+			i++
+		}
+		// update the total amount
+		c.size = start
+		return bucket.Put(ZeroIndex, byteutil.Uint64ToBytesBigEndian(start))
+	})
+}
+
+// Close makes the index not usable
+func (c *countingIndex) Close() {
+	// frees reference to db, the db object itself will be closed/freed by its owner, not here
+	c.db = nil
+	c.batch = nil
+	c.bucket = nil
+}
+
+// Commit commits a batch
+func (c *countingIndex) Commit() (err error) {
+	if c.batch == nil {
+		return nil
+	}
+
+	succeed := true
+	c.batch.Lock()
+	defer func() {
+		if succeed {
+			// clear the batch if commit succeeds
+			c.batch.ClearAndUnlock()
+			c.batch = nil
+		} else {
+			c.batch.Unlock()
+		}
+	}()
+
+	numRetries := c.numRetries
+	for i := uint8(0); i < numRetries; i++ {
+		if err = c.db.Update(func(tx *bolt.Tx) error {
+			bucket := tx.Bucket(c.bucket)
+			if bucket == nil {
+				return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", c.bucket)
+			}
+			// set an aggressive fill percent
+			// b/c counting index only appends, further inserts to the bucket would never split the page
+			bucket.FillPercent = 1.0
+			for i := 0; i < c.batch.Size(); i++ {
+				write, err := c.batch.Entry(i)
+				if err != nil {
+					return err
+				}
+				if err := bucket.Put(write.key, write.value); err != nil {
+					return errors.Wrapf(err, write.errorFormat, write.errorArgs)
+				}
+			}
+			// update the total amount
+			return bucket.Put(ZeroIndex, byteutil.Uint64ToBytesBigEndian(c.size))
+		}); err == nil {
+			break
+		}
+	}
+
+	if err != nil {
+		succeed = false
+		err = errors.Wrap(ErrIO, err.Error())
+	}
+	return err
+}
+
+// NewInMemCountingIndex creates a new instance of memCountingIndex
+func NewInMemCountingIndex(mem *memKVStore, name []byte, size uint64) (CountingIndex, error) {
+	if mem == nil {
+		return nil, errors.Wrap(ErrInvalid, "memKVStore object is nil")
+	}
+	if len(name) == 0 {
+		return nil, errors.Wrap(ErrInvalid, "bucket name is nil")
+	}
+	bucket := make([]byte, len(name))
+	copy(bucket, name)
+	return &memCountingIndex{
+		kvstore: mem,
+		bucket:  bucket,
+		size:    size,
+	}, nil
+}
+
+// Size returns the total number of keys so far
+func (m *memCountingIndex) Size() uint64 {
+	return m.size
+}
+
+// Add inserts a value into the index
+func (m *memCountingIndex) Add(value []byte, batch bool) error {
+	if err := m.checkBucket(); err != nil {
+		return err
+	}
+	if batch {
+		return m.addBatch(value)
+	}
+	if m.batch != nil {
+		return errors.Wrap(ErrInvalid, "cannot call Add in batch mode, call Commit() first to exit batch mode")
+	}
+	last := byteutil.Uint64ToBytesBigEndian(m.size + 1)
+	if err := m.kvstore.Put(string(m.bucket), last, value); err != nil {
+		return err
+	}
+	// update the total amount
+	if err := m.kvstore.Put(string(m.bucket), ZeroIndex, last); err != nil {
+		return err
+	}
+	m.size++
+	return nil
+}
+
+// addBatch inserts a value into the index in batch mode
+func (m *memCountingIndex) addBatch(value []byte) error {
+	if m.batch == nil {
+		m.batch = NewBatch()
+	}
+	m.batch.Put(string(m.bucket), byteutil.Uint64ToBytesBigEndian(m.size+1), value, "failed to put")
+	m.size++
+	return nil
+}
+
+// Get return value of key[slot]
+func (m *memCountingIndex) Get(slot uint64) ([]byte, error) {
+	if err := m.checkBucket(); err != nil {
+		return nil, err
+	}
+	if slot >= m.size {
+		return nil, errors.Wrapf(ErrNotExist, "slot: %d", slot)
+	}
+	return m.kvstore.Get(string(m.bucket), byteutil.Uint64ToBytesBigEndian(slot+1))
+}
+
+// Range return value of keys [start, start+count)
+func (m *memCountingIndex) Range(start, count uint64) ([][]byte, error) {
+	if err := m.checkBucket(); err != nil {
+		return nil, err
+	}
+	if start+count > m.size || count == 0 {
+		return nil, errors.Wrapf(ErrInvalid, "start: %d, count: %d", start, count)
+	}
+
+	value := make([][]byte, count)
+	for i := uint64(0); i < count; i++ {
+		v, err := m.kvstore.Get(string(m.bucket), byteutil.Uint64ToBytesBigEndian(start+1+i))
+		if err != nil {
+			return nil, errors.Wrapf(ErrNotExist, "entry at %d doesn't exist", start+1+i)
+		}
+		value[i] = make([]byte, len(v))
+		copy(value[i], v)
+	}
+	return value, nil
+}
+
+// Revert removes entries from end
+func (m *memCountingIndex) Revert(count uint64) error {
+	if err := m.checkBucket(); err != nil {
+		return err
+	}
+	if m.batch != nil {
+		return errors.Wrap(ErrInvalid, "cannot call Revert in batch mode, call Commit() first to exit batch mode")
+	}
+	if count == 0 || count > m.size {
+		return errors.Wrapf(ErrInvalid, "count: %d", count)
+	}
+
+	start := m.size - count
+	for i := uint64(0); i < count; i++ {
+		if err := m.kvstore.Delete(string(m.bucket), byteutil.Uint64ToBytesBigEndian(start+1+i)); err != nil {
+			return err
+		}
+	}
+	// update the total amount
+	m.size = start
+	return m.kvstore.Put(string(m.bucket), ZeroIndex, byteutil.Uint64ToBytesBigEndian(start))
+}
+
+// Close makes the index not usable
+func (m *memCountingIndex) Close() {
+	// frees reference to KVStore, the KVStore object itself will be closed/freed by its owner, not here
+	m.kvstore = nil
+	m.batch = nil
+	m.bucket = nil
+}
+
+// Commit commits a batch
+func (m *memCountingIndex) Commit() error {
+	if err := m.checkBucket(); err != nil {
+		return err
+	}
+	if m.batch == nil {
+		return nil
+	}
+	// commit the batch
+	if err := m.kvstore.Commit(m.batch); err != nil {
+		return err
+	}
+	m.batch = nil
+	// update the total amount
+	return m.kvstore.Put(string(m.bucket), ZeroIndex, byteutil.Uint64ToBytesBigEndian(m.size))
+}
+
+func (m *memCountingIndex) checkBucket() error {
+	if _, ok := m.kvstore.bucket.Load(string(m.bucket)); !ok {
+		return errors.Wrapf(ErrBucketNotExist, "bucket = %s doesn't exist", m.bucket)
+	}
+	return nil
+}

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -1,0 +1,230 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	bolt "go.etcd.io/bbolt"
+
+	"github.com/iotexproject/iotex-core/testutil"
+)
+
+func TestNewCountingIndex(t *testing.T) {
+	require := require.New(t)
+
+	_, err := NewCountingIndex(nil, 3, []byte{1}, 0)
+	require.Equal(ErrInvalid, errors.Cause(err))
+	_, err = NewCountingIndex(&bolt.DB{}, 3, nil, 0)
+	require.Equal(ErrInvalid, errors.Cause(err))
+	_, err = NewCountingIndex(&bolt.DB{}, 3, []byte{}, 0)
+	require.Equal(ErrInvalid, errors.Cause(err))
+}
+
+func TestCountingIndex(t *testing.T) {
+	testFunc := func(kv KVStore, t *testing.T) {
+		require := require.New(t)
+
+		require.NoError(kv.Start(context.Background()))
+		defer func() {
+			require.NoError(kv.Stop(context.Background()))
+		}()
+
+		bucket := []byte("test")
+		_, err := kv.CountingIndex(bucket)
+		require.Equal(ErrBucketNotExist, errors.Cause(err))
+
+		index, err := kv.CreateCountingIndexNX(bucket)
+		require.NoError(err)
+		require.Equal(uint64(0), index.Size())
+
+		// write 200 entries in batch mode
+		for i := 0; i < 200; i++ {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			require.NoError(index.Add(h[:], true))
+		}
+		// cannot Add() before Commit() in batch mode
+		require.Equal(ErrInvalid, errors.Cause(index.Add([]byte{1}, false)))
+		require.NoError(index.Commit())
+		require.EqualValues(200, index.Size())
+		// cannot get > size
+		_, err = index.Get(index.Size())
+		require.Equal(ErrNotExist, errors.Cause(err))
+		k, err := index.Get(10)
+		require.NoError(err)
+		h := hash.Hash160b([]byte(strconv.Itoa(10)))
+		require.Equal(h[:], k)
+		index.Close()
+
+		// re-open the bucket
+		index, err = kv.CountingIndex(bucket)
+		require.NoError(err)
+		// write another 100 entries
+		for i := 200; i < 300; i++ {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			require.NoError(index.Add(h[:], false))
+		}
+		require.EqualValues(300, index.Size())
+
+		v, err := index.Range(248, 0)
+		require.Equal(ErrInvalid, errors.Cause(err))
+		v, err = index.Range(248, 53)
+		require.Equal(ErrInvalid, errors.Cause(err))
+
+		// last key
+		v, err = index.Range(299, 1)
+		require.NoError(err)
+		require.Equal(1, len(v))
+		h = hash.Hash160b([]byte(strconv.Itoa(299)))
+		require.Equal(h[:], v[0])
+
+		// first 5 keys
+		v, err = index.Range(0, 5)
+		require.NoError(err)
+		require.Equal(5, len(v))
+		for i := range v {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			require.Equal(h[:], v[i])
+		}
+
+		// last 40 keys
+		v, err = index.Range(260, 40)
+		require.NoError(err)
+		require.Equal(40, len(v))
+		for i := range v {
+			h := hash.Hash160b([]byte(strconv.Itoa(260 + i)))
+			require.Equal(h[:], v[i])
+		}
+		index.Close()
+
+		// re-open the bucket, verify size = 300
+		index1, err := kv.CountingIndex(bucket)
+		require.NoError(err)
+		require.EqualValues(300, index1.Size())
+
+		// revert last 40 keys
+		err = index1.Revert(0)
+		require.Equal(ErrInvalid, errors.Cause(err))
+		err = index1.Revert(index1.Size() + 1)
+		require.Equal(ErrInvalid, errors.Cause(err))
+		require.NoError(index1.Revert(40))
+		require.EqualValues(260, index1.Size())
+
+		// last 40 keys
+		_, err = index1.Range(220, 41)
+		require.Equal(ErrInvalid, errors.Cause(err))
+		v, err = index1.Range(220, 40)
+		require.NoError(err)
+		require.Equal(40, len(v))
+		for i := range v {
+			h := hash.Hash160b([]byte(strconv.Itoa(220 + i)))
+			require.Equal(h[:], v[i])
+		}
+	}
+
+	t.Run("in-mem KVStore", func(t *testing.T) {
+		testFunc(NewMemKVStore(), t)
+	})
+
+	path := "test-iterate.bolt"
+	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testPath := testFile.Name()
+	cfg.DbPath = testPath
+	t.Run("Bolt DB", func(t *testing.T) {
+		testutil.CleanupPath(t, testPath)
+		defer testutil.CleanupPath(t, testPath)
+		testFunc(NewBoltDB(cfg), t)
+	})
+}
+
+const (
+	Tenants = 10000
+	Keys    = 200
+)
+
+func TestBulk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	testFunc := func(kv KVStore, t *testing.T) {
+		require := require.New(t)
+
+		require.NoError(kv.Start(context.Background()))
+		defer func() {
+			require.NoError(kv.Stop(context.Background()))
+		}()
+
+		// create 10000 tenants
+		for i := 0; i < Tenants; i++ {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			tenant, err := kv.CreateCountingIndexNX(h[:])
+			require.NoError(err)
+
+			for i := 0; i < Keys; i++ {
+				h := hash.Hash160b([]byte(strconv.Itoa(i)))
+				require.NoError(tenant.Add(h[:], true))
+			}
+			require.NoError(tenant.Commit())
+			tenant.Close()
+			fmt.Printf("write tenant %d:\n", i)
+		}
+	}
+
+	cfg.DbPath = "test-bulk.dat"
+	t.Run("Bolt DB", func(t *testing.T) {
+		testutil.CleanupPath(t, cfg.DbPath)
+		testFunc(NewBoltDB(cfg), t)
+	})
+}
+
+func TestCheckBulk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	testFunc := func(kv KVStore, t *testing.T) {
+		require := require.New(t)
+
+		require.NoError(kv.Start(context.Background()))
+		defer func() {
+			require.NoError(kv.Stop(context.Background()))
+		}()
+
+		// verify 1000 tenants
+		for i := 0; i < Tenants; i++ {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			index, err := kv.CountingIndex(h[:])
+			require.NoError(err)
+			require.EqualValues(Keys, index.Size())
+
+			value, err := index.Range(0, Keys)
+			require.NoError(err)
+			require.EqualValues(Keys, len(value))
+
+			for i := range value {
+				h := hash.Hash160b([]byte(strconv.Itoa(i)))
+				require.Equal(h[:], value[i])
+			}
+			fmt.Printf("verify tenant: %d\n", i)
+		}
+	}
+
+	cfg.DbPath = "test-bulk.dat"
+	t.Run("Bolt DB", func(t *testing.T) {
+		defer testutil.CleanupPath(t, cfg.DbPath)
+		testFunc(NewBoltDB(cfg), t)
+	})
+}

--- a/pkg/util/byteutil/byteutil.go
+++ b/pkg/util/byteutil/byteutil.go
@@ -7,32 +7,55 @@
 package byteutil
 
 import (
+	"encoding/binary"
 	"github.com/iotexproject/iotex-core/pkg/enc"
 )
 
-// Uint32ToBytes converts a uint32 to 4 bytes with the machine endian
+// Uint32ToBytes converts a uint32 to 4 bytes in little-endian
 func Uint32ToBytes(value uint32) []byte {
 	bytes := make([]byte, 4)
 	enc.MachineEndian.PutUint32(bytes, value)
 	return bytes
 }
 
-// Uint64ToBytes converts a uint64 to 8 bytes with the machine endian
+// Uint64ToBytes converts a uint64 to 8 bytes in little-endian
 func Uint64ToBytes(value uint64) []byte {
 	bytes := make([]byte, 8)
 	enc.MachineEndian.PutUint64(bytes, value)
 	return bytes
 }
 
-// BytesToUint64 converts 8 bytes with the machine endian to uint64
+// BytesToUint64 converts 8 bytes to uint64 in little-endian
 func BytesToUint64(value []byte) uint64 {
 	return enc.MachineEndian.Uint64(value)
 }
 
-// Must is a helper wraps a call to a function returing ([]byte, error) and panics if the error is not nil.
+// Must is a helper wraps a call to a function returning ([]byte, error) and panics if the error is not nil.
 func Must(d []byte, err error) []byte {
 	if err != nil {
 		panic(err)
 	}
 	return d
+}
+
+// convert number sequence 0, 1, 2, ... n to big-endian results in byte-sorted []byte slice
+// we leverage this nice property to search/iterate action index stored within a bucket
+
+// Uint32ToBytesBigEndian converts a uint32 to 4 bytes in big-endian
+func Uint32ToBytesBigEndian(value uint32) []byte {
+	bytes := make([]byte, 4)
+	binary.BigEndian.PutUint32(bytes, value)
+	return bytes
+}
+
+// Uint64ToBytesBigEndian converts a uint64 to 8 bytes in big-endian
+func Uint64ToBytesBigEndian(value uint64) []byte {
+	bytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(bytes, value)
+	return bytes
+}
+
+// BytesToUint64BigEndian converts 8 bytes to uint64 in big-endian
+func BytesToUint64BigEndian(value []byte) uint64 {
+	return binary.BigEndian.Uint64(value)
 }

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -288,30 +288,30 @@ func (mr *MockBlockchainMockRecorder) GetReceiptByActionHash(h interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptByActionHash", reflect.TypeOf((*MockBlockchain)(nil).GetReceiptByActionHash), h)
 }
 
-// GetActionsFromAddress mocks base method
-func (m *MockBlockchain) GetActionsFromAddress(address string) ([]hash.Hash256, error) {
-	ret := m.ctrl.Call(m, "GetActionsFromAddress", address)
-	ret0, _ := ret[0].([]hash.Hash256)
+// GetActionsFromIndex mocks base method
+func (m *MockBlockchain) GetActionsFromIndex(arg0, arg1 uint64) ([][]byte, error) {
+	ret := m.ctrl.Call(m, "GetActionsFromIndex", arg0, arg1)
+	ret0, _ := ret[0].([][]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetActionsFromAddress indicates an expected call of GetActionsFromAddress
-func (mr *MockBlockchainMockRecorder) GetActionsFromAddress(address interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsFromAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionsFromAddress), address)
+// GetActionsFromIndex indicates an expected call of GetActionsFromIndex
+func (mr *MockBlockchainMockRecorder) GetActionsFromIndex(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsFromIndex", reflect.TypeOf((*MockBlockchain)(nil).GetActionsFromIndex), arg0, arg1)
 }
 
-// GetActionsToAddress mocks base method
-func (m *MockBlockchain) GetActionsToAddress(address string) ([]hash.Hash256, error) {
-	ret := m.ctrl.Call(m, "GetActionsToAddress", address)
-	ret0, _ := ret[0].([]hash.Hash256)
+// GetActionsByAddress mocks base method
+func (m *MockBlockchain) GetActionsByAddress(arg0 string, arg1, arg2 uint64) ([][]byte, error) {
+	ret := m.ctrl.Call(m, "GetActionsByAddress", arg0, arg1, arg2)
+	ret0, _ := ret[0].([][]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetActionsToAddress indicates an expected call of GetActionsToAddress
-func (mr *MockBlockchainMockRecorder) GetActionsToAddress(address interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsToAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionsToAddress), address)
+// GetActionsByAddress indicates an expected call of GetActionsByAddress
+func (mr *MockBlockchainMockRecorder) GetActionsByAddress(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionsByAddress", reflect.TypeOf((*MockBlockchain)(nil).GetActionsByAddress), arg0, arg1, arg2)
 }
 
 // GetActionCountByAddress mocks base method
@@ -558,17 +558,4 @@ func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscribe
 // RemoveSubscriber indicates an expected call of RemoveSubscriber
 func (mr *MockBlockchainMockRecorder) RemoveSubscriber(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubscriber", reflect.TypeOf((*MockBlockchain)(nil).RemoveSubscriber), arg0)
-}
-
-// GetActionHashFromIndex mocks base method
-func (m *MockBlockchain) GetActionHashFromIndex(index uint64) (hash.Hash256, error) {
-	ret := m.ctrl.Call(m, "GetActionHashFromIndex", index)
-	ret0, _ := ret[0].(hash.Hash256)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetActionHashFromIndex indicates an expected call of GetActionHashFromIndex
-func (mr *MockBlockchainMockRecorder) GetActionHashFromIndex(index interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionHashFromIndex", reflect.TypeOf((*MockBlockchain)(nil).GetActionHashFromIndex), index)
 }


### PR DESCRIPTION
1. improve address <--> action indexing using counting index
2. this change allows to get rid of the time-consuming sort() when performing getActionsByIndex() and getActionsByAddress()
3. removed redundant indexing namespace "a2r"
4. improved test coverage for blockdao_test.go, and added indexbuilder_test.go