### PR TITLE
Modify load or create account

### DIFF
--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -58,7 +58,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
-	p := NewProtocol()
+	p := NewProtocol(rewarding.DepositGas)
 	reward := rewarding.NewProtocol(nil, rolldpos.NewProtocol(1, 1, 1))
 	registry := protocol.NewRegistry()
 	require.NoError(registry.Register(rewarding.ProtocolID, reward))
@@ -167,7 +167,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 
 func TestProtocol_ValidateTransfer(t *testing.T) {
 	require := require.New(t)
-	protocol := NewProtocol()
+	protocol := NewProtocol(rewarding.DepositGas)
 	// Case I: Oversized data
 	tmpPayload := [32769]byte{}
 	payload := tmpPayload[:]

--- a/action/protocol/account/util/util.go
+++ b/action/protocol/account/util/util.go
@@ -29,7 +29,7 @@ func SetNonce(i noncer, state *state.Account) {
 }
 
 // LoadOrCreateAccount either loads an account state or creates an account state
-func LoadOrCreateAccount(sm protocol.StateManager, encodedAddr string, init *big.Int) (*state.Account, error) {
+func LoadOrCreateAccount(sm protocol.StateManager, encodedAddr string) (*state.Account, error) {
 	var account state.Account
 	addr, err := address.FromString(encodedAddr)
 	if err != nil {
@@ -39,11 +39,10 @@ func LoadOrCreateAccount(sm protocol.StateManager, encodedAddr string, init *big
 	addrHash := hash.BytesToHash160(addr.Bytes())
 	err = sm.State(addrHash, &account)
 	if err == nil {
-		// TODO: init value cannot be non-zero
 		return &account, nil
 	}
 	if errors.Cause(err) == state.ErrStateNotExist {
-		account.Balance = init
+		account.Balance = big.NewInt(0)
 		account.VotingWeight = big.NewInt(0)
 		if err := sm.PutState(addrHash, account); err != nil {
 			return nil, errors.Wrapf(err, "failed to put state for account %x", addrHash)

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -60,7 +60,7 @@ func TestCreateContract(t *testing.T) {
 	sm.EXPECT().GetDB().Return(store).AnyTimes()
 	sm.EXPECT().GetCachedBatch().Return(cb).AnyTimes()
 	addr := identityset.Address(28)
-	_, err := accountutil.LoadOrCreateAccount(sm, addr.String(), big.NewInt(0))
+	_, err := accountutil.LoadOrCreateAccount(sm, addr.String())
 	require.NoError(err)
 	hu := config.NewHeightUpgrade(&cfg.Genesis)
 	stateDB := NewStateDBAdapter(sm, 0, hu.IsPre(config.Aleutian, 0), hash.ZeroHash256)
@@ -84,7 +84,7 @@ func TestCreateContract(t *testing.T) {
 	require.NoError(stateDB.CommitContracts())
 	stateDB.clear()
 	// reload same contract
-	contract1, err := accountutil.LoadOrCreateAccount(sm, addr.String(), big.NewInt(0))
+	contract1, err := accountutil.LoadOrCreateAccount(sm, addr.String())
 	require.NoError(err)
 	require.Equal(codeHash[:], contract1.CodeHash)
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -192,7 +192,7 @@ func ExecuteContract(
 	}
 	if depositGas-remainingGas > 0 {
 		gasValue := new(big.Int).Mul(new(big.Int).SetUint64(depositGas-remainingGas), ps.context.GasPrice)
-		if err := rewarding.DepositGas(ctx, sm, gasValue, bcCtx.Registry); err != nil {
+		if err := rewarding.DepositGas(ctx, sm, gasValue); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -124,7 +124,7 @@ func (stateDB *StateDBAdapter) CreateAccount(evmAddr common.Address) {
 		log.L().Error("Failed to convert evm address.", zap.Error(err))
 		return
 	}
-	_, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String(), big.NewInt(0))
+	_, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String())
 	if err != nil {
 		log.L().Error("Failed to create account.", zap.Error(err))
 		stateDB.logError(err)
@@ -180,7 +180,7 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, amount *big.In
 	if contract, ok := stateDB.cachedContract[addrHash]; ok {
 		state = contract.SelfState()
 	} else {
-		state, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String(), big.NewInt(0))
+		state, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String())
 		if err != nil {
 			log.L().Error("Failed to add balance.", log.Hex("addrHash", evmAddr[:]))
 			stateDB.logError(err)

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -284,7 +284,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 		cfg.Genesis.InitBalanceMap[expectedBalance.Account] = expectedBalance.Balance().String()
 	}
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	r.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	r.NoError(registry.Register(rolldpos.ProtocolID, rp))
@@ -454,7 +454,7 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Genesis.EnableGravityChainVoting = false
 		cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(1000000000).String()
 		registry := protocol.NewRegistry()
-		acc := account.NewProtocol()
+		acc := account.NewProtocol(rewarding.DepositGas)
 		require.NoError(registry.Register(account.ProtocolID, acc))
 		rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 		require.NoError(registry.Register(rolldpos.ProtocolID, rp))

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -627,7 +627,7 @@ func setCandidates(
 	height uint64,
 ) error {
 	for _, candidate := range candidates {
-		delegate, err := accountutil.LoadOrCreateAccount(sm, candidate.Address, big.NewInt(0))
+		delegate, err := accountutil.LoadOrCreateAccount(sm, candidate.Address)
 		if err != nil {
 			return errors.Wrapf(err, "failed to load or create the account for delegate %s", candidate.Address)
 		}

--- a/action/protocol/rewarding/fund.go
+++ b/action/protocol/rewarding/fund.go
@@ -69,7 +69,7 @@ func (p *Protocol) Deposit(
 		return err
 	}
 	// Subtract balance from caller
-	acc, err := accountutil.LoadOrCreateAccount(sm, actionCtx.Caller.String(), big.NewInt(0))
+	acc, err := accountutil.LoadAccount(sm, hash.BytesToHash160(actionCtx.Caller.Bytes()))
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (p *Protocol) assertEnoughBalance(
 }
 
 // DepositGas deposits gas into the rewarding fund
-func DepositGas(ctx context.Context, sm protocol.StateManager, amount *big.Int, registry *protocol.Registry) error {
+func DepositGas(ctx context.Context, sm protocol.StateManager, amount *big.Int) error {
 	// If the gas fee is 0, return immediately
 	if amount.Cmp(big.NewInt(0)) == 0 {
 		return nil
@@ -138,10 +138,11 @@ func DepositGas(ctx context.Context, sm protocol.StateManager, amount *big.Int, 
 	if blkCtx.BlockHeight == 0 {
 		return nil
 	}
-	if registry == nil {
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	if bcCtx.Registry == nil {
 		return nil
 	}
-	p, ok := registry.Find(ProtocolID)
+	p, ok := bcCtx.Registry.Find(ProtocolID)
 	if !ok {
 		return nil
 	}

--- a/action/protocol/rewarding/fund_test.go
+++ b/action/protocol/rewarding/fund_test.go
@@ -45,9 +45,6 @@ func TestProtocol_Fund(t *testing.T) {
 
 func TestDepositNegativeGasFee(t *testing.T) {
 	testProtocol(t, func(t *testing.T, ctx context.Context, sm protocol.StateManager, p *Protocol) {
-		r := protocol.NewRegistry()
-		r.Register(ProtocolID, p)
-
-		require.Error(t, DepositGas(ctx, sm, big.NewInt(-1), r))
+		require.Error(t, DepositGas(ctx, sm, big.NewInt(-1)))
 	}, false)
 }

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -231,14 +231,13 @@ func (p *Protocol) settleAction(
 ) (*action.Receipt, error) {
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	if status == uint64(iotextypes.ReceiptStatus_Failure) {
 		if err := sm.Revert(si); err != nil {
 			return nil, err
 		}
 	}
 	gasFee := big.NewInt(0).Mul(actionCtx.GasPrice, big.NewInt(0).SetUint64(actionCtx.IntrinsicGas))
-	if err := DepositGas(ctx, sm, gasFee, bcCtx.Registry); err != nil {
+	if err := DepositGas(ctx, sm, gasFee); err != nil {
 		return nil, err
 	}
 	if err := p.increaseNonce(sm, actionCtx.Caller, actionCtx.Nonce); err != nil {
@@ -248,7 +247,7 @@ func (p *Protocol) settleAction(
 }
 
 func (p *Protocol) increaseNonce(sm protocol.StateManager, addr address.Address, nonce uint64) error {
-	acc, err := accountutil.LoadOrCreateAccount(sm, addr.String(), big.NewInt(0))
+	acc, err := accountutil.LoadOrCreateAccount(sm, addr.String())
 	if err != nil {
 		return err
 	}

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -339,7 +339,7 @@ func (p *Protocol) claimFromAccount(sm protocol.StateManager, addr address.Addre
 	}
 
 	// Update primary account
-	primAcc, err := accountutil.LoadOrCreateAccount(sm, addr.String(), big.NewInt(0))
+	primAcc, err := accountutil.LoadOrCreateAccount(sm, addr.String())
 	if err != nil {
 		return err
 	}

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
 	"github.com/iotexproject/iotex-core/action/protocol/execution"
+	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -86,7 +87,7 @@ func TestActPool_validateGenericAction(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	re := protocol.NewRegistry()
-	require.NoError(re.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(re.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	bc := blockchain.NewBlockchain(
 		cfg,
 		nil,
@@ -158,7 +159,7 @@ func TestActPool_AddActs(t *testing.T) {
 	defer ctrl.Finish()
 	require := require.New(t)
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	cfg.Genesis.InitBalanceMap[addr2] = "10"
@@ -177,7 +178,7 @@ func TestActPool_AddActs(t *testing.T) {
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
 	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-	ap.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+	ap.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 	// Test actpool status after adding a sequence of Tsfs/votes: need to check confirmed nonce, pending nonce, and pending balance
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
 	require.NoError(err)
@@ -322,7 +323,7 @@ func TestActPool_PickActs(t *testing.T) {
 	createActPool := func(cfg config.ActPool) (*actPool, []action.SealedEnvelope, []action.SealedEnvelope, []action.SealedEnvelope) {
 		require := require.New(t)
 		registry := protocol.NewRegistry()
-		require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+		require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 		cfgDefault := config.Default
 		cfgDefault.Genesis.InitBalanceMap[addr1] = "100"
 		cfgDefault.Genesis.InitBalanceMap[addr2] = "10"
@@ -340,7 +341,7 @@ func TestActPool_PickActs(t *testing.T) {
 		ap, ok := Ap.(*actPool)
 		require.True(ok)
 		ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-		ap.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+		ap.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 
 		tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
 		require.NoError(err)
@@ -407,7 +408,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	require.NoError(registry.Register(execution.ProtocolID, execution.NewProtocol(bc.BlockDAO().GetBlockHash)))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool
@@ -417,7 +418,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
 	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-	ap.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+	ap.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 
 	tsf1, err := testutil.SignedTransfer(addr1, priKey1, uint64(1), big.NewInt(10), []byte{}, uint64(100000), big.NewInt(0))
 	require.NoError(err)
@@ -461,7 +462,7 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 func TestActPool_Reset(t *testing.T) {
 	require := require.New(t)
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	cfg.Genesis.InitBalanceMap[addr2] = "200"
@@ -484,13 +485,13 @@ func TestActPool_Reset(t *testing.T) {
 	ap1, ok := Ap1.(*actPool)
 	require.True(ok)
 	ap1.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-	ap1.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+	ap1.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 	Ap2, err := NewActPool(bc, apConfig, EnableExperimentalActions())
 	require.NoError(err)
 	ap2, ok := Ap2.(*actPool)
 	require.True(ok)
 	ap2.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-	ap2.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+	ap2.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 
 	// Tsfs to be added to ap1
 	tsf1, err := testutil.SignedTransfer(addr2, priKey1, uint64(1), big.NewInt(50), []byte{}, uint64(20000), big.NewInt(0))
@@ -838,7 +839,7 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	bc := blockchain.NewBlockchain(
 		cfg,
 		nil,
@@ -886,7 +887,7 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	cfg.Genesis.InitBalanceMap[addr2] = "100"
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	bc := blockchain.NewBlockchain(
 		cfg,
 		nil,
@@ -930,7 +931,7 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	cfg.Genesis.InitBalanceMap[addr2] = "100"
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	bc := blockchain.NewBlockchain(
 		cfg,
 		nil,
@@ -1027,7 +1028,7 @@ func TestActPool_GetSize(t *testing.T) {
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	re := protocol.NewRegistry()
-	require.NoError(re.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(re.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	bc := blockchain.NewBlockchain(
 		cfg,
 		nil,
@@ -1044,7 +1045,7 @@ func TestActPool_GetSize(t *testing.T) {
 	ap, ok := Ap.(*actPool)
 	require.True(ok)
 	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(bc.Factory().Nonce))
-	ap.AddActionValidators(account.NewProtocol(), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
+	ap.AddActionValidators(account.NewProtocol(rewarding.DepositGas), execution.NewProtocol(bc.BlockDAO().GetBlockHash))
 	require.Zero(ap.GetSize())
 	require.Zero(ap.GetGasSize())
 

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
 	"github.com/iotexproject/iotex-core/action/protocol/execution"
+	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/unit"
@@ -102,7 +103,7 @@ func TestWrongNonce(t *testing.T) {
 
 	require := require.New(t)
 	registry := protocol.NewRegistry()
-	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 
 	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
 	testTriePath := testTrieFile.Name()
@@ -353,7 +354,7 @@ func TestWrongAddress(t *testing.T) {
 		err := bc.Stop(ctx)
 		require.NoError(t, err)
 	}()
-	require.NoError(t, registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(t, registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	require.NoError(t, registry.Register(execution.ProtocolID, execution.NewProtocol(bc.BlockDAO().GetBlockHash)))
 
 	ctx = protocol.WithBlockchainCtx(
@@ -423,7 +424,7 @@ func TestBlackListAddress(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	require.NoError(t, registry.Register(account.ProtocolID, account.NewProtocol()))
+	require.NoError(t, registry.Register(account.ProtocolID, account.NewProtocol(rewarding.DepositGas)))
 	require.NoError(t, registry.Register(execution.ProtocolID, execution.NewProtocol(bc.BlockDAO().GetBlockHash)))
 
 	ctx = protocol.WithBlockchainCtx(

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
+	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/actpool"
 	bc "github.com/iotexproject/iotex-core/blockchain"
@@ -176,7 +177,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	cfg, err := newTestConfig()
 	require.NoError(err)
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
@@ -235,7 +236,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	cfg, err := newTestConfig()
 	require.NoError(err)
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))
@@ -327,7 +328,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	cfg, err := newTestConfig()
 	require.NoError(err)
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(registry.Register(account.ProtocolID, acc))
 	rolldposProtocol := rolldpos.NewProtocol(
 		cfg.Genesis.NumCandidateDelegates,

--- a/blocksync/buffer_test.go
+++ b/blocksync/buffer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
+	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
@@ -34,7 +35,7 @@ func TestBlockBufferFlush(t *testing.T) {
 	require.NoError(err)
 
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(registry.Register(rolldpos.ProtocolID, rp))

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -278,7 +278,7 @@ func New(
 				actPool,
 			)
 	}
-	accountProtocol := account.NewProtocol()
+	accountProtocol := account.NewProtocol(rewarding.DepositGas)
 	executionProtocol := execution.NewProtocol(chain.BlockDAO().GetBlockHash)
 	rewardingProtocol := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
 		return blockchain.ProductivityByEpoch(chain, epochNum)

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -9,7 +9,6 @@ package rolldpos
 import (
 	"encoding/hex"
 	"fmt"
-	"math/big"
 	"net"
 	"sync"
 	"testing"
@@ -30,6 +29,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
@@ -422,7 +422,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 			for j := 0; j < numNodes; j++ {
 				ws, err := sf.NewWorkingSet()
 				require.NoError(t, err)
-				_, err = accountutil.LoadOrCreateAccount(ws, chainRawAddrs[j], big.NewInt(0))
+				_, err = accountutil.LoadOrCreateAccount(ws, chainRawAddrs[j])
 				require.NoError(t, err)
 				gasLimit := testutil.TestGasLimit
 				wsctx := protocol.WithBlockCtx(
@@ -445,7 +445,7 @@ func TestRollDPoSConsensus(t *testing.T) {
 				require.NoError(t, sf.Commit(ws))
 			}
 			registry := protocol.NewRegistry()
-			acc := account.NewProtocol()
+			acc := account.NewProtocol(rewarding.DepositGas)
 			require.NoError(t, registry.Register(account.ProtocolID, acc))
 			rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 			require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -190,7 +190,7 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol) {
 		return blockchain.ProductivityByEpoch(chain, epochNum)
 	}, rolldposProtocol)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	registry.Register(account.ProtocolID, acc)
 	require.NoError(registry.Register(poll.ProtocolID, poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)))
 	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain.Factory().Nonce))

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -72,7 +72,7 @@ func prepareBlockchain(ctx context.Context, executor string, r *require.Assertio
 	cfg.Genesis.EnableGravityChainVoting = false
 	cfg.Genesis.InitBalanceMap[executor] = "1000000000000000000000000000"
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	r.NoError(registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	r.NoError(registry.Register(rolldpos.ProtocolID, rp))

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -178,7 +178,7 @@ func TestLocalCommit(t *testing.T) {
 	require.NoError(registry.Register(rolldpos.ProtocolID, rolldposProtocol))
 	rewardingProtocol := rewarding.NewProtocol(nil, rolldposProtocol)
 	registry.Register(rewarding.ProtocolID, rewardingProtocol)
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	registry.Register(account.ProtocolID, acc)
 	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(chain.Factory().Nonce))
 	require.NoError(chain.Start(ctx))

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -42,7 +42,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))
@@ -116,7 +116,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
 	registry := protocol.NewRegistry()
-	acc := account.NewProtocol()
+	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, registry.Register(account.ProtocolID, acc))
 	rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 	require.NoError(t, registry.Register(rolldpos.ProtocolID, rp))


### PR DESCRIPTION
LoadOrCreateAccount shouldn't come with init balance parameter. This PR deletes the "init" parameter, and introduce a "createAccount" in account protocol to initialize account balance.