### PR TITLE
Full state history node 1370

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -7,7 +7,9 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"math/big"
 	"os"
 	"strconv"
@@ -21,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	bolt "go.etcd.io/bbolt"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -182,6 +185,8 @@ type blockchain struct {
 	registry *protocol.Registry
 
 	enableExperimentalActions bool
+	// make sure there's only one goroutine deleting
+	deletingTrieHistory chan struct{}
 }
 
 // Option sets blockchain construction parameter
@@ -294,8 +299,9 @@ func EnableExperimentalActions() Option {
 func NewBlockchain(cfg config.Config, opts ...Option) Blockchain {
 	// create the Blockchain
 	chain := &blockchain{
-		config: cfg,
-		clk:    clock.New(),
+		config:              cfg,
+		clk:                 clock.New(),
+		deletingTrieHistory: make(chan struct{}, 1),
 	}
 	for _, opt := range opts {
 		if err := opt(chain, cfg); err != nil {
@@ -1032,7 +1038,11 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 
 	if bc.sf != nil {
 		sfTimer := bc.timerFactory.NewTimer("sf.Commit")
-		err := bc.sf.Commit(blk.WorkingSet)
+		heightToKeyCache, err := blk.WorkingSet.GetDB().SaveDeletedTrieNode(blk.WorkingSet.GetCachedBatch(), bc.tipHeight, heightToTrieNodeKeyNS, heightToTrieNodeKeyPrefix)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save trie's node on height %d", blk.Height())
+		}
+		err = bc.sf.Commit(blk.WorkingSet)
 		sfTimer.End()
 		// detach working set so it can be freed by GC
 		blk.WorkingSet = nil
@@ -1047,14 +1057,89 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 		if err != nil {
 			return errors.Wrapf(err, "failed to put smart contract receipts into DB on height %d", blk.Height())
 		}
+		err = bc.saveHistory(heightToKeyCache, blk.Height())
+		if err != nil {
+			return errors.Wrapf(err, "failed to save history on height %d", blk.Height())
+		}
 	}
 	blk.HeaderLogger(log.L()).Info("Committed a block.", log.Hex("tipHash", bc.tipHash[:]))
 
 	// emit block to all block subscribers
 	bc.emitToSubscribers(blk)
+	// delete trie node history asynchronously
+	bc.deleteTrieHistory(bc.tipHeight)
 	return nil
 }
 
+func (bc *blockchain) saveHistory(heightToKeyCache db.KVStoreBatch, height uint64) error {
+	// commit to chain.db
+	err := bc.dao.kvstore.Commit(heightToKeyCache)
+	if err != nil {
+		return errors.Wrapf(err, "Error when commit height->trie node key hash on height %d", height)
+	}
+	return nil
+}
+
+func (bc *blockchain) deleteTrieHistory(hei uint64) {
+	if bc.config.DB.EnableHistoryState && hei%factory.CheckHistoryDeleteInterval == 0 {
+		ws, err := bc.sf.NewWorkingSet()
+		if err != nil {
+			log.L().Error("Error when NewWorkingSet.", zap.Error(err))
+			return
+		}
+		dbstore := ws.GetDB()
+		if dbstore == nil {
+			log.L().Error("Error when GetDB.", zap.Error(err))
+			return
+		}
+		cb := db.NewCachedBatch()
+		go func() {
+			// make sure there's only one goroutine doing this
+			bc.deletingTrieHistory <- struct{}{}
+			defer func() {
+				<-bc.deletingTrieHistory
+			}()
+			kvstore := bc.dao.kvstore.DB()
+			boltdb, ok := kvstore.(*bolt.DB)
+			if !ok {
+				return
+			}
+			// caculate the block height,later will delete trie node before this height
+			if hei < bc.config.DB.HistoryStateHeight {
+				return
+			}
+			deleteStartHeight := hei - bc.config.DB.HistoryStateHeight
+			var endHeight uint64
+			if deleteStartHeight < bc.config.DB.HistoryStateHeight {
+				endHeight = 1
+			} else {
+				endHeight = deleteStartHeight - bc.config.DB.HistoryStateHeight
+			}
+
+			for i := deleteStartHeight; i > endHeight; i-- {
+				heightBytes := make([]byte, 8)
+				binary.BigEndian.PutUint64(heightBytes, i)
+				keyPrefix := append(heightToTrieNodeKeyPrefix, heightBytes...)
+				err = boltdb.Update(func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte(heightToTrieNodeKeyNS))
+					c := b.Cursor()
+					for k, _ := c.Seek(keyPrefix); bytes.HasPrefix(k, keyPrefix); k, _ = c.Next() {
+						// delete height->trie node hash directly
+						b.Delete(k)
+						// put into cache
+						cb.Delete(db.ContractKVNameSpace, k[len(keyPrefix):], "failed to delete key %x", k[len(keyPrefix):])
+					}
+					return nil
+				})
+				if err != nil {
+					return
+				}
+			}
+			dbstore.Commit(cb) // delete trie node
+
+		}()
+	}
+}
 func (bc *blockchain) runActions(
 	acts block.RunnableActions,
 	ws factory.WorkingSet,

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -1072,6 +1072,9 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 }
 
 func (bc *blockchain) saveHistory(heightToKeyCache db.KVStoreBatch, height uint64) error {
+	if heightToKeyCache == nil {
+		return nil
+	}
 	// commit to chain.db
 	err := bc.dao.kvstore.Commit(heightToKeyCache)
 	if err != nil {

--- a/blockchain/blockdao.go
+++ b/blockchain/blockdao.go
@@ -51,7 +51,7 @@ const (
 	receiptsNS                       = "rpt"
 	numActionsNS                     = "nac"
 	transferAmountNS                 = "tfa"
-
+	heightToTrieNodeKeyNS            = "htn"
 	hashOffset = 12
 )
 
@@ -66,6 +66,7 @@ var (
 	actionFromPrefix         = []byte("fr.")
 	actionToPrefix           = []byte("to.")
 	heightToFilePrefix       = []byte("hf.")
+	heightToTrieNodeKeyPrefix = []byte("hnk.")
 )
 
 var (

--- a/config/config.go
+++ b/config/config.go
@@ -166,8 +166,10 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
-			SplitDBSizeMB: 0,
-			SplitDBHeight: 900000,
+			SplitDBSizeMB:      0,
+			SplitDBHeight:      900000,
+			EnableHistoryState: true,
+			HistoryStateHeight: 2000,
 		},
 		Genesis: genesis.Default,
 		Reindex: false,
@@ -324,6 +326,12 @@ type (
 
 		// SplitDBHeight is the config for DB's split start height
 		SplitDBHeight uint64 `yaml:"splitDBHeight"`
+
+		// EnableHistoryState is the config enable history state
+		EnableHistoryState bool `yaml:"enableHistoryState"`
+
+		// HistoryStateHeight is the config for DB history height
+		HistoryStateHeight uint64 `yaml:"historyStateHeight"`
 	}
 
 	// RDS is the cloud rds config

--- a/db/db.go
+++ b/db/db.go
@@ -38,6 +38,10 @@ type KVStore interface {
 	Delete(string, []byte) error
 	// Commit commits a batch
 	Commit(KVStoreBatch) error
+	// DB return dao
+	DB() interface{}
+	// SaveDeletedTrieNode save deleted trie node
+	SaveDeletedTrieNode(KVStoreBatch, uint64, string, []byte) (KVStoreBatch, error)
 }
 
 const (
@@ -57,7 +61,9 @@ func NewMemKVStore() KVStore {
 		data:   &sync.Map{},
 	}
 }
-
+func (m *memKVStore) DB() interface{} {
+	return nil
+}
 func (m *memKVStore) Start(_ context.Context) error { return nil }
 
 func (m *memKVStore) Stop(_ context.Context) error { return nil }
@@ -121,4 +127,9 @@ func (m *memKVStore) Commit(b KVStoreBatch) (e error) {
 	}
 
 	return e
+}
+
+// SaveDeletedTrieNode save trie node history
+func (m *memKVStore) SaveDeletedTrieNode(KVStoreBatch, uint64, string, []byte) (KVStoreBatch, error) {
+	return nil, nil
 }

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -43,6 +43,11 @@ const (
 	AccountTrieRootKey = "accountTrieRoot"
 )
 
+var (
+	// AccountMaxVersionPrefix is for account history
+	AccountMaxVersionPrefix = []byte("vp.")
+)
+
 type (
 	// Factory defines an interface for managing states
 	Factory interface {

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -618,7 +618,7 @@ func TestCachedBatch(t *testing.T) {
 }
 
 func TestSTXCachedBatch(t *testing.T) {
-	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))})
+	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))}, config.Default.DB)
 	testCachedBatch(ws, t, true)
 }
 
