### PR TITLE
Return Protocols in order

### DIFF
--- a/action/protocol/account/protocol_test.go
+++ b/action/protocol/account/protocol_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -65,7 +64,7 @@ func TestLoadOrCreateAccountState(t *testing.T) {
 }
 
 func TestProtocol_Initialize(t *testing.T) {
-	p := NewProtocol()
+	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
@@ -88,8 +87,8 @@ func TestProtocol_Initialize(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
+	p := NewProtocol()
 	require.NoError(
-		t,
 		p.Initialize(
 			protocol.WithRunActionsCtx(context.Background(), protocol.RunActionsCtx{
 				BlockHeight: 0,
@@ -107,9 +106,9 @@ func TestProtocol_Initialize(t *testing.T) {
 		),
 	)
 	acc0, err := accountutil.LoadOrCreateAccount(sm, identityset.Address(0).String(), big.NewInt(0))
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(100), acc0.Balance)
+	require.NoError(err)
+	require.Equal(big.NewInt(100), acc0.Balance)
 	acc1, err := accountutil.LoadOrCreateAccount(sm, identityset.Address(1).String(), big.NewInt(0))
-	require.NoError(t, err)
-	assert.Equal(t, big.NewInt(200), acc1.Balance)
+	require.NoError(err)
+	require.Equal(big.NewInt(200), acc1.Balance)
 }

--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -120,6 +120,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, act action.Action, sm pro
 			return nil, err
 		}
 	}
+
 	return &action.Receipt{
 		Status:          uint64(iotextypes.ReceiptStatus_Success),
 		BlockHeight:     raCtx.BlockHeight,

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -39,7 +39,6 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 	cfg := config.Default
 	ctx := context.Background()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
-	cm := mock_chainmanager.NewMockChainManager(ctrl)
 	cb := db.NewCachedBatch()
 	sm.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(addrHash hash.Hash160, account interface{}) error {
@@ -60,7 +59,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 		}).AnyTimes()
 
 	p := NewProtocol()
-	reward := rewarding.NewProtocol(cm, rolldpos.NewProtocol(1, 1, 1))
+	reward := rewarding.NewProtocol(nil, rolldpos.NewProtocol(1, 1, 1))
 	registry := protocol.Registry{}
 	require.NoError(registry.Register(rewarding.ProtocolID, reward))
 	require.NoError(

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -60,7 +60,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 
 	p := NewProtocol()
 	reward := rewarding.NewProtocol(nil, rolldpos.NewProtocol(1, 1, 1))
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	require.NoError(registry.Register(rewarding.ProtocolID, reward))
 	require.NoError(
 		reward.Initialize(
@@ -70,7 +70,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 					Producer:    identityset.Address(27),
 					Caller:      identityset.Address(28),
 					GasLimit:    testutil.TestGasLimit,
-					Registry:    &registry,
+					Registry:    registry,
 					Genesis:     cfg.Genesis,
 				}),
 			sm,
@@ -117,7 +117,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 			Caller:       identityset.Address(28),
 			GasLimit:     testutil.TestGasLimit,
 			IntrinsicGas: gas,
-			Registry:     &registry,
+			Registry:     registry,
 		})
 	receipt, err := p.Handle(ctx, transfer, sm)
 	require.NoError(err)

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/iotexproject/iotex-core/state"
 )
 
 type runActionsCtxKey struct{}
@@ -43,6 +44,8 @@ type RunActionsCtx struct {
 	IntrinsicGas uint64
 	// Nonce is the nonce of the action
 	Nonce uint64
+	// Candidates is a list of candidates of current round
+	Candidates []*state.Candidate
 	// Registry is the pointer protocol registry
 	Registry *Registry
 }

--- a/action/protocol/context_test.go
+++ b/action/protocol/context_test.go
@@ -23,7 +23,7 @@ func TestWithRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil, nil}
 	require.NotNil(WithRunActionsCtx(context.Background(), actionCtx))
 }
 
@@ -31,7 +31,7 @@ func TestGetRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil, nil}
 	ctx := WithRunActionsCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	ret, ok := GetRunActionsCtx(ctx)
@@ -43,7 +43,7 @@ func TestMustGetRunActionsCtx(t *testing.T) {
 	require := require.New(t)
 	addr, err := address.FromString("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms")
 	require.NoError(err)
-	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil}
+	actionCtx := RunActionsCtx{1111, time.Now(), 1, config.Default.Genesis, addr, addr, hash.ZeroHash256, nil, 0, 0, nil, nil}
 	ctx := WithRunActionsCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	// Case I: Normal

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -298,7 +298,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 		blockchain.InMemStateFactoryOption(),
 		blockchain.RegistryOption(&registry),
 	)
