### PR TITLE
change last block time and footer validation rule

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/clock"
-	"github.com/iotexproject/go-fsm"
+	fsm "github.com/iotexproject/go-fsm"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
@@ -136,11 +136,10 @@ func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 	if err != nil {
 		return err
 	}
-	if round.Proposer() != blk.ProducerAddress() {
+	if !round.IsDelegate(blk.ProducerAddress()) {
 		return errors.Errorf(
-			"block proposer %s is invalid, %s expected",
+			"block proposer %s is not a valid delegate",
 			blk.ProducerAddress(),
-			round.proposer,
 		)
 	}
 	if err := round.AddBlock(blk); err != nil {

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -189,10 +189,10 @@ func TestValidateBlockFooter(t *testing.T) {
 	}
 	clock := clock.NewMock()
 	blockHeight := uint64(8)
-	footer := &block.Footer{}
+	header := &block.Header{}
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().GenesisTimestamp().Return(int64(1500000000)).Times(5)
-	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(5)
+	blockchain.EXPECT().BlockHeaderByHeight(blockHeight).Return(header, nil).Times(5)
 	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
 		{Address: candidates[0]},
 		{Address: candidates[1]},
@@ -265,11 +265,11 @@ func TestRollDPoS_Metrics(t *testing.T) {
 
 	clock := clock.NewMock()
 	blockHeight := uint64(8)
-	footer := &block.Footer{}
+	header := &block.Header{}
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().TipHeight().Return(blockHeight).Times(1)
 	blockchain.EXPECT().GenesisTimestamp().Return(int64(1500000000)).Times(2)
-	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(2)
+	blockchain.EXPECT().BlockHeaderByHeight(blockHeight).Return(header, nil).Times(2)
 	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
 		{Address: candidates[0]},
 		{Address: candidates[1]},

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -133,12 +133,11 @@ func (c *roundCalculator) roundInfo(
 ) (roundNum uint32, roundStartTime time.Time, err error) {
 	lastBlockTime := time.Unix(c.chain.GenesisTimestamp(), 0)
 	if height > 1 {
-		var lastBlock *block.Footer
-		if lastBlock, err = c.chain.BlockFooterByHeight(height - 1); err != nil {
+		var lastBlock *block.Header
+		if lastBlock, err = c.chain.BlockHeaderByHeight(height - 1); err != nil {
 			return
 		}
-		lastBlockCommitTime := lastBlock.CommitTime()
-		lastBlockTime = lastBlockTime.Add(lastBlockCommitTime.Sub(lastBlockTime) / c.blockInterval * c.blockInterval)
+		lastBlockTime = lastBlockTime.Add(lastBlock.Timestamp().Sub(lastBlockTime) / c.blockInterval * c.blockInterval)
 	}
 	if !lastBlockTime.Before(now) {
 		err = errors.Errorf(


### PR DESCRIPTION
The time of last block was calculated based on the commit time saved in block footer. As the commit time may not be consistent from delegate to delegate, it causes the problem that some nodes with a different commit time reject blocks from block sync.
Fixes:
1. Instead of checking the block producer is the right proposer according to the block time, check whether the producer is a delegate instead. With this fix, even the block commit time is different, it will still be accepted as long as the producer is a consensus delegate and there are enough endorsements.
2. Use the block timestamp as the last block time instead of commit time, to make sure that the consensus delegates get the same round number. This will cause problem that if it took more than one round on a height, the delegate who suppose to be the first proposer for the next height will get passed as the next height won't start from round 0.
