### PR TITLE
Full state history node 1370

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -7,7 +7,9 @@
 package blockchain
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"math/big"
 	"os"
 	"strconv"
@@ -25,6 +27,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
+	bolt "go.etcd.io/bbolt"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -52,6 +55,10 @@ import (
 	"github.com/iotexproject/iotex-core/state/factory"
 )
 
+const (
+	heightToTrieNodeKeyNS = "htn"
+)
+
 var (
 	blockMtc = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
@@ -61,7 +68,8 @@ var (
 		},
 		[]string{"type"},
 	)
-	errDelegatesNotExist = errors.New("delegates cannot be found")
+	errDelegatesNotExist      = errors.New("delegates cannot be found")
+	heightToTrieNodeKeyPrefix = []byte("hnk.")
 )
 
 func init() {
@@ -185,6 +193,8 @@ type blockchain struct {
 	sf factory.Factory
 
 	registry *protocol.Registry
+	// make sure there's only one goroutine deleting
+	deletingTrieHistory chan struct{}
 }
 
 // ActPoolManager defines the actpool interface
@@ -295,8 +305,9 @@ func RegistryOption(registry *protocol.Registry) Option {
 func NewBlockchain(cfg config.Config, opts ...Option) Blockchain {
 	// create the Blockchain
 	chain := &blockchain{
-		config: cfg,
-		clk:    clock.New(),
+		config:              cfg,
+		clk:                 clock.New(),
+		deletingTrieHistory: make(chan struct{}, 1),
 	}
 	for _, opt := range opts {
 		if err := opt(chain, cfg); err != nil {
@@ -1040,6 +1051,12 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	bc.tipHash = blk.HashBlock()
 
 	if bc.sf != nil {
+		// save trie node that will be deleted in this block
+		heightToKeyCache, err := blk.WorkingSet.GetDB().SaveDeletedTrieNode(blk.WorkingSet.GetCachedBatch(), bc.tipHeight, heightToTrieNodeKeyNS, heightToTrieNodeKeyPrefix)
+		if err != nil {
+			return errors.Wrapf(err, "failed to save trie's node on height %d", blk.Height())
+		}
+
 		// write smart contract receipt into DB
 		receiptTimer := bc.timerFactory.NewTimer("putReceipt")
 		err = bc.dao.PutReceipts(blk.Height(), blk.Receipts)
@@ -1049,19 +1066,101 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 		}
 
 		sfTimer := bc.timerFactory.NewTimer("sf.Commit")
-		err := bc.sf.Commit(blk.WorkingSet)
+		err = bc.sf.Commit(blk.WorkingSet)
 		sfTimer.End()
 		// detach working set so it can be freed by GC
 		blk.WorkingSet = nil
 		if err != nil {
 			log.L().Panic("Error when committing states.", zap.Error(err))
 		}
+		err = bc.saveHistory(heightToKeyCache, blk.Height())
+		if err != nil {
+			return errors.Wrapf(err, "failed to save history on height %d", blk.Height())
+		}
 	}
 	blk.HeaderLogger(log.L()).Info("Committed a block.", log.Hex("tipHash", bc.tipHash[:]))
 
 	// emit block to all block subscribers
 	bc.emitToSubscribers(blk)
+	// delete trie node history asynchronously
+	bc.deleteTrieHistory(bc.tipHeight)
 	return nil
+}
+
+func (bc *blockchain) saveHistory(heightToKeyCache db.KVStoreBatch, height uint64) error {
+	if heightToKeyCache == nil {
+		return nil
+	}
+	// commit to chain.db
+	err := bc.dao.KVStore().Commit(heightToKeyCache)
+	if err != nil {
+		return errors.Wrapf(err, "Error when commit height->trie node key hash on height %d", height)
+	}
+	return nil
+}
+
+func (bc *blockchain) deleteTrieHistory(hei uint64) {
+	if bc.config.DB.EnableHistoryState && hei%factory.CheckHistoryDeleteInterval == 0 {
+		ws, err := bc.sf.NewWorkingSet()
+		if err != nil {
+			log.L().Error("Error when call NewWorkingSet.", zap.Error(err))
+			return
+		}
+		dbstore := ws.GetDB()
+		if dbstore == nil {
+			log.L().Error("Error when call GetDB.", zap.Error(err))
+			return
+		}
+		cb := db.NewCachedBatch()
+		go func() {
+			// make sure there's only one goroutine doing this
+			bc.deletingTrieHistory <- struct{}{}
+			defer func() {
+				<-bc.deletingTrieHistory
+			}()
+			kvstore := bc.dao.KVStore().DB()
+			boltdb, ok := kvstore.(*bolt.DB)
+			if !ok {
+				log.L().Error("convert to bolt db error")
+				return
+			}
+			// caculate the block height,later will delete trie node that before this height
+			if hei < bc.config.DB.HistoryStateHeight {
+				return
+			}
+			deleteStartHeight := hei - bc.config.DB.HistoryStateHeight
+			var endHeight uint64
+			if deleteStartHeight < bc.config.DB.HistoryStateHeight {
+				endHeight = 1
+			} else {
+				endHeight = deleteStartHeight - bc.config.DB.HistoryStateHeight
+			}
+
+			for i := deleteStartHeight; i > endHeight; i-- {
+				heightBytes := make([]byte, 8)
+				binary.BigEndian.PutUint64(heightBytes, i)
+				keyPrefix := append(heightToTrieNodeKeyPrefix, heightBytes...)
+				err = boltdb.Update(func(tx *bolt.Tx) error {
+					b := tx.Bucket([]byte(heightToTrieNodeKeyNS))
+					if b == nil {
+						return nil
+					}
+					c := b.Cursor()
+					for k, _ := c.Seek(keyPrefix); bytes.HasPrefix(k, keyPrefix); k, _ = c.Next() {
+						// delete height->trie node hash directly
+						b.Delete(k)
+						// put into cache
+						cb.Delete(db.ContractKVNameSpace, k[len(keyPrefix):], "failed to delete key %x", k[len(keyPrefix):])
+					}
+					return nil
+				})
+				if err != nil {
+					return
+				}
+			}
+			dbstore.Commit(cb) // delete trie node
+		}()
+	}
 }
 
 func (bc *blockchain) runActions(

--- a/config/config.go
+++ b/config/config.go
@@ -176,9 +176,11 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
-			SplitDBSizeMB: 0,
-			SplitDBHeight: 900000,
-			Reindex:       false,
+			SplitDBSizeMB:      0,
+			SplitDBHeight:      900000,
+			Reindex:            false,
+			EnableHistoryState: true,
+			HistoryStateHeight: 2000,
 		},
 		Genesis: genesis.Default,
 	}
@@ -341,6 +343,10 @@ type (
 		SplitDBHeight uint64 `yaml:"splitDBHeight"`
 		// Reindex will rebuild index if set to true
 		Reindex bool `yaml:"reindex"`
+		// EnableHistoryState is the config enable history state
+		EnableHistoryState bool `yaml:"enableHistoryState"`
+		// HistoryStateHeight is the config for DB history height
+		HistoryStateHeight uint64 `yaml:"historyStateHeight"`
 	}
 
 	// RDS is the cloud rds config

--- a/db/db.go
+++ b/db/db.go
@@ -45,6 +45,10 @@ type KVStore interface {
 	CountingIndex([]byte) (CountingIndex, error)
 	// CreateCountingIndexNX creates a new index if it does not exist, otherwise return existing index
 	CreateCountingIndexNX([]byte) (CountingIndex, error)
+	// DB return dao
+	DB() interface{}
+	// SaveDeletedTrieNode save deleted trie node
+	SaveDeletedTrieNode(KVStoreBatch, uint64, string, []byte) (KVStoreBatch, error)
 }
 
 const (
@@ -64,7 +68,9 @@ func NewMemKVStore() KVStore {
 		data:   &sync.Map{},
 	}
 }
-
+func (m *memKVStore) DB() interface{} {
+	return nil
+}
 func (m *memKVStore) Start(_ context.Context) error { return nil }
 
 func (m *memKVStore) Stop(_ context.Context) error { return nil }
@@ -154,4 +160,9 @@ func (m *memKVStore) CreateCountingIndexNX(name []byte) (CountingIndex, error) {
 		size = byteutil.BytesToUint64BigEndian(total)
 	}
 	return NewInMemCountingIndex(m, name, size)
+}
+
+// SaveDeletedTrieNode save trie node history
+func (m *memKVStore) SaveDeletedTrieNode(KVStoreBatch, uint64, string, []byte) (KVStoreBatch, error) {
+	return nil, nil
 }

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -43,6 +43,11 @@ const (
 	AccountTrieRootKey = "accountTrieRoot"
 )
 
+var (
+	// AccountMaxVersionPrefix is for account history
+	AccountMaxVersionPrefix = []byte("vp.")
+)
+
 type (
 	// Factory defines an interface for managing states
 	Factory interface {

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -618,7 +618,7 @@ func TestCachedBatch(t *testing.T) {
 }
 
 func TestSTXCachedBatch(t *testing.T) {
-	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))})
+	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))}, config.Default.DB)
 	testCachedBatch(ws, t, true)
 }
 
