### PR TITLE
define blockindexer interface in blockdao

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -40,7 +40,6 @@ import (
 	"github.com/iotexproject/iotex-core/actpool/actioniterator"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
-	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/db"
@@ -151,7 +150,6 @@ type Blockchain interface {
 type blockchain struct {
 	mu            sync.RWMutex // mutex to protect utk, tipHeight and tipHash
 	dao           blockdao.BlockDAO
-	indexer       blockindex.Indexer
 	config        config.Config
 	tipHeight     uint64
 	tipHash       hash.Hash256
@@ -222,7 +220,7 @@ func BoltDBDaoOption() Option {
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath // TODO: remove this after moving TrieDBPath from cfg.Chain to cfg.DB
 		bc.dao = blockdao.NewBlockDAO(
 			db.NewBoltDB(cfg.DB),
-			bc.indexer,
+			nil,
 			cfg.Chain.CompressBlock,
 			cfg.DB,
 		)
@@ -238,7 +236,7 @@ func InMemDaoOption() Option {
 		}
 		bc.dao = blockdao.NewBlockDAO(
 			db.NewMemKVStore(),
-			bc.indexer,
+			nil,
 			cfg.Chain.CompressBlock,
 			cfg.DB,
 		)
@@ -901,7 +899,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	if err = bc.dao.PutBlock(blk); err == nil {
+	if err = bc.dao.PutBlock(blk); err != nil {
 		err = bc.dao.Commit()
 	}
 	putTimer.End()

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -899,7 +899,7 @@ func (bc *blockchain) commitBlock(blk *block.Block) error {
 	}
 	// write block into DB
 	putTimer := bc.timerFactory.NewTimer("putBlock")
-	if err = bc.dao.PutBlock(blk); err != nil {
+	if err = bc.dao.PutBlock(blk); err == nil {
 		err = bc.dao.Commit()
 	}
 	putTimer.End()

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -286,7 +286,7 @@ func TestBlockDAO(t *testing.T) {
 			}
 		}
 		// cannot delete genesis block
-		require.Equal("cannot delete genesis block", dao.DeleteTipBlock().Error())
+		require.Error(dao.DeleteTipBlock())
 	}
 
 	t.Run("In-memory KV Store for blocks", func(t *testing.T) {

--- a/blockindex/indexer.go
+++ b/blockindex/indexer.go
@@ -47,7 +47,7 @@ type (
 		Stop(context.Context) error
 		Commit() error
 		PutBlock(*block.Block) error
-		DeleteBlock(*block.Block) error
+		DeleteTipBlock(*block.Block) error
 		GetBlockchainHeight() (uint64, error)
 		GetBlockHash(height uint64) (hash.Hash256, error)
 		GetBlockHeight(hash hash.Hash256) (uint64, error)
@@ -162,7 +162,7 @@ func (x *blockIndexer) PutBlock(blk *block.Block) error {
 }
 
 // DeleteBlock deletes a block's index
-func (x *blockIndexer) DeleteBlock(blk *block.Block) error {
+func (x *blockIndexer) DeleteTipBlock(blk *block.Block) error {
 	x.mutex.Lock()
 	defer x.mutex.Unlock()
 

--- a/blockindex/indexer_test.go
+++ b/blockindex/indexer_test.go
@@ -277,7 +277,7 @@ func TestIndexer(t *testing.T) {
 				// tests[0] is the whole address/action data at block height 3
 				continue
 			}
-			require.NoError(indexer.DeleteBlock(blks[3-i]))
+			require.NoError(indexer.DeleteTipBlock(blks[3-i]))
 			tipHeight, err := indexer.GetBlockchainHeight()
 			require.NoError(err)
 			require.EqualValues(uint64(3-i), tipHeight)


### PR DESCRIPTION
Blockdao is using a complicated interface defined in blockindex now. The PR tries to simplify the interface definition, and define it in blockdao.

Test plan: make test && make minicluster