### PR TITLE
mockgen script should not remove existing mocks

### DIFF
--- a/consensus/consensusfsm/mock_context_test.go
+++ b/consensus/consensusfsm/mock_context_test.go
@@ -37,16 +37,19 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 
 // Activate mocks base method
 func (m *MockContext) Activate(arg0 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Activate", arg0)
 }
 
 // Activate indicates an expected call of Activate
 func (mr *MockContextMockRecorder) Activate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Activate", reflect.TypeOf((*MockContext)(nil).Activate), arg0)
 }
 
 // Active mocks base method
 func (m *MockContext) Active() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Active")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -54,11 +57,13 @@ func (m *MockContext) Active() bool {
 
 // Active indicates an expected call of Active
 func (mr *MockContextMockRecorder) Active() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockContext)(nil).Active))
 }
 
 // IsStaleEvent mocks base method
 func (m *MockContext) IsStaleEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsStaleEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -66,11 +71,13 @@ func (m *MockContext) IsStaleEvent(arg0 *ConsensusEvent) bool {
 
 // IsStaleEvent indicates an expected call of IsStaleEvent
 func (mr *MockContextMockRecorder) IsStaleEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStaleEvent", reflect.TypeOf((*MockContext)(nil).IsStaleEvent), arg0)
 }
 
 // IsFutureEvent mocks base method
 func (m *MockContext) IsFutureEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsFutureEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -78,11 +85,13 @@ func (m *MockContext) IsFutureEvent(arg0 *ConsensusEvent) bool {
 
 // IsFutureEvent indicates an expected call of IsFutureEvent
 func (mr *MockContextMockRecorder) IsFutureEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsFutureEvent", reflect.TypeOf((*MockContext)(nil).IsFutureEvent), arg0)
 }
 
 // IsStaleUnmatchedEvent mocks base method
 func (m *MockContext) IsStaleUnmatchedEvent(arg0 *ConsensusEvent) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsStaleUnmatchedEvent", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -90,11 +99,13 @@ func (m *MockContext) IsStaleUnmatchedEvent(arg0 *ConsensusEvent) bool {
 
 // IsStaleUnmatchedEvent indicates an expected call of IsStaleUnmatchedEvent
 func (mr *MockContextMockRecorder) IsStaleUnmatchedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStaleUnmatchedEvent", reflect.TypeOf((*MockContext)(nil).IsStaleUnmatchedEvent), arg0)
 }
 
 // Logger mocks base method
 func (m *MockContext) Logger() *zap.Logger {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Logger")
 	ret0, _ := ret[0].(*zap.Logger)
 	return ret0
@@ -102,11 +113,13 @@ func (m *MockContext) Logger() *zap.Logger {
 
 // Logger indicates an expected call of Logger
 func (mr *MockContextMockRecorder) Logger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Logger", reflect.TypeOf((*MockContext)(nil).Logger))
 }
 
 // Height mocks base method
 func (m *MockContext) Height() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Height")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -114,11 +127,13 @@ func (m *MockContext) Height() uint64 {
 
 // Height indicates an expected call of Height
 func (mr *MockContextMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContext)(nil).Height))
 }
 
 // NewConsensusEvent mocks base method
 func (m *MockContext) NewConsensusEvent(arg0 go_fsm.EventType, arg1 interface{}) *ConsensusEvent {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewConsensusEvent", arg0, arg1)
 	ret0, _ := ret[0].(*ConsensusEvent)
 	return ret0
@@ -126,11 +141,13 @@ func (m *MockContext) NewConsensusEvent(arg0 go_fsm.EventType, arg1 interface{})
 
 // NewConsensusEvent indicates an expected call of NewConsensusEvent
 func (mr *MockContextMockRecorder) NewConsensusEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewConsensusEvent", reflect.TypeOf((*MockContext)(nil).NewConsensusEvent), arg0, arg1)
 }
 
 // NewBackdoorEvt mocks base method
 func (m *MockContext) NewBackdoorEvt(arg0 go_fsm.State) *ConsensusEvent {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewBackdoorEvt", arg0)
 	ret0, _ := ret[0].(*ConsensusEvent)
 	return ret0
@@ -138,21 +155,25 @@ func (m *MockContext) NewBackdoorEvt(arg0 go_fsm.State) *ConsensusEvent {
 
 // NewBackdoorEvt indicates an expected call of NewBackdoorEvt
 func (mr *MockContextMockRecorder) NewBackdoorEvt(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewBackdoorEvt", reflect.TypeOf((*MockContext)(nil).NewBackdoorEvt), arg0)
 }
 
 // Broadcast mocks base method
 func (m *MockContext) Broadcast(arg0 interface{}) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Broadcast", arg0)
 }
 
 // Broadcast indicates an expected call of Broadcast
 func (mr *MockContextMockRecorder) Broadcast(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Broadcast", reflect.TypeOf((*MockContext)(nil).Broadcast), arg0)
 }
 
 // Prepare mocks base method
 func (m *MockContext) Prepare() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Prepare")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -160,11 +181,13 @@ func (m *MockContext) Prepare() error {
 
 // Prepare indicates an expected call of Prepare
 func (mr *MockContextMockRecorder) Prepare() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Prepare", reflect.TypeOf((*MockContext)(nil).Prepare))
 }
 
 // IsDelegate mocks base method
 func (m *MockContext) IsDelegate() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsDelegate")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -172,11 +195,13 @@ func (m *MockContext) IsDelegate() bool {
 
 // IsDelegate indicates an expected call of IsDelegate
 func (mr *MockContextMockRecorder) IsDelegate() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsDelegate", reflect.TypeOf((*MockContext)(nil).IsDelegate))
 }
 
 // Proposal mocks base method
 func (m *MockContext) Proposal() (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Proposal")
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -185,11 +210,13 @@ func (m *MockContext) Proposal() (interface{}, error) {
 
 // Proposal indicates an expected call of Proposal
 func (mr *MockContextMockRecorder) Proposal() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Proposal", reflect.TypeOf((*MockContext)(nil).Proposal))
 }
 
 // WaitUntilRoundStart mocks base method
 func (m *MockContext) WaitUntilRoundStart() time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WaitUntilRoundStart")
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -197,11 +224,13 @@ func (m *MockContext) WaitUntilRoundStart() time.Duration {
 
 // WaitUntilRoundStart indicates an expected call of WaitUntilRoundStart
 func (mr *MockContextMockRecorder) WaitUntilRoundStart() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilRoundStart", reflect.TypeOf((*MockContext)(nil).WaitUntilRoundStart))
 }
 
 // PreCommitEndorsement mocks base method
 func (m *MockContext) PreCommitEndorsement() interface{} {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreCommitEndorsement")
 	ret0, _ := ret[0].(interface{})
 	return ret0
@@ -209,11 +238,13 @@ func (m *MockContext) PreCommitEndorsement() interface{} {
 
 // PreCommitEndorsement indicates an expected call of PreCommitEndorsement
 func (mr *MockContextMockRecorder) PreCommitEndorsement() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreCommitEndorsement", reflect.TypeOf((*MockContext)(nil).PreCommitEndorsement))
 }
 
 // NewProposalEndorsement mocks base method
 func (m *MockContext) NewProposalEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewProposalEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -222,11 +253,13 @@ func (m *MockContext) NewProposalEndorsement(arg0 interface{}) (interface{}, err
 
 // NewProposalEndorsement indicates an expected call of NewProposalEndorsement
 func (mr *MockContextMockRecorder) NewProposalEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewProposalEndorsement", reflect.TypeOf((*MockContext)(nil).NewProposalEndorsement), arg0)
 }
 
 // NewLockEndorsement mocks base method
 func (m *MockContext) NewLockEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewLockEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -235,11 +268,13 @@ func (m *MockContext) NewLockEndorsement(arg0 interface{}) (interface{}, error) 
 
 // NewLockEndorsement indicates an expected call of NewLockEndorsement
 func (mr *MockContextMockRecorder) NewLockEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLockEndorsement", reflect.TypeOf((*MockContext)(nil).NewLockEndorsement), arg0)
 }
 
 // NewPreCommitEndorsement mocks base method
 func (m *MockContext) NewPreCommitEndorsement(arg0 interface{}) (interface{}, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewPreCommitEndorsement", arg0)
 	ret0, _ := ret[0].(interface{})
 	ret1, _ := ret[1].(error)
@@ -248,11 +283,13 @@ func (m *MockContext) NewPreCommitEndorsement(arg0 interface{}) (interface{}, er
 
 // NewPreCommitEndorsement indicates an expected call of NewPreCommitEndorsement
 func (mr *MockContextMockRecorder) NewPreCommitEndorsement(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewPreCommitEndorsement", reflect.TypeOf((*MockContext)(nil).NewPreCommitEndorsement), arg0)
 }
 
 // Commit mocks base method
 func (m *MockContext) Commit(arg0 interface{}) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -261,11 +298,13 @@ func (m *MockContext) Commit(arg0 interface{}) (bool, error) {
 
 // Commit indicates an expected call of Commit
 func (mr *MockContextMockRecorder) Commit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockContext)(nil).Commit), arg0)
 }
 
 // EventChanSize mocks base method
 func (m *MockContext) EventChanSize() uint {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EventChanSize")
 	ret0, _ := ret[0].(uint)
 	return ret0
@@ -273,11 +312,13 @@ func (m *MockContext) EventChanSize() uint {
 
 // EventChanSize indicates an expected call of EventChanSize
 func (mr *MockContextMockRecorder) EventChanSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EventChanSize", reflect.TypeOf((*MockContext)(nil).EventChanSize))
 }
 
 // UnmatchedEventTTL mocks base method
 func (m *MockContext) UnmatchedEventTTL(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmatchedEventTTL", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -285,11 +326,13 @@ func (m *MockContext) UnmatchedEventTTL(arg0 uint64) time.Duration {
 
 // UnmatchedEventTTL indicates an expected call of UnmatchedEventTTL
 func (mr *MockContextMockRecorder) UnmatchedEventTTL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmatchedEventTTL", reflect.TypeOf((*MockContext)(nil).UnmatchedEventTTL), arg0)
 }
 
 // UnmatchedEventInterval mocks base method
 func (m *MockContext) UnmatchedEventInterval(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UnmatchedEventInterval", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -297,11 +340,13 @@ func (m *MockContext) UnmatchedEventInterval(arg0 uint64) time.Duration {
 
 // UnmatchedEventInterval indicates an expected call of UnmatchedEventInterval
 func (mr *MockContextMockRecorder) UnmatchedEventInterval(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmatchedEventInterval", reflect.TypeOf((*MockContext)(nil).UnmatchedEventInterval), arg0)
 }
 
 // AcceptBlockTTL mocks base method
 func (m *MockContext) AcceptBlockTTL(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptBlockTTL", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -309,11 +354,13 @@ func (m *MockContext) AcceptBlockTTL(arg0 uint64) time.Duration {
 
 // AcceptBlockTTL indicates an expected call of AcceptBlockTTL
 func (mr *MockContextMockRecorder) AcceptBlockTTL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptBlockTTL", reflect.TypeOf((*MockContext)(nil).AcceptBlockTTL), arg0)
 }
 
 // AcceptProposalEndorsementTTL mocks base method
 func (m *MockContext) AcceptProposalEndorsementTTL(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptProposalEndorsementTTL", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -321,11 +368,13 @@ func (m *MockContext) AcceptProposalEndorsementTTL(arg0 uint64) time.Duration {
 
 // AcceptProposalEndorsementTTL indicates an expected call of AcceptProposalEndorsementTTL
 func (mr *MockContextMockRecorder) AcceptProposalEndorsementTTL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptProposalEndorsementTTL", reflect.TypeOf((*MockContext)(nil).AcceptProposalEndorsementTTL), arg0)
 }
 
 // AcceptLockEndorsementTTL mocks base method
 func (m *MockContext) AcceptLockEndorsementTTL(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AcceptLockEndorsementTTL", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -333,11 +382,13 @@ func (m *MockContext) AcceptLockEndorsementTTL(arg0 uint64) time.Duration {
 
 // AcceptLockEndorsementTTL indicates an expected call of AcceptLockEndorsementTTL
 func (mr *MockContextMockRecorder) AcceptLockEndorsementTTL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptLockEndorsementTTL", reflect.TypeOf((*MockContext)(nil).AcceptLockEndorsementTTL), arg0)
 }
 
 // CommitTTL mocks base method
 func (m *MockContext) CommitTTL(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitTTL", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -345,11 +396,13 @@ func (m *MockContext) CommitTTL(arg0 uint64) time.Duration {
 
 // CommitTTL indicates an expected call of CommitTTL
 func (mr *MockContextMockRecorder) CommitTTL(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitTTL", reflect.TypeOf((*MockContext)(nil).CommitTTL), arg0)
 }
 
 // BlockInterval mocks base method
 func (m *MockContext) BlockInterval(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockInterval", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -357,11 +410,13 @@ func (m *MockContext) BlockInterval(arg0 uint64) time.Duration {
 
 // BlockInterval indicates an expected call of BlockInterval
 func (mr *MockContextMockRecorder) BlockInterval(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockInterval", reflect.TypeOf((*MockContext)(nil).BlockInterval), arg0)
 }
 
 // Delay mocks base method
 func (m *MockContext) Delay(arg0 uint64) time.Duration {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delay", arg0)
 	ret0, _ := ret[0].(time.Duration)
 	return ret0
@@ -369,5 +424,6 @@ func (m *MockContext) Delay(arg0 uint64) time.Duration {
 
 // Delay indicates an expected call of Delay
 func (mr *MockContextMockRecorder) Delay(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delay", reflect.TypeOf((*MockContext)(nil).Delay), arg0)
 }

--- a/misc/scripts/mockgen.sh
+++ b/misc/scripts/mockgen.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-rm -rf ./test/mock
 mkdir -p ./test/mock
 
 mkdir -p ./test/mock/mock_dispatcher
@@ -19,6 +18,7 @@ mockgen -destination=./test/mock/mock_blockchain/mock_blockchain.go  \
 mkdir -p ./test/mock/mock_blocksync
 mockgen -destination=./test/mock/mock_blocksync/mock_blocksync.go  \
         -source=./blocksync/blocksync.go \
+        -self_package=github.com/iotexproject/iotex-core/blocksync \
         -package=mock_blocksync \
         BlockSync
 

--- a/test/mock/mock_actioniterator/mock_actioniterator.go
+++ b/test/mock/mock_actioniterator/mock_actioniterator.go
@@ -35,6 +35,7 @@ func (m *MockActionIterator) EXPECT() *MockActionIteratorMockRecorder {
 
 // Next mocks base method
 func (m *MockActionIterator) Next() (action.SealedEnvelope, bool) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Next")
 	ret0, _ := ret[0].(action.SealedEnvelope)
 	ret1, _ := ret[1].(bool)
@@ -43,15 +44,18 @@ func (m *MockActionIterator) Next() (action.SealedEnvelope, bool) {
 
 // Next indicates an expected call of Next
 func (mr *MockActionIteratorMockRecorder) Next() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockActionIterator)(nil).Next))
 }
 
 // PopAccount mocks base method
 func (m *MockActionIterator) PopAccount() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "PopAccount")
 }
 
 // PopAccount indicates an expected call of PopAccount
 func (mr *MockActionIteratorMockRecorder) PopAccount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PopAccount", reflect.TypeOf((*MockActionIterator)(nil).PopAccount))
 }

--- a/test/mock/mock_actpool/mock_actpool.go
+++ b/test/mock/mock_actpool/mock_actpool.go
@@ -37,16 +37,19 @@ func (m *MockActPool) EXPECT() *MockActPoolMockRecorder {
 
 // Reset mocks base method
 func (m *MockActPool) Reset() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Reset")
 }
 
 // Reset indicates an expected call of Reset
 func (mr *MockActPoolMockRecorder) Reset() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reset", reflect.TypeOf((*MockActPool)(nil).Reset))
 }
 
 // PendingActionMap mocks base method
 func (m *MockActPool) PendingActionMap() map[string][]action.SealedEnvelope {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PendingActionMap")
 	ret0, _ := ret[0].(map[string][]action.SealedEnvelope)
 	return ret0
@@ -54,11 +57,13 @@ func (m *MockActPool) PendingActionMap() map[string][]action.SealedEnvelope {
 
 // PendingActionMap indicates an expected call of PendingActionMap
 func (mr *MockActPoolMockRecorder) PendingActionMap() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PendingActionMap", reflect.TypeOf((*MockActPool)(nil).PendingActionMap))
 }
 
 // Add mocks base method
 func (m *MockActPool) Add(act action.SealedEnvelope) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", act)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -66,11 +71,13 @@ func (m *MockActPool) Add(act action.SealedEnvelope) error {
 
 // Add indicates an expected call of Add
 func (mr *MockActPoolMockRecorder) Add(act interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockActPool)(nil).Add), act)
 }
 
 // GetPendingNonce mocks base method
 func (m *MockActPool) GetPendingNonce(addr string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPendingNonce", addr)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -79,11 +86,13 @@ func (m *MockActPool) GetPendingNonce(addr string) (uint64, error) {
 
 // GetPendingNonce indicates an expected call of GetPendingNonce
 func (mr *MockActPoolMockRecorder) GetPendingNonce(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingNonce", reflect.TypeOf((*MockActPool)(nil).GetPendingNonce), addr)
 }
 
 // GetUnconfirmedActs mocks base method
 func (m *MockActPool) GetUnconfirmedActs(addr string) []action.SealedEnvelope {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUnconfirmedActs", addr)
 	ret0, _ := ret[0].([]action.SealedEnvelope)
 	return ret0
@@ -91,11 +100,13 @@ func (m *MockActPool) GetUnconfirmedActs(addr string) []action.SealedEnvelope {
 
 // GetUnconfirmedActs indicates an expected call of GetUnconfirmedActs
 func (mr *MockActPoolMockRecorder) GetUnconfirmedActs(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUnconfirmedActs", reflect.TypeOf((*MockActPool)(nil).GetUnconfirmedActs), addr)
 }
 
 // GetActionByHash mocks base method
 func (m *MockActPool) GetActionByHash(hash hash.Hash256) (action.SealedEnvelope, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionByHash", hash)
 	ret0, _ := ret[0].(action.SealedEnvelope)
 	ret1, _ := ret[1].(error)
@@ -104,11 +115,13 @@ func (m *MockActPool) GetActionByHash(hash hash.Hash256) (action.SealedEnvelope,
 
 // GetActionByHash indicates an expected call of GetActionByHash
 func (mr *MockActPoolMockRecorder) GetActionByHash(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionByHash", reflect.TypeOf((*MockActPool)(nil).GetActionByHash), hash)
 }
 
 // GetSize mocks base method
 func (m *MockActPool) GetSize() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSize")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -116,11 +129,13 @@ func (m *MockActPool) GetSize() uint64 {
 
 // GetSize indicates an expected call of GetSize
 func (mr *MockActPoolMockRecorder) GetSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSize", reflect.TypeOf((*MockActPool)(nil).GetSize))
 }
 
 // GetCapacity mocks base method
 func (m *MockActPool) GetCapacity() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCapacity")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -128,11 +143,13 @@ func (m *MockActPool) GetCapacity() uint64 {
 
 // GetCapacity indicates an expected call of GetCapacity
 func (mr *MockActPoolMockRecorder) GetCapacity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCapacity", reflect.TypeOf((*MockActPool)(nil).GetCapacity))
 }
 
 // GetGasSize mocks base method
 func (m *MockActPool) GetGasSize() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGasSize")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -140,11 +157,13 @@ func (m *MockActPool) GetGasSize() uint64 {
 
 // GetGasSize indicates an expected call of GetGasSize
 func (mr *MockActPoolMockRecorder) GetGasSize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGasSize", reflect.TypeOf((*MockActPool)(nil).GetGasSize))
 }
 
 // GetGasCapacity mocks base method
 func (m *MockActPool) GetGasCapacity() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetGasCapacity")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -152,11 +171,13 @@ func (m *MockActPool) GetGasCapacity() uint64 {
 
 // GetGasCapacity indicates an expected call of GetGasCapacity
 func (mr *MockActPoolMockRecorder) GetGasCapacity() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGasCapacity", reflect.TypeOf((*MockActPool)(nil).GetGasCapacity))
 }
 
 // AddActionValidators mocks base method
 func (m *MockActPool) AddActionValidators(arg0 ...protocol.ActionValidator) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -166,11 +187,13 @@ func (m *MockActPool) AddActionValidators(arg0 ...protocol.ActionValidator) {
 
 // AddActionValidators indicates an expected call of AddActionValidators
 func (mr *MockActPoolMockRecorder) AddActionValidators(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActionValidators", reflect.TypeOf((*MockActPool)(nil).AddActionValidators), arg0...)
 }
 
 // AddActionEnvelopeValidators mocks base method
 func (m *MockActPool) AddActionEnvelopeValidators(arg0 ...protocol.ActionEnvelopeValidator) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -180,5 +203,6 @@ func (m *MockActPool) AddActionEnvelopeValidators(arg0 ...protocol.ActionEnvelop
 
 // AddActionEnvelopeValidators indicates an expected call of AddActionEnvelopeValidators
 func (mr *MockActPoolMockRecorder) AddActionEnvelopeValidators(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActionEnvelopeValidators", reflect.TypeOf((*MockActPool)(nil).AddActionEnvelopeValidators), arg0...)
 }

--- a/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
+++ b/test/mock/mock_apiserviceclient/mock_apiserviceclient.go
@@ -37,6 +37,7 @@ func (m *MockServiceClient) EXPECT() *MockServiceClientMockRecorder {
 
 // GetAccount mocks base method
 func (m *MockServiceClient) GetAccount(ctx context.Context, in *iotexapi.GetAccountRequest, opts ...grpc.CallOption) (*iotexapi.GetAccountResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -49,12 +50,14 @@ func (m *MockServiceClient) GetAccount(ctx context.Context, in *iotexapi.GetAcco
 
 // GetAccount indicates an expected call of GetAccount
 func (mr *MockServiceClientMockRecorder) GetAccount(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAccount", reflect.TypeOf((*MockServiceClient)(nil).GetAccount), varargs...)
 }
 
 // GetActions mocks base method
 func (m *MockServiceClient) GetActions(ctx context.Context, in *iotexapi.GetActionsRequest, opts ...grpc.CallOption) (*iotexapi.GetActionsResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -67,12 +70,14 @@ func (m *MockServiceClient) GetActions(ctx context.Context, in *iotexapi.GetActi
 
 // GetActions indicates an expected call of GetActions
 func (mr *MockServiceClientMockRecorder) GetActions(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActions", reflect.TypeOf((*MockServiceClient)(nil).GetActions), varargs...)
 }
 
 // GetBlockMetas mocks base method
 func (m *MockServiceClient) GetBlockMetas(ctx context.Context, in *iotexapi.GetBlockMetasRequest, opts ...grpc.CallOption) (*iotexapi.GetBlockMetasResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -85,12 +90,14 @@ func (m *MockServiceClient) GetBlockMetas(ctx context.Context, in *iotexapi.GetB
 
 // GetBlockMetas indicates an expected call of GetBlockMetas
 func (mr *MockServiceClientMockRecorder) GetBlockMetas(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockMetas", reflect.TypeOf((*MockServiceClient)(nil).GetBlockMetas), varargs...)
 }
 
 // GetChainMeta mocks base method
 func (m *MockServiceClient) GetChainMeta(ctx context.Context, in *iotexapi.GetChainMetaRequest, opts ...grpc.CallOption) (*iotexapi.GetChainMetaResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -103,12 +110,14 @@ func (m *MockServiceClient) GetChainMeta(ctx context.Context, in *iotexapi.GetCh
 
 // GetChainMeta indicates an expected call of GetChainMeta
 func (mr *MockServiceClientMockRecorder) GetChainMeta(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChainMeta", reflect.TypeOf((*MockServiceClient)(nil).GetChainMeta), varargs...)
 }
 
 // GetServerMeta mocks base method
 func (m *MockServiceClient) GetServerMeta(ctx context.Context, in *iotexapi.GetServerMetaRequest, opts ...grpc.CallOption) (*iotexapi.GetServerMetaResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -121,12 +130,14 @@ func (m *MockServiceClient) GetServerMeta(ctx context.Context, in *iotexapi.GetS
 
 // GetServerMeta indicates an expected call of GetServerMeta
 func (mr *MockServiceClientMockRecorder) GetServerMeta(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServerMeta", reflect.TypeOf((*MockServiceClient)(nil).GetServerMeta), varargs...)
 }
 
 // SendAction mocks base method
 func (m *MockServiceClient) SendAction(ctx context.Context, in *iotexapi.SendActionRequest, opts ...grpc.CallOption) (*iotexapi.SendActionResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -139,12 +150,14 @@ func (m *MockServiceClient) SendAction(ctx context.Context, in *iotexapi.SendAct
 
 // SendAction indicates an expected call of SendAction
 func (mr *MockServiceClientMockRecorder) SendAction(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendAction", reflect.TypeOf((*MockServiceClient)(nil).SendAction), varargs...)
 }
 
 // GetReceiptByAction mocks base method
 func (m *MockServiceClient) GetReceiptByAction(ctx context.Context, in *iotexapi.GetReceiptByActionRequest, opts ...grpc.CallOption) (*iotexapi.GetReceiptByActionResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -157,12 +170,14 @@ func (m *MockServiceClient) GetReceiptByAction(ctx context.Context, in *iotexapi
 
 // GetReceiptByAction indicates an expected call of GetReceiptByAction
 func (mr *MockServiceClientMockRecorder) GetReceiptByAction(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptByAction", reflect.TypeOf((*MockServiceClient)(nil).GetReceiptByAction), varargs...)
 }
 
 // ReadContract mocks base method
 func (m *MockServiceClient) ReadContract(ctx context.Context, in *iotexapi.ReadContractRequest, opts ...grpc.CallOption) (*iotexapi.ReadContractResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -175,12 +190,14 @@ func (m *MockServiceClient) ReadContract(ctx context.Context, in *iotexapi.ReadC
 
 // ReadContract indicates an expected call of ReadContract
 func (mr *MockServiceClientMockRecorder) ReadContract(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadContract", reflect.TypeOf((*MockServiceClient)(nil).ReadContract), varargs...)
 }
 
 // SuggestGasPrice mocks base method
 func (m *MockServiceClient) SuggestGasPrice(ctx context.Context, in *iotexapi.SuggestGasPriceRequest, opts ...grpc.CallOption) (*iotexapi.SuggestGasPriceResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -193,12 +210,14 @@ func (m *MockServiceClient) SuggestGasPrice(ctx context.Context, in *iotexapi.Su
 
 // SuggestGasPrice indicates an expected call of SuggestGasPrice
 func (mr *MockServiceClientMockRecorder) SuggestGasPrice(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SuggestGasPrice", reflect.TypeOf((*MockServiceClient)(nil).SuggestGasPrice), varargs...)
 }
 
 // EstimateGasForAction mocks base method
 func (m *MockServiceClient) EstimateGasForAction(ctx context.Context, in *iotexapi.EstimateGasForActionRequest, opts ...grpc.CallOption) (*iotexapi.EstimateGasForActionResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -211,12 +230,14 @@ func (m *MockServiceClient) EstimateGasForAction(ctx context.Context, in *iotexa
 
 // EstimateGasForAction indicates an expected call of EstimateGasForAction
 func (mr *MockServiceClientMockRecorder) EstimateGasForAction(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateGasForAction", reflect.TypeOf((*MockServiceClient)(nil).EstimateGasForAction), varargs...)
 }
 
 // EstimateActionGasConsumption mocks base method
 func (m *MockServiceClient) EstimateActionGasConsumption(ctx context.Context, in *iotexapi.EstimateActionGasConsumptionRequest, opts ...grpc.CallOption) (*iotexapi.EstimateActionGasConsumptionResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -229,12 +250,14 @@ func (m *MockServiceClient) EstimateActionGasConsumption(ctx context.Context, in
 
 // EstimateActionGasConsumption indicates an expected call of EstimateActionGasConsumption
 func (mr *MockServiceClientMockRecorder) EstimateActionGasConsumption(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateActionGasConsumption", reflect.TypeOf((*MockServiceClient)(nil).EstimateActionGasConsumption), varargs...)
 }
 
 // ReadState mocks base method
 func (m *MockServiceClient) ReadState(ctx context.Context, in *iotexapi.ReadStateRequest, opts ...grpc.CallOption) (*iotexapi.ReadStateResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -247,12 +270,14 @@ func (m *MockServiceClient) ReadState(ctx context.Context, in *iotexapi.ReadStat
 
 // ReadState indicates an expected call of ReadState
 func (mr *MockServiceClientMockRecorder) ReadState(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadState", reflect.TypeOf((*MockServiceClient)(nil).ReadState), varargs...)
 }
 
 // GetEpochMeta mocks base method
 func (m *MockServiceClient) GetEpochMeta(ctx context.Context, in *iotexapi.GetEpochMetaRequest, opts ...grpc.CallOption) (*iotexapi.GetEpochMetaResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -265,12 +290,14 @@ func (m *MockServiceClient) GetEpochMeta(ctx context.Context, in *iotexapi.GetEp
 
 // GetEpochMeta indicates an expected call of GetEpochMeta
 func (mr *MockServiceClientMockRecorder) GetEpochMeta(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEpochMeta", reflect.TypeOf((*MockServiceClient)(nil).GetEpochMeta), varargs...)
 }
 
 // GetRawBlocks mocks base method
 func (m *MockServiceClient) GetRawBlocks(ctx context.Context, in *iotexapi.GetRawBlocksRequest, opts ...grpc.CallOption) (*iotexapi.GetRawBlocksResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -283,12 +310,14 @@ func (m *MockServiceClient) GetRawBlocks(ctx context.Context, in *iotexapi.GetRa
 
 // GetRawBlocks indicates an expected call of GetRawBlocks
 func (mr *MockServiceClientMockRecorder) GetRawBlocks(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRawBlocks", reflect.TypeOf((*MockServiceClient)(nil).GetRawBlocks), varargs...)
 }
 
 // GetLogs mocks base method
 func (m *MockServiceClient) GetLogs(ctx context.Context, in *iotexapi.GetLogsRequest, opts ...grpc.CallOption) (*iotexapi.GetLogsResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -301,12 +330,14 @@ func (m *MockServiceClient) GetLogs(ctx context.Context, in *iotexapi.GetLogsReq
 
 // GetLogs indicates an expected call of GetLogs
 func (mr *MockServiceClientMockRecorder) GetLogs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockServiceClient)(nil).GetLogs), varargs...)
 }
 
 // GetVotes mocks base method
 func (m *MockServiceClient) GetVotes(ctx context.Context, in *iotexapi.GetVotesRequest, opts ...grpc.CallOption) (*iotexapi.GetVotesResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -319,12 +350,14 @@ func (m *MockServiceClient) GetVotes(ctx context.Context, in *iotexapi.GetVotesR
 
 // GetVotes indicates an expected call of GetVotes
 func (mr *MockServiceClientMockRecorder) GetVotes(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVotes", reflect.TypeOf((*MockServiceClient)(nil).GetVotes), varargs...)
 }
 
 // StreamBlocks mocks base method
 func (m *MockServiceClient) StreamBlocks(ctx context.Context, in *iotexapi.StreamBlocksRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamBlocksClient, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -337,12 +370,14 @@ func (m *MockServiceClient) StreamBlocks(ctx context.Context, in *iotexapi.Strea
 
 // StreamBlocks indicates an expected call of StreamBlocks
 func (mr *MockServiceClientMockRecorder) StreamBlocks(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamBlocks", reflect.TypeOf((*MockServiceClient)(nil).StreamBlocks), varargs...)
 }
 
 // StreamLogs mocks base method
 func (m *MockServiceClient) StreamLogs(ctx context.Context, in *iotexapi.StreamLogsRequest, opts ...grpc.CallOption) (iotexapi.APIService_StreamLogsClient, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -355,12 +390,14 @@ func (m *MockServiceClient) StreamLogs(ctx context.Context, in *iotexapi.StreamL
 
 // StreamLogs indicates an expected call of StreamLogs
 func (mr *MockServiceClientMockRecorder) StreamLogs(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StreamLogs", reflect.TypeOf((*MockServiceClient)(nil).StreamLogs), varargs...)
 }
 
 // GetElectionBuckets mocks base method
 func (m *MockServiceClient) GetElectionBuckets(ctx context.Context, in *iotexapi.GetElectionBucketsRequest, opts ...grpc.CallOption) (*iotexapi.GetElectionBucketsResponse, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, in}
 	for _, a := range opts {
 		varargs = append(varargs, a)
@@ -373,6 +410,7 @@ func (m *MockServiceClient) GetElectionBuckets(ctx context.Context, in *iotexapi
 
 // GetElectionBuckets indicates an expected call of GetElectionBuckets
 func (mr *MockServiceClientMockRecorder) GetElectionBuckets(ctx, in interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, in}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetElectionBuckets", reflect.TypeOf((*MockServiceClient)(nil).GetElectionBuckets), varargs...)
 }

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -44,6 +44,7 @@ func (m *MockBlockchain) EXPECT() *MockBlockchainMockRecorder {
 
 // Start mocks base method
 func (m *MockBlockchain) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -51,11 +52,13 @@ func (m *MockBlockchain) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockBlockchainMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockBlockchain)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockBlockchain) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -63,11 +66,13 @@ func (m *MockBlockchain) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockBlockchainMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockchain)(nil).Stop), arg0)
 }
 
 // Balance mocks base method
 func (m *MockBlockchain) Balance(addr string) (*big.Int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance", addr)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
@@ -76,11 +81,13 @@ func (m *MockBlockchain) Balance(addr string) (*big.Int, error) {
 
 // Balance indicates an expected call of Balance
 func (mr *MockBlockchainMockRecorder) Balance(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Balance", reflect.TypeOf((*MockBlockchain)(nil).Balance), addr)
 }
 
 // Nonce mocks base method
 func (m *MockBlockchain) Nonce(addr string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce", addr)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -89,11 +96,13 @@ func (m *MockBlockchain) Nonce(addr string) (uint64, error) {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockBlockchainMockRecorder) Nonce(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockBlockchain)(nil).Nonce), addr)
 }
 
 // CreateState mocks base method
 func (m *MockBlockchain) CreateState(addr string, init *big.Int) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateState", addr, init)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -102,11 +111,13 @@ func (m *MockBlockchain) CreateState(addr string, init *big.Int) (*state.Account
 
 // CreateState indicates an expected call of CreateState
 func (mr *MockBlockchainMockRecorder) CreateState(addr, init interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateState", reflect.TypeOf((*MockBlockchain)(nil).CreateState), addr, init)
 }
 
 // CandidatesByHeight mocks base method
 func (m *MockBlockchain) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CandidatesByHeight", height)
 	ret0, _ := ret[0].([]*state.Candidate)
 	ret1, _ := ret[1].(error)
@@ -115,11 +126,13 @@ func (m *MockBlockchain) CandidatesByHeight(height uint64) ([]*state.Candidate, 
 
 // CandidatesByHeight indicates an expected call of CandidatesByHeight
 func (mr *MockBlockchainMockRecorder) CandidatesByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockBlockchain)(nil).CandidatesByHeight), height)
 }
 
 // ProductivityByEpoch mocks base method
 func (m *MockBlockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProductivityByEpoch", epochNum)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(map[string]uint64)
@@ -129,11 +142,13 @@ func (m *MockBlockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[strin
 
 // ProductivityByEpoch indicates an expected call of ProductivityByEpoch
 func (mr *MockBlockchainMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockBlockchain)(nil).ProductivityByEpoch), epochNum)
 }
 
 // GetHeightByHash mocks base method
 func (m *MockBlockchain) GetHeightByHash(h hash.Hash256) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHeightByHash", h)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -142,11 +157,13 @@ func (m *MockBlockchain) GetHeightByHash(h hash.Hash256) (uint64, error) {
 
 // GetHeightByHash indicates an expected call of GetHeightByHash
 func (mr *MockBlockchainMockRecorder) GetHeightByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHeightByHash", reflect.TypeOf((*MockBlockchain)(nil).GetHeightByHash), h)
 }
 
 // GetHashByHeight mocks base method
 func (m *MockBlockchain) GetHashByHeight(height uint64) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHashByHeight", height)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -155,11 +172,13 @@ func (m *MockBlockchain) GetHashByHeight(height uint64) (hash.Hash256, error) {
 
 // GetHashByHeight indicates an expected call of GetHashByHeight
 func (mr *MockBlockchainMockRecorder) GetHashByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHashByHeight", reflect.TypeOf((*MockBlockchain)(nil).GetHashByHeight), height)
 }
 
 // GetBlockByHeight mocks base method
 func (m *MockBlockchain) GetBlockByHeight(height uint64) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockByHeight", height)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -168,11 +187,13 @@ func (m *MockBlockchain) GetBlockByHeight(height uint64) (*block.Block, error) {
 
 // GetBlockByHeight indicates an expected call of GetBlockByHeight
 func (mr *MockBlockchainMockRecorder) GetBlockByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockBlockchain)(nil).GetBlockByHeight), height)
 }
 
 // GetBlockByHash mocks base method
 func (m *MockBlockchain) GetBlockByHash(h hash.Hash256) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockByHash", h)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -181,11 +202,13 @@ func (m *MockBlockchain) GetBlockByHash(h hash.Hash256) (*block.Block, error) {
 
 // GetBlockByHash indicates an expected call of GetBlockByHash
 func (mr *MockBlockchainMockRecorder) GetBlockByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHash", reflect.TypeOf((*MockBlockchain)(nil).GetBlockByHash), h)
 }
 
 // BlockHeaderByHeight mocks base method
 func (m *MockBlockchain) BlockHeaderByHeight(height uint64) (*block.Header, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockHeaderByHeight", height)
 	ret0, _ := ret[0].(*block.Header)
 	ret1, _ := ret[1].(error)
@@ -194,11 +217,13 @@ func (m *MockBlockchain) BlockHeaderByHeight(height uint64) (*block.Header, erro
 
 // BlockHeaderByHeight indicates an expected call of BlockHeaderByHeight
 func (mr *MockBlockchainMockRecorder) BlockHeaderByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHeight), height)
 }
 
 // BlockHeaderByHash mocks base method
 func (m *MockBlockchain) BlockHeaderByHash(h hash.Hash256) (*block.Header, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockHeaderByHash", h)
 	ret0, _ := ret[0].(*block.Header)
 	ret1, _ := ret[1].(error)
@@ -207,11 +232,13 @@ func (m *MockBlockchain) BlockHeaderByHash(h hash.Hash256) (*block.Header, error
 
 // BlockHeaderByHash indicates an expected call of BlockHeaderByHash
 func (mr *MockBlockchainMockRecorder) BlockHeaderByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHash), h)
 }
 
 // BlockFooterByHeight mocks base method
 func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockFooterByHeight", height)
 	ret0, _ := ret[0].(*block.Footer)
 	ret1, _ := ret[1].(error)
@@ -220,11 +247,13 @@ func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, erro
 
 // BlockFooterByHeight indicates an expected call of BlockFooterByHeight
 func (mr *MockBlockchainMockRecorder) BlockFooterByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHeight), height)
 }
 
 // BlockFooterByHash mocks base method
 func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockFooterByHash", h)
 	ret0, _ := ret[0].(*block.Footer)
 	ret1, _ := ret[1].(error)
@@ -233,11 +262,13 @@ func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error
 
 // BlockFooterByHash indicates an expected call of BlockFooterByHash
 func (mr *MockBlockchainMockRecorder) BlockFooterByHash(h interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHash), h)
 }
 
 // GetFactory mocks base method
 func (m *MockBlockchain) GetFactory() factory.Factory {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFactory")
 	ret0, _ := ret[0].(factory.Factory)
 	return ret0
@@ -245,11 +276,13 @@ func (m *MockBlockchain) GetFactory() factory.Factory {
 
 // GetFactory indicates an expected call of GetFactory
 func (mr *MockBlockchainMockRecorder) GetFactory() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFactory", reflect.TypeOf((*MockBlockchain)(nil).GetFactory))
 }
 
 // ChainID mocks base method
 func (m *MockBlockchain) ChainID() uint32 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainID")
 	ret0, _ := ret[0].(uint32)
 	return ret0
@@ -257,11 +290,13 @@ func (m *MockBlockchain) ChainID() uint32 {
 
 // ChainID indicates an expected call of ChainID
 func (mr *MockBlockchainMockRecorder) ChainID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockBlockchain)(nil).ChainID))
 }
 
 // ChainAddress mocks base method
 func (m *MockBlockchain) ChainAddress() string {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainAddress")
 	ret0, _ := ret[0].(string)
 	return ret0
@@ -269,11 +304,13 @@ func (m *MockBlockchain) ChainAddress() string {
 
 // ChainAddress indicates an expected call of ChainAddress
 func (mr *MockBlockchainMockRecorder) ChainAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainAddress", reflect.TypeOf((*MockBlockchain)(nil).ChainAddress))
 }
 
 // TipHash mocks base method
 func (m *MockBlockchain) TipHash() hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TipHash")
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -281,11 +318,13 @@ func (m *MockBlockchain) TipHash() hash.Hash256 {
 
 // TipHash indicates an expected call of TipHash
 func (mr *MockBlockchainMockRecorder) TipHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipHash", reflect.TypeOf((*MockBlockchain)(nil).TipHash))
 }
 
 // TipHeight mocks base method
 func (m *MockBlockchain) TipHeight() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TipHeight")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -293,11 +332,13 @@ func (m *MockBlockchain) TipHeight() uint64 {
 
 // TipHeight indicates an expected call of TipHeight
 func (mr *MockBlockchainMockRecorder) TipHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TipHeight", reflect.TypeOf((*MockBlockchain)(nil).TipHeight))
 }
 
 // StateByAddr mocks base method
 func (m *MockBlockchain) StateByAddr(address string) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateByAddr", address)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -306,11 +347,13 @@ func (m *MockBlockchain) StateByAddr(address string) (*state.Account, error) {
 
 // StateByAddr indicates an expected call of StateByAddr
 func (mr *MockBlockchainMockRecorder) StateByAddr(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateByAddr", reflect.TypeOf((*MockBlockchain)(nil).StateByAddr), address)
 }
 
 // RecoverChainAndState mocks base method
 func (m *MockBlockchain) RecoverChainAndState(targetHeight uint64) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RecoverChainAndState", targetHeight)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -318,11 +361,13 @@ func (m *MockBlockchain) RecoverChainAndState(targetHeight uint64) error {
 
 // RecoverChainAndState indicates an expected call of RecoverChainAndState
 func (mr *MockBlockchainMockRecorder) RecoverChainAndState(targetHeight interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecoverChainAndState", reflect.TypeOf((*MockBlockchain)(nil).RecoverChainAndState), targetHeight)
 }
 
 // GenesisTimestamp mocks base method
 func (m *MockBlockchain) GenesisTimestamp() int64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenesisTimestamp")
 	ret0, _ := ret[0].(int64)
 	return ret0
@@ -330,11 +375,13 @@ func (m *MockBlockchain) GenesisTimestamp() int64 {
 
 // GenesisTimestamp indicates an expected call of GenesisTimestamp
 func (mr *MockBlockchainMockRecorder) GenesisTimestamp() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenesisTimestamp", reflect.TypeOf((*MockBlockchain)(nil).GenesisTimestamp))
 }
 
 // MintNewBlock mocks base method
 func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, timestamp time.Time) (*block.Block, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MintNewBlock", actionMap, timestamp)
 	ret0, _ := ret[0].(*block.Block)
 	ret1, _ := ret[1].(error)
@@ -343,11 +390,13 @@ func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelo
 
 // MintNewBlock indicates an expected call of MintNewBlock
 func (mr *MockBlockchainMockRecorder) MintNewBlock(actionMap, timestamp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintNewBlock", reflect.TypeOf((*MockBlockchain)(nil).MintNewBlock), actionMap, timestamp)
 }
 
 // CommitBlock mocks base method
 func (m *MockBlockchain) CommitBlock(blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CommitBlock", blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -355,11 +404,13 @@ func (m *MockBlockchain) CommitBlock(blk *block.Block) error {
 
 // CommitBlock indicates an expected call of CommitBlock
 func (mr *MockBlockchainMockRecorder) CommitBlock(blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CommitBlock", reflect.TypeOf((*MockBlockchain)(nil).CommitBlock), blk)
 }
 
 // ValidateBlock mocks base method
 func (m *MockBlockchain) ValidateBlock(blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateBlock", blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -367,11 +418,13 @@ func (m *MockBlockchain) ValidateBlock(blk *block.Block) error {
 
 // ValidateBlock indicates an expected call of ValidateBlock
 func (mr *MockBlockchainMockRecorder) ValidateBlock(blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateBlock", reflect.TypeOf((*MockBlockchain)(nil).ValidateBlock), blk)
 }
 
 // Validator mocks base method
 func (m *MockBlockchain) Validator() blockchain.Validator {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validator")
 	ret0, _ := ret[0].(blockchain.Validator)
 	return ret0
@@ -379,21 +432,25 @@ func (m *MockBlockchain) Validator() blockchain.Validator {
 
 // Validator indicates an expected call of Validator
 func (mr *MockBlockchainMockRecorder) Validator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validator", reflect.TypeOf((*MockBlockchain)(nil).Validator))
 }
 
 // SetValidator mocks base method
 func (m *MockBlockchain) SetValidator(val blockchain.Validator) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetValidator", val)
 }
 
 // SetValidator indicates an expected call of SetValidator
 func (mr *MockBlockchainMockRecorder) SetValidator(val interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidator", reflect.TypeOf((*MockBlockchain)(nil).SetValidator), val)
 }
 
 // ExecuteContractRead mocks base method
 func (m *MockBlockchain) ExecuteContractRead(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteContractRead", caller, ex)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(*action.Receipt)
@@ -403,11 +460,13 @@ func (m *MockBlockchain) ExecuteContractRead(caller address.Address, ex *action.
 
 // ExecuteContractRead indicates an expected call of ExecuteContractRead
 func (mr *MockBlockchainMockRecorder) ExecuteContractRead(caller, ex interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteContractRead", reflect.TypeOf((*MockBlockchain)(nil).ExecuteContractRead), caller, ex)
 }
 
 // AddSubscriber mocks base method
 func (m *MockBlockchain) AddSubscriber(arg0 blockchain.BlockCreationSubscriber) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddSubscriber", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -415,11 +474,13 @@ func (m *MockBlockchain) AddSubscriber(arg0 blockchain.BlockCreationSubscriber) 
 
 // AddSubscriber indicates an expected call of AddSubscriber
 func (mr *MockBlockchainMockRecorder) AddSubscriber(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSubscriber", reflect.TypeOf((*MockBlockchain)(nil).AddSubscriber), arg0)
 }
 
 // RemoveSubscriber mocks base method
 func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscriber) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveSubscriber", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -427,6 +488,7 @@ func (m *MockBlockchain) RemoveSubscriber(arg0 blockchain.BlockCreationSubscribe
 
 // RemoveSubscriber indicates an expected call of RemoveSubscriber
 func (mr *MockBlockchainMockRecorder) RemoveSubscriber(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSubscriber", reflect.TypeOf((*MockBlockchain)(nil).RemoveSubscriber), arg0)
 }
 
@@ -455,6 +517,7 @@ func (m *MockActPoolManager) EXPECT() *MockActPoolManagerMockRecorder {
 
 // GetActionByHash mocks base method
 func (m *MockActPoolManager) GetActionByHash(hash hash.Hash256) (action.SealedEnvelope, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetActionByHash", hash)
 	ret0, _ := ret[0].(action.SealedEnvelope)
 	ret1, _ := ret[1].(error)
@@ -463,5 +526,6 @@ func (m *MockActPoolManager) GetActionByHash(hash hash.Hash256) (action.SealedEn
 
 // GetActionByHash indicates an expected call of GetActionByHash
 func (mr *MockActPoolManagerMockRecorder) GetActionByHash(hash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActionByHash", reflect.TypeOf((*MockActPoolManager)(nil).GetActionByHash), hash)
 }

--- a/test/mock/mock_blocksync/mock_blocksync.go
+++ b/test/mock/mock_blocksync/mock_blocksync.go
@@ -38,6 +38,7 @@ func (m *MockBlockSync) EXPECT() *MockBlockSyncMockRecorder {
 
 // Start mocks base method
 func (m *MockBlockSync) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -45,11 +46,13 @@ func (m *MockBlockSync) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockBlockSyncMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockBlockSync)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockBlockSync) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,11 +60,13 @@ func (m *MockBlockSync) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockBlockSyncMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockSync)(nil).Stop), arg0)
 }
 
 // TargetHeight mocks base method
 func (m *MockBlockSync) TargetHeight() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TargetHeight")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -69,11 +74,13 @@ func (m *MockBlockSync) TargetHeight() uint64 {
 
 // TargetHeight indicates an expected call of TargetHeight
 func (mr *MockBlockSyncMockRecorder) TargetHeight() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TargetHeight", reflect.TypeOf((*MockBlockSync)(nil).TargetHeight))
 }
 
 // ProcessSyncRequest mocks base method
 func (m *MockBlockSync) ProcessSyncRequest(ctx context.Context, peer go_libp2p_peerstore.PeerInfo, sync *iotexrpc.BlockSync) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessSyncRequest", ctx, peer, sync)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -81,11 +88,13 @@ func (m *MockBlockSync) ProcessSyncRequest(ctx context.Context, peer go_libp2p_p
 
 // ProcessSyncRequest indicates an expected call of ProcessSyncRequest
 func (mr *MockBlockSyncMockRecorder) ProcessSyncRequest(ctx, peer, sync interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessSyncRequest", reflect.TypeOf((*MockBlockSync)(nil).ProcessSyncRequest), ctx, peer, sync)
 }
 
 // ProcessBlock mocks base method
 func (m *MockBlockSync) ProcessBlock(ctx context.Context, blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessBlock", ctx, blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -93,11 +102,13 @@ func (m *MockBlockSync) ProcessBlock(ctx context.Context, blk *block.Block) erro
 
 // ProcessBlock indicates an expected call of ProcessBlock
 func (mr *MockBlockSyncMockRecorder) ProcessBlock(ctx, blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlock", reflect.TypeOf((*MockBlockSync)(nil).ProcessBlock), ctx, blk)
 }
 
 // ProcessBlockSync mocks base method
 func (m *MockBlockSync) ProcessBlockSync(ctx context.Context, blk *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessBlockSync", ctx, blk)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -105,5 +116,6 @@ func (m *MockBlockSync) ProcessBlockSync(ctx context.Context, blk *block.Block) 
 
 // ProcessBlockSync indicates an expected call of ProcessBlockSync
 func (mr *MockBlockSyncMockRecorder) ProcessBlockSync(ctx, blk interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlockSync", reflect.TypeOf((*MockBlockSync)(nil).ProcessBlockSync), ctx, blk)
 }

--- a/test/mock/mock_chainmanager/mock_chainmanager.go
+++ b/test/mock/mock_chainmanager/mock_chainmanager.go
@@ -41,6 +41,7 @@ func (m *MockProtocol) EXPECT() *MockProtocolMockRecorder {
 
 // Validate mocks base method
 func (m *MockProtocol) Validate(arg0 context.Context, arg1 action.Action) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,11 +49,13 @@ func (m *MockProtocol) Validate(arg0 context.Context, arg1 action.Action) error 
 
 // Validate indicates an expected call of Validate
 func (mr *MockProtocolMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockProtocol)(nil).Validate), arg0, arg1)
 }
 
 // Handle mocks base method
 func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Action, arg2 protocol.StateManager) (*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -61,11 +64,13 @@ func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Action, arg2 pro
 
 // Handle indicates an expected call of Handle
 func (mr *MockProtocolMockRecorder) Handle(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockProtocol)(nil).Handle), arg0, arg1, arg2)
 }
 
 // ReadState mocks base method
 func (m *MockProtocol) ReadState(arg0 context.Context, arg1 protocol.StateManager, arg2 []byte, arg3 ...[]byte) ([]byte, error) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
@@ -78,6 +83,7 @@ func (m *MockProtocol) ReadState(arg0 context.Context, arg1 protocol.StateManage
 
 // ReadState indicates an expected call of ReadState
 func (mr *MockProtocolMockRecorder) ReadState(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadState", reflect.TypeOf((*MockProtocol)(nil).ReadState), varargs...)
 }
@@ -107,6 +113,7 @@ func (m *MockActionValidator) EXPECT() *MockActionValidatorMockRecorder {
 
 // Validate mocks base method
 func (m *MockActionValidator) Validate(arg0 context.Context, arg1 action.Action) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -114,6 +121,7 @@ func (m *MockActionValidator) Validate(arg0 context.Context, arg1 action.Action)
 
 // Validate indicates an expected call of Validate
 func (mr *MockActionValidatorMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockActionValidator)(nil).Validate), arg0, arg1)
 }
 
@@ -142,6 +150,7 @@ func (m *MockActionEnvelopeValidator) EXPECT() *MockActionEnvelopeValidatorMockR
 
 // Validate mocks base method
 func (m *MockActionEnvelopeValidator) Validate(arg0 context.Context, arg1 action.SealedEnvelope) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -149,6 +158,7 @@ func (m *MockActionEnvelopeValidator) Validate(arg0 context.Context, arg1 action
 
 // Validate indicates an expected call of Validate
 func (mr *MockActionEnvelopeValidatorMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockActionEnvelopeValidator)(nil).Validate), arg0, arg1)
 }
 
@@ -177,6 +187,7 @@ func (m *MockActionHandler) EXPECT() *MockActionHandlerMockRecorder {
 
 // Handle mocks base method
 func (m *MockActionHandler) Handle(arg0 context.Context, arg1 action.Action, arg2 protocol.StateManager) (*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -185,6 +196,7 @@ func (m *MockActionHandler) Handle(arg0 context.Context, arg1 action.Action, arg
 
 // Handle indicates an expected call of Handle
 func (mr *MockActionHandlerMockRecorder) Handle(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockActionHandler)(nil).Handle), arg0, arg1, arg2)
 }
 
@@ -213,6 +225,7 @@ func (m *MockChainManager) EXPECT() *MockChainManagerMockRecorder {
 
 // ChainID mocks base method
 func (m *MockChainManager) ChainID() uint32 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ChainID")
 	ret0, _ := ret[0].(uint32)
 	return ret0
@@ -220,11 +233,13 @@ func (m *MockChainManager) ChainID() uint32 {
 
 // ChainID indicates an expected call of ChainID
 func (mr *MockChainManagerMockRecorder) ChainID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockChainManager)(nil).ChainID))
 }
 
 // GetHashByHeight mocks base method
 func (m *MockChainManager) GetHashByHeight(height uint64) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHashByHeight", height)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -233,11 +248,13 @@ func (m *MockChainManager) GetHashByHeight(height uint64) (hash.Hash256, error) 
 
 // GetHashByHeight indicates an expected call of GetHashByHeight
 func (mr *MockChainManagerMockRecorder) GetHashByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHashByHeight", reflect.TypeOf((*MockChainManager)(nil).GetHashByHeight), height)
 }
 
 // StateByAddr mocks base method
 func (m *MockChainManager) StateByAddr(address string) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StateByAddr", address)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -246,11 +263,13 @@ func (m *MockChainManager) StateByAddr(address string) (*state.Account, error) {
 
 // StateByAddr indicates an expected call of StateByAddr
 func (mr *MockChainManagerMockRecorder) StateByAddr(address interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StateByAddr", reflect.TypeOf((*MockChainManager)(nil).StateByAddr), address)
 }
 
 // Nonce mocks base method
 func (m *MockChainManager) Nonce(addr string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce", addr)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -259,11 +278,13 @@ func (m *MockChainManager) Nonce(addr string) (uint64, error) {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockChainManagerMockRecorder) Nonce(addr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockChainManager)(nil).Nonce), addr)
 }
 
 // CandidatesByHeight mocks base method
 func (m *MockChainManager) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CandidatesByHeight", height)
 	ret0, _ := ret[0].([]*state.Candidate)
 	ret1, _ := ret[1].(error)
@@ -272,11 +293,13 @@ func (m *MockChainManager) CandidatesByHeight(height uint64) ([]*state.Candidate
 
 // CandidatesByHeight indicates an expected call of CandidatesByHeight
 func (mr *MockChainManagerMockRecorder) CandidatesByHeight(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockChainManager)(nil).CandidatesByHeight), height)
 }
 
 // ProductivityByEpoch mocks base method
 func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProductivityByEpoch", epochNum)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(map[string]uint64)
@@ -286,11 +309,13 @@ func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[str
 
 // ProductivityByEpoch indicates an expected call of ProductivityByEpoch
 func (mr *MockChainManagerMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockChainManager)(nil).ProductivityByEpoch), epochNum)
 }
 
 // ExecuteContractRead mocks base method
 func (m *MockChainManager) ExecuteContractRead(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ExecuteContractRead", caller, ex)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(*action.Receipt)
@@ -300,6 +325,7 @@ func (m *MockChainManager) ExecuteContractRead(caller address.Address, ex *actio
 
 // ExecuteContractRead indicates an expected call of ExecuteContractRead
 func (mr *MockChainManagerMockRecorder) ExecuteContractRead(caller, ex interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExecuteContractRead", reflect.TypeOf((*MockChainManager)(nil).ExecuteContractRead), caller, ex)
 }
 
@@ -328,6 +354,7 @@ func (m *MockStateManager) EXPECT() *MockStateManagerMockRecorder {
 
 // Height mocks base method
 func (m *MockStateManager) Height() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Height")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -335,11 +362,13 @@ func (m *MockStateManager) Height() uint64 {
 
 // Height indicates an expected call of Height
 func (mr *MockStateManagerMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockStateManager)(nil).Height))
 }
 
 // Snapshot mocks base method
 func (m *MockStateManager) Snapshot() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -347,11 +376,13 @@ func (m *MockStateManager) Snapshot() int {
 
 // Snapshot indicates an expected call of Snapshot
 func (mr *MockStateManagerMockRecorder) Snapshot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockStateManager)(nil).Snapshot))
 }
 
 // Revert mocks base method
 func (m *MockStateManager) Revert(arg0 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revert", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -359,11 +390,13 @@ func (m *MockStateManager) Revert(arg0 int) error {
 
 // Revert indicates an expected call of Revert
 func (mr *MockStateManagerMockRecorder) Revert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockStateManager)(nil).Revert), arg0)
 }
 
 // State mocks base method
 func (m *MockStateManager) State(arg0 hash.Hash160, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -371,11 +404,13 @@ func (m *MockStateManager) State(arg0 hash.Hash160, arg1 interface{}) error {
 
 // State indicates an expected call of State
 func (mr *MockStateManagerMockRecorder) State(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockStateManager)(nil).State), arg0, arg1)
 }
 
 // PutState mocks base method
 func (m *MockStateManager) PutState(arg0 hash.Hash160, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -383,11 +418,13 @@ func (m *MockStateManager) PutState(arg0 hash.Hash160, arg1 interface{}) error {
 
 // PutState indicates an expected call of PutState
 func (mr *MockStateManagerMockRecorder) PutState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutState", reflect.TypeOf((*MockStateManager)(nil).PutState), arg0, arg1)
 }
 
 // DelState mocks base method
 func (m *MockStateManager) DelState(pkHash hash.Hash160) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DelState", pkHash)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -395,11 +432,13 @@ func (m *MockStateManager) DelState(pkHash hash.Hash160) error {
 
 // DelState indicates an expected call of DelState
 func (mr *MockStateManagerMockRecorder) DelState(pkHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelState", reflect.TypeOf((*MockStateManager)(nil).DelState), pkHash)
 }
 
 // GetDB mocks base method
 func (m *MockStateManager) GetDB() db.KVStore {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDB")
 	ret0, _ := ret[0].(db.KVStore)
 	return ret0
@@ -407,11 +446,13 @@ func (m *MockStateManager) GetDB() db.KVStore {
 
 // GetDB indicates an expected call of GetDB
 func (mr *MockStateManagerMockRecorder) GetDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDB", reflect.TypeOf((*MockStateManager)(nil).GetDB))
 }
 
 // GetCachedBatch mocks base method
 func (m *MockStateManager) GetCachedBatch() db.CachedBatch {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCachedBatch")
 	ret0, _ := ret[0].(db.CachedBatch)
 	return ret0
@@ -419,5 +460,6 @@ func (m *MockStateManager) GetCachedBatch() db.CachedBatch {
 
 // GetCachedBatch indicates an expected call of GetCachedBatch
 func (mr *MockStateManagerMockRecorder) GetCachedBatch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedBatch", reflect.TypeOf((*MockStateManager)(nil).GetCachedBatch))
 }

--- a/test/mock/mock_consensus/mock_consensus.go
+++ b/test/mock/mock_consensus/mock_consensus.go
@@ -38,6 +38,7 @@ func (m *MockConsensus) EXPECT() *MockConsensusMockRecorder {
 
 // Start mocks base method
 func (m *MockConsensus) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -45,11 +46,13 @@ func (m *MockConsensus) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockConsensusMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockConsensus)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockConsensus) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -57,11 +60,13 @@ func (m *MockConsensus) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockConsensusMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockConsensus)(nil).Stop), arg0)
 }
 
 // HandleConsensusMsg mocks base method
 func (m *MockConsensus) HandleConsensusMsg(arg0 *iotextypes.ConsensusMessage) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleConsensusMsg", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -69,21 +74,25 @@ func (m *MockConsensus) HandleConsensusMsg(arg0 *iotextypes.ConsensusMessage) er
 
 // HandleConsensusMsg indicates an expected call of HandleConsensusMsg
 func (mr *MockConsensusMockRecorder) HandleConsensusMsg(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleConsensusMsg", reflect.TypeOf((*MockConsensus)(nil).HandleConsensusMsg), arg0)
 }
 
 // Calibrate mocks base method
 func (m *MockConsensus) Calibrate(arg0 uint64) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Calibrate", arg0)
 }
 
 // Calibrate indicates an expected call of Calibrate
 func (mr *MockConsensusMockRecorder) Calibrate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Calibrate", reflect.TypeOf((*MockConsensus)(nil).Calibrate), arg0)
 }
 
 // ValidateBlockFooter mocks base method
 func (m *MockConsensus) ValidateBlockFooter(arg0 *block.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ValidateBlockFooter", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -91,11 +100,13 @@ func (m *MockConsensus) ValidateBlockFooter(arg0 *block.Block) error {
 
 // ValidateBlockFooter indicates an expected call of ValidateBlockFooter
 func (mr *MockConsensusMockRecorder) ValidateBlockFooter(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateBlockFooter", reflect.TypeOf((*MockConsensus)(nil).ValidateBlockFooter), arg0)
 }
 
 // Metrics mocks base method
 func (m *MockConsensus) Metrics() (scheme.ConsensusMetrics, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Metrics")
 	ret0, _ := ret[0].(scheme.ConsensusMetrics)
 	ret1, _ := ret[1].(error)
@@ -104,21 +115,25 @@ func (m *MockConsensus) Metrics() (scheme.ConsensusMetrics, error) {
 
 // Metrics indicates an expected call of Metrics
 func (mr *MockConsensusMockRecorder) Metrics() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Metrics", reflect.TypeOf((*MockConsensus)(nil).Metrics))
 }
 
 // Activate mocks base method
 func (m *MockConsensus) Activate(arg0 bool) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Activate", arg0)
 }
 
 // Activate indicates an expected call of Activate
 func (mr *MockConsensusMockRecorder) Activate(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Activate", reflect.TypeOf((*MockConsensus)(nil).Activate), arg0)
 }
 
 // Active mocks base method
 func (m *MockConsensus) Active() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Active")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -126,5 +141,6 @@ func (m *MockConsensus) Active() bool {
 
 // Active indicates an expected call of Active
 func (mr *MockConsensusMockRecorder) Active() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockConsensus)(nil).Active))
 }

