### PR TITLE
Add save history as a factory option

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -43,6 +43,8 @@ type RunActionsCtx struct {
 	IntrinsicGas uint64
 	// Nonce is the nonce of the action
 	Nonce uint64
+	// History indicates whether to save account/contract history or not
+	History bool
 	// Registry is the pointer protocol registry
 	Registry *Registry
 }

--- a/action/protocol/context_test.go
+++ b/action/protocol/context_test.go
@@ -23,7 +23,7 @@ func TestWithRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, false, nil}
 	require.NotNil(WithRunActionsCtx(context.Background(), actionCtx))
 }
 
@@ -31,7 +31,7 @@ func TestGetRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, false, nil}
 	ctx := WithRunActionsCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	ret, ok := GetRunActionsCtx(ctx)
@@ -43,7 +43,7 @@ func TestMustGetRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, false, nil}
 	ctx := WithRunActionsCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	// Case I: Normal

--- a/action/protocol/execution/evm/contract.go
+++ b/action/protocol/execution/evm/contract.go
@@ -14,18 +14,19 @@ import (
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/db/trie"
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/state"
 )
 
 const (
 	// CodeKVNameSpace is the bucket name for code
 	CodeKVNameSpace = "Code"
-
 	// ContractKVNameSpace is the bucket name for contract data storage
 	ContractKVNameSpace = "Contract"
-
 	// PreimageKVNameSpace is the bucket name for preimage data storage
 	PreimageKVNameSpace = "Preimage"
+	// PruneKVNameSpace is the bucket name for entries to be pruned
+	PruneKVNameSpace = "cp"
 )
 
 type (
@@ -46,15 +47,30 @@ type (
 
 	contract struct {
 		*state.Account
-		dirtyCode  bool   // contract's code has been set
-		dirtyState bool   // contract's account state has changed
-		code       []byte // contract byte-code
-		root       hash.Hash256
-		committed  map[hash.Hash256][]byte
-		dao        db.KVStore
-		trie       trie.Trie // storage trie of the contract
+		dirtyCode   bool   // contract's code has been set
+		dirtyState  bool   // contract's account state has changed
+		code        []byte // contract byte-code
+		root        hash.Hash256
+		committed   map[hash.Hash256][]byte
+		dao         db.KVStore
+		trie        trie.Trie // storage trie of the contract
+		saveHistory bool
+		height      uint64 // height at which contract state changes
+
 	}
 )
+
+// ContractOption set contract construction param
+type ContractOption func(*contract) error
+
+// HistoryRetentionOption creates contract with history
+func HistoryRetentionOption(height uint64) ContractOption {
+	return func(c *contract) error {
+		c.saveHistory = true
+		c.height = height
+		return nil
+	}
+}
 
 func (c *contract) Iterator() (trie.Iterator, error) {
 	return trie.NewLeafIterator(c.trie)
@@ -157,9 +173,20 @@ func (c *contract) Snapshot() Contract {
 	}
 }
 
-// NewContract returns a Contract instance
-func newContract(addr hash.Hash160, state *state.Account, dao db.KVStore, batch db.CachedBatch) (Contract, error) {
-	dbForTrie, err := db.NewKVStoreForTrie(ContractKVNameSpace, dao, db.CachedBatchOption(batch))
+// newContract returns a Contract instance
+func newContract(addr hash.Hash160, account *state.Account, dao db.KVStore, batch db.CachedBatch, opts ...ContractOption) (Contract, error) {
+	c := &contract{
+		Account:   account,
+		root:      account.Root,
+		committed: make(map[hash.Hash256][]byte),
+		dao:       dao,
+	}
+	for _, opt := range opts {
+		if err := opt(c); err != nil {
+			log.L().Panic("failed to execute contract creation option")
+		}
+	}
+	dbForTrie, err := db.NewKVStoreForTrie(ContractKVNameSpace, PruneKVNameSpace, dao, db.CachedBatchOption(batch))
 	if err != nil {
 		return nil, err
 	}
@@ -170,8 +197,11 @@ func newContract(addr hash.Hash160, state *state.Account, dao db.KVStore, batch 
 			return trie.DefaultHashFunc(append(addr[:], data...))
 		}),
 	}
-	if state.Root != hash.ZeroHash256 {
-		options = append(options, trie.RootHashOption(state.Root[:]))
+	if c.saveHistory {
+		options = append(options, trie.HistoryRetentionOption(c.height))
+	}
+	if account.Root != hash.ZeroHash256 {
+		options = append(options, trie.RootHashOption(account.Root[:]))
 	}
 
 	tr, err := trie.NewTrie(options...)
@@ -181,12 +211,6 @@ func newContract(addr hash.Hash160, state *state.Account, dao db.KVStore, batch 
 	if err := tr.Start(context.Background()); err != nil {
 		return nil, err
 	}
-
-	return &contract{
-		Account:   state,
-		root:      state.Root,
-		committed: make(map[hash.Hash256][]byte),
-		dao:       dao,
-		trie:      tr,
-	}, nil
+	c.trie = tr
+	return c, nil
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -143,12 +143,23 @@ func ExecuteContract(
 ) ([]byte, *action.Receipt, error) {
 	raCtx := protocol.MustGetRunActionsCtx(ctx)
 	hu := config.NewHeightUpgrade(&raCtx.Genesis)
-	stateDB := NewStateDBAdapter(
-		sm,
-		raCtx.BlockHeight,
-		hu.IsPre(config.Aleutian, raCtx.BlockHeight),
-		execution.Hash(),
-	)
+	var stateDB *StateDBAdapter
+	if raCtx.History {
+		stateDB = NewStateDBAdapter(
+			sm,
+			raCtx.BlockHeight,
+			hu.IsPre(config.Aleutian, raCtx.BlockHeight),
+			execution.Hash(),
+			SaveHistoryOption(),
+		)
+	} else {
+		stateDB = NewStateDBAdapter(
+			sm,
+			raCtx.BlockHeight,
+			hu.IsPre(config.Aleutian, raCtx.BlockHeight),
+			execution.Hash(),
+		)
+	}
 	ps, err := NewParams(raCtx, execution, stateDB, getBlockHash)
 	if err != nil {
 		return nil, nil, err

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -143,8 +143,7 @@ type blockchain struct {
 	timerFactory  *prometheustimer.TimerFactory
 
 	// used by account-based model
-	sf factory.Factory
-
+	sf       factory.Factory
 	registry *protocol.Registry
 }
 
@@ -160,6 +159,9 @@ type Option func(*blockchain, config.Config) error
 // DefaultStateFactoryOption sets blockchain's sf from config
 func DefaultStateFactoryOption() Option {
 	return func(bc *blockchain, cfg config.Config) (err error) {
+		if bc.sf != nil {
+			return nil
+		}
 		if cfg.Chain.EnableTrielessStateDB {
 			bc.sf, err = factory.NewStateDB(cfg, factory.DefaultStateDBOption())
 		} else {
@@ -175,8 +177,10 @@ func DefaultStateFactoryOption() Option {
 // PrecreatedStateFactoryOption sets blockchain's state.Factory to sf
 func PrecreatedStateFactoryOption(sf factory.Factory) Option {
 	return func(bc *blockchain, conf config.Config) error {
+		if bc.sf != nil {
+			return nil
+		}
 		bc.sf = sf
-
 		return nil
 	}
 }
@@ -184,6 +188,9 @@ func PrecreatedStateFactoryOption(sf factory.Factory) Option {
 // InMemStateFactoryOption sets blockchain's factory.Factory as in memory sf
 func InMemStateFactoryOption() Option {
 	return func(bc *blockchain, cfg config.Config) error {
+		if bc.sf != nil {
+			return nil
+		}
 		sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 		if err != nil {
 			return errors.Wrapf(err, "Failed to create state factory")
@@ -849,6 +856,7 @@ func (bc *blockchain) runActions(
 			GasLimit:       gasLimit,
 			Registry:       bc.registry,
 			Genesis:        bc.config.Genesis,
+			History:        ws.History(),
 		})
 
 	if acts.BlockHeight() == bc.config.Genesis.AleutianBlockHeight {

--- a/config/config.go
+++ b/config/config.go
@@ -115,6 +115,7 @@ var (
 			AllowedBlockGasResidue:        10000,
 			MaxCacheSize:                  0,
 			PollInitialCandidatesInterval: 10 * time.Second,
+			EnableHistoryStateDB:          false,
 		},
 		ActPool: ActPool{
 			MaxNumActsPerPool:  32000,
@@ -175,8 +176,9 @@ var (
 			SQLITE3: SQLITE3{
 				SQLite3File: "./explorer.db",
 			},
-			SplitDBSizeMB: 0,
-			SplitDBHeight: 900000,
+			SplitDBSizeMB:         0,
+			SplitDBHeight:         900000,
+			HistoryStateRetention: 2000,
 		},
 		Genesis: genesis.Default,
 	}
@@ -225,6 +227,7 @@ type (
 		Committee       committee.Config `yaml:"committee"`
 
 		EnableTrielessStateDB bool `yaml:"enableTrielessStateDB"`
+		EnableHistoryStateDB  bool `yaml:"enableHistoryStateDB"`
 		// EnableAsyncIndexWrite enables writing the block actions' and receipts' index asynchronously
 		EnableAsyncIndexWrite bool `yaml:"enableAsyncIndexWrite"`
 		// CompressBlock enables gzip compression on block data
@@ -339,6 +342,8 @@ type (
 		SplitDBSizeMB uint64 `yaml:"splitDBSizeMB"`
 		// SplitDBHeight is the config for DB's split start height
 		SplitDBHeight uint64 `yaml:"splitDBHeight"`
+		// HistoryStateRetention is the number of blocks account/contract state will be retained
+		HistoryStateRetention uint64 `yaml:"historyStateRetention"`
 	}
 
 	// RDS is the cloud rds config

--- a/db/batch_test.go
+++ b/db/batch_test.go
@@ -48,24 +48,12 @@ func TestCachedBatch(t *testing.T) {
 	require.Equal([]byte(nil), w.value)
 	require.Equal(Delete, w.writeType)
 
-	// test clone
-	c := cb.clone()
-	_, err = c.Get(bucket1, testK1[0])
-	require.Equal(ErrAlreadyDeleted, errors.Cause(err))
-
-	w, err = c.Entry(0)
-	require.NoError(err)
-	require.Equal(bucket1, w.namespace)
-	require.Equal(testK1[0], w.key)
-	require.Equal(testV1[0], w.value)
-	require.Equal(Put, w.writeType)
-
-	w, err = c.Entry(2)
-	require.NoError(err)
-	require.Equal(bucket1, w.namespace)
-	require.Equal(testK1[0], w.key)
-	require.Equal([]byte(nil), w.value)
-	require.Equal(Delete, w.writeType)
+	// test ExcludeEntries
+	d := cb.Digest()
+	require.Equal(3, cb.Size())
+	r := cb.ExcludeEntries(bucket1, Delete)
+	require.Equal(1, r.Size())
+	require.NotEqual(d, r.Digest())
 }
 
 func TestSnapshot(t *testing.T) {

--- a/db/db.go
+++ b/db/db.go
@@ -47,6 +47,10 @@ type KVStore interface {
 	CreateCountingIndexNX([]byte) (CountingIndex, error)
 	// CreateRangeIndexNX creates a new range index if it does not exist, otherwise return existing index
 	CreateRangeIndexNX([]byte, []byte) (RangeIndex, error)
+	// GetBucketByPrefix retrieves all bucket those with const namespace prefix
+	GetBucketByPrefix([]byte) ([][]byte, error)
+	// GetKeyByPrefix retrieves all keys those with const prefix
+	GetKeyByPrefix(namespace, prefix []byte) ([][]byte, error)
 }
 
 const (
@@ -161,4 +165,14 @@ func (m *memKVStore) CreateCountingIndexNX(name []byte) (CountingIndex, error) {
 // CreateRangeIndexNX creates a new range index if it does not exist, otherwise return existing index
 func (m *memKVStore) CreateRangeIndexNX(name, init []byte) (RangeIndex, error) {
 	return nil, ErrInvalid
+}
+
+// GetBucketByPrefix retrieves all bucket those with const namespace prefix
+func (m *memKVStore) GetBucketByPrefix(namespace []byte) ([][]byte, error) {
+	return nil, nil
+}
+
+// GetKeyByPrefix retrieves all keys those with const prefix
+func (m *memKVStore) GetKeyByPrefix(namespace, prefix []byte) ([][]byte, error) {
+	return nil, nil
 }

--- a/db/kvstore4trie_test.go
+++ b/db/kvstore4trie_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestKVStoreForTrie_ErrNotExist(t *testing.T) {
-	store, err := NewKVStoreForTrie("test", NewMemKVStore())
+	store, err := NewKVStoreForTrie("test", "prune", NewMemKVStore())
 	require.NoError(t, err)
 	require.NoError(t, store.Put([]byte("key"), []byte("value1")))
 	require.NoError(t, store.Flush())

--- a/db/range_index.go
+++ b/db/range_index.go
@@ -18,6 +18,8 @@ import (
 var (
 	// MaxKey is the special key such that bytes.Compare(MaxUint64, MaxKey) = -1
 	MaxKey = []byte{255, 255, 255, 255, 255, 255, 255, 255, 0}
+	// NotExist is the empty byte slice to indicate a key does not exist (as a result of calling Purge())
+	NotExist = []byte{}
 )
 
 type (
@@ -44,6 +46,8 @@ type (
 		Get(uint64) ([]byte, error)
 		// Delete deletes an existing key
 		Delete(uint64) error
+		// Purge deletes an existing key and all keys before it
+		Purge(uint64) error
 		// Close makes the index not usable
 		Close()
 	}
@@ -68,6 +72,7 @@ func NewRangeIndex(db *bolt.DB, retry uint8, name []byte) (RangeIndex, error) {
 
 	bucket := make([]byte, len(name))
 	copy(bucket, name)
+
 	return &rangeIndex{
 		db:         db,
 		numRetries: retry,
@@ -88,17 +93,22 @@ func (r *rangeIndex) Insert(key uint64, value []byte) error {
 			if bucket == nil {
 				return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", r.bucket)
 			}
-			// read current value
-			curr := bucket.Get(MaxKey)
-			if curr == nil {
-				return errors.Wrap(ErrIO, "cannot read current value")
+			cur := bucket.Cursor()
+			ak := byteutil.Uint64ToBytesBigEndian(key - 1)
+			k, v := cur.Seek(ak)
+			if !bytes.Equal(k, ak) {
+				// insert new key
+				if err := bucket.Put(ak, v); err != nil {
+					return err
+				}
+			} else {
+				// update an existing key
+				k, _ = cur.Next()
 			}
-			// keys up to key-1 should have current value
-			if err := bucket.Put(byteutil.Uint64ToBytesBigEndian(key-1), curr); err != nil {
-				return err
+			if k != nil {
+				return bucket.Put(k, value)
 			}
-			// write new value
-			return bucket.Put(MaxKey, value)
+			return nil
 		}); err == nil {
 			break
 		}
@@ -150,10 +160,48 @@ func (r *rangeIndex) Delete(key uint64) error {
 				// return nil if the key does not exist
 				return nil
 			}
-			bucket.Delete(ak)
-			// need to move the corresponding value to next key
-			k, _ = cur.Seek(byteutil.Uint64ToBytesBigEndian(key))
-			return bucket.Put(k, v)
+			if err := bucket.Delete(ak); err != nil {
+				return err
+			}
+			// write the corresponding value to next key
+			k, _ = cur.Next()
+			if k != nil {
+				return bucket.Put(k, v)
+			}
+			return nil
+		}); err == nil {
+			break
+		}
+	}
+	return err
+}
+
+// Purge deletes an existing key and all keys before it
+func (r *rangeIndex) Purge(key uint64) error {
+	// cannot delete key 0, which holds initial value
+	if key == 0 {
+		return errors.Wrap(ErrInvalid, "cannot delete key 0")
+	}
+	var err error
+	for i := uint8(0); i < r.numRetries; i++ {
+		if err = r.db.Update(func(tx *bolt.Tx) error {
+			bucket := tx.Bucket(r.bucket)
+			if bucket == nil {
+				return errors.Wrapf(ErrBucketNotExist, "bucket = %x doesn't exist", r.bucket)
+			}
+			cur := bucket.Cursor()
+			nk, _ := cur.Seek(byteutil.Uint64ToBytesBigEndian(key))
+			// delete all keys before this key
+			for k, _ := cur.Prev(); k != nil; k, _ = cur.Prev() {
+				if err := bucket.Delete(k); err != nil {
+					return err
+				}
+			}
+			// write not exist value to next key
+			if nk != nil {
+				return bucket.Put(nk, NotExist)
+			}
+			return nil
 		}); err == nil {
 			break
 		}

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -68,11 +68,11 @@ func TestRangeIndex(t *testing.T) {
 		gap := e.k - rangeTests[i-1].k
 		for j := 0; j < 5; j++ {
 			k := rangeTests[i-1].k + uint64(rand.Intn(int(gap)))
-			v, err := index.Get(k)
+			v, err = index.Get(k)
 			require.NoError(err)
 			require.Equal(rangeTests[i-1].v, v)
 		}
-		v, err := index.Get(e.k - 1)
+		v, err = index.Get(e.k - 1)
 		require.NoError(err)
 		require.Equal(rangeTests[i-1].v, v)
 		v, err = index.Get(e.k)
@@ -82,7 +82,7 @@ func TestRangeIndex(t *testing.T) {
 		// test 5 random keys beyond new insertion
 		for j := 0; j < 5; j++ {
 			k := e.k + uint64(rand.Int())
-			v, err := index.Get(k)
+			v, err = index.Get(k)
 			require.NoError(err)
 			require.Equal(e.v, v)
 		}
@@ -193,7 +193,7 @@ func TestRangeIndex2(t *testing.T) {
 	for i := uint64(1); i < 6; i++ {
 		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
 		require.NoError(err)
-		v, err := index.Get(i)
+		v, err = index.Get(i)
 		require.NoError(err)
 		require.Equal(v, NotExist)
 	}
@@ -201,7 +201,7 @@ func TestRangeIndex2(t *testing.T) {
 	for i := uint64(7); i < 10; i++ {
 		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
 		require.NoError(err)
-		v, err := index.Get(i)
+		v, err = index.Get(i)
 		require.NoError(err)
 		require.Equal([]byte("7"), v)
 	}
@@ -212,7 +212,7 @@ func TestRangeIndex2(t *testing.T) {
 	require.NoError(err)
 	for i := uint64(7); i < 10; i++ {
 		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
-		v, err := index.Get(i)
+		v, err = index.Get(i)
 		require.NoError(err)
 		require.Equal([]byte("7777"), v)
 	}
@@ -238,7 +238,7 @@ func TestRangeIndex2(t *testing.T) {
 	for i := uint64(1); i < 66; i++ {
 		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
 		require.NoError(err)
-		v, err := index.Get(i)
+		v, err = index.Get(i)
 		require.NoError(err)
 		require.Equal(v, NotExist)
 	}
@@ -263,7 +263,7 @@ func TestRangeIndex2(t *testing.T) {
 	for i := uint64(1); i < 80; i++ {
 		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
 		require.NoError(err)
-		v, err := index.Get(i)
+		v, err = index.Get(i)
 		require.NoError(err)
 		require.Equal(v, NotExist)
 	}

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -31,6 +31,7 @@ func TestRangeIndex(t *testing.T) {
 		{7, []byte("seven")},
 		{29, []byte("twenty-nine")},
 		{100, []byte("hundred")},
+		{999, []byte("nine-nine-nine")},
 	}
 
 	path := "test-indexer"
@@ -93,7 +94,7 @@ func TestRangeIndex(t *testing.T) {
 	v, err = index.Get(rangeTests[1].k)
 	require.NoError(err)
 	require.Equal(rangeTests[0].v, v)
-	for i := 2; i <= 3; i++ {
+	for i := 2; i < len(rangeTests); i++ {
 		v, err = index.Get(rangeTests[i].k)
 		require.NoError(err)
 		require.Equal(rangeTests[i].v, v)
@@ -105,9 +106,179 @@ func TestRangeIndex(t *testing.T) {
 	// delete rangeTests[3].k
 	require.NoError(index.Delete(rangeTests[3].k))
 	v, err = index.Get(rangeTests[3].k)
+	for i := 2; i <= 3; i++ {
+		v, err = index.Get(rangeTests[i].k)
+		require.NoError(err)
+		require.Equal(rangeTests[2].v, v)
+		v, err = index.Get(rangeTests[i].k + 1)
+		require.NoError(err)
+		require.Equal(rangeTests[2].v, v)
+	}
+
+	// key 4 not affected
+	v, err = index.Get(rangeTests[4].k)
 	require.NoError(err)
-	require.Equal(rangeTests[2].v, v)
-	v, err = index.Get(rangeTests[3].k + 1)
+	require.Equal(rangeTests[4].v, v)
+	v, err = index.Get(rangeTests[4].k + 1)
 	require.NoError(err)
-	require.Equal(rangeTests[2].v, v)
+	require.Equal(rangeTests[4].v, v)
+
+	// add rangeTests[3].k back with a diff value
+	rangeTests[3].v = []byte("not-hundred")
+	require.NoError(index.Insert(rangeTests[3].k, rangeTests[3].v))
+	for i := 2; i < len(rangeTests); i++ {
+		v, err = index.Get(rangeTests[i].k)
+		require.NoError(err)
+		require.Equal(rangeTests[i].v, v)
+		v, err = index.Get(rangeTests[i].k + 1)
+		require.NoError(err)
+		require.Equal(rangeTests[i].v, v)
+	}
+
+	// purge rangeTests[3].k
+	require.NoError(index.Purge(rangeTests[3].k))
+	for i := 1; i <= 3; i++ {
+		v, err = index.Get(rangeTests[i].k)
+		require.NoError(err)
+		require.Equal(NotExist, v)
+		v, err = index.Get(rangeTests[i].k + 1)
+		require.NoError(err)
+		require.Equal(NotExist, v)
+	}
+
+	// key 4 not affected
+	v, err = index.Get(rangeTests[4].k)
+	require.NoError(err)
+	require.Equal(rangeTests[4].v, v)
+	v, err = index.Get(rangeTests[4].k + 1)
+	require.NoError(err)
+	require.Equal(rangeTests[4].v, v)
+}
+
+func TestRangeIndex2(t *testing.T) {
+	require := require.New(t)
+
+	path := "test-ranger"
+	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testPath := testFile.Name()
+	cfg := config.Default.DB
+	cfg.DbPath = testPath
+	testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPath(t, testPath)
+
+	kv := NewBoltDB(cfg)
+	require.NotNil(kv)
+
+	require.NoError(kv.Start(context.Background()))
+	defer func() {
+		require.NoError(kv.Stop(context.Background()))
+	}()
+
+	testNS := []byte("test")
+	index, err := kv.CreateRangeIndexNX(testNS, NotExist)
+	require.NoError(err)
+	// special case: insert 1
+	err = index.Insert(1, []byte("1"))
+	require.NoError(err)
+	v, err := index.Get(5)
+	require.NoError(err)
+	require.Equal([]byte("1"), v)
+
+	err = index.Purge(1)
+	require.NoError(err)
+
+	err = index.Insert(7, []byte("7"))
+	require.NoError(err)
+	// Case I: key before 7
+	for i := uint64(1); i < 6; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err := index.Get(i)
+		require.NoError(err)
+		require.Equal(v, NotExist)
+	}
+	// Case II: key is 7 and greater than 7
+	for i := uint64(7); i < 10; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err := index.Get(i)
+		require.NoError(err)
+		require.Equal([]byte("7"), v)
+	}
+	// Case III: duplicate key
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	require.NoError(err)
+	err = index.Insert(7, []byte("7777"))
+	require.NoError(err)
+	for i := uint64(7); i < 10; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		v, err := index.Get(i)
+		require.NoError(err)
+		require.Equal([]byte("7777"), v)
+	}
+	// Case IV: delete key less than 7
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	require.NoError(err)
+	err = index.Insert(66, []byte("66"))
+	require.NoError(err)
+	for i := uint64(1); i < 7; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		err = index.Delete(i)
+		require.NoError(err)
+	}
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	require.NoError(err)
+	v, err = index.Get(7)
+	require.NoError(err)
+	require.Equal([]byte("7777"), v)
+	// Case V: delete key 7
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	err = index.Purge(10)
+	require.NoError(err)
+	for i := uint64(1); i < 66; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err := index.Get(i)
+		require.NoError(err)
+		require.Equal(v, NotExist)
+	}
+	for i := uint64(66); i < 70; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err = index.Get(i)
+		require.Equal([]byte("66"), v)
+	}
+	// Case VI: delete key before 80,all keys deleted
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	err = index.Insert(70, []byte("70"))
+	require.NoError(err)
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	err = index.Insert(80, []byte("80"))
+	require.NoError(err)
+	err = index.Insert(91, []byte("91"))
+	require.NoError(err)
+	index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+	err = index.Purge(79)
+	require.NoError(err)
+	for i := uint64(1); i < 80; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err := index.Get(i)
+		require.NoError(err)
+		require.Equal(v, NotExist)
+	}
+	for i := uint64(80); i < 91; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err = index.Get(i)
+		require.NoError(err)
+		require.Equal([]byte("80"), v)
+	}
+	for i := uint64(91); i < 100; i++ {
+		index, err = kv.CreateRangeIndexNX(testNS, NotExist)
+		require.NoError(err)
+		v, err = index.Get(i)
+		require.NoError(err)
+		require.Equal([]byte("91"), v)
+	}
 }

--- a/db/trie/branchroottrie.go
+++ b/db/trie/branchroottrie.go
@@ -11,11 +11,12 @@ import (
 	"context"
 	"sync"
 
-	"github.com/iotexproject/iotex-core/db"
-
 	"github.com/golang/protobuf/proto"
 	"github.com/iotexproject/iotex-core/db/trie/triepb"
 	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 type (
@@ -29,6 +30,8 @@ type (
 		root      *branchNode
 		rootHash  []byte
 		rootKey   string
+		saveNode  bool
+		height    uint64 // height at which the trie is updated
 	}
 )
 
@@ -138,6 +141,13 @@ func (tr *branchRootTrie) DB() KVStore {
 
 func (tr *branchRootTrie) deleteNodeFromDB(tn Node) error {
 	h := tr.nodeHash(tn)
+	if tr.saveNode {
+		// mark the height-hash to be purged in later pruning
+		tag := byteutil.Uint64ToBytesBigEndian(tr.height)
+		if err := tr.kvStore.Purge(tag, h); err != nil {
+			return err
+		}
+	}
 	return tr.kvStore.Delete(h)
 }
 

--- a/db/trie/kvstore.go
+++ b/db/trie/kvstore.go
@@ -18,6 +18,8 @@ type KVStore interface {
 	Stop(context.Context) error
 	// Put puts key, value pair into KVStore
 	Put([]byte, []byte) error
+	// Purge marks a key for future deletion
+	Purge([]byte, []byte) error
 	// Delete deletes record from KVStore by key
 	Delete([]byte) error
 	// Get gets the value from KVStore by key
@@ -70,5 +72,9 @@ func (s *inMemKVStore) Delete(k []byte) error {
 	dbKey := castKeyType(k)
 	delete(s.kvpairs, dbKey)
 
+	return nil
+}
+
+func (s *inMemKVStore) Purge(tag, k []byte) error {
 	return nil
 }

--- a/db/trie/trie.go
+++ b/db/trie/trie.go
@@ -9,9 +9,8 @@ package trie
 import (
 	"context"
 
-	"github.com/pkg/errors"
-
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -101,6 +100,20 @@ func RootHashOption(h []byte) Option {
 		case *branchRootTrie:
 			t.rootHash = make([]byte, len(h))
 			copy(t.rootHash, h)
+		default:
+			return errors.New("invalid trie type")
+		}
+		return nil
+	}
+}
+
+// HistoryRetentionOption sets the save history option for the trie
+func HistoryRetentionOption(height uint64) Option {
+	return func(tr Trie) error {
+		switch t := tr.(type) {
+		case *branchRootTrie:
+			t.saveNode = true
+			t.height = height
 		default:
 			return errors.New("invalid trie type")
 		}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -721,7 +721,7 @@ func TestDeleteAndPutSameKey(t *testing.T) {
 		testDeleteAndPutSameKey(t, ws)
 	})
 	t.Run("stateTx", func(t *testing.T) {
-		ws := newStateTX(0, db.NewMemKVStore(), nil)
+		ws := newStateTX(0, db.NewMemKVStore(), nil, false)
 		testDeleteAndPutSameKey(t, ws)
 	})
 }

--- a/state/factory/statetx.go
+++ b/state/factory/statetx.go
@@ -9,12 +9,13 @@ package factory
 import (
 	"context"
 
+	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/execution/evm"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
@@ -27,6 +28,7 @@ type stateTX struct {
 	cb             db.CachedBatch // cached batch for pending writes
 	dao            db.KVStore     // the underlying DB for account/contract storage
 	actionHandlers []protocol.ActionHandler
+	saveHistory    bool
 }
 
 // newStateTX creates a new state tx
@@ -34,11 +36,13 @@ func newStateTX(
 	version uint64,
 	kv db.KVStore,
 	registry *protocol.Registry,
+	saveHistory bool,
 ) *stateTX {
 	st := &stateTX{
-		ver: version,
-		cb:  db.NewCachedBatch(),
-		dao: kv,
+		ver:         version,
+		cb:          db.NewCachedBatch(),
+		dao:         kv,
+		saveHistory: saveHistory,
 	}
 	if registry != nil {
 		for _, p := range registry.All() {
@@ -52,13 +56,25 @@ func newStateTX(
 func (stx *stateTX) RootHash() hash.Hash256 { return hash.ZeroHash256 }
 
 // Digest returns the delta state digest
-func (stx *stateTX) Digest() hash.Hash256 { return stx.GetCachedBatch().Digest() }
+func (stx *stateTX) Digest() hash.Hash256 {
+	var cb db.KVStoreBatch
+	if stx.saveHistory {
+		// exclude trie pruning entries before calculating digest
+		cb = stx.cb.ExcludeEntries(evm.PruneKVNameSpace, db.Put)
+	} else {
+		cb = stx.cb
+	}
+	return cb.Digest()
+}
 
 // Version returns the Version of this working set
 func (stx *stateTX) Version() uint64 { return stx.ver }
 
 // Height returns the Height of the block being worked on
 func (stx *stateTX) Height() uint64 { return stx.blkHeight }
+
+// History returns if the DB retains history
+func (stx *stateTX) History() bool { return stx.saveHistory }
 
 // RunActions runs actions in the block and track pending changes in working set
 func (stx *stateTX) RunActions(
@@ -141,7 +157,14 @@ func (stx *stateTX) Revert(snapshot int) error { return stx.cb.Revert(snapshot) 
 func (stx *stateTX) Commit() error {
 	// Commit all changes in a batch
 	dbBatchSizelMtc.WithLabelValues().Set(float64(stx.cb.Size()))
-	if err := stx.dao.Commit(stx.cb); err != nil {
+	var cb db.KVStoreBatch
+	if stx.saveHistory {
+		// exclude trie deletion
+		cb = stx.cb.ExcludeEntries(evm.ContractKVNameSpace, db.Delete)
+	} else {
+		cb = stx.cb
+	}
+	if err := stx.dao.Commit(cb); err != nil {
 		return errors.Wrap(err, "failed to Commit all changes to underlying DB in a batch")
 	}
 	return nil
@@ -183,6 +206,9 @@ func (stx *stateTX) PutState(pkHash hash.Hash160, s interface{}) error {
 		return errors.Wrapf(err, "failed to convert account %v to bytes", s)
 	}
 	stx.cb.Put(AccountKVNameSpace, pkHash[:], ss, "error when putting k = %x", pkHash)
+	if stx.saveHistory {
+		return stx.putIndex(pkHash, ss)
+	}
 	return nil
 }
 
@@ -195,4 +221,15 @@ func (stx *stateTX) DelState(pkHash hash.Hash160) error {
 // addActionHandlers adds action handlers to the state factory
 func (stx *stateTX) addActionHandlers(actionHandlers ...protocol.ActionHandler) {
 	stx.actionHandlers = append(stx.actionHandlers, actionHandlers...)
+}
+
+// putIndex insert height-state
+func (stx *stateTX) putIndex(pkHash hash.Hash160, ss []byte) error {
+	version := stx.ver + 1
+	ns := append([]byte(AccountKVNameSpace), pkHash[:]...)
+	ri, err := stx.dao.CreateRangeIndexNX(ns, db.NotExist)
+	if err != nil {
+		return err
+	}
+	return ri.Insert(version, ss)
 }

--- a/test/mock/mock_factory/mock_workingset.go
+++ b/test/mock/mock_factory/mock_workingset.go
@@ -179,6 +179,20 @@ func (mr *MockWorkingSetMockRecorder) Height() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockWorkingSet)(nil).Height))
 }
 
+// History mocks base method
+func (m *MockWorkingSet) History() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "History")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// History indicates an expected call of History
+func (mr *MockWorkingSetMockRecorder) History() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "History", reflect.TypeOf((*MockWorkingSet)(nil).History))
+}
+
 // State mocks base method
 func (m *MockWorkingSet) State(arg0 hash.Hash160, arg1 interface{}) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
1. for state, state is stored using a RangeIndex so that it can be retrieved later using specific height
2. for contract, "height-node" is marked for deletion and stored into a separate namespace, these nodes will be pruned later depending on height