### PR TITLE
Full state history node 1370

### DIFF
--- a/db/db_bolt.go
+++ b/db/db_bolt.go
@@ -8,6 +8,7 @@ package db
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"
@@ -16,6 +17,9 @@ import (
 )
 
 const fileMode = 0600
+
+// ContractKVNameSpace for ignore delete
+var ContractKVNameSpace = "Contract"
 
 // boltDB is KVStore implementation based bolt DB
 type boltDB struct {
@@ -156,12 +160,15 @@ func (b *boltDB) Commit(batch KVStoreBatch) (err error) {
 						return errors.Wrapf(err, write.errorFormat, write.errorArgs)
 					}
 				} else if write.writeType == Delete {
-					bucket := tx.Bucket([]byte(write.namespace))
-					if bucket == nil {
-						continue
-					}
-					if err := bucket.Delete(write.key); err != nil {
-						return errors.Wrapf(err, write.errorFormat, write.errorArgs)
+					// ignore delete for contract state
+					if !strings.EqualFold(write.namespace, ContractKVNameSpace) {
+						bucket := tx.Bucket([]byte(write.namespace))
+						if bucket == nil {
+							continue
+						}
+						if err := bucket.Delete(write.key); err != nil {
+							return errors.Wrapf(err, write.errorFormat, write.errorArgs)
+						}
 					}
 				}
 			}

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -43,6 +43,11 @@ const (
 	AccountTrieRootKey = "accountTrieRoot"
 )
 
+var (
+	// AccountMaxVersionPrefix is for account history
+	AccountMaxVersionPrefix = []byte("vp.")
+)
+
 type (
 	// Factory defines an interface for managing states
 	Factory interface {

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -8,6 +8,7 @@ package factory
 
 import (
 	"context"
+	"encoding/binary"
 
 	"github.com/pkg/errors"
 
@@ -178,7 +179,34 @@ func (stx *stateTX) PutState(pkHash hash.Hash160, s interface{}) error {
 		return errors.Wrapf(err, "failed to convert account %v to bytes", s)
 	}
 	stx.cb.Put(AccountKVNameSpace, pkHash[:], ss, "error when putting k = %x", pkHash)
-	return nil
+	return stx.putIndex(pkHash, ss)
+}
+
+func (stx *stateTX) getMaxVersion(pkHash hash.Hash160) (uint64, error) {
+	indexKey := append(AccountMaxVersionPrefix, pkHash[:]...)
+	value, err := stx.dao.Get(AccountKVNameSpace, indexKey)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(value), nil
+}
+
+func (stx *stateTX) putIndex(pkHash hash.Hash160, ss []byte) error {
+	version := stx.ver + 1
+	maxVersion, _ := stx.getMaxVersion(pkHash)
+	if (maxVersion != 0) && (maxVersion != 1) && (maxVersion > version) {
+		return nil
+	}
+
+	currentVersion := make([]byte, 8)
+	binary.BigEndian.PutUint64(currentVersion, version)
+	indexKey := append(AccountMaxVersionPrefix, pkHash[:]...)
+	err := stx.dao.Put(AccountKVNameSpace, indexKey, currentVersion)
+	if err != nil {
+		return err
+	}
+	stateKey := append(pkHash[:], currentVersion...)
+	return stx.dao.Put(AccountKVNameSpace, stateKey, ss)
 }
 
 // DelState deletes a state from DB


### PR DESCRIPTION
work on #1370 

Test code is  https://github.com/lzxm160/iotex-core/tree/13709 ,the following is test api:

**1.account history**
grpcurl -v -plaintext -d '{"address": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.GetAccount

**2.readstate,add a new method:**
grpcurl -v -plaintext -d '{"protocolID": "cG9sbA==", "methodName": "R2V0U3RvcmFnZUF0", "arguments": ["aW8xNjRzZWh5NW5tMnl0NXNydGx0Y214am11OHloeWNkcTZtMDZlY2U=","ZTJhNDU2YTg3NWZjMTljMmQ2YzYwYmQ1MWE1ZDFhZjk4NDE3NTUxYjI5Mzc3YzQyMGM5MzQ5N2EzNmI0NzIwYw==","ODg0MzE2"]}' 127.0.0.1:14014 iotexapi.APIService.ReadState

**3.readcontract,execute a contract method with block height:**
grpcurl -v -plaintext -d '{"execution":{"amount":"0","contract":"io164sehy5nm2yt5srtltcmxjmu8yhycdq6m06ece","data":"cKCCMQAAAAAAAAAAAAAAAGNWkIrOCSaBMN7it95kMxS76zaD"}, "callerAddress": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.ReadContract

After this we will add api to support history state