@@ -668,7 +668,7 @@ func TestGetDB(t *testing.T) {
 }
 
 func TestSTXGetDB(t *testing.T) {
-	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))})
+	ws := newStateTX(0, db.NewMemKVStore(), []protocol.ActionHandler{account.NewProtocol(config.NewHeightUpgrade(config.Default))}, config.Default.DB)
 	testGetDB(ws, t)
 }
 
@@ -699,7 +699,7 @@ func TestDeleteAndPutSameKey(t *testing.T) {
 		testDeleteAndPutSameKey(t, ws)
 	})
 	t.Run("stateTx", func(t *testing.T) {
-		ws := newStateTX(0, db.NewMemKVStore(), nil)
+		ws := newStateTX(0, db.NewMemKVStore(), nil, config.Default.DB)
 		testDeleteAndPutSameKey(t, ws)
 	})
 }

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -7,16 +7,13 @@
 package factory
 
 import (
-	"bytes"
 	"context"
-	"encoding/binary"
 	"fmt"
 	"math/big"
 	"strconv"
 	"sync"
 
 	"github.com/pkg/errors"
-	bolt "go.etcd.io/bbolt"
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/go-pkgs/hash"


### PR DESCRIPTION
work on #1370

Test code is https://github.com/lzxm160/iotex-core/tree/137018 ,the following is test api:

1.account history
grpcurl -v -plaintext -d '{"address": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.GetAccount

2.readstate,add a new method,GetStorageAt:
grpcurl -v -plaintext -d '{"protocolID": "cG9sbA==", "methodName": "R2V0U3RvcmFnZUF0", "arguments": ["aW8xNjRzZWh5NW5tMnl0NXNydGx0Y214am11OHloeWNkcTZtMDZlY2U=","ZTJhNDU2YTg3NWZjMTljMmQ2YzYwYmQ1MWE1ZDFhZjk4NDE3NTUxYjI5Mzc3YzQyMGM5MzQ5N2EzNmI0NzIwYw==","ODg0MzE2"]}' 127.0.0.1:14014 iotexapi.APIService.ReadState

3.readcontract,execute a contract method with block height:
grpcurl -v -plaintext -d '{"execution":{"amount":"0","contract":"io164sehy5nm2yt5srtltcmxjmu8yhycdq6m06ece","data":"cKCCMQAAAAAAAAAAAAAAAGNWkIrOCSaBMN7it95kMxS76zaD"}, "callerAddress": "io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg884314"}' 127.0.0.1:14014 iotexapi.APIService.ReadContract

After this we will add api according to branch 137018 to support history state