### PR TITLE
Delete get votes api

### DIFF
--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -20,10 +20,10 @@ import (
 
 type stakingCommittee struct {
 	hu                config.HeightUpgrade
-	governanceStaking Protocol
-	nativeStaking     *NativeStaking
 	getEpochHeight    GetEpochHeight
 	getEpochNum       GetEpochNum
+	governanceStaking Protocol
+	nativeStaking     *NativeStaking
 	scoreThreshold    *big.Int
 }
 

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -228,7 +228,6 @@ func New(
 		dispatcher,
 		actPool,
 		&registry,
-		electionCommittee,
 		api.WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
 			ctx = p2p.WitContext(ctx, p2p.Context{ChainID: chainID})
 			return p2pAgent.BroadcastOutbound(ctx, msg)

--- a/tools/actioninjector.v2/internal/client/client_test.go
+++ b/tools/actioninjector.v2/internal/client/client_test.go
@@ -56,7 +56,7 @@ func TestClient(t *testing.T) {
 	newOption := api.WithBroadcastOutbound(func(_ context.Context, _ uint32, _ proto.Message) error {
 		return nil
 	})
-	apiServer, err := api.NewServer(cfg, bc, dp, ap, nil, nil, newOption)
+	apiServer, err := api.NewServer(cfg, bc, dp, ap, nil, newOption)
 	require.NoError(err)
 	require.NoError(apiServer.Start())
 	// test New()


### PR DESCRIPTION
As stated below, this is a confusing API. Two ways to query votes by height:
1. Query Ethereum contract
2. Query election committee

Providing an API for users to query iotex-core by ethereum height is not the right way.