@@ -668,7 +668,7 @@ func TestGetDB(t *testing.T) {
 }
 
 func TestSTXGetDB(t *testing.T) {
-	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))})
+	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))}, config.Default.DB)
 	testGetDB(ws, t)
 }
 
@@ -699,7 +699,7 @@ func TestDeleteAndPutSameKey(t *testing.T) {
 		testDeleteAndPutSameKey(t, ws)
 	})
 	t.Run("stateTx", func(t *testing.T) {
-		ws := newStateTX(0, db.NewMemKVStore(), nil)
+		ws := newStateTX(0, db.NewMemKVStore(), nil, config.Default.DB)
 		testDeleteAndPutSameKey(t, ws)
 	})
 }

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -7,17 +7,27 @@
 package factory
 
 import (
+	"bytes"
 	"context"
-
-	"github.com/pkg/errors"
+	"encoding/binary"
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
+)
+
+const (
+	// 30 block heights to check if history needs to delete
+	CheckHistoryDeleteInterval = 30
 )
 
 // stateTX implements stateTX interface, tracks pending changes to account/contract in local cache
@@ -27,6 +37,8 @@ type stateTX struct {
 	cb             db.CachedBatch // cached batch for pending writes
 	dao            db.KVStore     // the underlying DB for account/contract storage
 	actionHandlers []protocol.ActionHandler
+	deleting       chan struct{} // make sure there's only one goroutine deleting history state
+	cfg            config.DB
 }
 
 // newStateTX creates a new state tx
