### PR TITLE
Simplify run actions

### DIFF
--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -81,12 +81,14 @@ func MustGetProtocol(registry *protocol.Registry) Protocol {
 	}
 	p, ok := registry.Find(ProtocolID)
 	if !ok {
-		log.S().Panic("rolldpos protocol is not registered")
+		log.S().Panic("poll protocol is not registered")
 	}
+
 	pp, ok := p.(Protocol)
 	if !ok {
-		log.S().Panic("fail to cast to poll protocol")
+		log.S().Panic("fail to cast poll protocol")
 	}
+
 	return pp
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1485,8 +1485,11 @@ func TestServer_GetEpochMeta(t *testing.T) {
 				if height > 0 && height <= 4 {
 					pk := identityset.PrivateKey(int(height))
 					blk, err := block.NewBuilder(
-						block.NewRunnableActionsBuilder().SetHeight(height).Build(pk.PublicKey()),
-					).SignAndBuild(pk)
+						block.NewRunnableActionsBuilder().Build(),
+					).
+						SetHeight(height).
+						SetTimestamp(time.Time{}).
+						SignAndBuild(pk)
 					if err != nil {
 						return &block.Header{}, err
 					}

--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -111,13 +111,7 @@ func (b *Block) VerifyReceiptRoot(root hash.Hash256) error {
 
 // RunnableActions abstructs RunnableActions from a Block.
 func (b *Block) RunnableActions() RunnableActions {
-	return RunnableActions{
-		blockHeight:         b.Header.height,
-		blockTimeStamp:      b.Header.timestamp,
-		blockProducerPubKey: b.Header.pubkey,
-		actions:             b.Actions,
-		txHash:              b.txRoot,
-	}
+	return RunnableActions{actions: b.Actions, txHash: b.txRoot}
 }
 
 // Finalize creates a footer for the block

--- a/blockchain/block/block_test.go
+++ b/blockchain/block/block_test.go
@@ -199,12 +199,11 @@ func makeBlock(tb testing.TB, n int) *Block {
 		sevlps = append(sevlps, sevlp)
 	}
 	rap := RunnableActionsBuilder{}
-	ra := rap.
-		SetHeight(1).
-		SetTimeStamp(time.Now()).
-		AddActions(sevlps...).
-		Build(identityset.PrivateKey(0).PublicKey())
+	ra := rap.AddActions(sevlps...).
+		Build()
 	blk, err := NewBuilder(ra).
+		SetHeight(1).
+		SetTimestamp(time.Now()).
 		SetVersion(1).
 		SetReceiptRoot(hash.Hash256b([]byte("hello, world!"))).
 		SetDeltaStateDigest(hash.Hash256b([]byte("world, hello!"))).

--- a/blockchain/block/builder_test.go
+++ b/blockchain/block/builder_test.go
@@ -17,12 +17,11 @@ import (
 )
 
 func TestBuilder(t *testing.T) {
-	ra := NewRunnableActionsBuilder().
-		SetHeight(1).
-		SetTimeStamp(testutil.TimestampNow()).
-		Build(identityset.PrivateKey(29).PublicKey())
+	ra := NewRunnableActionsBuilder().Build()
 
 	nblk, err := NewBuilder(ra).
+		SetHeight(1).
+		SetTimestamp(testutil.TimestampNow()).
 		SetPrevBlockHash(hash.ZeroHash256).
 		SignAndBuild(identityset.PrivateKey(29))
 	require.NoError(t, err)

--- a/blockchain/block/runnable.go
+++ b/blockchain/block/runnable.go
@@ -7,9 +7,6 @@
 package block
 
 import (
-	"time"
-
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/action"
@@ -17,26 +14,8 @@ import (
 
 // RunnableActions is abstructed from block which contains information to execute all actions in a block.
 type RunnableActions struct {
-	blockHeight         uint64
-	blockTimeStamp      time.Time
-	blockProducerPubKey crypto.PublicKey
-	txHash              hash.Hash256
-	actions             []action.SealedEnvelope
-}
-
-// BlockHeight returns block height.
-func (ra RunnableActions) BlockHeight() uint64 {
-	return ra.blockHeight
-}
-
-// BlockTimeStamp returns blockTimeStamp.
-func (ra RunnableActions) BlockTimeStamp() time.Time {
-	return ra.blockTimeStamp
-}
-
-// BlockProducerPubKey return BlockProducerPubKey.
-func (ra RunnableActions) BlockProducerPubKey() crypto.PublicKey {
-	return ra.blockProducerPubKey
+	txHash  hash.Hash256
+	actions []action.SealedEnvelope
 }
 
 // TxHash returns TxHash.
@@ -53,18 +32,6 @@ type RunnableActionsBuilder struct{ ra RunnableActions }
 // NewRunnableActionsBuilder creates a RunnableActionsBuilder.
 func NewRunnableActionsBuilder() *RunnableActionsBuilder { return &RunnableActionsBuilder{} }
 
-// SetHeight sets the block height for block which is building.
-func (b *RunnableActionsBuilder) SetHeight(h uint64) *RunnableActionsBuilder {
-	b.ra.blockHeight = h
-	return b
-}
-
-// SetTimeStamp sets the time stamp for block which is building.
-func (b *RunnableActionsBuilder) SetTimeStamp(ts time.Time) *RunnableActionsBuilder {
-	b.ra.blockTimeStamp = ts
-	return b
-}
-
 // AddActions adds actions for block which is building.
 func (b *RunnableActionsBuilder) AddActions(acts ...action.SealedEnvelope) *RunnableActionsBuilder {
 	if b.ra.actions == nil {
@@ -75,8 +42,7 @@ func (b *RunnableActionsBuilder) AddActions(acts ...action.SealedEnvelope) *Runn
 }
 
 // Build signs and then builds a block.
-func (b *RunnableActionsBuilder) Build(producerPubKey crypto.PublicKey) RunnableActions {
-	b.ra.blockProducerPubKey = producerPubKey
+func (b *RunnableActionsBuilder) Build() RunnableActions {
 	b.ra.txHash = calculateTxRoot(b.ra.actions)
 	return b.ra
 }

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -257,7 +257,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	cs1.EXPECT().Calibrate(gomock.Any()).Times(3)
 
 	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
-	require.Nil(err)
+	require.NoError(err)
 	registry2 := protocol.NewRegistry()
 	require.NoError(registry2.Register(account.ProtocolID, acc))
 	require.NoError(registry2.Register(rolldpos.ProtocolID, rp))
@@ -325,7 +325,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 
 	ctx := context.Background()
 	cfg, err := newTestConfig()
-	require.Nil(err)
+	require.NoError(err)
 	registry := protocol.NewRegistry()
 	acc := account.NewProtocol()
 	require.NoError(registry.Register(account.ProtocolID, acc))
@@ -352,7 +352,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	cs1.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(3)
 	cs1.EXPECT().Calibrate(gomock.Any()).Times(3)
 	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
-	require.Nil(err)
+	require.NoError(err)
 	registry2 := protocol.NewRegistry()
 	require.NoError(registry2.Register(account.ProtocolID, acc))
 	require.NoError(registry2.Register(rolldpos.ProtocolID, rolldposProtocol))

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -147,11 +147,10 @@ func makeBlock(t *testing.T, accountIndex, numOfEndosements int, makeInvalidEndo
 	}
 	timeT := time.Unix(blkTime, 0)
 	rap := block.RunnableActionsBuilder{}
-	ra := rap.
-		SetHeight(uint64(height)).
-		SetTimeStamp(timeT).
-		Build(identityset.PrivateKey(accountIndex).PublicKey())
+	ra := rap.Build()
 	blk, err := block.NewBuilder(ra).
+		SetHeight(uint64(height)).
+		SetTimestamp(timeT).
 		SetVersion(1).
 		SetReceiptRoot(hash.Hash256b([]byte("hello, world!"))).
 		SetDeltaStateDigest(hash.Hash256b([]byte("world, hello!"))).


### PR DESCRIPTION
This PR is based on #1661, please jump to the last commit to review.

RunnableActions doesn't use height, timestamp, and public key in any way. Moreover, public key could be set when signing a block with a private key.