--- a/test/mock/mock_dispatcher/mock_dispatcher.go
+++ b/test/mock/mock_dispatcher/mock_dispatcher.go
@@ -40,6 +40,7 @@ func (m *MockSubscriber) EXPECT() *MockSubscriberMockRecorder {
 
 // HandleAction mocks base method
 func (m *MockSubscriber) HandleAction(arg0 context.Context, arg1 *iotextypes.Action) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleAction", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -47,11 +48,13 @@ func (m *MockSubscriber) HandleAction(arg0 context.Context, arg1 *iotextypes.Act
 
 // HandleAction indicates an expected call of HandleAction
 func (mr *MockSubscriberMockRecorder) HandleAction(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleAction", reflect.TypeOf((*MockSubscriber)(nil).HandleAction), arg0, arg1)
 }
 
 // HandleBlock mocks base method
 func (m *MockSubscriber) HandleBlock(arg0 context.Context, arg1 *iotextypes.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleBlock", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -59,11 +62,13 @@ func (m *MockSubscriber) HandleBlock(arg0 context.Context, arg1 *iotextypes.Bloc
 
 // HandleBlock indicates an expected call of HandleBlock
 func (mr *MockSubscriberMockRecorder) HandleBlock(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlock", reflect.TypeOf((*MockSubscriber)(nil).HandleBlock), arg0, arg1)
 }
 
 // HandleBlockSync mocks base method
 func (m *MockSubscriber) HandleBlockSync(arg0 context.Context, arg1 *iotextypes.Block) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleBlockSync", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -71,11 +76,13 @@ func (m *MockSubscriber) HandleBlockSync(arg0 context.Context, arg1 *iotextypes.
 
 // HandleBlockSync indicates an expected call of HandleBlockSync
 func (mr *MockSubscriberMockRecorder) HandleBlockSync(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlockSync", reflect.TypeOf((*MockSubscriber)(nil).HandleBlockSync), arg0, arg1)
 }
 
 // HandleSyncRequest mocks base method
 func (m *MockSubscriber) HandleSyncRequest(arg0 context.Context, arg1 go_libp2p_peerstore.PeerInfo, arg2 *iotexrpc.BlockSync) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncRequest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -83,11 +90,13 @@ func (m *MockSubscriber) HandleSyncRequest(arg0 context.Context, arg1 go_libp2p_
 
 // HandleSyncRequest indicates an expected call of HandleSyncRequest
 func (mr *MockSubscriberMockRecorder) HandleSyncRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleSyncRequest", reflect.TypeOf((*MockSubscriber)(nil).HandleSyncRequest), arg0, arg1, arg2)
 }
 
 // HandleConsensusMsg mocks base method
 func (m *MockSubscriber) HandleConsensusMsg(arg0 *iotextypes.ConsensusMessage) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleConsensusMsg", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -95,6 +104,7 @@ func (m *MockSubscriber) HandleConsensusMsg(arg0 *iotextypes.ConsensusMessage) e
 
 // HandleConsensusMsg indicates an expected call of HandleConsensusMsg
 func (mr *MockSubscriberMockRecorder) HandleConsensusMsg(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleConsensusMsg", reflect.TypeOf((*MockSubscriber)(nil).HandleConsensusMsg), arg0)
 }
 
@@ -123,6 +133,7 @@ func (m *MockDispatcher) EXPECT() *MockDispatcherMockRecorder {
 
 // Start mocks base method
 func (m *MockDispatcher) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -130,11 +141,13 @@ func (m *MockDispatcher) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockDispatcherMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDispatcher)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockDispatcher) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -142,35 +155,42 @@ func (m *MockDispatcher) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockDispatcherMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockDispatcher)(nil).Stop), arg0)
 }
 
 // AddSubscriber mocks base method
 func (m *MockDispatcher) AddSubscriber(arg0 uint32, arg1 dispatcher.Subscriber) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "AddSubscriber", arg0, arg1)
 }
 
 // AddSubscriber indicates an expected call of AddSubscriber
 func (mr *MockDispatcherMockRecorder) AddSubscriber(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSubscriber", reflect.TypeOf((*MockDispatcher)(nil).AddSubscriber), arg0, arg1)
 }
 
 // HandleBroadcast mocks base method
 func (m *MockDispatcher) HandleBroadcast(arg0 context.Context, arg1 uint32, arg2 proto.Message) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleBroadcast", arg0, arg1, arg2)
 }
 
 // HandleBroadcast indicates an expected call of HandleBroadcast
 func (mr *MockDispatcherMockRecorder) HandleBroadcast(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBroadcast", reflect.TypeOf((*MockDispatcher)(nil).HandleBroadcast), arg0, arg1, arg2)
 }
 
 // HandleTell mocks base method
 func (m *MockDispatcher) HandleTell(arg0 context.Context, arg1 uint32, arg2 go_libp2p_peerstore.PeerInfo, arg3 proto.Message) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleTell", arg0, arg1, arg2, arg3)
 }
 
 // HandleTell indicates an expected call of HandleTell
 func (mr *MockDispatcherMockRecorder) HandleTell(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleTell", reflect.TypeOf((*MockDispatcher)(nil).HandleTell), arg0, arg1, arg2, arg3)
 }

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -40,6 +40,7 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 
 // Start mocks base method
 func (m *MockFactory) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -47,11 +48,13 @@ func (m *MockFactory) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockFactoryMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockFactory)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockFactory) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -59,11 +62,13 @@ func (m *MockFactory) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockFactoryMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockFactory)(nil).Stop), arg0)
 }
 
 // Balance mocks base method
 func (m *MockFactory) Balance(arg0 string) (*big.Int, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Balance", arg0)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
@@ -72,11 +77,13 @@ func (m *MockFactory) Balance(arg0 string) (*big.Int, error) {
 
 // Balance indicates an expected call of Balance
 func (mr *MockFactoryMockRecorder) Balance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Balance", reflect.TypeOf((*MockFactory)(nil).Balance), arg0)
 }
 
 // Nonce mocks base method
 func (m *MockFactory) Nonce(arg0 string) (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Nonce", arg0)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -85,11 +92,13 @@ func (m *MockFactory) Nonce(arg0 string) (uint64, error) {
 
 // Nonce indicates an expected call of Nonce
 func (mr *MockFactoryMockRecorder) Nonce(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Nonce", reflect.TypeOf((*MockFactory)(nil).Nonce), arg0)
 }
 
 // AccountState mocks base method
 func (m *MockFactory) AccountState(arg0 string) (*state.Account, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AccountState", arg0)
 	ret0, _ := ret[0].(*state.Account)
 	ret1, _ := ret[1].(error)
@@ -98,11 +107,13 @@ func (m *MockFactory) AccountState(arg0 string) (*state.Account, error) {
 
 // AccountState indicates an expected call of AccountState
 func (mr *MockFactoryMockRecorder) AccountState(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AccountState", reflect.TypeOf((*MockFactory)(nil).AccountState), arg0)
 }
 
 // RootHash mocks base method
 func (m *MockFactory) RootHash() hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RootHash")
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -110,11 +121,13 @@ func (m *MockFactory) RootHash() hash.Hash256 {
 
 // RootHash indicates an expected call of RootHash
 func (mr *MockFactoryMockRecorder) RootHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockFactory)(nil).RootHash))
 }
 
 // RootHashByHeight mocks base method
 func (m *MockFactory) RootHashByHeight(arg0 uint64) (hash.Hash256, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RootHashByHeight", arg0)
 	ret0, _ := ret[0].(hash.Hash256)
 	ret1, _ := ret[1].(error)
@@ -123,11 +136,13 @@ func (m *MockFactory) RootHashByHeight(arg0 uint64) (hash.Hash256, error) {
 
 // RootHashByHeight indicates an expected call of RootHashByHeight
 func (mr *MockFactoryMockRecorder) RootHashByHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHashByHeight", reflect.TypeOf((*MockFactory)(nil).RootHashByHeight), arg0)
 }
 
 // Height mocks base method
 func (m *MockFactory) Height() (uint64, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Height")
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
@@ -136,11 +151,13 @@ func (m *MockFactory) Height() (uint64, error) {
 
 // Height indicates an expected call of Height
 func (mr *MockFactoryMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockFactory)(nil).Height))
 }
 
 // NewWorkingSet mocks base method
 func (m *MockFactory) NewWorkingSet() (factory.WorkingSet, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewWorkingSet")
 	ret0, _ := ret[0].(factory.WorkingSet)
 	ret1, _ := ret[1].(error)
@@ -149,11 +166,13 @@ func (m *MockFactory) NewWorkingSet() (factory.WorkingSet, error) {
 
 // NewWorkingSet indicates an expected call of NewWorkingSet
 func (mr *MockFactoryMockRecorder) NewWorkingSet() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWorkingSet", reflect.TypeOf((*MockFactory)(nil).NewWorkingSet))
 }
 
 // Commit mocks base method
 func (m *MockFactory) Commit(arg0 factory.WorkingSet) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -161,11 +180,13 @@ func (m *MockFactory) Commit(arg0 factory.WorkingSet) error {
 
 // Commit indicates an expected call of Commit
 func (mr *MockFactoryMockRecorder) Commit(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockFactory)(nil).Commit), arg0)
 }
 
 // CandidatesByHeight mocks base method
 func (m *MockFactory) CandidatesByHeight(arg0 uint64) ([]*state.Candidate, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CandidatesByHeight", arg0)
 	ret0, _ := ret[0].([]*state.Candidate)
 	ret1, _ := ret[1].(error)
@@ -174,11 +195,13 @@ func (m *MockFactory) CandidatesByHeight(arg0 uint64) ([]*state.Candidate, error
 
 // CandidatesByHeight indicates an expected call of CandidatesByHeight
 func (mr *MockFactoryMockRecorder) CandidatesByHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockFactory)(nil).CandidatesByHeight), arg0)
 }
 
 // State mocks base method
 func (m *MockFactory) State(arg0 hash.Hash160, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -186,11 +209,13 @@ func (m *MockFactory) State(arg0 hash.Hash160, arg1 interface{}) error {
 
 // State indicates an expected call of State
 func (mr *MockFactoryMockRecorder) State(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockFactory)(nil).State), arg0, arg1)
 }
 
 // AddActionHandlers mocks base method
 func (m *MockFactory) AddActionHandlers(arg0 ...protocol.ActionHandler) {
+	m.ctrl.T.Helper()
 	varargs := []interface{}{}
 	for _, a := range arg0 {
 		varargs = append(varargs, a)
@@ -200,5 +225,6 @@ func (m *MockFactory) AddActionHandlers(arg0 ...protocol.ActionHandler) {
 
 // AddActionHandlers indicates an expected call of AddActionHandlers
 func (mr *MockFactoryMockRecorder) AddActionHandlers(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActionHandlers", reflect.TypeOf((*MockFactory)(nil).AddActionHandlers), arg0...)
 }

--- a/test/mock/mock_factory/mock_workingset.go
+++ b/test/mock/mock_factory/mock_workingset.go
@@ -39,6 +39,7 @@ func (m *MockWorkingSet) EXPECT() *MockWorkingSetMockRecorder {
 
 // RunAction mocks base method
 func (m *MockWorkingSet) RunAction(arg0 protocol.RunActionsCtx, arg1 action.SealedEnvelope) (*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunAction", arg0, arg1)
 	ret0, _ := ret[0].(*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -47,11 +48,13 @@ func (m *MockWorkingSet) RunAction(arg0 protocol.RunActionsCtx, arg1 action.Seal
 
 // RunAction indicates an expected call of RunAction
 func (mr *MockWorkingSetMockRecorder) RunAction(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunAction", reflect.TypeOf((*MockWorkingSet)(nil).RunAction), arg0, arg1)
 }
 
 // UpdateBlockLevelInfo mocks base method
 func (m *MockWorkingSet) UpdateBlockLevelInfo(blockHeight uint64) hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateBlockLevelInfo", blockHeight)
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -59,11 +62,13 @@ func (m *MockWorkingSet) UpdateBlockLevelInfo(blockHeight uint64) hash.Hash256 {
 
 // UpdateBlockLevelInfo indicates an expected call of UpdateBlockLevelInfo
 func (mr *MockWorkingSetMockRecorder) UpdateBlockLevelInfo(blockHeight interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateBlockLevelInfo", reflect.TypeOf((*MockWorkingSet)(nil).UpdateBlockLevelInfo), blockHeight)
 }
 
 // RunActions mocks base method
 func (m *MockWorkingSet) RunActions(arg0 context.Context, arg1 uint64, arg2 []action.SealedEnvelope) ([]*action.Receipt, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RunActions", arg0, arg1, arg2)
 	ret0, _ := ret[0].([]*action.Receipt)
 	ret1, _ := ret[1].(error)
@@ -72,11 +77,13 @@ func (m *MockWorkingSet) RunActions(arg0 context.Context, arg1 uint64, arg2 []ac
 
 // RunActions indicates an expected call of RunActions
 func (mr *MockWorkingSetMockRecorder) RunActions(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunActions", reflect.TypeOf((*MockWorkingSet)(nil).RunActions), arg0, arg1, arg2)
 }
 
 // Snapshot mocks base method
 func (m *MockWorkingSet) Snapshot() int {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Snapshot")
 	ret0, _ := ret[0].(int)
 	return ret0
@@ -84,11 +91,13 @@ func (m *MockWorkingSet) Snapshot() int {
 
 // Snapshot indicates an expected call of Snapshot
 func (mr *MockWorkingSetMockRecorder) Snapshot() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Snapshot", reflect.TypeOf((*MockWorkingSet)(nil).Snapshot))
 }
 
 // Revert mocks base method
 func (m *MockWorkingSet) Revert(arg0 int) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Revert", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -96,11 +105,13 @@ func (m *MockWorkingSet) Revert(arg0 int) error {
 
 // Revert indicates an expected call of Revert
 func (mr *MockWorkingSetMockRecorder) Revert(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Revert", reflect.TypeOf((*MockWorkingSet)(nil).Revert), arg0)
 }
 
 // Commit mocks base method
 func (m *MockWorkingSet) Commit() error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Commit")
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -108,11 +119,13 @@ func (m *MockWorkingSet) Commit() error {
 
 // Commit indicates an expected call of Commit
 func (mr *MockWorkingSetMockRecorder) Commit() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockWorkingSet)(nil).Commit))
 }
 
 // RootHash mocks base method
 func (m *MockWorkingSet) RootHash() hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RootHash")
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -120,11 +133,13 @@ func (m *MockWorkingSet) RootHash() hash.Hash256 {
 
 // RootHash indicates an expected call of RootHash
 func (mr *MockWorkingSetMockRecorder) RootHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockWorkingSet)(nil).RootHash))
 }
 
 // Digest mocks base method
 func (m *MockWorkingSet) Digest() hash.Hash256 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Digest")
 	ret0, _ := ret[0].(hash.Hash256)
 	return ret0
@@ -132,11 +147,13 @@ func (m *MockWorkingSet) Digest() hash.Hash256 {
 
 // Digest indicates an expected call of Digest
 func (mr *MockWorkingSetMockRecorder) Digest() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Digest", reflect.TypeOf((*MockWorkingSet)(nil).Digest))
 }
 
 // Version mocks base method
 func (m *MockWorkingSet) Version() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Version")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -144,11 +161,13 @@ func (m *MockWorkingSet) Version() uint64 {
 
 // Version indicates an expected call of Version
 func (mr *MockWorkingSetMockRecorder) Version() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Version", reflect.TypeOf((*MockWorkingSet)(nil).Version))
 }
 
 // Height mocks base method
 func (m *MockWorkingSet) Height() uint64 {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Height")
 	ret0, _ := ret[0].(uint64)
 	return ret0
@@ -156,11 +175,13 @@ func (m *MockWorkingSet) Height() uint64 {
 
 // Height indicates an expected call of Height
 func (mr *MockWorkingSetMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockWorkingSet)(nil).Height))
 }
 
 // State mocks base method
 func (m *MockWorkingSet) State(arg0 hash.Hash160, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "State", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -168,11 +189,13 @@ func (m *MockWorkingSet) State(arg0 hash.Hash160, arg1 interface{}) error {
 
 // State indicates an expected call of State
 func (mr *MockWorkingSetMockRecorder) State(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "State", reflect.TypeOf((*MockWorkingSet)(nil).State), arg0, arg1)
 }
 
 // PutState mocks base method
 func (m *MockWorkingSet) PutState(arg0 hash.Hash160, arg1 interface{}) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutState", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -180,11 +203,13 @@ func (m *MockWorkingSet) PutState(arg0 hash.Hash160, arg1 interface{}) error {
 
 // PutState indicates an expected call of PutState
 func (mr *MockWorkingSetMockRecorder) PutState(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutState", reflect.TypeOf((*MockWorkingSet)(nil).PutState), arg0, arg1)
 }
 
 // DelState mocks base method
 func (m *MockWorkingSet) DelState(pkHash hash.Hash160) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DelState", pkHash)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -192,11 +217,13 @@ func (m *MockWorkingSet) DelState(pkHash hash.Hash160) error {
 
 // DelState indicates an expected call of DelState
 func (mr *MockWorkingSetMockRecorder) DelState(pkHash interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelState", reflect.TypeOf((*MockWorkingSet)(nil).DelState), pkHash)
 }
 
 // GetDB mocks base method
 func (m *MockWorkingSet) GetDB() db.KVStore {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDB")
 	ret0, _ := ret[0].(db.KVStore)
 	return ret0
@@ -204,11 +231,13 @@ func (m *MockWorkingSet) GetDB() db.KVStore {
 
 // GetDB indicates an expected call of GetDB
 func (mr *MockWorkingSetMockRecorder) GetDB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDB", reflect.TypeOf((*MockWorkingSet)(nil).GetDB))
 }
 
 // GetCachedBatch mocks base method
 func (m *MockWorkingSet) GetCachedBatch() db.CachedBatch {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetCachedBatch")
 	ret0, _ := ret[0].(db.CachedBatch)
 	return ret0
@@ -216,5 +245,6 @@ func (m *MockWorkingSet) GetCachedBatch() db.CachedBatch {
 
 // GetCachedBatch indicates an expected call of GetCachedBatch
 func (mr *MockWorkingSetMockRecorder) GetCachedBatch() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCachedBatch", reflect.TypeOf((*MockWorkingSet)(nil).GetCachedBatch))
 }

--- a/test/mock/mock_lifecycle/mock_lifecycle.go
+++ b/test/mock/mock_lifecycle/mock_lifecycle.go
@@ -35,6 +35,7 @@ func (m *MockStartStopper) EXPECT() *MockStartStopperMockRecorder {
 
 // Start mocks base method
 func (m *MockStartStopper) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -42,11 +43,13 @@ func (m *MockStartStopper) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockStartStopperMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockStartStopper)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockStartStopper) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -54,5 +57,6 @@ func (m *MockStartStopper) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockStartStopperMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockStartStopper)(nil).Stop), arg0)
 }

--- a/test/mock/mock_trie/mock_trie.go
+++ b/test/mock/mock_trie/mock_trie.go
@@ -36,6 +36,7 @@ func (m *MockTrie) EXPECT() *MockTrieMockRecorder {
 
 // Start mocks base method
 func (m *MockTrie) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Start", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -43,11 +44,13 @@ func (m *MockTrie) Start(arg0 context.Context) error {
 
 // Start indicates an expected call of Start
 func (mr *MockTrieMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTrie)(nil).Start), arg0)
 }
 
 // Stop mocks base method
 func (m *MockTrie) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stop", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -55,11 +58,13 @@ func (m *MockTrie) Stop(arg0 context.Context) error {
 
 // Stop indicates an expected call of Stop
 func (mr *MockTrieMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockTrie)(nil).Stop), arg0)
 }
 
 // Upsert mocks base method
 func (m *MockTrie) Upsert(arg0, arg1 []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Upsert", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -67,11 +72,13 @@ func (m *MockTrie) Upsert(arg0, arg1 []byte) error {
 
 // Upsert indicates an expected call of Upsert
 func (mr *MockTrieMockRecorder) Upsert(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upsert", reflect.TypeOf((*MockTrie)(nil).Upsert), arg0, arg1)
 }
 
 // Get mocks base method
 func (m *MockTrie) Get(arg0 []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
@@ -80,11 +87,13 @@ func (m *MockTrie) Get(arg0 []byte) ([]byte, error) {
 
 // Get indicates an expected call of Get
 func (mr *MockTrieMockRecorder) Get(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockTrie)(nil).Get), arg0)
 }
 
 // Delete mocks base method
 func (m *MockTrie) Delete(arg0 []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -92,11 +101,13 @@ func (m *MockTrie) Delete(arg0 []byte) error {
 
 // Delete indicates an expected call of Delete
 func (mr *MockTrieMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTrie)(nil).Delete), arg0)
 }
 
 // RootHash mocks base method
 func (m *MockTrie) RootHash() []byte {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RootHash")
 	ret0, _ := ret[0].([]byte)
 	return ret0
@@ -104,11 +115,13 @@ func (m *MockTrie) RootHash() []byte {
 
 // RootHash indicates an expected call of RootHash
 func (mr *MockTrieMockRecorder) RootHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RootHash", reflect.TypeOf((*MockTrie)(nil).RootHash))
 }
 
 // SetRootHash mocks base method
 func (m *MockTrie) SetRootHash(arg0 []byte) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRootHash", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -116,11 +129,13 @@ func (m *MockTrie) SetRootHash(arg0 []byte) error {
 
 // SetRootHash indicates an expected call of SetRootHash
 func (mr *MockTrieMockRecorder) SetRootHash(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRootHash", reflect.TypeOf((*MockTrie)(nil).SetRootHash), arg0)
 }
 
 // DB mocks base method
 func (m *MockTrie) DB() trie.KVStore {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DB")
 	ret0, _ := ret[0].(trie.KVStore)
 	return ret0
@@ -128,11 +143,13 @@ func (m *MockTrie) DB() trie.KVStore {
 
 // DB indicates an expected call of DB
 func (mr *MockTrieMockRecorder) DB() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DB", reflect.TypeOf((*MockTrie)(nil).DB))
 }
 
 // deleteNodeFromDB mocks base method
 func (m *MockTrie) deleteNodeFromDB(tn trie.Node) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "deleteNodeFromDB", tn)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -140,11 +157,13 @@ func (m *MockTrie) deleteNodeFromDB(tn trie.Node) error {
 
 // deleteNodeFromDB indicates an expected call of deleteNodeFromDB
 func (mr *MockTrieMockRecorder) deleteNodeFromDB(tn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteNodeFromDB", reflect.TypeOf((*MockTrie)(nil).deleteNodeFromDB), tn)
 }
 
 // putNodeIntoDB mocks base method
 func (m *MockTrie) putNodeIntoDB(tn trie.Node) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "putNodeIntoDB", tn)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -152,11 +171,13 @@ func (m *MockTrie) putNodeIntoDB(tn trie.Node) error {
 
 // putNodeIntoDB indicates an expected call of putNodeIntoDB
 func (mr *MockTrieMockRecorder) putNodeIntoDB(tn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "putNodeIntoDB", reflect.TypeOf((*MockTrie)(nil).putNodeIntoDB), tn)
 }
 
 // loadNodeFromDB mocks base method
 func (m *MockTrie) loadNodeFromDB(arg0 []byte) (trie.Node, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "loadNodeFromDB", arg0)
 	ret0, _ := ret[0].(trie.Node)
 	ret1, _ := ret[1].(error)
@@ -165,11 +186,13 @@ func (m *MockTrie) loadNodeFromDB(arg0 []byte) (trie.Node, error) {
 
 // loadNodeFromDB indicates an expected call of loadNodeFromDB
 func (mr *MockTrieMockRecorder) loadNodeFromDB(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "loadNodeFromDB", reflect.TypeOf((*MockTrie)(nil).loadNodeFromDB), arg0)
 }
 
 // isEmptyRootHash mocks base method
 func (m *MockTrie) isEmptyRootHash(arg0 []byte) bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "isEmptyRootHash", arg0)
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -177,11 +200,13 @@ func (m *MockTrie) isEmptyRootHash(arg0 []byte) bool {
 
 // isEmptyRootHash indicates an expected call of isEmptyRootHash
 func (mr *MockTrieMockRecorder) isEmptyRootHash(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isEmptyRootHash", reflect.TypeOf((*MockTrie)(nil).isEmptyRootHash), arg0)
 }
 
 // emptyRootHash mocks base method
 func (m *MockTrie) emptyRootHash() []byte {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "emptyRootHash")
 	ret0, _ := ret[0].([]byte)
 	return ret0
@@ -189,11 +214,13 @@ func (m *MockTrie) emptyRootHash() []byte {
 
 // emptyRootHash indicates an expected call of emptyRootHash
 func (mr *MockTrieMockRecorder) emptyRootHash() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "emptyRootHash", reflect.TypeOf((*MockTrie)(nil).emptyRootHash))
 }
 
 // nodeHash mocks base method
 func (m *MockTrie) nodeHash(tn trie.Node) []byte {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "nodeHash", tn)
 	ret0, _ := ret[0].([]byte)
 	return ret0
@@ -201,5 +228,6 @@ func (m *MockTrie) nodeHash(tn trie.Node) []byte {
 
 // nodeHash indicates an expected call of nodeHash
 func (mr *MockTrieMockRecorder) nodeHash(tn interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "nodeHash", reflect.TypeOf((*MockTrie)(nil).nodeHash), tn)
 }


### PR DESCRIPTION
removing existing mocks first cause mockgen failed on blocksync mock building.