### PR TITLE
rewrite error message of execution simulation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1255,7 +1255,7 @@ func (api *Server) estimateActionGasConsumptionForExecution(exec *iotextypes.Exe
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	if receipt.Status != uint64(iotextypes.ReceiptStatus_Success) {
-		return nil, status.Error(codes.Internal, "receipt status failed")
+		return nil, status.Error(codes.Internal, "execution simulation gets failure status")
 	}
 	return &iotexapi.EstimateActionGasConsumptionResponse{
 		Gas: receipt.GasConsumed,


### PR DESCRIPTION
When I invoke an execution from ioctl without setting gas limit, ioctl will call ExecuteContractRead to estimate gas consume. If the execution gets failure status, the error message user gets will be `Error: failed to fix Execution gaslimit: receipt status failed` that may be confusing for a non-developer.

Therefore, I'd like to change the error message that node returns to ioctl into `execution simulation gets failure status`. And user may get `Error: failed to fix Execution gaslimit: execution simulation gets failure status`