@@ -34,12 +46,15 @@ func newStateTX(
 	version uint64,
 	kv db.KVStore,
 	actionHandlers []protocol.ActionHandler,
+	cfg config.DB,
 ) *stateTX {
 	return &stateTX{
 		ver:            version,
 		cb:             db.NewCachedBatch(),
 		dao:            kv,
 		actionHandlers: actionHandlers,
+		deleting:       make(chan struct{}, 1),
+		cfg:            cfg,
 	}
 }
 
@@ -121,6 +136,9 @@ func (stx *stateTX) RunAction(
 
 // UpdateBlockLevelInfo runs action in the block and track pending changes in working set
 func (stx *stateTX) UpdateBlockLevelInfo(blockHeight uint64) hash.Hash256 {
+	if stx.cfg.EnableHistoryState && blockHeight%CheckHistoryDeleteInterval == 0 {
+		stx.deleteHistory()
+	}
 	stx.blkHeight = blockHeight
 	// Persist current chain Height
 	h := byteutil.Uint64ToBytes(blockHeight)
@@ -178,6 +196,98 @@ func (stx *stateTX) PutState(pkHash hash.Hash160, s interface{}) error {
 		return errors.Wrapf(err, "failed to convert account %v to bytes", s)
 	}
 	stx.cb.Put(AccountKVNameSpace, pkHash[:], ss, "error when putting k = %x", pkHash)
+	if !stx.cfg.EnableHistoryState {
+		return nil
+	}
+	return stx.putIndex(pkHash, ss)
+}
+
+func (stx *stateTX) getMaxVersion(pkHash hash.Hash160) (uint64, error) {
+	indexKey := append(AccountMaxVersionPrefix, pkHash[:]...)
+	value, err := stx.dao.Get(AccountKVNameSpace, indexKey)
+	if err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(value), nil
+}
+
+func (stx *stateTX) putIndex(pkHash hash.Hash160, ss []byte) error {
+	version := stx.ver + 1
+	maxVersion, _ := stx.getMaxVersion(pkHash)
+	if (maxVersion != 0) && (maxVersion != 1) && (maxVersion > version) {
+		return nil
+	}
+
+	currentVersion := make([]byte, 8)
+	binary.BigEndian.PutUint64(currentVersion, version)
+	indexKey := append(AccountMaxVersionPrefix, pkHash[:]...)
+	err := stx.dao.Put(AccountKVNameSpace, indexKey, currentVersion)
+	if err != nil {
+		return err
+	}
+	stateKey := append(pkHash[:], currentVersion...)
+	return stx.dao.Put(AccountKVNameSpace, stateKey, ss)
+}
+
+// deleteAccountHistory delete history of account
+func (stx *stateTX) deleteAccountHistory(pkHash hash.Hash160, deleteHeight uint64) error {
+	db := stx.dao.DB()
+	boltdb, ok := db.(*bolt.DB)
+	if !ok {
+		log.L().Error("convert to bolt db error")
+		return nil
+	}
+	prefix := pkHash[:]
+	err := boltdb.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket([]byte(AccountKVNameSpace))
+		if b == nil {
+			return errors.New("bucket is nil")
+		}
+		c := b.Cursor()
+		for k, _ := c.Seek(prefix); bytes.HasPrefix(k, prefix); k, _ = c.Next() {
+			if len(k) <= len(pkHash) || len(k) > len(pkHash)+8 {
+				continue
+			}
+			kHeight := binary.BigEndian.Uint64(k[20:])
+			if kHeight < deleteHeight {
+				b.Delete(k)
+			}
+		}
+		return nil
+	})
+	return err
+}
+
+// delete history asynchronous,this will find all account
+func (stx *stateTX) deleteHistory() error {
+	currentHeight := stx.ver + 1
+	if currentHeight < stx.cfg.HistoryStateHeight {
+		return nil
+	}
+	deleteHeight := currentHeight - stx.cfg.HistoryStateHeight
+	go func() {
+		stx.deleting <- struct{}{}
+		db := stx.dao.DB()
+		boltdb, ok := db.(*bolt.DB)
+		if !ok {
+			log.L().Error("convert to bolt db error")
+			return
+		}
+		allPk := make([]hash.Hash160, 0)
+		boltdb.View(func(tx *bolt.Tx) error {
+			c := tx.Bucket([]byte(AccountKVNameSpace)).Cursor()
+			for k, _ := c.Seek(AccountMaxVersionPrefix); bytes.HasPrefix(k, AccountMaxVersionPrefix); k, _ = c.Next() {
+				addrHash := k[len(AccountMaxVersionPrefix):]
+				h := hash.BytesToHash160(addrHash)
+				allPk = append(allPk, h)
+			}
+			return nil
+		})
+		for _, h := range allPk {
+			stx.deleteAccountHistory(h, deleteHeight)
+		}
+		<-stx.deleting
+	}()
 	return nil
 }
 

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	// 30 block heights to check if history needs to delete
+	// CheckHistoryDeleteInterval 30 block heights to check if history needs to delete
 	CheckHistoryDeleteInterval = 30
 )
 

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -136,7 +136,7 @@ func (stx *stateTX) RunAction(
 
 // UpdateBlockLevelInfo runs action in the block and track pending changes in working set
 func (stx *stateTX) UpdateBlockLevelInfo(blockHeight uint64) hash.Hash256 {
-	if stx.cfg.EnableHistoryState && blockHeight%CheckHistoryDeleteInterval == 0 {
+	if stx.cfg.EnableHistoryState && blockHeight%CheckHistoryDeleteInterval == 0 && blockHeight != 0 {
 		stx.deleteHistory()
 	}
 	stx.blkHeight = blockHeight


### PR DESCRIPTION
work on #1370 
add config for save how many histories (e.g., past 10,100,1000,... block heights') ,default is 2000
every 30 block height will check if it's time to delete history asynchronous.

Test code is https://github.com/lzxm160/iotex-core/tree/137014 ,the following is test api:

1.account history
grpcurl -v -plaintext -d '{"address": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.GetAccount

2.readstate,add a new method:
grpcurl -v -plaintext -d '{"protocolID": "cG9sbA==", "methodName": "R2V0U3RvcmFnZUF0", "arguments": ["aW8xNjRzZWh5NW5tMnl0NXNydGx0Y214am11OHloeWNkcTZtMDZlY2U=","ZTJhNDU2YTg3NWZjMTljMmQ2YzYwYmQ1MWE1ZDFhZjk4NDE3NTUxYjI5Mzc3YzQyMGM5MzQ5N2EzNmI0NzIwYw==","ODg0MzE2"]}' 127.0.0.1:14014 iotexapi.APIService.ReadState

3.readcontract,execute a contract method with block height:
grpcurl -v -plaintext -d '{"execution":{"amount":"0","contract":"io164sehy5nm2yt5srtltcmxjmu8yhycdq6m06ece","data":"cKCCMQAAAAAAAAAAAAAAAGNWkIrOCSaBMN7it95kMxS76zaD"}, "callerAddress": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.ReadContract

After this we will add api to support history state