### PR TITLE
Old calibrate event not to return error 

### DIFF
--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -73,6 +73,8 @@ var (
 	ErrEvtConvert = errors.New("error when converting the event from/to the proto message")
 	// ErrEvtType represents an unexpected event type error
 	ErrEvtType = errors.New("error when check the event type")
+	// ErrOldCalibrateEvt indicates the error of ignoring old calibrate event
+	ErrOldCalibrateEvt = errors.New("ignore old calibrate event")
 
 	// consensusStates is a slice consisting of all consensus states
 	consensusStates = []fsm.State{
@@ -347,6 +349,11 @@ func (m *ConsensusFSM) handle(evt *ConsensusEvent) error {
 			zap.Error(err),
 		)
 		consensusEvtsMtc.WithLabelValues(string(evt.Type()), "backoff").Inc()
+	case ErrOldCalibrateEvt:
+		m.ctx.Logger().Debug(
+			"failed handle eCalibrate, because consensus height is bigger than eCalibrate height",
+			zap.Error(err),
+		)
 	default:
 		return errors.Wrapf(
 			err,
@@ -369,7 +376,7 @@ func (m *ConsensusFSM) calibrate(evt fsm.Event) (fsm.State, error) {
 	}
 	consensusHeight := m.ctx.Height()
 	if consensusHeight > height {
-		return sPrepare, errors.New("ignore old calibrate event")
+		return sPrepare, ErrOldCalibrateEvt
 	}
 	m.ctx.Logger().Debug(
 		"Calibrate consensus context",

--- a/consensus/consensusfsm/fsm.go
+++ b/consensus/consensusfsm/fsm.go
@@ -351,7 +351,7 @@ func (m *ConsensusFSM) handle(evt *ConsensusEvent) error {
 		consensusEvtsMtc.WithLabelValues(string(evt.Type()), "backoff").Inc()
 	case ErrOldCalibrateEvt:
 		m.ctx.Logger().Debug(
-			"failed handle eCalibrate, because consensus height is bigger than eCalibrate height",
+			"failed to handle eCalibrate, event height is less than current height",
 			zap.Error(err),
 		)
 	default:


### PR DESCRIPTION
works on #1543 

Old calibrate event should be ignored, So try not to return error and change it to the debug logging  