### PR TITLE
use bering height to synchronize last block time switch

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -313,6 +313,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.encodedAddr,
 		b.priKey,
 		b.clock,
+		b.cfg.Genesis.BeringBlockHeight,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing consensus context")

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -189,10 +189,10 @@ func TestValidateBlockFooter(t *testing.T) {
 	}
 	clock := clock.NewMock()
 	blockHeight := uint64(8)
-	header := &block.Header{}
+	footer := &block.Footer{}
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().GenesisTimestamp().Return(int64(1500000000)).Times(5)
-	blockchain.EXPECT().BlockHeaderByHeight(blockHeight).Return(header, nil).Times(5)
+	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(5)
 	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
 		{Address: candidates[0]},
 		{Address: candidates[1]},
@@ -265,11 +265,11 @@ func TestRollDPoS_Metrics(t *testing.T) {
 
 	clock := clock.NewMock()
 	blockHeight := uint64(8)
-	header := &block.Header{}
+	footer := &block.Footer{}
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().TipHeight().Return(blockHeight).Times(1)
 	blockchain.EXPECT().GenesisTimestamp().Return(int64(1500000000)).Times(2)
-	blockchain.EXPECT().BlockHeaderByHeight(blockHeight).Return(header, nil).Times(2)
+	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(2)
 	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
 		{Address: candidates[0]},
 		{Address: candidates[1]},

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -107,6 +107,7 @@ func newRollDPoSCtx(
 	encodedAddr string,
 	priKey crypto.PrivateKey,
 	clock clock.Clock,
+	beringHeight uint64,
 ) (*rollDPoSCtx, error) {
 	if chain == nil {
 		return nil, errors.New("chain cannot be nil")
@@ -140,6 +141,7 @@ func newRollDPoSCtx(
 		chain:                  chain,
 		rp:                     rp,
 		timeBasedRotation:      timeBasedRotation,
+		beringHeight:           beringHeight,
 	}
 	return &rollDPoSCtx{
 		cfg:               cfg,

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -30,12 +30,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, nil, nil, nil, nil, nil, "", nil, nil)
+		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, nil, nil, nil, nil, nil, "", nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, nil, nil, nil, "", nil, nil)
+		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, nil, nil, nil, "", nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -45,7 +45,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		config.Default.Genesis.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, rp, nil, nil, "", nil, nil)
+		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, rp, nil, nil, "", nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -55,13 +55,15 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, rp, nil, nil, "", nil, c)
+		_, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*10, time.Second, true, b, nil, rp, nil, nil, "", nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 5:normal", func(t *testing.T) {
-		rctx, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c)
+		bh := config.Default.Genesis.BeringBlockHeight
+		rctx, err := newRollDPoSCtx(cfg, dbConfig, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c, bh)
 		require.NoError(err)
+		require.Equal(bh, rctx.roundCalc.beringHeight)
 		require.NotNil(rctx)
 	})
 }
@@ -76,7 +78,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 		config.Default.Genesis.NumSubEpochs,
 	)
 	c := clock.New()
-	rctx, err := newRollDPoSCtx(cfg, config.Default.DB, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c)
+	rctx, err := newRollDPoSCtx(cfg, config.Default.DB, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c, config.Default.Genesis.BeringBlockHeight)
 	require.NoError(err)
 	require.NotNil(rctx)
 
@@ -97,7 +99,7 @@ func TestCheckBlockProposer(t *testing.T) {
 	cfg := config.Default.Consensus.RollDPoS
 	b, rp := makeChain(t)
 	c := clock.New()
-	rctx, err := newRollDPoSCtx(cfg, config.Default.DB, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c)
+	rctx, err := newRollDPoSCtx(cfg, config.Default.DB, true, time.Second*20, time.Second, true, b, nil, rp, nil, nil, "", nil, c, config.Default.Genesis.BeringBlockHeight)
 	require.NoError(err)
 	require.NotNil(rctx)
 	block := getBlockforctx(t, 0, false)

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -32,7 +32,7 @@ import (
 func TestUpdateRound(t *testing.T) {
 	require := require.New(t)
 	bc, roll := makeChain(t)
-	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight}
+	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight, 0}
 	ra, err := rc.NewRound(1, time.Unix(1562382392, 0), nil)
 	require.NoError(err)
 
@@ -57,7 +57,7 @@ func TestUpdateRound(t *testing.T) {
 func TestNewRound(t *testing.T) {
 	require := require.New(t)
 	bc, roll := makeChain(t)
-	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight}
+	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight, 0}
 	proposer, err := rc.calculateProposer(5, 1, []string{"1", "2", "3", "4", "5"})
 	require.Error(err)
 	var validDelegates [24]string
@@ -91,7 +91,7 @@ func TestNewRound(t *testing.T) {
 func TestDelegates(t *testing.T) {
 	require := require.New(t)
 	bc, roll := makeChain(t)
-	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight}
+	rc := &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight, 0}
 	_, err := rc.Delegates(361)
 	require.Error(err)
 
@@ -105,11 +105,11 @@ func TestDelegates(t *testing.T) {
 
 func TestRoundInfo(t *testing.T) {
 	require := require.New(t)
-	rc := &roundCalculator{nil, time.Second, true, nil, nil}
+	rc := &roundCalculator{nil, time.Second, true, nil, nil, 0}
 	require.NotNil(rc)
 	require.Equal(time.Second, rc.BlockInterval())
 	bc, roll := makeChain(t)
-	rc = &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight}
+	rc = &roundCalculator{bc, time.Second, true, roll, bc.CandidatesByHeight, 0}
 
 	// error for lastBlockTime.Before(now)
 	_, _, err := rc.RoundInfo(1, time.Unix(1562382300, 0))


### PR DESCRIPTION
1. as title, so delegates can switch to using block header time in sync
2. after mainnet pass bering height, this change can be reverted (contingent on verifying full-node can sync all blocks by reverting it) 