-	reward := rewarding.NewProtocol(bc, rp)
+	reward := rewarding.NewProtocol(nil, rp)
 	r.NoError(registry.Register(rewarding.ProtocolID, reward))
 
 	r.NotNil(bc)

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -205,7 +205,6 @@ func NewSmartContractTest(t *testing.T, file string) {
 
 func runExecution(
 	bc blockchain.Blockchain,
-	dao blockdao.BlockDAO,
 	ecfg *ExecutionConfig,
 	contractAddr string,
 ) ([]byte, *action.Receipt, error) {
@@ -230,7 +229,8 @@ func runExecution(
 		if err != nil {
 			return nil, nil, err
 		}
-		return bc.SimulateExecution(addr, exec)
+
+		return blockchain.SimulateExecution(bc, addr, exec)
 	}
 	builder := &action.EnvelopeBuilder{}
 	elp := builder.SetAction(exec).
@@ -262,7 +262,7 @@ func runExecution(
 	t2 := time.Now()
 	fmt.Println("exec time:", t1.Sub(t))
 	fmt.Println("commit time:", t2.Sub(t1))
-	receipt, err := dao.GetReceiptByActionHash(exec.Hash(), blk.Height())
+	receipt, err := bc.BlockDAO().GetReceiptByActionHash(exec.Hash(), blk.Height())
 
 	return nil, receipt, err
 }
@@ -270,7 +270,7 @@ func runExecution(
 func (sct *SmartContractTest) prepareBlockchain(
 	ctx context.Context,
 	r *require.Assertions,
-) (blockchain.Blockchain, blockdao.BlockDAO) {
+) blockchain.Blockchain {
 	cfg := config.Default
 	defer func() {
 		delete(cfg.Plugins, config.GatewayPlugin)
@@ -323,19 +323,18 @@ func (sct *SmartContractTest) prepareBlockchain(
 	_, err = ws.RunActions(ctx, 0, nil)
 	r.NoError(err)
 	r.NoError(sf.Commit(ws))
-	return bc, dao
+	return bc
 }
 
 func (sct *SmartContractTest) deployContracts(
 	bc blockchain.Blockchain,
-	dao blockdao.BlockDAO,
 	r *require.Assertions,
 ) (contractAddresses []string) {
 	for i, contract := range sct.Deployments {
 		if contract.AppendContractAddress {
 			contract.ContractAddressToAppend = contractAddresses[contract.ContractIndexToAppend]
 		}
-		_, receipt, err := runExecution(bc, dao, &contract, action.EmptyAddress)
+		_, receipt, err := runExecution(bc, &contract, action.EmptyAddress)
 		r.NoError(err)
 		r.NotNil(receipt)
 		if sct.InitGenesis.IsBering {
@@ -376,13 +375,13 @@ func (sct *SmartContractTest) deployContracts(
 func (sct *SmartContractTest) run(r *require.Assertions) {
 	// prepare blockchain
 	ctx := context.Background()
-	bc, dao := sct.prepareBlockchain(ctx, r)
+	bc := sct.prepareBlockchain(ctx, r)
 	defer func() {
 		r.NoError(bc.Stop(ctx))
 	}()
 
 	// deploy smart contract
-	contractAddresses := sct.deployContracts(bc, dao, r)
+	contractAddresses := sct.deployContracts(bc, r)
 	if len(contractAddresses) == 0 {
 		return
 	}
@@ -393,7 +392,7 @@ func (sct *SmartContractTest) run(r *require.Assertions) {
 		if exec.AppendContractAddress {
 			exec.ContractAddressToAppend = contractAddresses[exec.ContractIndexToAppend]
 		}
-		retval, receipt, err := runExecution(bc, dao, &exec, contractAddr)
+		retval, receipt, err := runExecution(bc, &exec, contractAddr)
 		r.NoError(err)
 		r.NotNil(receipt)
 

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -281,7 +281,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 	if sct.InitGenesis.IsBering {
 		cfg.Genesis.Blockchain.BeringBlockHeight = 0
 	}
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	r.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
@@ -296,7 +296,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 		cfg,
 		dao,
 		blockchain.InMemStateFactoryOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	reward := rewarding.NewProtocol(nil, rp)
 	r.NoError(registry.Register(rewarding.ProtocolID, reward))
@@ -464,7 +464,7 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Chain.IndexDBPath = testIndexPath
 		cfg.Chain.EnableAsyncIndexWrite = false
 		cfg.Genesis.EnableGravityChainVoting = false
-		registry := protocol.Registry{}
+		registry := protocol.NewRegistry()
 		acc := account.NewProtocol()
 		require.NoError(registry.Register(account.ProtocolID, acc))
 		rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
@@ -481,7 +481,7 @@ func TestProtocol_Handle(t *testing.T) {
 			cfg,
 			dao,
 			blockchain.DefaultStateFactoryOption(),
-			blockchain.RegistryOption(&registry),
+			blockchain.RegistryOption(registry),
 		)
 		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 		bc.Validator().AddActionValidators(account.NewProtocol(), NewProtocol(bc.BlockDAO().GetBlockHash))

--- a/action/protocol/poll/nativestaking.go
+++ b/action/protocol/poll/nativestaking.go
@@ -131,6 +131,7 @@ func (ns *NativeStaking) readBuckets(prevIndx, limit *big.Int, height uint64, ts
 	if len(pygg.CanNames) == 0 {
 		return nil, ErrEndOfData
 	}
+
 	buckets := make([]*types.Bucket, len(pygg.CanNames))
 	for i := range pygg.CanNames {
 		buckets[i], err = types.NewBucket(

--- a/action/protocol/poll/nativestaking.go
+++ b/action/protocol/poll/nativestaking.go
@@ -17,15 +17,12 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-election/types"
 )
 
 var (
-	dummyCaller, _ = address.FromString(address.ZeroAddress)
 	// ErrNoData is an error that there's no data in the contract
 	ErrNoData = errors.New("no data")
 	// ErrEndOfData is an error that reaching end of data in the contract
@@ -33,12 +30,13 @@ var (
 )
 
 type (
+	// ReadContract defines a callback function to read contract
+	ReadContract func(string, uint64, time.Time, []byte) ([]byte, error)
 	// NativeStaking represents native staking struct
 	NativeStaking struct {
-		cm              protocol.ChainManager
-		getTipBlockTime GetTipBlockTime
-		contract        string
-		abi             abi.ABI
+		readContract ReadContract
+		contract     string
+		abi          abi.ABI
 	}
 
 	pygg struct {
@@ -60,34 +58,28 @@ type (
 )
 
 // NewNativeStaking creates a NativeStaking instance
-func NewNativeStaking(cm protocol.ChainManager, getTipBlockTime GetTipBlockTime) (*NativeStaking, error) {
+func NewNativeStaking(readContract ReadContract) (*NativeStaking, error) {
 	abi, err := abi.JSON(strings.NewReader(NsAbi))
 	if err != nil {
 		return nil, err
 	}
-	if cm == nil {
+
+	if readContract == nil {
 		return nil, errors.New("failed to create native staking: empty chain manager")
 	}
-	if getTipBlockTime == nil {
-		return nil, errors.New("failed to create native staking: empty getBlockTime")
-	}
+
 	return &NativeStaking{
-		cm:              cm,
-		getTipBlockTime: getTipBlockTime,
-		abi:             abi,
+		abi:          abi,
+		readContract: readContract,
 	}, nil
 }
 
 // Votes returns the votes on height
-func (ns *NativeStaking) Votes() (*VoteTally, time.Time, error) {
+func (ns *NativeStaking) Votes(height uint64, ts time.Time) (*VoteTally, time.Time, error) {
 	if ns.contract == "" {
 		return nil, time.Time{}, ErrNoData
 	}
 
-	now, err := ns.getTipBlockTime()
-	if err != nil {
-		return nil, time.Time{}, errors.Wrap(err, "failed to get current block time")
-	}
 	// read voter list from staking contract
 	votes := VoteTally{
 		Candidates: make(map[[12]byte]*state.Candidate),
@@ -97,37 +89,32 @@ func (ns *NativeStaking) Votes() (*VoteTally, time.Time, error) {
 	limit := big.NewInt(256)
 
 	for {
-		vote, err := ns.readBuckets(prevIndex, limit)
+		vote, err := ns.readBuckets(prevIndex, limit, height, ts)
 		log.L().Debug("Read native buckets from contract", zap.Int("size", len(vote)))
 		if err == ErrEndOfData {
 			// all data been read
 			break
 		}
 		if err != nil {
-			return nil, now, err
+			return nil, ts, err
 		}
-		votes.tally(vote, now)
+		votes.tally(vote, ts)
 		if len(vote) < int(limit.Int64()) {
 			// all data been read
 			break
 		}
 		prevIndex.Add(prevIndex, limit)
 	}
-	return &votes, now, nil
+	return &votes, ts, nil
 }
 
-func (ns *NativeStaking) readBuckets(prevIndx, limit *big.Int) ([]*types.Bucket, error) {
+func (ns *NativeStaking) readBuckets(prevIndx, limit *big.Int, height uint64, ts time.Time) ([]*types.Bucket, error) {
 	data, err := ns.abi.Pack("getActivePyggs", prevIndx, limit)
 	if err != nil {
 		return nil, err
 	}
 
-	// read the staking contract
-	ex, err := action.NewExecution(ns.contract, 1, big.NewInt(0), 1000000, big.NewInt(0), data)
-	if err != nil {
-		return nil, err
-	}
-	data, _, err = ns.cm.SimulateExecution(dummyCaller, ex)
+	data, err = ns.readContract(ns.contract, height, ts, data)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/poll/nativestaking_test.go
+++ b/action/protocol/poll/nativestaking_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-election/types"
@@ -37,11 +36,9 @@ var (
 func TestStaking(t *testing.T) {
 	require := require.New(t)
 
-	mcm := &protocol.MockChainManager{}
-	getTime := func() (time.Time, error) { return time.Now(), nil }
-	ns, err := NewNativeStaking(mcm, nil)
-	require.Error(err)
-	ns, err = NewNativeStaking(mcm, getTime)
+	ns, err := NewNativeStaking(func(string, uint64, time.Time, []byte) ([]byte, error) {
+		return nil, nil
+	})
 	ns.SetContract("io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7")
 	require.NoError(err)
 

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -47,11 +47,11 @@ var ErrProposedDelegatesLength = errors.New("the proposed delegate list length")
 // ErrDelegatesNotAsExpected is an error that the delegates are not as expected
 var ErrDelegatesNotAsExpected = errors.New("delegates are not as expected")
 
+// CandidatesByHeight returns the candidates of a given height
+type CandidatesByHeight func(uint64) ([]*state.Candidate, error)
+
 // GetBlockTime defines a function to get block creation time
 type GetBlockTime func(uint64) (time.Time, error)
-
-// GetTipBlockTime defines a function to get tip block creation time
-type GetTipBlockTime func() (time.Time, error)
 
 // GetEpochHeight defines a function to get the corresponding epoch height given an epoch number
 type GetEpochHeight func(uint64) uint64
@@ -84,10 +84,10 @@ type lifeLongDelegatesProtocol struct {
 // NewProtocol instantiates a rewarding protocol instance.
 func NewProtocol(
 	cfg config.Config,
-	cm protocol.ChainManager,
+	readContract ReadContract,
+	candidatesByHeight CandidatesByHeight,
 	electionCommittee committee.Committee,
 	getBlockTimeFunc GetBlockTime,
-	getBlockTipHeightFunc GetTipBlockTime,
 	rp *rolldpos.Protocol) (Protocol, error) {
 	genesisConfig := cfg.Genesis
 	if cfg.Consensus.Scheme == config.RollDPoSScheme && genesisConfig.EnableGravityChainVoting {
@@ -96,7 +96,7 @@ func NewProtocol(
 		if genesisConfig.GravityChainStartHeight != 0 && electionCommittee != nil {
 			var governance Protocol
 			if governance, err = NewGovernanceChainCommitteeProtocol(
-				cm,
+				candidatesByHeight,
 				electionCommittee,
 				genesisConfig.GravityChainStartHeight,
 				getBlockTimeFunc,
@@ -115,8 +115,8 @@ func NewProtocol(
 			if pollProtocol, err = NewStakingCommittee(
 				electionCommittee,
 				governance,
-				cm,
-				getBlockTipHeightFunc,
+				readContract,
+				getBlockTimeFunc,
 				rp.GetEpochHeight,
 				rp.GetEpochNum,
 				cfg.Genesis.NativeStakingContractAddress,
@@ -213,7 +213,7 @@ func (p *lifeLongDelegatesProtocol) readBlockProducers() ([]byte, error) {
 }
 
 type governanceChainCommitteeProtocol struct {
-	cm                        protocol.ChainManager
+	candidatesByHeight        CandidatesByHeight
 	getBlockTime              GetBlockTime
 	getEpochHeight            GetEpochHeight
 	getEpochNum               GetEpochNum
@@ -227,7 +227,7 @@ type governanceChainCommitteeProtocol struct {
 
 // NewGovernanceChainCommitteeProtocol creates a Poll Protocol which fetch result from governance chain
 func NewGovernanceChainCommitteeProtocol(
-	cm protocol.ChainManager,
+	candidatesByHeight CandidatesByHeight,
 	electionCommittee committee.Committee,
 	initGravityChainHeight uint64,
 	getBlockTime GetBlockTime,
@@ -257,7 +257,7 @@ func NewGovernanceChainCommitteeProtocol(
 		log.L().Panic("Error when constructing the address of poll protocol", zap.Error(err))
 	}
 	return &governanceChainCommitteeProtocol{
-		cm:                        cm,
+		candidatesByHeight:        candidatesByHeight,
 		electionCommittee:         electionCommittee,
 		initGravityChainHeight:    initGravityChainHeight,
 		getBlockTime:              getBlockTime,
@@ -409,7 +409,7 @@ func (p *governanceChainCommitteeProtocol) SetNativeStakingContract(contract str
 
 func (p *governanceChainCommitteeProtocol) readDelegatesByEpoch(epochNum uint64) (state.CandidateList, error) {
 	epochHeight := p.getEpochHeight(epochNum)
-	return p.cm.CandidatesByHeight(epochHeight)
+	return p.candidatesByHeight(epochHeight)
 }
 
 func (p *governanceChainCommitteeProtocol) readBlockProducersByEpoch(epochNum uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -28,6 +28,7 @@ import (
 )
 
 type stakingCommittee struct {
+	candidatesByHeight   CandidatesByHeight
 	getBlockTime         GetBlockTime
 	getEpochHeight       GetEpochHeight
 	getEpochNum          GetEpochNum
@@ -44,6 +45,7 @@ func NewStakingCommittee(
 	ec committee.Committee,
 	gs Protocol,
 	readContract ReadContract,
+	candidatesByHeight CandidatesByHeight,
 	getBlockTime GetBlockTime,
 	getEpochHeight GetEpochHeight,
 	getEpochNum GetEpochNum,
@@ -73,14 +75,15 @@ func NewStakingCommittee(
 		}
 	}
 	return &stakingCommittee{
-		electionCommittee: ec,
-		governanceStaking: gs,
-		nativeStaking:     ns,
-		getBlockTime:      getBlockTime,
-		getEpochHeight:    getEpochHeight,
-		getEpochNum:       getEpochNum,
-		rp:                rp,
-		scoreThreshold:    scoreThreshold,
+		candidatesByHeight: candidatesByHeight,
+		electionCommittee:  ec,
+		governanceStaking:  gs,
+		nativeStaking:      ns,
+		getBlockTime:       getBlockTime,
+		getEpochHeight:     getEpochHeight,
+		getEpochNum:        getEpochNum,
+		rp:                 rp,
+		scoreThreshold:     scoreThreshold,
 	}, nil
 }
 
@@ -129,6 +132,10 @@ func (sc *stakingCommittee) DelegatesByHeight(hu config.HeightUpgrade, height ui
 	}
 	sc.currentNativeBuckets = nativeVotes.Buckets
 	return sc.mergeDelegates(cand, nativeVotes, ts), nil
+}
+
+func (sc *stakingCommittee) CandidatesByHeight(height uint64) (state.CandidateList, error) {
+	return sc.candidatesByHeight(sc.getEpochHeight(sc.getEpochNum(height)))
 }
 
 func (sc *stakingCommittee) ReadState(ctx context.Context, sm protocol.StateManager, method []byte, args ...[]byte) ([]byte, error) {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -134,6 +134,10 @@ func (sc *stakingCommittee) DelegatesByHeight(hu config.HeightUpgrade, height ui
 	return sc.mergeDelegates(cand, nativeVotes, ts), nil
 }
 
+func (sc *stakingCommittee) DelegatesByEpoch(ctx context.Context, epochNum uint64) (state.CandidateList, error) {
+	return sc.governanceStaking.DelegatesByEpoch(ctx, epochNum)
+}
+
 func (sc *stakingCommittee) CandidatesByHeight(height uint64) (state.CandidateList, error) {
 	return sc.candidatesByHeight(sc.getEpochHeight(sc.getEpochNum(height)))
 }

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -15,7 +15,6 @@ import (
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/db"
-	"github.com/iotexproject/iotex-core/state"
 )
 
 var (
@@ -51,8 +50,6 @@ type ActionHandler interface {
 type ChainManager interface {
 	// ChainID returns the chain ID
 	ChainID() uint32
-	// CandidatesByHeight returns the candidate list by a given height
-	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
 	// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
 	ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error)
 }
@@ -86,11 +83,6 @@ func (m *MockChainManager) Nonce(addr string) (uint64, error) {
 // ChainID return chain ID
 func (m *MockChainManager) ChainID() uint32 {
 	return 0
-}
-
-// CandidatesByHeight returns the candidate list by a given height
-func (m *MockChainManager) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
-	return nil, nil
 }
 
 // ProductivityByEpoch returns the number of produced blocks per delegate in an epoch

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -8,7 +8,6 @@ package protocol
 
 import (
 	"context"
-	"strings"
 
 	"github.com/pkg/errors"
 
@@ -46,14 +45,6 @@ type ActionHandler interface {
 	Handle(context.Context, action.Action, StateManager) (*action.Receipt, error)
 }
 
-// ChainManager defines the blockchain interface
-type ChainManager interface {
-	// ChainID returns the chain ID
-	ChainID() uint32
-	// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
-	ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error)
-}
-
 // StateManager defines the state DB interface atop IoTeX blockchain
 type StateManager interface {
 	// Accounts
@@ -66,26 +57,4 @@ type StateManager interface {
 	DelState(pkHash hash.Hash160) error
 	GetDB() db.KVStore
 	GetCachedBatch() db.CachedBatch
-}
-
-// MockChainManager mocks ChainManager interface
-type MockChainManager struct {
-}
-
-// Nonce mocks base method
-func (m *MockChainManager) Nonce(addr string) (uint64, error) {
-	if strings.EqualFold("io1emxf8zzqckhgjde6dqd97ts0y3q496gm3fdrl6", addr) {
-		return 0, errors.New("MockChainManager nonce error")
-	}
-	return 2, nil
-}
-
-// ChainID return chain ID
-func (m *MockChainManager) ChainID() uint32 {
-	return 0
-}
-
-// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
-func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
-	return 0, nil, nil
 }

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -56,8 +55,6 @@ type ChainManager interface {
 	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
 	// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
 	ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error)
-	// SimulateExecution simulates a running of smart contract operation
-	SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error)
 }
 
 // StateManager defines the state DB interface atop IoTeX blockchain
@@ -99,9 +96,4 @@ func (m *MockChainManager) CandidatesByHeight(height uint64) ([]*state.Candidate
 // ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
 func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
 	return 0, nil, nil
-}
-
-// SimulateExecution simulates a running of smart contract operation
-func (m *MockChainManager) SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
-	return nil, nil, nil
 }

--- a/action/protocol/registry.go
+++ b/action/protocol/registry.go
@@ -10,53 +10,73 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-
-	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 // Registry is the hub of all protocols deployed on the chain
 type Registry struct {
-	protocols sync.Map
+	mu        sync.RWMutex
+	ids       map[string]int
+	protocols []Protocol
+}
+
+// NewRegistry create a new Registry
+func NewRegistry() *Registry {
+	return &Registry{
+		ids:       make(map[string]int, 0),
+		protocols: make([]Protocol, 0),
+	}
+}
+
+func (r *Registry) register(id string, p Protocol, force bool) error {
+	idx, loaded := r.ids[id]
+	if loaded {
+		if !force {
+			return errors.Errorf("Protocol with ID %s is already registered", id)
+		}
+		r.protocols[idx] = p
+
+		return nil
+	}
+	r.ids[id] = len(r.ids)
+	r.protocols = append(r.protocols, p)
+
+	return nil
 }
 
 // Register registers the protocol with a unique ID
 func (r *Registry) Register(id string, p Protocol) error {
-	_, loaded := r.protocols.LoadOrStore(id, p)
-	if loaded {
-		return errors.Errorf("Protocol with ID %s is already registered", id)
-	}
-	return nil
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.register(id, p, false)
 }
 
 // ForceRegister registers the protocol with a unique ID and force replacing the previous protocol if it exists
 func (r *Registry) ForceRegister(id string, p Protocol) error {
-	r.protocols.Store(id, p)
-	return nil
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return r.register(id, p, true)
 }
 
 // Find finds a protocol by ID
 func (r *Registry) Find(id string) (Protocol, bool) {
-	value, ok := r.protocols.Load(id)
-	if !ok {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	idx, loaded := r.ids[id]
+	if !loaded {
 		return nil, false
 	}
-	p, ok := value.(Protocol)
-	if !ok {
-		log.S().Panic("Registry stores the item which is not a protocol")
-	}
-	return p, true
+
+	return r.protocols[idx], true
 }
 
 // All returns all protocols
 func (r *Registry) All() []Protocol {
-	all := make([]Protocol, 0)
-	r.protocols.Range(func(_, value interface{}) bool {
-		p, ok := value.(Protocol)
-		if !ok {
-			log.S().Panic("Registry stores the item which is not a protocol")
-		}
-		all = append(all, p)
-		return true
-	})
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	all := make([]Protocol, len(r.protocols))
+	copy(all, r.protocols)
+
 	return all
 }

--- a/action/protocol/registry_test.go
+++ b/action/protocol/registry_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestRegister(t *testing.T) {
 	require := require.New(t)
-	reg := &Registry{}
+	reg := NewRegistry()
 	// Case I: Normal
 	require.NoError(reg.Register("1", nil))
 	// Case II: Protocol with ID is already registered
@@ -24,7 +24,7 @@ func TestRegister(t *testing.T) {
 }
 func TestFind(t *testing.T) {
 	require := require.New(t)
-	reg := &Registry{}
+	reg := NewRegistry()
 	p := &MockProtocol{}
 	require.NoError(reg.Register("1", p))
 	// Case I: Normal
@@ -35,18 +35,22 @@ func TestFind(t *testing.T) {
 	require.False(ok)
 	// Case III: Registry stores the item which is not a protocol
 	require.NoError(reg.Register("2", nil))
-	require.Panics(func() { reg.Find("2") }, "Registry stores the item which is not a protocol")
+	require.Nil(reg.Find("2"))
 }
+
 func TestAll(t *testing.T) {
 	require := require.New(t)
-	reg := &Registry{}
+	reg := NewRegistry()
 	p := &MockProtocol{}
 	require.NoError(reg.Register("1", p))
 	// Case I: Normal
 	require.Equal(1, len(reg.All()))
 	// Case II: Registry stores the item which is not a protocol
 	require.NoError(reg.Register("2", nil))
-	require.Panics(func() { reg.All() }, "Registry stores the item which is not a protocol")
+	all := reg.All()
+	require.Equal(2, len(all))
+	require.Equal(all[0], p)
+	require.Nil(all[1])
 }
 
 type MockProtocol struct {

--- a/action/protocol/rewarding/fund_test.go
+++ b/action/protocol/rewarding/fund_test.go
@@ -45,9 +45,9 @@ func TestProtocol_Fund(t *testing.T) {
 
 func TestDepositNegativeGasFee(t *testing.T) {
 	testProtocol(t, func(t *testing.T, ctx context.Context, sm protocol.StateManager, p *Protocol) {
-		r := protocol.Registry{}
+		r := protocol.NewRegistry()
 		r.Register(ProtocolID, p)
 
-		require.Error(t, DepositGas(ctx, sm, big.NewInt(-1), &r))
+		require.Error(t, DepositGas(ctx, sm, big.NewInt(-1), r))
 	}, false)
 }

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -39,28 +39,31 @@ var (
 	exemptKey                   = []byte("xpt")
 )
 
+// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
+type ProductivityByEpoch func(uint64) (uint64, map[string]uint64, error)
+
 // Protocol defines the protocol of the rewarding fund and the rewarding process. It allows the admin to config the
 // reward amount, users to donate tokens to the fund, block producers to grant them block and epoch reward and,
 // beneficiaries to claim the balance into their personal account.
 type Protocol struct {
-	cm        protocol.ChainManager
-	keyPrefix []byte
-	addr      address.Address
-	rp        *rolldpos.Protocol
+	productivityByEpoch ProductivityByEpoch
+	keyPrefix           []byte
+	addr                address.Address
+	rp                  *rolldpos.Protocol
 }
 
 // NewProtocol instantiates a rewarding protocol instance.
-func NewProtocol(cm protocol.ChainManager, rp *rolldpos.Protocol) *Protocol {
+func NewProtocol(productivityByEpoch ProductivityByEpoch, rp *rolldpos.Protocol) *Protocol {
 	h := hash.Hash160b([]byte(ProtocolID))
 	addr, err := address.FromBytes(h[:])
 	if err != nil {
 		log.L().Panic("Error when constructing the address of rewarding protocol", zap.Error(err))
 	}
 	return &Protocol{
-		cm:        cm,
-		keyPrefix: h[:],
-		addr:      addr,
-		rp:        rp,
+		productivityByEpoch: productivityByEpoch,
+		keyPrefix:           h[:],
+		addr:                addr,
+		rp:                  rp,
 	}
 }
 

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -55,19 +55,17 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 			return nil
 		}).AnyTimes()
 
-	chain := mock_chainmanager.NewMockChainManager(ctrl)
-	chain.EXPECT().ProductivityByEpoch(gomock.Any()).Return(
-		uint64(19),
-		map[string]uint64{
-			identityset.Address(27).String(): 3,
-			identityset.Address(28).String(): 7,
-			identityset.Address(29).String(): 1,
-			identityset.Address(30).String(): 6,
-			identityset.Address(31).String(): 2,
-		},
-		nil,
-	).AnyTimes()
-	p := NewProtocol(chain, rolldpos.NewProtocol(
+	p := NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+		return uint64(19),
+			map[string]uint64{
+				identityset.Address(27).String(): 3,
+				identityset.Address(28).String(): 7,
+				identityset.Address(29).String(): 1,
+				identityset.Address(30).String(): 6,
+				identityset.Address(31).String(): 2,
+			},
+			nil
+	}, rolldpos.NewProtocol(
 		genesis.Default.NumCandidateDelegates,
 		genesis.Default.NumDelegates,
 		genesis.Default.NumSubEpochs,
@@ -219,13 +217,14 @@ func TestProtocol_Handle(t *testing.T) {
 	sm.EXPECT().Snapshot().Return(1).AnyTimes()
 	sm.EXPECT().Revert(gomock.Any()).Return(nil).AnyTimes()
 
-	chain := mock_chainmanager.NewMockChainManager(ctrl)
 	rp := rolldpos.NewProtocol(
 		cfg.Genesis.NumCandidateDelegates,
 		cfg.Genesis.NumDelegates,
 		cfg.Genesis.NumSubEpochs,
 	)
-	p := NewProtocol(chain, rp)
+	p := NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+		return 0, nil, nil
+	}, rp)
 
 	ctx := protocol.WithRunActionsCtx(
 		context.Background(),

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -413,7 +413,7 @@ func (p *Protocol) unqualifiedDelegates(
 	productivityThreshold uint64,
 ) (map[string]interface{}, error) {
 	unqualifiedDelegates := make(map[string]interface{}, 0)
-	numBlks, produce, err := p.cm.ProductivityByEpoch(epochNum)
+	numBlks, produce, err := p.productivityByEpoch(epochNum)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -72,15 +72,9 @@ func (p *Protocol) GrantBlockReward(
 		return nil, err
 	}
 
-	// Get the reward address for the block producer
-	epochNum := p.rp.GetEpochNum(raCtx.BlockHeight)
-	candidates, err := p.cm.CandidatesByHeight(p.rp.GetEpochHeight(epochNum))
-	if err != nil {
-		return nil, err
-	}
 	producerAddrStr := raCtx.Producer.String()
 	rewardAddrStr := ""
-	for _, candidate := range candidates {
+	for _, candidate := range raCtx.Candidates {
 		if candidate.Address == producerAddrStr {
 			rewardAddrStr = candidate.RewardAddress
 			break
@@ -144,11 +138,6 @@ func (p *Protocol) GrantEpochReward(
 	if err := p.state(sm, adminKey, &a); err != nil {
 		return nil, err
 	}
-	// We need to consistently use the votes on of first block height in this epoch
-	candidates, err := p.cm.CandidatesByHeight(p.rp.GetEpochHeight(epochNum))
-	if err != nil {
-		return nil, err
-	}
 
 	// Get the delegate list who exempts epoch reward
 	e := exempt{}
@@ -166,6 +155,7 @@ func (p *Protocol) GrantEpochReward(
 		return nil, err
 	}
 
+	candidates := raCtx.Candidates
 	addrs, amounts, err := p.splitEpochReward(sm, candidates, a.epochReward, a.numDelegatesForEpochReward, exemptAddrs, uqd)
 	if err != nil {
 		return nil, err

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -291,18 +291,6 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 		}).AnyTimes()
 
 	chain := mock_chainmanager.NewMockChainManager(ctrl)
-	chain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
-		{
-			Address:       identityset.Address(0).String(),
-			Votes:         unit.ConvertIotxToRau(1000000),
-			RewardAddress: "",
-		},
-		{
-			Address:       identityset.Address(1).String(),
-			Votes:         unit.ConvertIotxToRau(1000000),
-			RewardAddress: identityset.Address(1).String(),
-		},
-	}, nil).AnyTimes()
 	chain.EXPECT().ProductivityByEpoch(gomock.Any()).Return(
 		uint64(19),
 		map[string]uint64{
@@ -350,6 +338,18 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 			Producer:    identityset.Address(0),
 			Caller:      identityset.Address(0),
 			BlockHeight: genesis.Default.NumDelegates * genesis.Default.NumSubEpochs,
+			Candidates: []*state.Candidate{
+				{
+					Address:       identityset.Address(0).String(),
+					Votes:         unit.ConvertIotxToRau(1000000),
+					RewardAddress: "",
+				},
+				{
+					Address:       identityset.Address(1).String(),
+					Votes:         unit.ConvertIotxToRau(1000000),
+					RewardAddress: identityset.Address(1).String(),
+				},
+			},
 		},
 	)
 	require.NoError(t, p.Deposit(ctx, sm, big.NewInt(200)))

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -290,16 +290,14 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
-	chain := mock_chainmanager.NewMockChainManager(ctrl)
-	chain.EXPECT().ProductivityByEpoch(gomock.Any()).Return(
-		uint64(19),
-		map[string]uint64{
-			identityset.Address(0).String(): 9,
-			identityset.Address(1).String(): 10,
-		},
-		nil,
-	).AnyTimes()
-	p := NewProtocol(chain, rolldpos.NewProtocol(
+	p := NewProtocol(func(uint64) (uint64, map[string]uint64, error) {
+		return uint64(19),
+			map[string]uint64{
+				identityset.Address(0).String(): 9,
+				identityset.Address(1).String(): 10,
+			},
+			nil
+	}, rolldpos.NewProtocol(
 		genesis.Default.NumCandidateDelegates,
 		genesis.Default.NumDelegates,
 		genesis.Default.NumSubEpochs,

--- a/action/protocol/rolldpos/epoch.go
+++ b/action/protocol/rolldpos/epoch.go
@@ -30,6 +30,22 @@ type Protocol struct {
 	dardanellesOn           bool
 }
 
+// MustGetProtocol return a registered protocol from registry
+func MustGetProtocol(registry *protocol.Registry) *Protocol {
+	if registry == nil {
+		log.S().Panic("registry cannot be nil")
+	}
+	p, ok := registry.Find(ProtocolID)
+	if !ok {
+		log.S().Panic("rolldpos protocol is not registered")
+	}
+	rp, ok := p.(*Protocol)
+	if !ok {
+		log.S().Panic("fail to cast rolldpos protocol")
+	}
+	return rp
+}
+
 // Option is optional setting for epoch protocol
 type Option func(*Protocol) error
 

--- a/api/api.go
+++ b/api/api.go
@@ -497,7 +497,7 @@ func (api *Server) GetEpochMeta(
 		GravityChainStartHeight: gravityChainStartHeight,
 	}
 
-	numBlks, produce, err := api.bc.ProductivityByEpoch(in.EpochNumber)
+	numBlks, produce, err := blockchain.ProductivityByEpoch(api.bc, in.EpochNumber)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1220,7 +1220,6 @@ func TestServer_ReadDelegatesByEpoch(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mbc := mock_blockchain.NewMockBlockchain(ctrl)
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1234,7 +1233,6 @@ func TestServer_ReadDelegatesByEpoch(t *testing.T) {
 			RewardAddress: "rewardAddress",
 		},
 	}
-	mbc.EXPECT().CandidatesByHeight(gomock.Any()).Return(candidates, nil).Times(1)
 
 	for _, test := range readDelegatesByEpochTests {
 		var pol poll.Protocol
@@ -1243,7 +1241,7 @@ func TestServer_ReadDelegatesByEpoch(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				mbc,
+				func(uint64) ([]*state.Candidate, error) { return candidates, nil },
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1276,7 +1274,6 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mbc := mock_blockchain.NewMockBlockchain(ctrl)
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1290,7 +1287,6 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 			RewardAddress: "rewardAddress",
 		},
 	}
-	mbc.EXPECT().CandidatesByHeight(gomock.Any()).Return(candidates, nil).Times(2)
 
 	for _, test := range readBlockProducersByEpochTests {
 		var pol poll.Protocol
@@ -1299,7 +1295,7 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				mbc,
+				func(uint64) ([]*state.Candidate, error) { return candidates, nil },
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1332,7 +1328,6 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	mbc := mock_blockchain.NewMockBlockchain(ctrl)
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1346,7 +1341,6 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 			RewardAddress: "rewardAddress",
 		},
 	}
-	mbc.EXPECT().CandidatesByHeight(gomock.Any()).Return(candidates, nil).Times(2)
 
 	for _, test := range readActiveBlockProducersByEpochTests {
 		var pol poll.Protocol
@@ -1355,7 +1349,7 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				mbc,
+				func(uint64) ([]*state.Candidate, error) { return candidates, nil },
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1430,10 +1424,10 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			require.NoError(svr.registry.ForceRegister(poll.ProtocolID, pol))
 		} else if test.pollProtocolType == "governanceChainCommittee" {
 			committee := mock_committee.NewMockCommittee(ctrl)
-			mbc := mock_blockchain.NewMockBlockchain(ctrl)
 			msf := mock_factory.NewMockFactory(ctrl)
+			mbc := mock_blockchain.NewMockBlockchain(ctrl)
 			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
-				mbc,
+				mbc.CandidatesByHeight,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1445,9 +1439,6 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			)
 			require.NoError(svr.registry.ForceRegister(poll.ProtocolID, pol))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)
-			mbc.EXPECT().TipHeight().Return(uint64(4)).Times(2)
-			mbc.EXPECT().Factory().Return(msf).Times(2)
-			msf.EXPECT().NewWorkingSet().Return(nil, nil).Times(2)
 
 			candidates := []*state.Candidate{
 				{
@@ -1487,6 +1478,9 @@ func TestServer_GetEpochMeta(t *testing.T) {
 				"address3": uint64(1),
 				"address4": uint64(1),
 			}
+			mbc.EXPECT().TipHeight().Return(uint64(4)).Times(2)
+			mbc.EXPECT().Factory().Return(msf).Times(2)
+			msf.EXPECT().NewWorkingSet().Return(nil, nil).Times(2)
 			mbc.EXPECT().ProductivityByEpoch(test.EpochNumber).Return(uint64(4), blksPerDelegate, nil).Times(1)
 			mbc.EXPECT().CandidatesByHeight(uint64(1)).
 				Return(candidates, nil).Times(1)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1776,12 +1776,12 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 		return nil, nil, nil, nil, errors.New("failed to create blockdao")
 	}
 	// create chain
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	bc := blockchain.NewBlockchain(
 		cfg,
 		dao,
 		blockchain.PrecreatedStateFactoryOption(sf),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	if bc == nil {
 		return nil, nil, nil, nil, errors.New("failed to create blockchain")
@@ -1822,7 +1822,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 	bc.Validator().AddActionValidators(acc, evm, r)
 
-	return bc, dao, indexer, &registry, nil
+	return bc, dao, indexer, registry, nil
 }
 
 func setupActPool(bc blockchain.Blockchain, cfg config.ActPool) (actpool.ActPool, error) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -702,7 +702,7 @@ var (
 			topics:    []*iotexapi.Topics{},
 			fromBlock: 1,
 			count:     100,
-			numLogs:   0,
+			numLogs:   4,
 		},
 	}
 )
@@ -1427,7 +1427,40 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			msf := mock_factory.NewMockFactory(ctrl)
 			mbc := mock_blockchain.NewMockBlockchain(ctrl)
 			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
-				mbc.CandidatesByHeight,
+				func(uint64) ([]*state.Candidate, error) {
+					return []*state.Candidate{
+						{
+							Address:       "address1",
+							Votes:         big.NewInt(6),
+							RewardAddress: "rewardAddress",
+						},
+						{
+							Address:       "address2",
+							Votes:         big.NewInt(5),
+							RewardAddress: "rewardAddress",
+						},
+						{
+							Address:       "address3",
+							Votes:         big.NewInt(4),
+							RewardAddress: "rewardAddress",
+						},
+						{
+							Address:       "address4",
+							Votes:         big.NewInt(3),
+							RewardAddress: "rewardAddress",
+						},
+						{
+							Address:       "address5",
+							Votes:         big.NewInt(2),
+							RewardAddress: "rewardAddress",
+						},
+						{
+							Address:       "address6",
+							Votes:         big.NewInt(1),
+							RewardAddress: "rewardAddress",
+						},
+					}, nil
+				},
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1440,38 +1473,6 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			require.NoError(svr.registry.ForceRegister(poll.ProtocolID, pol))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)
 
-			candidates := []*state.Candidate{
-				{
-					Address:       "address1",
-					Votes:         big.NewInt(6),
-					RewardAddress: "rewardAddress",
-				},
-				{
-					Address:       "address2",
-					Votes:         big.NewInt(5),
-					RewardAddress: "rewardAddress",
-				},
-				{
-					Address:       "address3",
-					Votes:         big.NewInt(4),
-					RewardAddress: "rewardAddress",
-				},
-				{
-					Address:       "address4",
-					Votes:         big.NewInt(3),
-					RewardAddress: "rewardAddress",
-				},
-				{
-					Address:       "address5",
-					Votes:         big.NewInt(2),
-					RewardAddress: "rewardAddress",
-				},
-				{
-					Address:       "address6",
-					Votes:         big.NewInt(1),
-					RewardAddress: "rewardAddress",
-				},
-			}
 			blksPerDelegate := map[string]uint64{
 				"address1": uint64(1),
 				"address2": uint64(1),
@@ -1482,8 +1483,6 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			mbc.EXPECT().Factory().Return(msf).Times(2)
 			msf.EXPECT().NewWorkingSet().Return(nil, nil).Times(2)
 			mbc.EXPECT().ProductivityByEpoch(test.EpochNumber).Return(uint64(4), blksPerDelegate, nil).Times(1)
-			mbc.EXPECT().CandidatesByHeight(uint64(1)).
-				Return(candidates, nil).Times(1)
 			svr.bc = mbc
 		}
 		res, err := svr.GetEpochMeta(context.Background(), &iotexapi.GetEpochMetaRequest{EpochNumber: test.EpochNumber})

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -98,6 +98,7 @@ type Blockchain interface {
 	RecoverChainAndState(targetHeight uint64) error
 	// Genesis returns the genesis
 	Genesis() genesis.Genesis
+	RunActionsContext() (*protocol.RunActionsCtx, error)
 
 	// For block operations
 	// MintNewBlock creates a new block with given actions
@@ -117,16 +118,33 @@ type Blockchain interface {
 	// SetValidator sets the current validator object
 	SetValidator(val Validator)
 
-	// For smart contract operations
-	// SimulateExecution simulates a running of smart contract operation, this is done off the network since it does not
-	// cause any state change
-	SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error)
-
 	// AddSubscriber make you listen to every single produced block
 	AddSubscriber(BlockCreationSubscriber) error
 
 	// RemoveSubscriber make you listen to every single produced block
 	RemoveSubscriber(BlockCreationSubscriber) error
+}
+
+// SimulateExecution simulates a running of smart contract operation, this is done off the network since it does not
+// cause any state change
+func SimulateExecution(bc Blockchain, caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
+	ws, err := bc.Factory().NewWorkingSet()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to obtain working set from state factory")
+	}
+
+	raCtx, err := bc.RunActionsContext()
+	if err != nil {
+		return nil, nil, err
+	}
+	raCtx.Caller = caller
+
+	return evm.ExecuteContract(
+		protocol.WithRunActionsCtx(context.Background(), *raCtx),
+		ws,
+		ex,
+		bc.BlockDAO().GetBlockHash,
+	)
 }
 
 // blockchain implements the Blockchain interface
@@ -376,11 +394,15 @@ func (bc *blockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[string]u
 	if !ok {
 		return 0, nil, errors.New("poll protocol is not registered")
 	}
-	ctx := protocol.WithRunActionsCtx(context.Background(), protocol.RunActionsCtx{
-		BlockHeight: bc.tipHeight,
-		Registry:    bc.registry,
-		Genesis:     bc.config.Genesis,
-	})
+
+	// TODO: move the function out of blockchain
+	// This is a weird call, which shows that the function should not be an API of blockchain
+	raCtx, err := bc.RunActionsContext()
+	if err != nil {
+		return 0, nil, err
+	}
+
+	ctx := protocol.WithRunActionsCtx(context.Background(), *raCtx)
 	ws, err := bc.sf.NewWorkingSet()
 	if err != nil {
 		return 0, nil, err
@@ -451,6 +473,30 @@ func (bc *blockchain) ValidateBlock(blk *block.Block) error {
 	return bc.validateBlock(blk)
 }
 
+func (bc *blockchain) RunActionsContext() (*protocol.RunActionsCtx, error) {
+	bc.mu.RLock()
+	defer bc.mu.RUnlock()
+	header, err := bc.blockHeaderByHeight(bc.tipHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	return bc.runActionsContext(bc.config.ProducerAddress(), header.Height(), header.Timestamp())
+}
+
+func (bc *blockchain) runActionsContext(producer address.Address, height uint64, timestamp time.Time) (*protocol.RunActionsCtx, error) {
+	return &protocol.RunActionsCtx{
+		BlockHeight:    height,
+		BlockTimeStamp: timestamp,
+		Producer:       producer,
+		GasLimit:       bc.config.Genesis.BlockGasLimit,
+		GasPrice:       big.NewInt(0),
+		IntrinsicGas:   0,
+		Registry:       bc.registry,
+		Genesis:        bc.config.Genesis,
+	}, nil
+}
+
 func (bc *blockchain) MintNewBlock(
 	actionMap map[string][]action.SealedEnvelope,
 	timestamp time.Time,
@@ -467,17 +513,13 @@ func (bc *blockchain) MintNewBlock(
 		return nil, errors.Wrap(err, "Failed to obtain working set from state factory")
 	}
 
-	gasLimitForContext := bc.config.Genesis.BlockGasLimit
-	ctx := protocol.WithRunActionsCtx(context.Background(),
-		protocol.RunActionsCtx{
-			BlockHeight:    newblockHeight,
-			BlockTimeStamp: timestamp,
-			Producer:       bc.config.ProducerAddress(),
-			GasLimit:       gasLimitForContext,
-			Registry:       bc.registry,
-			Genesis:        bc.config.Genesis,
-		})
+	raCtx, err := bc.runActionsContext(bc.config.ProducerAddress(), newblockHeight, timestamp)
+	if err != nil {
+		return nil, err
+	}
 
+	ctx := protocol.WithRunActionsCtx(context.Background(), *raCtx)
+	// TODO: move the height judgment into protocols
 	if newblockHeight == bc.config.Genesis.AleutianBlockHeight {
 		if err := bc.updateAleutianEpochRewardAmount(ctx, ws); err != nil {
 			return nil, err
@@ -577,41 +619,6 @@ func (bc *blockchain) RemoveSubscriber(s BlockCreationSubscriber) error {
 //======================================
 // internal functions
 //=====================================
-
-// SimulateExecution simulates a running of smart contract operation, this is done off the network since it does not
-// cause any state change
-// If getting account/contract state depends on a specific block height, we need to change the block height in running context in order
-// to make sure that the state returned is always the newest one
-func (bc *blockchain) SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
-	// use latest block as carrier to run the offline execution
-	// the block itself is not used
-	h := bc.TipHeight()
-	header, err := bc.BlockHeaderByHeight(h)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to get block in SimulateExecution")
-	}
-	ws, err := bc.sf.NewWorkingSet()
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to obtain working set from state factory")
-	}
-	producer, err := address.FromString(header.ProducerAddress())
-	if err != nil {
-		return nil, nil, err
-	}
-	gasLimit := bc.config.Genesis.BlockGasLimit
-	ctx := protocol.WithRunActionsCtx(context.Background(), protocol.RunActionsCtx{
-		BlockHeight:    header.Height(),
-		BlockTimeStamp: header.Timestamp(),
-		Producer:       producer,
-		Caller:         caller,
-		GasLimit:       gasLimit,
-		GasPrice:       big.NewInt(0),
-		IntrinsicGas:   0,
-		Genesis:        bc.config.Genesis,
-	})
-
-	return evm.ExecuteContract(ctx, ws, ex, bc.dao.GetBlockHash)
-}
 
 // RecoverChainAndState recovers the chain to target height and refresh state db if necessary
 func (bc *blockchain) RecoverChainAndState(targetHeight uint64) error {
@@ -834,23 +841,17 @@ func (bc *blockchain) runActions(
 	if bc.sf == nil {
 		return nil, errors.New("statefactory cannot be nil")
 	}
-	gasLimit := bc.config.Genesis.BlockGasLimit
-	// update state factory
+
 	producer, err := address.FromBytes(acts.BlockProducerPubKey().Hash())
 	if err != nil {
 		return nil, err
 	}
+	raCtx, err := bc.runActionsContext(producer, acts.BlockHeight(), acts.BlockTimeStamp())
+	if err != nil {
+		return nil, err
+	}
 
-	ctx := protocol.WithRunActionsCtx(context.Background(),
-		protocol.RunActionsCtx{
-			BlockHeight:    acts.BlockHeight(),
-			BlockTimeStamp: acts.BlockTimeStamp(),
-			Producer:       producer,
-			GasLimit:       gasLimit,
-			Registry:       bc.registry,
-			Genesis:        bc.config.Genesis,
-		})
-
+	ctx := protocol.WithRunActionsCtx(context.Background(), *raCtx)
 	if acts.BlockHeight() == bc.config.Genesis.AleutianBlockHeight {
 		if err := bc.updateAleutianEpochRewardAmount(ctx, ws); err != nil {
 			return nil, err
@@ -1104,6 +1105,7 @@ func (bc *blockchain) createGrantRewardAction(rewardType int, height uint64) (ac
 	sk := bc.config.ProducerPrivateKey()
 	return action.Sign(envelope, sk)
 }
+
 func (bc *blockchain) loadingNativeStakingContract() {
 	if bc.config.Genesis.NativeStakingContractAddress == "" && bc.config.Genesis.NativeStakingContractCode != "" {
 		p, ok := bc.registry.Find(poll.ProtocolID)

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -421,12 +421,12 @@ func TestCreateBlockchain(t *testing.T) {
 	cfg.Chain.TrieDBPath = ""
 	cfg.Genesis.EnableGravityChainVoting = false
 	// create chain
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
-	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(&registry))
+	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(registry))
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 	exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
 	require.NoError(registry.Register(execution.ProtocolID, exec))
@@ -453,12 +453,12 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))
-	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(&registry))
+	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(registry))
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 	exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
 	require.NoError(t, registry.Register(execution.ProtocolID, exec))
@@ -518,10 +518,10 @@ func TestBlockchain_MintNewBlock_PopAccount(t *testing.T) {
 	ctx := context.Background()
 	cfg := config.Default
 	cfg.Genesis.EnableGravityChainVoting = false
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
-	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(&registry))
+	bc := NewBlockchain(cfg, nil, InMemStateFactoryOption(), InMemDaoOption(), RegistryOption(registry))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
@@ -606,7 +606,7 @@ func TestConstantinople(t *testing.T) {
 		require.NoError(err)
 		acc := account.NewProtocol()
 		sf.AddActionHandlers(acc)
-		registry := protocol.Registry{}
+		registry := protocol.NewRegistry()
 		require.NoError(registry.Register(account.ProtocolID, acc))
 		rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 		require.NoError(registry.Register(rolldpos.ProtocolID, rp))
@@ -622,7 +622,7 @@ func TestConstantinople(t *testing.T) {
 			cfg,
 			dao,
 			PrecreatedStateFactoryOption(sf),
-			RegistryOption(&registry),
+			RegistryOption(registry),
 		)
 		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 		exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
@@ -763,7 +763,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		require.NoError(err)
 		acc := account.NewProtocol()
 		sf.AddActionHandlers(acc)
-		registry := protocol.Registry{}
+		registry := protocol.NewRegistry()
 		require.NoError(registry.Register(account.ProtocolID, acc))
 		rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 		require.NoError(registry.Register(rolldpos.ProtocolID, rp))
@@ -782,7 +782,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 			cfg,
 			dao,
 			PrecreatedStateFactoryOption(sf),
-			RegistryOption(&registry),
+			RegistryOption(registry),
 		)
 		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 		exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
@@ -804,13 +804,13 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 
 		// Load a blockchain from DB
 		accountProtocol := account.NewProtocol()
-		registry = protocol.Registry{}
+		registry = protocol.NewRegistry()
 		require.NoError(registry.Register(account.ProtocolID, accountProtocol))
 		bc = NewBlockchain(
 			cfg,
 			dao,
 			PrecreatedStateFactoryOption(sf),
-			RegistryOption(&registry),
+			RegistryOption(registry),
 		)
 		rolldposProtocol := rolldpos.NewProtocol(
 			genesis.Default.NumCandidateDelegates,
@@ -1051,14 +1051,14 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 	require.NoError(err)
 	accountProtocol := account.NewProtocol()
 	sf.AddActionHandlers(accountProtocol)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	require.NoError(registry.Register(account.ProtocolID, accountProtocol))
 	bc := NewBlockchain(
 		cfg,
 		nil,
 		PrecreatedStateFactoryOption(sf),
 		BoltDBDaoOption(),
-		RegistryOption(&registry),
+		RegistryOption(registry),
 	)
 	rolldposProtocol := rolldpos.NewProtocol(
 		genesis.Default.NumCandidateDelegates,

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -818,7 +818,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 			genesis.Default.NumSubEpochs,
 		)
 		require.NoError(registry.Register(rolldpos.ProtocolID, rolldposProtocol))
-		rewardingProtocol := rewarding.NewProtocol(bc, rolldposProtocol)
+		rewardingProtocol := rewarding.NewProtocol(nil, rolldposProtocol)
 		require.NoError(registry.Register(rewarding.ProtocolID, rewardingProtocol))
 		bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 		bc.Validator().AddActionValidators(accountProtocol)
@@ -1066,7 +1066,7 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 		genesis.Default.NumSubEpochs,
 	)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rolldposProtocol))
-	rewardingProtocol := rewarding.NewProtocol(bc, rolldposProtocol)
+	rewardingProtocol := rewarding.NewProtocol(nil, rolldposProtocol)
 	require.NoError(registry.Register(rewarding.ProtocolID, rewardingProtocol))
 	require.NoError(registry.Register(poll.ProtocolID, poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)))
 	require.NoError(bc.Start(context.Background()))

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -175,7 +175,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
 	chain := bc.NewBlockchain(
@@ -183,7 +183,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 		nil,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.RegistryOption(&registry),
+		bc.RegistryOption(registry),
 	)
 	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain.Factory().Nonce))
 	chain.Validator().AddActionValidators(account.NewProtocol())
@@ -233,7 +233,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
 	chain1 := bc.NewBlockchain(
@@ -241,7 +241,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 		nil,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.RegistryOption(&registry),
+		bc.RegistryOption(registry),
 	)
 	require.NotNil(chain1)
 	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1.Factory().Nonce))
@@ -256,14 +256,14 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 
 	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
 	require.Nil(err)
-	registry2 := protocol.Registry{}
+	registry2 := protocol.NewRegistry()
 	require.NoError(registry2.Register(rolldpos.ProtocolID, rp))
 	chain2 := bc.NewBlockchain(
 		cfg,
 		nil,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.RegistryOption(&registry2),
+		bc.RegistryOption(registry2),
 	)
 	require.NotNil(chain2)
 	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2.Factory().Nonce))
@@ -324,7 +324,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rolldposProtocol := rolldpos.NewProtocol(
 		cfg.Genesis.NumCandidateDelegates,
 		cfg.Genesis.NumDelegates,
@@ -336,7 +336,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 		nil,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.RegistryOption(&registry),
+		bc.RegistryOption(registry),
 	)
 	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain1.Factory().Nonce))
 	chain1.Validator().AddActionValidators(account.NewProtocol())
@@ -350,14 +350,14 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	cs1.EXPECT().Calibrate(gomock.Any()).Times(3)
 	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
 	require.Nil(err)
-	registry2 := protocol.Registry{}
+	registry2 := protocol.NewRegistry()
 	require.NoError(registry2.Register(rolldpos.ProtocolID, rolldposProtocol))
 	chain2 := bc.NewBlockchain(
 		cfg,
 		nil,
 		bc.InMemStateFactoryOption(),
 		bc.InMemDaoOption(),
-		bc.RegistryOption(&registry2),
+		bc.RegistryOption(registry2),
 	)
 	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain2.Factory().Nonce))
 	chain2.Validator().AddActionValidators(account.NewProtocol())
@@ -417,10 +417,10 @@ func TestBlockSyncerSync(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
-	chain := bc.NewBlockchain(cfg, nil, bc.InMemStateFactoryOption(), bc.InMemDaoOption(), bc.RegistryOption(&registry))
+	chain := bc.NewBlockchain(cfg, nil, bc.InMemStateFactoryOption(), bc.InMemDaoOption(), bc.RegistryOption(registry))
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
 	ap, err := actpool.NewActPool(chain, cfg.ActPool, actpool.EnableExperimentalActions())

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -33,7 +33,7 @@ func TestBlockBufferFlush(t *testing.T) {
 	cfg, err := newTestConfig()
 	require.Nil(err)
 
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
 	chain := blockchain.NewBlockchain(
@@ -41,7 +41,7 @@ func TestBlockBufferFlush(t *testing.T) {
 		nil,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain.Factory().Nonce))
 	chain.Validator().AddActionValidators(account.NewProtocol())
@@ -134,7 +134,7 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 	ctx := context.Background()
 	cfg, err := newTestConfig()
 	require.Nil(err)
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
 	chain := blockchain.NewBlockchain(
@@ -142,7 +142,7 @@ func TestBlockBufferGetBlocksIntervalsToSync(t *testing.T) {
 		nil,
 		blockchain.InMemStateFactoryOption(),
 		blockchain.InMemDaoOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	require.NotNil(chain)
 	require.NoError(chain.Start(ctx))

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -8,9 +8,11 @@ package chainservice
 
 import (
 	"context"
+	"math/big"
 	"time"
 
 	"github.com/golang/protobuf/proto"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexrpc"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
@@ -412,7 +414,22 @@ func (cs *ChainService) registerDefaultProtocols(cfg config.Config) (err error) 
 	}
 	pollProtocol, err := poll.NewProtocol(
 		cfg,
-		cs.chain,
+		func(contract string, height uint64, ts time.Time, params []byte) ([]byte, error) {
+			ex, err := action.NewExecution(contract, 1, big.NewInt(0), 1000000, big.NewInt(0), params)
+			if err != nil {
+				return nil, err
+			}
+
+			addr, err := address.FromString(address.ZeroAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			data, _, err := blockchain.SimulateExecution(cs.chain, addr, ex)
+
+			return data, err
+		},
+		cs.chain.CandidatesByHeight,
 		cs.electionCommittee,
 		func(height uint64) (time.Time, error) {
 			header, err := cs.chain.BlockHeaderByHeight(height)
@@ -420,16 +437,6 @@ func (cs *ChainService) registerDefaultProtocols(cfg config.Config) (err error) 
 				return time.Now(), errors.Wrapf(
 					err, "error when getting the block at height: %d",
 					height,
-				)
-			}
-			return header.Timestamp(), nil
-		},
-		func() (time.Time, error) {
-			header, err := cs.chain.BlockHeaderByHeight(cs.chain.TipHeight())
-			if err != nil {
-				return time.Now(), errors.Wrapf(
-					err, "error when getting the block at height: %d",
-					cs.chain.TipHeight(),
 				)
 			}
 			return header.Timestamp(), nil

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -49,7 +49,6 @@ type ChainService struct {
 	consensus         consensus.Consensus
 	chain             blockchain.Blockchain
 	electionCommittee committee.Committee
-	rDPoSProtocol     *rolldpos.Protocol
 	// TODO: explorer dependency deleted at #1085, need to api related params
 	api          *api.Server
 	indexBuilder *blockdao.IndexBuilder
@@ -186,11 +185,50 @@ func New(
 		cfg.Genesis.NumSubEpochs,
 		rolldpos.EnableDardanellesSubEpoch(cfg.Genesis.DardanellesBlockHeight, cfg.Genesis.DardanellesNumSubEpochs),
 	)
+	pollProtocol, err := poll.NewProtocol(
+		cfg,
+		func(contract string, height uint64, ts time.Time, params []byte) ([]byte, error) {
+			ex, err := action.NewExecution(contract, 1, big.NewInt(0), 1000000, big.NewInt(0), params)
+			if err != nil {
+				return nil, err
+			}
+
+			addr, err := address.FromString(address.ZeroAddress)
+			if err != nil {
+				return nil, err
+			}
+
+			data, _, err := blockchain.SimulateExecution(
+				chain,
+				addr,
+				ex,
+			)
+
+			return data, err
+		},
+		chain.Factory().CandidatesByHeight,
+		electionCommittee,
+		func(height uint64) (time.Time, error) {
+			header, err := chain.BlockHeaderByHeight(height)
+			if err != nil {
+				return time.Now(), errors.Wrapf(
+					err, "error when getting the block at height: %d",
+					height,
+				)
+			}
+			return header.Timestamp(), nil
+		},
+		rDPoSProtocol,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to generate poll protocol")
+	}
 	copts := []consensus.Option{
 		consensus.WithBroadcast(func(msg proto.Message) error {
 			return p2pAgent.BroadcastOutbound(p2p.WitContext(context.Background(), p2p.Context{ChainID: chain.ChainID()}), msg)
 		}),
 		consensus.WithRollDPoSProtocol(rDPoSProtocol),
+		consensus.WithPollProtocol(pollProtocol),
 	}
 	// TODO: explorer dependency deleted at #1085, need to revive by migrating to api
 	consensus, err := consensus.NewConsensus(cfg, chain, actPool, copts...)
@@ -244,20 +282,21 @@ func New(
 				actPool,
 			)
 	}
-
+	accountProtocol := account.NewProtocol()
+	executionProtocol := execution.NewProtocol(chain.BlockDAO().GetBlockHash)
+	rewardingProtocol := rewarding.NewProtocol(chain, rDPoSProtocol)
 	cs := &ChainService{
 		actpool:           actPool,
 		chain:             chain,
 		blocksync:         bs,
 		consensus:         consensus,
-		rDPoSProtocol:     rDPoSProtocol,
 		electionCommittee: electionCommittee,
 		indexBuilder:      indexBuilder,
 		api:               apiSvr,
 		registry:          &registry,
 	}
 	// Install protocols
-	if err := cs.registerDefaultProtocols(cfg); err != nil {
+	if err := cs.registerDefaultProtocols(accountProtocol, rDPoSProtocol, pollProtocol, executionProtocol, rewardingProtocol); err != nil {
 		return nil, err
 	}
 	return cs, nil
@@ -397,6 +436,7 @@ func (cs *ChainService) registerProtocol(id string, p protocol.Protocol) error {
 	cs.chain.Factory().AddActionHandlers(p)
 	cs.actpool.AddActionValidators(p)
 	cs.chain.Validator().AddActionValidators(p)
+
 	return nil
 }
 
@@ -404,46 +444,11 @@ func (cs *ChainService) registerProtocol(id string, p protocol.Protocol) error {
 func (cs *ChainService) Registry() *protocol.Registry { return cs.registry }
 
 // registerDefaultProtocols registers default protocol into chainservice's registry
-func (cs *ChainService) registerDefaultProtocols(cfg config.Config) (err error) {
-	accountProtocol := account.NewProtocol()
+func (cs *ChainService) registerDefaultProtocols(accountProtocol *account.Protocol, rDPoSProtocol *rolldpos.Protocol, pollProtocol poll.Protocol, executionProtocol *execution.Protocol, rewardingProtocol *rewarding.Protocol) (err error) {
 	if err = cs.registerProtocol(account.ProtocolID, accountProtocol); err != nil {
 		return
 	}
-	if err = cs.registerProtocol(rolldpos.ProtocolID, cs.rDPoSProtocol); err != nil {
-		return
-	}
-	pollProtocol, err := poll.NewProtocol(
-		cfg,
-		func(contract string, height uint64, ts time.Time, params []byte) ([]byte, error) {
-			ex, err := action.NewExecution(contract, 1, big.NewInt(0), 1000000, big.NewInt(0), params)
-			if err != nil {
-				return nil, err
-			}
-
-			addr, err := address.FromString(address.ZeroAddress)
-			if err != nil {
-				return nil, err
-			}
-
-			data, _, err := blockchain.SimulateExecution(cs.chain, addr, ex)
-
-			return data, err
-		},
-		cs.chain.CandidatesByHeight,
-		cs.electionCommittee,
-		func(height uint64) (time.Time, error) {
-			header, err := cs.chain.BlockHeaderByHeight(height)
-			if err != nil {
-				return time.Now(), errors.Wrapf(
-					err, "error when getting the block at height: %d",
-					height,
-				)
-			}
-			return header.Timestamp(), nil
-		},
-		cs.rDPoSProtocol,
-	)
-	if err != nil {
+	if err = cs.registerProtocol(rolldpos.ProtocolID, rDPoSProtocol); err != nil {
 		return
 	}
 	if pollProtocol != nil {
@@ -451,10 +456,9 @@ func (cs *ChainService) registerDefaultProtocols(cfg config.Config) (err error) 
 			return
 		}
 	}
-	executionProtocol := execution.NewProtocol(cs.chain.BlockDAO().GetBlockHash)
 	if err = cs.registerProtocol(execution.ProtocolID, executionProtocol); err != nil {
 		return
 	}
-	rewardingProtocol := rewarding.NewProtocol(cs.chain, cs.rDPoSProtocol)
+
 	return cs.registerProtocol(rewarding.ProtocolID, rewardingProtocol)
 }

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -104,8 +104,8 @@ func New(
 			blockchain.DefaultStateFactoryOption(),
 		}
 	}
-	registry := protocol.Registry{}
-	chainOpts = append(chainOpts, blockchain.RegistryOption(&registry))
+	registry := protocol.NewRegistry()
+	chainOpts = append(chainOpts, blockchain.RegistryOption(registry))
 	var electionCommittee committee.Committee
 	if cfg.Genesis.EnableGravityChainVoting {
 		committeeConfig := cfg.Chain.Committee
@@ -253,7 +253,7 @@ func New(
 		dao,
 		indexer,
 		actPool,
-		&registry,
+		registry,
 		api.WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
 			ctx = p2p.WitContext(ctx, p2p.Context{ChainID: chainID})
 			return p2pAgent.BroadcastOutbound(ctx, msg)
@@ -291,7 +291,7 @@ func New(
 		electionCommittee: electionCommittee,
 		indexBuilder:      indexBuilder,
 		api:               apiSvr,
-		registry:          &registry,
+		registry:          registry,
 	}
 	// Install protocols
 	if err := cs.registerDefaultProtocols(accountProtocol, rDPoSProtocol, pollProtocol, executionProtocol, rewardingProtocol); err != nil {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -198,11 +198,7 @@ func New(
 				return nil, err
 			}
 
-			data, _, err := blockchain.SimulateExecution(
-				chain,
-				addr,
-				ex,
-			)
+			data, _, err := blockchain.SimulateExecution(chain, addr, ex)
 
 			return data, err
 		},
@@ -284,7 +280,9 @@ func New(
 	}
 	accountProtocol := account.NewProtocol()
 	executionProtocol := execution.NewProtocol(chain.BlockDAO().GetBlockHash)
-	rewardingProtocol := rewarding.NewProtocol(chain, rDPoSProtocol)
+	rewardingProtocol := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+		return blockchain.ProductivityByEpoch(chain, epochNum)
+	}, rDPoSProtocol)
 	cs := &ChainService{
 		actpool:           actPool,
 		chain:             chain,

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -27,7 +27,6 @@ import (
 	"github.com/iotexproject/iotex-core/consensus/scheme"
 	"github.com/iotexproject/iotex-core/endorsement"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/state"
 )
 
 var (
@@ -41,8 +40,6 @@ var (
 
 // ChainManager defines the blockchain interface
 type ChainManager interface {
-	// CandidatesByHeight returns the candidate list by a given height
-	CandidatesByHeight(height uint64) ([]*state.Candidate, error)
 	// Genesis returns the genesis
 	Genesis() genesis.Genesis
 	// BlockHeaderByHeight return block header by height
@@ -203,7 +200,7 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 		return metrics, errors.Wrap(err, "error when calculating round")
 	}
 	// Get all candidates
-	candidates, err := r.ctx.chain.CandidatesByHeight(height)
+	candidates, err := r.ctx.roundCalc.candidatesByHeightFunc(height)
 	if err != nil {
 		return metrics, errors.Wrap(err, "error when getting all candidates")
 	}

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -137,6 +137,7 @@ func TestNewRollDPoS(t *testing.T) {
 		assert.Nil(t, r)
 	})
 }
+
 func makeBlock(t *testing.T, accountIndex, numOfEndosements int, makeInvalidEndorse bool, height int) *block.Block {
 	unixTime := 1500000000
 	blkTime := int64(-1)

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -63,6 +63,7 @@ func TestNewRollDPoS(t *testing.T) {
 		cfg.Genesis.NumDelegates,
 		cfg.Genesis.NumSubEpochs,
 	)
+	candidatesByHeight := func(uint64) (state.CandidateList, error) { return nil, nil }
 	t.Run("normal", func(t *testing.T) {
 		sk := identityset.PrivateKey(0)
 		r, err := NewRollDPoSBuilder().
@@ -74,6 +75,7 @@ func TestNewRollDPoS(t *testing.T) {
 			SetBroadcast(func(_ proto.Message) error {
 				return nil
 			}).
+			SetCandidatesByHeightFunc(candidatesByHeight).
 			RegisterProtocol(rp).
 			Build()
 		assert.NoError(t, err)
@@ -91,6 +93,7 @@ func TestNewRollDPoS(t *testing.T) {
 				return nil
 			}).
 			SetClock(clock.NewMock()).
+			SetCandidatesByHeightFunc(candidatesByHeight).
 			RegisterProtocol(rp).
 			Build()
 		assert.NoError(t, err)
@@ -111,6 +114,7 @@ func TestNewRollDPoS(t *testing.T) {
 				return nil
 			}).
 			SetClock(clock.NewMock()).
+			SetCandidatesByHeightFunc(candidatesByHeight).
 			RegisterProtocol(rp).
 			Build()
 		assert.NoError(t, err)
@@ -126,6 +130,7 @@ func TestNewRollDPoS(t *testing.T) {
 			SetBroadcast(func(_ proto.Message) error {
 				return nil
 			}).
+			SetCandidatesByHeightFunc(candidatesByHeight).
 			RegisterProtocol(rp).
 			Build()
 		assert.Error(t, err)
@@ -192,13 +197,6 @@ func TestValidateBlockFooter(t *testing.T) {
 	footer := &block.Footer{}
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(5)
-	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
-		{Address: candidates[0]},
-		{Address: candidates[1]},
-		{Address: candidates[2]},
-		{Address: candidates[3]},
-		{Address: candidates[4]},
-	}, nil).AnyTimes()
 
 	sk1 := identityset.PrivateKey(1)
 	cfg := config.Default
@@ -220,6 +218,15 @@ func TestValidateBlockFooter(t *testing.T) {
 		SetActPool(mock_actpool.NewMockActPool(ctrl)).
 		SetBroadcast(func(_ proto.Message) error {
 			return nil
+		}).
+		SetCandidatesByHeightFunc(func(uint64) (state.CandidateList, error) {
+			return []*state.Candidate{
+				{Address: candidates[0]},
+				{Address: candidates[1]},
+				{Address: candidates[2]},
+				{Address: candidates[3]},
+				{Address: candidates[4]},
+			}, nil
 		}).
 		SetClock(clock).
 		RegisterProtocol(rp).
@@ -270,13 +277,6 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	blockchain := mock_blockchain.NewMockBlockchain(ctrl)
 	blockchain.EXPECT().TipHeight().Return(blockHeight).Times(1)
 	blockchain.EXPECT().BlockFooterByHeight(blockHeight).Return(footer, nil).Times(2)
-	blockchain.EXPECT().CandidatesByHeight(gomock.Any()).Return([]*state.Candidate{
-		{Address: candidates[0]},
-		{Address: candidates[1]},
-		{Address: candidates[2]},
-		{Address: candidates[3]},
-		{Address: candidates[4]},
-	}, nil).AnyTimes()
 
 	sk1 := identityset.PrivateKey(1)
 	cfg := config.Default
@@ -300,6 +300,15 @@ func TestRollDPoS_Metrics(t *testing.T) {
 			return nil
 		}).
 		SetClock(clock).
+		SetCandidatesByHeightFunc(func(uint64) (state.CandidateList, error) {
+			return []*state.Candidate{
+				{Address: candidates[0]},
+				{Address: candidates[1]},
+				{Address: candidates[2]},
+				{Address: candidates[3]},
+				{Address: candidates[4]},
+			}, nil
+		}).
 		RegisterProtocol(rp).
 		Build()
 	require.NoError(t, err)
@@ -393,7 +402,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 			chainAddrs[i] = addressMap[rawAddress]
 		}
 
-		candidatesByHeightFunc := func(_ uint64) ([]*state.Candidate, error) {
+		candidatesByHeightFunc := func(_ uint64) (state.CandidateList, error) {
 			candidates := make([]*state.Candidate, 0, numNodes)
 			for _, addr := range chainAddrs {
 				candidates = append(candidates, &state.Candidate{Address: addr.encodedAddr})

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -436,7 +436,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, sf.Commit(ws))
 			}
-			registry := protocol.Registry{}
+			registry := protocol.NewRegistry()
 			acc := account.NewProtocol()
 			require.NoError(t, registry.Register(account.ProtocolID, acc))
 			rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
@@ -446,7 +446,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				nil,
 				blockchain.InMemDaoOption(),
 				blockchain.PrecreatedStateFactoryOption(sf),
-				blockchain.RegistryOption(&registry),
+				blockchain.RegistryOption(registry),
 			)
 			chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain.Factory().Nonce))
 			chain.Validator().AddActionValidators(account.NewProtocol())

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 // CandidatesByHeightFunc defines a function to overwrite candidates
-type CandidatesByHeightFunc func(uint64) ([]*state.Candidate, error)
+type CandidatesByHeightFunc func(uint64) (state.CandidateList, error)
 type rollDPoSCtx struct {
 	consensusfsm.ConsensusConfig
 
@@ -119,7 +119,7 @@ func newRollDPoSCtx(
 		return nil, errors.New("clock cannot be nil")
 	}
 	if candidatesByHeightFunc == nil {
-		candidatesByHeightFunc = chain.CandidatesByHeight
+		return nil, errors.New("canidates by height function cannot be nil")
 	}
 	if cfg.AcceptBlockTTL(0)+cfg.AcceptProposalEndorsementTTL(0)+cfg.AcceptLockEndorsementTTL(0)+cfg.CommitTTL(0) > cfg.BlockInterval(0) {
 		return nil, errors.Errorf(

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -171,13 +171,13 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol) {
 		}
 	}
 
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	chain := blockchain.NewBlockchain(
 		cfg,
 		nil,
 		blockchain.DefaultStateFactoryOption(),
 		blockchain.BoltDBDaoOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	rolldposProtocol := rolldpos.NewProtocol(
 		cfg.Genesis.NumCandidateDelegates,

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -186,7 +186,9 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol) {
 	)
 
 	require.NoError(registry.Register(rolldpos.ProtocolID, rolldposProtocol))
-	rewardingProtocol := rewarding.NewProtocol(chain, rolldposProtocol)
+	rewardingProtocol := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+		return blockchain.ProductivityByEpoch(chain, epochNum)
+	}, rolldposProtocol)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
 	acc := account.NewProtocol()
 	registry.Register(account.ProtocolID, acc)

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -51,6 +51,7 @@ func TestTransfer_Negative(t *testing.T) {
 	r.NoError(err)
 	r.Equal(0, balance.Cmp(balanceBeforeTransfer))
 }
+
 func TestAction_Negative(t *testing.T) {
 	r := require.New(t)
 	ctx := context.Background()

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -76,7 +76,7 @@ func prepareBlockchain(
 	cfg := config.Default
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.EnableGravityChainVoting = false
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	r.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
@@ -86,7 +86,7 @@ func prepareBlockchain(
 		nil,
 		blockchain.InMemDaoOption(),
 		blockchain.InMemStateFactoryOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	r.NotNil(bc)
 	reward := rewarding.NewProtocol(nil, rp)

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -89,7 +89,7 @@ func prepareBlockchain(
 		blockchain.RegistryOption(&registry),
 	)
 	r.NotNil(bc)
-	reward := rewarding.NewProtocol(bc, rp)
+	reward := rewarding.NewProtocol(nil, rp)
 	r.NoError(registry.Register(rewarding.ProtocolID, reward))
 
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -173,7 +173,7 @@ func TestLocalCommit(t *testing.T) {
 		cfg.Genesis.NumSubEpochs,
 	)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rolldposProtocol))
-	rewardingProtocol := rewarding.NewProtocol(chain, rolldposProtocol)
+	rewardingProtocol := rewarding.NewProtocol(nil, rolldposProtocol)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
 	acc := account.NewProtocol()
 	registry.Register(account.ProtocolID, acc)

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -159,13 +159,13 @@ func TestLocalCommit(t *testing.T) {
 	require.NoError(copyDB(testTriePath, testTriePath2))
 	require.NoError(copyDB(testDBPath, testDBPath2))
 	require.NoError(copyDB(indexDBPath, indexDBPath2))
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	chain := blockchain.NewBlockchain(
 		cfg,
 		nil,
 		blockchain.DefaultStateFactoryOption(),
 		blockchain.BoltDBDaoOption(),
-		blockchain.RegistryOption(&registry),
+		blockchain.RegistryOption(registry),
 	)
 	rolldposProtocol := rolldpos.NewProtocol(
 		cfg.Genesis.NumCandidateDelegates,

--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -100,7 +100,8 @@ func (gs *GasStation) EstimateGasForAction(actPb *iotextypes.Action) (uint64, er
 		if err != nil {
 			return 0, err
 		}
-		_, receipt, err := gs.bc.SimulateExecution(callerAddr, sc)
+
+		_, receipt, err := blockchain.SimulateExecution(gs.bc, callerAddr, sc)
 		if err != nil {
 			return 0, err
 		}

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -40,14 +40,14 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))
 	blkState := blockchain.InMemStateFactoryOption()
 	blkMemDao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
-	blkRegistryOption := blockchain.RegistryOption(&registry)
+	blkRegistryOption := blockchain.RegistryOption(registry)
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, blkState, blkRegistryOption)
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 	exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
@@ -114,14 +114,14 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
-	registry := protocol.Registry{}
+	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))
 	blkState := blockchain.InMemStateFactoryOption()
 	blkMemDao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
-	blkRegistryOption := blockchain.RegistryOption(&registry)
+	blkRegistryOption := blockchain.RegistryOption(registry)
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, blkState, blkRegistryOption)
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
 	exec := execution.NewProtocol(bc.BlockDAO().GetBlockHash)

--- a/misc/scripts/mockgen.sh
+++ b/misc/scripts/mockgen.sh
@@ -83,7 +83,7 @@ mkdir -p ./test/mock/mock_chainmanager
 mockgen -destination=./test/mock/mock_chainmanager/mock_chainmanager.go  \
         -source=./action/protocol/protocol.go \
         -package=mock_chainmanager \
-        ChainManager
+        StateManager
 
 mkdir -p ./test/mock/mock_apiserviceclient
 mockgen -destination=./test/mock/mock_apiserviceclient/mock_apiserviceclient.go  \

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -59,7 +59,7 @@ type (
 		Height() (uint64, error)
 		NewWorkingSet() (WorkingSet, error)
 		Commit(WorkingSet) error
-		// Candidate pool
+		// CandidatesByHeight returns array of Candidates in candidate pool of a given height
 		CandidatesByHeight(uint64) ([]*state.Candidate, error)
 
 		State(hash.Hash160, interface{}) error
@@ -319,7 +319,7 @@ func (sf *factory) Commit(ws WorkingSet) error {
 //======================================
 // Candidate functions
 //======================================
-// CandidatesByHeight returns array of Candidates in candidate pool of a given height
+
 func (sf *factory) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -145,6 +145,7 @@ func (sdb *stateDB) AddActionHandlers(actionHandlers ...protocol.ActionHandler) 
 //======================================
 // account functions
 //======================================
+
 // Balance returns balance
 func (sdb *stateDB) Balance(addr string) (*big.Int, error) {
 	sdb.mutex.RLock()

--- a/state/factory/util.go
+++ b/state/factory/util.go
@@ -49,6 +49,7 @@ func createGenesisStates(ctx context.Context, cfg config.Config, ws WorkingSet) 
 		return err
 	}
 	_ = ws.UpdateBlockLevelInfo(0)
+
 	return nil
 }
 

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -9,7 +9,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	hash "github.com/iotexproject/go-pkgs/hash"
 	action "github.com/iotexproject/iotex-core/action"
-	protocol "github.com/iotexproject/iotex-core/action/protocol"
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	blockdao "github.com/iotexproject/iotex-core/blockchain/blockdao"
@@ -68,22 +67,6 @@ func (m *MockBlockchain) Stop(arg0 context.Context) error {
 func (mr *MockBlockchainMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockchain)(nil).Stop), arg0)
-}
-
-// ProductivityByEpoch mocks base method
-func (m *MockBlockchain) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProductivityByEpoch", epochNum)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(map[string]uint64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ProductivityByEpoch indicates an expected call of ProductivityByEpoch
-func (mr *MockBlockchainMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockBlockchain)(nil).ProductivityByEpoch), epochNum)
 }
 
 // BlockHeaderByHeight mocks base method
@@ -258,19 +241,19 @@ func (mr *MockBlockchainMockRecorder) Genesis() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Genesis", reflect.TypeOf((*MockBlockchain)(nil).Genesis))
 }
 
-// RunActionsContext mocks base method
-func (m *MockBlockchain) RunActionsContext() (*protocol.RunActionsCtx, error) {
+// Context mocks base method
+func (m *MockBlockchain) Context() (context.Context, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunActionsContext")
-	ret0, _ := ret[0].(*protocol.RunActionsCtx)
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RunActionsContext indicates an expected call of RunActionsContext
-func (mr *MockBlockchainMockRecorder) RunActionsContext() *gomock.Call {
+// Context indicates an expected call of Context
+func (mr *MockBlockchainMockRecorder) Context() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunActionsContext", reflect.TypeOf((*MockBlockchain)(nil).RunActionsContext))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockBlockchain)(nil).Context))
 }
 
 // MintNewBlock mocks base method

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -8,8 +8,8 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	hash "github.com/iotexproject/go-pkgs/hash"
-	address "github.com/iotexproject/iotex-address/address"
 	action "github.com/iotexproject/iotex-core/action"
+	protocol "github.com/iotexproject/iotex-core/action/protocol"
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	blockdao "github.com/iotexproject/iotex-core/blockchain/blockdao"
@@ -274,6 +274,21 @@ func (mr *MockBlockchainMockRecorder) Genesis() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Genesis", reflect.TypeOf((*MockBlockchain)(nil).Genesis))
 }
 
+// RunActionsContext mocks base method
+func (m *MockBlockchain) RunActionsContext() (*protocol.RunActionsCtx, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunActionsContext")
+	ret0, _ := ret[0].(*protocol.RunActionsCtx)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunActionsContext indicates an expected call of RunActionsContext
+func (mr *MockBlockchainMockRecorder) RunActionsContext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunActionsContext", reflect.TypeOf((*MockBlockchain)(nil).RunActionsContext))
+}
+
 // MintNewBlock mocks base method
 func (m *MockBlockchain) MintNewBlock(actionMap map[string][]action.SealedEnvelope, timestamp time.Time) (*block.Block, error) {
 	m.ctrl.T.Helper()
@@ -341,22 +356,6 @@ func (m *MockBlockchain) SetValidator(val blockchain.Validator) {
 func (mr *MockBlockchainMockRecorder) SetValidator(val interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidator", reflect.TypeOf((*MockBlockchain)(nil).SetValidator), val)
-}
-
-// SimulateExecution mocks base method
-func (m *MockBlockchain) SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SimulateExecution", caller, ex)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(*action.Receipt)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// SimulateExecution indicates an expected call of SimulateExecution
-func (mr *MockBlockchainMockRecorder) SimulateExecution(caller, ex interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateExecution", reflect.TypeOf((*MockBlockchain)(nil).SimulateExecution), caller, ex)
 }
 
 // AddSubscriber mocks base method

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -14,7 +14,6 @@ import (
 	block "github.com/iotexproject/iotex-core/blockchain/block"
 	blockdao "github.com/iotexproject/iotex-core/blockchain/blockdao"
 	genesis "github.com/iotexproject/iotex-core/blockchain/genesis"
-	state "github.com/iotexproject/iotex-core/state"
 	factory "github.com/iotexproject/iotex-core/state/factory"
 	reflect "reflect"
 	time "time"
@@ -69,21 +68,6 @@ func (m *MockBlockchain) Stop(arg0 context.Context) error {
 func (mr *MockBlockchainMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockchain)(nil).Stop), arg0)
-}
-
-// CandidatesByHeight mocks base method
-func (m *MockBlockchain) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidatesByHeight", height)
-	ret0, _ := ret[0].([]*state.Candidate)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CandidatesByHeight indicates an expected call of CandidatesByHeight
-func (mr *MockBlockchainMockRecorder) CandidatesByHeight(height interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockBlockchain)(nil).CandidatesByHeight), height)
 }
 
 // ProductivityByEpoch mocks base method

--- a/test/mock/mock_chainmanager/mock_chainmanager.go
+++ b/test/mock/mock_chainmanager/mock_chainmanager.go
@@ -8,7 +8,6 @@ import (
 	context "context"
 	gomock "github.com/golang/mock/gomock"
 	hash "github.com/iotexproject/go-pkgs/hash"
-	address "github.com/iotexproject/iotex-address/address"
 	action "github.com/iotexproject/iotex-core/action"
 	protocol "github.com/iotexproject/iotex-core/action/protocol"
 	db "github.com/iotexproject/iotex-core/db"
@@ -266,22 +265,6 @@ func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[str
 func (mr *MockChainManagerMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockChainManager)(nil).ProductivityByEpoch), epochNum)
-}
-
-// SimulateExecution mocks base method
-func (m *MockChainManager) SimulateExecution(caller address.Address, ex *action.Execution) ([]byte, *action.Receipt, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SimulateExecution", caller, ex)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(*action.Receipt)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// SimulateExecution indicates an expected call of SimulateExecution
-func (mr *MockChainManagerMockRecorder) SimulateExecution(caller, ex interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateExecution", reflect.TypeOf((*MockChainManager)(nil).SimulateExecution), caller, ex)
 }
 
 // MockStateManager is a mock of StateManager interface

--- a/test/mock/mock_chainmanager/mock_chainmanager.go
+++ b/test/mock/mock_chainmanager/mock_chainmanager.go
@@ -11,7 +11,6 @@ import (
 	action "github.com/iotexproject/iotex-core/action"
 	protocol "github.com/iotexproject/iotex-core/action/protocol"
 	db "github.com/iotexproject/iotex-core/db"
-	state "github.com/iotexproject/iotex-core/state"
 	reflect "reflect"
 )
 
@@ -234,21 +233,6 @@ func (m *MockChainManager) ChainID() uint32 {
 func (mr *MockChainManagerMockRecorder) ChainID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockChainManager)(nil).ChainID))
-}
-
-// CandidatesByHeight mocks base method
-func (m *MockChainManager) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidatesByHeight", height)
-	ret0, _ := ret[0].([]*state.Candidate)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CandidatesByHeight indicates an expected call of CandidatesByHeight
-func (mr *MockChainManagerMockRecorder) CandidatesByHeight(height interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidatesByHeight", reflect.TypeOf((*MockChainManager)(nil).CandidatesByHeight), height)
 }
 
 // ProductivityByEpoch mocks base method

--- a/test/mock/mock_chainmanager/mock_chainmanager.go
+++ b/test/mock/mock_chainmanager/mock_chainmanager.go
@@ -198,59 +198,6 @@ func (mr *MockActionHandlerMockRecorder) Handle(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Handle", reflect.TypeOf((*MockActionHandler)(nil).Handle), arg0, arg1, arg2)
 }
 
-// MockChainManager is a mock of ChainManager interface
-type MockChainManager struct {
-	ctrl     *gomock.Controller
-	recorder *MockChainManagerMockRecorder
-}
-
-// MockChainManagerMockRecorder is the mock recorder for MockChainManager
-type MockChainManagerMockRecorder struct {
-	mock *MockChainManager
-}
-
-// NewMockChainManager creates a new mock instance
-func NewMockChainManager(ctrl *gomock.Controller) *MockChainManager {
-	mock := &MockChainManager{ctrl: ctrl}
-	mock.recorder = &MockChainManagerMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockChainManager) EXPECT() *MockChainManagerMockRecorder {
-	return m.recorder
-}
-
-// ChainID mocks base method
-func (m *MockChainManager) ChainID() uint32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ChainID")
-	ret0, _ := ret[0].(uint32)
-	return ret0
-}
-
-// ChainID indicates an expected call of ChainID
-func (mr *MockChainManagerMockRecorder) ChainID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ChainID", reflect.TypeOf((*MockChainManager)(nil).ChainID))
-}
-
-// ProductivityByEpoch mocks base method
-func (m *MockChainManager) ProductivityByEpoch(epochNum uint64) (uint64, map[string]uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProductivityByEpoch", epochNum)
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(map[string]uint64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ProductivityByEpoch indicates an expected call of ProductivityByEpoch
-func (mr *MockChainManagerMockRecorder) ProductivityByEpoch(epochNum interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProductivityByEpoch", reflect.TypeOf((*MockChainManager)(nil).ProductivityByEpoch), epochNum)
-}
-
 // MockStateManager is a mock of StateManager interface
 type MockStateManager struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Refactor Registry to return protocols in the order they are added. This is based on #1654, please jump to the last commit to review.