### PR TITLE
correctly initialize state factory

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -303,19 +303,28 @@ func (bc *blockchain) ChainAddress() string {
 }
 
 // Start starts the blockchain
-func (bc *blockchain) Start(ctx context.Context) (err error) {
+func (bc *blockchain) Start(ctx context.Context) error {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()
-	if err = bc.lifecycle.OnStart(ctx); err != nil {
+	if err := bc.lifecycle.OnStart(ctx); err != nil {
 		return err
+	}
+	// init state factory if needed
+	sfHeight, err := bc.sf.Height()
+	if err != nil {
+		return err
+	}
+	if sfHeight == 0 {
+		if err := bc.sf.Initialize(bc.config, bc.registry); err != nil {
+			return err
+		}
 	}
 	// get blockchain tip height
 	if bc.tipHeight, err = bc.dao.GetTipHeight(); err != nil {
 		return err
 	}
-	//start empty blockchain
 	if bc.tipHeight == 0 {
-		return bc.sf.Initialize(bc.config, bc.registry)
+		return nil
 	}
 	// get blockchain tip hash
 	if bc.tipHash, err = bc.dao.GetTipHash(); err != nil {
@@ -614,6 +623,9 @@ func (bc *blockchain) RecoverChainAndState(targetHeight uint64) error {
 	var buildStateFromScratch bool
 	stateHeight, err := bc.sf.Height()
 	if err != nil {
+		return err
+	}
+	if stateHeight == 0 {
 		buildStateFromScratch = true
 	}
 	if targetHeight > 0 {

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -524,7 +524,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 	// Delete state db and recover to tip
 	testutil.CleanupPath(t, testTriePath)
 	require.NoError(svr.Stop(ctx))
-	require.Error(svr.ChainService(cfg.Chain.ID).Blockchain().Start(ctx))
+	require.NoError(svr.ChainService(cfg.Chain.ID).Blockchain().Start(ctx))
 	// Refresh state DB
 	require.NoError(bc.RecoverChainAndState(0))
 	require.NoError(svr.ChainService(cfg.Chain.ID).Blockchain().Stop(ctx))

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -160,14 +160,19 @@ func (sf *factory) Start(ctx context.Context) error {
 	}
 	// check factory height
 	_, err := sf.dao.Get(AccountKVNameSpace, []byte(CurrentHeightKey))
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		if err := sf.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
+	switch errors.Cause(err) {
+	case nil:
+		break
+	case db.ErrNotExist:
+		if err = sf.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
 			return errors.Wrap(err, "failed to init factory's height")
 		}
 		// init the state factory
-		if err := sf.initialize(ctx); err != nil {
+		if err = sf.initialize(ctx); err != nil {
 			return err
 		}
+	default:
+		return err
 	}
 	return sf.lifecycle.OnStart(ctx)
 }

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -13,11 +13,11 @@ import (
 	"strconv"
 	"sync"
 
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/action/protocol/vote/candidatesutil"
@@ -64,8 +64,6 @@ type (
 
 		State(hash.Hash160, interface{}) error
 		AddActionHandlers(...protocol.ActionHandler)
-		// empty blockchain
-		Initialize(config.Config, *protocol.Registry) error
 	}
 
 	// factory implements StateFactory interface, tracks changes to account/contract and batch-commits to DB
@@ -165,6 +163,10 @@ func (sf *factory) Start(ctx context.Context) error {
 	if err != nil && errors.Cause(err) == db.ErrNotExist {
 		if err := sf.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
 			return errors.Wrap(err, "failed to init factory's height")
+		}
+		// init the state factory
+		if err := sf.initialize(ctx); err != nil {
+			return err
 		}
 	}
 	return sf.lifecycle.OnStart(ctx)
@@ -414,15 +416,17 @@ func (sf *factory) commit(ws WorkingSet) error {
 }
 
 // Initialize initializes the state factory
-func (sf *factory) Initialize(cfg config.Config, registry *protocol.Registry) error {
-	sf.mutex.RLock()
-	defer sf.mutex.RUnlock()
-	var ws WorkingSet
-	var err error
-	if ws, err = NewWorkingSet(sf.currentChainHeight, sf.dao, sf.rootHash(), sf.actionHandlers); err != nil {
+func (sf *factory) initialize(ctx context.Context) error {
+	raCtx, ok := protocol.GetRunActionsCtx(ctx)
+	if !ok || raCtx.Registry == nil {
+		// not RunActionsCtx or no valid registry
+		return nil
+	}
+	ws, err := NewWorkingSet(sf.currentChainHeight, sf.dao, sf.rootHash(), sf.actionHandlers)
+	if err != nil {
 		return errors.Wrap(err, "failed to obtain working set from state factory")
 	}
-	if err := createGenesisStates(cfg, registry, ws); err != nil {
+	if err := createGenesisStates(ctx, sf.cfg, ws); err != nil {
 		return err
 	}
 	// add Genesis states

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -160,6 +160,13 @@ func (sf *factory) Start(ctx context.Context) error {
 	if err := sf.dao.Start(ctx); err != nil {
 		return err
 	}
+	// check factory height
+	_, err := sf.dao.Get(AccountKVNameSpace, []byte(CurrentHeightKey))
+	if err != nil && errors.Cause(err) == db.ErrNotExist {
+		if err := sf.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
+			return errors.Wrap(err, "failed to init factory's height")
+		}
+	}
 	return sf.lifecycle.OnStart(ctx)
 }
 

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -107,14 +107,19 @@ func (sdb *stateDB) Start(ctx context.Context) error {
 	}
 	// check factory height
 	_, err := sdb.dao.Get(AccountKVNameSpace, []byte(CurrentHeightKey))
-	if err != nil && errors.Cause(err) == db.ErrNotExist {
-		if err := sdb.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
+	switch errors.Cause(err) {
+	case nil:
+		break
+	case db.ErrNotExist:
+		if err = sdb.dao.Put(AccountKVNameSpace, []byte(CurrentHeightKey), byteutil.Uint64ToBytes(0)); err != nil {
 			return errors.Wrap(err, "failed to init statedb's height")
 		}
 		// init the state factory
-		if err := sdb.initialize(ctx); err != nil {
+		if err = sdb.initialize(ctx); err != nil {
 			return err
 		}
+	default:
+		return err
 	}
 	return nil
 }

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -9,7 +9,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	hash "github.com/iotexproject/go-pkgs/hash"
 	protocol "github.com/iotexproject/iotex-core/action/protocol"
-	config "github.com/iotexproject/iotex-core/config"
 	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
 	big "math/big"
@@ -243,18 +242,4 @@ func (m *MockFactory) AddActionHandlers(arg0 ...protocol.ActionHandler) {
 func (mr *MockFactoryMockRecorder) AddActionHandlers(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActionHandlers", reflect.TypeOf((*MockFactory)(nil).AddActionHandlers), arg0...)
-}
-
-// Initialize mocks base method
-func (m *MockFactory) Initialize(arg0 config.Config, arg1 *protocol.Registry) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Initialize indicates an expected call of Initialize
-func (mr *MockFactoryMockRecorder) Initialize(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Initialize", reflect.TypeOf((*MockFactory)(nil).Initialize), arg0, arg1)
 }


### PR DESCRIPTION
it could happen that bc.tipHeight > 0 while state factory DB file has been deleted
sf.Initialize() should be called based upon sf.Height() == 0, but not bc.tipHeight == 0

Test plan:
make test && make minicluster