### PR TITLE
fix candidates related bugs

### DIFF
--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -90,14 +90,17 @@ func NewStakingCommittee(
 }
 
 func (sc *stakingCommittee) CreateGenesisStates(ctx context.Context, sm protocol.StateManager) error {
-	raCtx := protocol.MustGetRunActionsCtx(ctx)
-	if raCtx.BlockHeight != 0 {
-		return errors.Errorf("Cannot create genesis state for height %d", raCtx.BlockHeight)
-	}
 	if gsc, ok := sc.governanceStaking.(protocol.GenesisStateCreator); ok {
 		if err := gsc.CreateGenesisStates(ctx, sm); err != nil {
 			return err
 		}
+	}
+	raCtx := protocol.MustGetRunActionsCtx(ctx)
+	if raCtx.BlockHeight != 0 {
+		return errors.Errorf("Cannot create genesis state for height %d", raCtx.BlockHeight)
+	}
+	if raCtx.Genesis.NativeStakingContractCode == "" || raCtx.Genesis.NativeStakingContractAddress != "" {
+		return nil
 	}
 	raCtx.Producer, _ = address.FromString(address.ZeroAddress)
 	raCtx.Caller, _ = address.FromString(nativeStakingContractCreator)

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -260,6 +260,9 @@ func (sf *factory) Commit(ws WorkingSet) error {
 //======================================
 
 func (sf *factory) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
+	if height == 0 {
+		return nil, nil
+	}
 	sf.mutex.RLock()
 	defer sf.mutex.RUnlock()
 	var candidates state.CandidateList

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -202,6 +202,9 @@ func (sdb *stateDB) Commit(ws WorkingSet) error {
 //======================================
 // CandidatesByHeight returns array of Candidates in candidate pool of a given height
 func (sdb *stateDB) CandidatesByHeight(height uint64) ([]*state.Candidate, error) {
+	if height == 0 {
+		return nil, nil
+	}
 	sdb.mutex.RLock()
 	defer sdb.mutex.RUnlock()
 	var candidates state.CandidateList


### PR DESCRIPTION
Two bugs:
1. Fetch candidates from state db with height = 0
   solution: return empty list
2. Create native staking contract in CreateGenesisStates
    solution: if native staking contract address is not empty or code is empty, skip contract creation