### PR TITLE
Make native staking contract be loadable from genesis

### DIFF
--- a/action/const.go
+++ b/action/const.go
@@ -12,7 +12,7 @@ var (
 	// ErrActPool indicates the error of actpool
 	ErrActPool = errors.New("invalid actpool")
 	// ErrHitGasLimit is the error when hit gas limit
-	ErrHitGasLimit = errors.New("Hit Gas Limit")
+	ErrHitGasLimit = errors.New("Hit gas limit")
 	// ErrInsufficientBalanceForGas is the error that the balance in executor account is lower than gas
 	ErrInsufficientBalanceForGas = errors.New("Insufficient balance for gas")
 	// ErrOutOfGas is the error when running out of gas

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -80,7 +80,7 @@ func NewParams(
 
 	gasLimit := execution.GasLimit()
 	// Reset gas limit to the system wide action gas limit cap if it's greater than it
-	if hu.IsPre(config.Aleutian, raCtx.BlockHeight) && gasLimit > preAleutianActionGasLimit {
+	if raCtx.BlockHeight > 0 && hu.IsPre(config.Aleutian, raCtx.BlockHeight) && gasLimit > preAleutianActionGasLimit {
 		gasLimit = preAleutianActionGasLimit
 	}
 

--- a/action/protocol/poll/nativestaking_test.go
+++ b/action/protocol/poll/nativestaking_test.go
@@ -39,13 +39,10 @@ func TestStaking(t *testing.T) {
 
 	mcm := &protocol.MockChainManager{}
 	getTime := func() (time.Time, error) { return time.Now(), nil }
-	ns, err := NewNativeStaking(nil, getTime, "")
+	ns, err := NewNativeStaking(mcm, nil)
 	require.Error(err)
-	ns, err = NewNativeStaking(mcm, nil, "")
-	require.Error(err)
-	ns, err = NewNativeStaking(mcm, getTime, "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39yn7")
-	require.Error(err)
-	ns, err = NewNativeStaking(mcm, getTime, "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7")
+	ns, err = NewNativeStaking(mcm, getTime)
+	ns.SetContract("io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7")
 	require.NoError(err)
 
 	pygg := &pygg{}

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -69,6 +69,8 @@ type Protocol interface {
 	DelegatesByHeight(uint64) (state.CandidateList, error)
 	// ReadState read the state on blockchain via protocol
 	ReadState(context.Context, protocol.StateManager, []byte, ...[]byte) ([]byte, error)
+	// SetContract sets the native staking contract address
+	SetNativeStakingContract(string)
 }
 
 type lifeLongDelegatesProtocol struct {
@@ -140,6 +142,10 @@ func (p *lifeLongDelegatesProtocol) ReadState(
 	default:
 		return nil, errors.New("corresponding method isn't found")
 	}
+}
+
+func (p *lifeLongDelegatesProtocol) SetNativeStakingContract(contract string) {
+	zap.S().Panic("Not implemented")
 }
 
 func (p *lifeLongDelegatesProtocol) readBlockProducers() ([]byte, error) {
@@ -335,6 +341,10 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 		return nil, errors.New("corresponding method isn't found")
 
 	}
+}
+
+func (p *governanceChainCommitteeProtocol) SetNativeStakingContract(contract string) {
+	zap.S().Panic("Not implemented")
 }
 
 func (p *governanceChainCommitteeProtocol) readDelegatesByEpoch(epochNum uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -49,7 +49,8 @@ func NewStakingCommittee(
 	getTipBlockTime GetTipBlockTime,
 	getEpochHeight GetEpochHeight,
 	getEpochNum GetEpochNum,
-	staking string,
+	nativeStakingContractAddress string,
+	nativeStakingContractCode string,
 	rp *rolldpos.Protocol,
 	scoreThreshold *big.Int,
 ) (Protocol, error) {
@@ -60,10 +61,13 @@ func NewStakingCommittee(
 		return nil, errors.New("failed to create native staking: empty getEpochNum")
 	}
 	var ns *NativeStaking
-	if staking != "" {
+	if nativeStakingContractAddress != "" || nativeStakingContractCode != "" {
 		var err error
-		if ns, err = NewNativeStaking(cm, getTipBlockTime, staking); err != nil {
+		if ns, err = NewNativeStaking(cm, getTipBlockTime); err != nil {
 			return nil, errors.New("failed to create native staking")
+		}
+		if nativeStakingContractAddress != "" {
+			ns.SetContract(nativeStakingContractAddress)
 		}
 	}
 	return &stakingCommittee{
@@ -123,6 +127,11 @@ func (sc *stakingCommittee) DelegatesByHeight(height uint64) (state.CandidateLis
 
 func (sc *stakingCommittee) ReadState(ctx context.Context, sm protocol.StateManager, method []byte, args ...[]byte) ([]byte, error) {
 	return sc.governanceStaking.ReadState(ctx, sm, method, args...)
+}
+
+// SetNativeStakingContract sets the address of native staking contract
+func (sc *stakingCommittee) SetNativeStakingContract(contract string) {
+	sc.nativeStaking.SetContract(contract)
 }
 
 func (sc *stakingCommittee) mergeDelegates(list state.CandidateList, votes *VoteTally, ts time.Time) state.CandidateList {

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -142,8 +142,10 @@ type (
 		RegisterContractAddress string `yaml:"registerContractAddress"`
 		// StakingContractAddress is the address of staking contract
 		StakingContractAddress string `yaml:"stakingContractAddress"`
-		// NativeStakingContractAddress is the address of staking contract on mainnet
+		// NativeStakingContractAddress is the address of native staking contract
 		NativeStakingContractAddress string `yaml:"nativeStakingContractAddress"`
+		// NativeStakingContractCode is the code of native staking contract
+		NativeStakingContractCode string `yaml:"nativeStakingContractCode"`
 		// VoteThreshold is the vote threshold amount in decimal string format
 		VoteThreshold string `yaml:"voteThreshold"`
 		// ScoreThreshold is the score threshold amount in decimal string format

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -319,6 +319,7 @@ func registerDefaultProtocols(cs *chainservice.ChainService, cfg config.Config) 
 				rolldposProtocol.GetEpochHeight,
 				rolldposProtocol.GetEpochNum,
 				cfg.Genesis.NativeStakingContractAddress,
+				cfg.Genesis.NativeStakingContractCode,
 				rolldposProtocol,
 				scoreThreshold,
 			); err != nil {


### PR DESCRIPTION
Allow config nativestakingcontractcode in the genesis so that we could start a chain with the native staking contract from scratch.

Verified the start and restart in the cluster and worked fine