### PR TITLE
Print less errors for non-delegate nodes

### DIFF
--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/clock"
-	"github.com/iotexproject/go-fsm"
+	fsm "github.com/iotexproject/go-fsm"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -397,16 +397,16 @@ func (m *ConsensusFSM) prepare(_ fsm.Event) (fsm.State, error) {
 		m.ctx.Logger().Error("Error during prepare", zap.Error(err))
 		return m.BackToPrepare(0)
 	}
-	if !m.ctx.IsDelegate() {
-		return m.BackToPrepare(0)
-	}
+	m.ctx.Logger().Info("Start a new round")
 	proposal, err := m.ctx.Proposal()
 	if err != nil {
 		m.ctx.Logger().Error("failed to generate block proposal", zap.Error(err))
 		return m.BackToPrepare(0)
 	}
-	m.ctx.Logger().Info("Start a new round")
 	overtime := m.ctx.WaitUntilRoundStart()
+	if !m.ctx.IsDelegate() {
+		return m.BackToPrepare(0)
+	}
 	if proposal != nil {
 		m.ctx.Broadcast(proposal)
 		m.ProduceReceiveBlockEvent(proposal)

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -102,6 +102,8 @@ func TestStateTransitionFunctions(t *testing.T) {
 		})
 		t.Run("stand-by-or-is-not-delegate", func(t *testing.T) {
 			mockCtx.EXPECT().Prepare().Return(nil).Times(1)
+			mockCtx.EXPECT().Proposal().Return(nil, nil).Times(1)
+			mockCtx.EXPECT().WaitUntilRoundStart().Return(time.Duration(0)).Times(1)
 			mockCtx.EXPECT().IsDelegate().Return(false).Times(1)
 			state, err := cfsm.prepare(nil)
 			require.NoError(err)

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -304,7 +304,7 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	require.NotNil(t, r)
 	clock.Add(r.ctx.RoundCalc().BlockInterval())
 	require.NoError(t, r.ctx.Start(context.Background()))
-	r.ctx.round, err = r.ctx.RoundCalc().UpdateRound(r.ctx.round, blockHeight+1, clock.Now())
+	r.ctx.round, err = r.ctx.RoundCalc().UpdateRound(r.ctx.round, blockHeight+1, clock.Now(), 2*time.Second)
 	require.NoError(t, err)
 
 	m, err := r.Metrics()


### PR DESCRIPTION
Previous' test was focusing on delegate nodes. As a result, a lot of errors were printed for non-delegate nodes. This PR tries to reduce those kind of errors.
1. return the same round with no error if "now" is before the start time of current round
2. for non-delegate, skip to next round

Test plan:
1. make test && make minicluster
2. start a non-delegate node