### PR TITLE
use existing context

### DIFF
--- a/action/protocol/poll/nativestaking_test.go
+++ b/action/protocol/poll/nativestaking_test.go
@@ -2,6 +2,7 @@ package poll
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"math/big"
 	"testing"
@@ -38,7 +39,7 @@ func TestStaking(t *testing.T) {
 
 	ns, err := NewNativeStaking(nil)
 	require.Error(err)
-	ns, err = NewNativeStaking(func(string, uint64, time.Time, []byte) ([]byte, error) {
+	ns, err = NewNativeStaking(func(context.Context, string, uint64, time.Time, []byte) ([]byte, error) {
 		return nil, nil
 	})
 	ns.SetContract("io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7")

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -211,7 +211,8 @@ func (sc *stakingCommittee) DelegatesByHeight(ctx context.Context, height uint64
 		return nil, errors.New("native staking was not set after cook height")
 	}
 
-	nativeVotes, err := sc.nativeStaking.Votes(bcCtx.Tip.Height, bcCtx.Tip.Timestamp)
+	// TODO: extract tip info inside of Votes function
+	nativeVotes, err := sc.nativeStaking.Votes(ctx, bcCtx.Tip.Height, bcCtx.Tip.Timestamp)
 	if err == ErrNoData {
 		// no native staking data
 		return sc.filterDelegates(cand), nil

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -40,7 +40,7 @@ var (
 )
 
 // ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
-type ProductivityByEpoch func(uint64) (uint64, map[string]uint64, error)
+type ProductivityByEpoch func(context.Context, uint64) (uint64, map[string]uint64, error)
 
 // Protocol defines the protocol of the rewarding fund and the rewarding process. It allows the admin to config the
 // reward amount, users to donate tokens to the fund, block producers to grant them block and epoch reward and,

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -60,7 +60,7 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 		genesis.Default.NumDelegates,
 		genesis.Default.NumSubEpochs,
 	)
-	p := NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+	p := NewProtocol(func(context.Context, uint64) (uint64, map[string]uint64, error) {
 		return uint64(19),
 			map[string]uint64{
 				identityset.Address(27).String(): 3,
@@ -227,7 +227,7 @@ func TestProtocol_Handle(t *testing.T) {
 		cfg.Genesis.NumSubEpochs,
 	)
 	require.NoError(t, rp.Register(registry))
-	p := NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+	p := NewProtocol(func(context.Context, uint64) (uint64, map[string]uint64, error) {
 		return 0, nil, nil
 	}, rp)
 	require.NoError(t, p.Register(registry))

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -154,7 +154,7 @@ func (p *Protocol) GrantEpochReward(
 	}
 
 	// Get unqualified delegate list
-	uqd, err := p.unqualifiedDelegates(blkCtx.Producer, epochNum, a.productivityThreshold)
+	uqd, err := p.unqualifiedDelegates(ctx, blkCtx.Producer, epochNum, a.productivityThreshold)
 	if err != nil {
 		return nil, err
 	}
@@ -412,12 +412,13 @@ func (p *Protocol) splitEpochReward(
 }
 
 func (p *Protocol) unqualifiedDelegates(
+	ctx context.Context,
 	producer address.Address,
 	epochNum uint64,
 	productivityThreshold uint64,
 ) (map[string]interface{}, error) {
 	unqualifiedDelegates := make(map[string]interface{}, 0)
-	numBlks, produce, err := p.productivityByEpoch(epochNum)
+	numBlks, produce, err := p.productivityByEpoch(ctx, epochNum)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -296,7 +296,7 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
-	p := NewProtocol(func(uint64) (uint64, map[string]uint64, error) {
+	p := NewProtocol(func(context.Context, uint64) (uint64, map[string]uint64, error) {
 		return uint64(19),
 			map[string]uint64{
 				identityset.Address(0).String(): 9,

--- a/api/api.go
+++ b/api/api.go
@@ -500,8 +500,11 @@ func (api *Server) GetEpochMeta(
 		Height:                  epochHeight,
 		GravityChainStartHeight: gravityChainStartHeight,
 	}
-
-	numBlks, produce, err := blockchain.ProductivityByEpoch(api.bc, in.EpochNumber)
+	bcCtx, err := api.bc.Context()
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	numBlks, produce, err := blockchain.ProductivityByEpoch(bcCtx, api.bc, in.EpochNumber)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1785,7 +1785,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 		genesis.Default.NumSubEpochs,
 		rolldpos.EnableDardanellesSubEpoch(cfg.Genesis.DardanellesBlockHeight, cfg.Genesis.DardanellesNumSubEpochs),
 	)
-	r := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
+	r := rewarding.NewProtocol(func(context.Context, uint64) (uint64, map[string]uint64, error) {
 		return 0, nil, nil
 	}, rolldposProtocol)
 

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -112,11 +112,7 @@ type Blockchain interface {
 }
 
 // ProductivityByEpoch returns the map of the number of blocks produced per delegate in an epoch
-func ProductivityByEpoch(bc Blockchain, epochNum uint64) (uint64, map[string]uint64, error) {
-	ctx, err := bc.Context()
-	if err != nil {
-		return 0, nil, err
-	}
+func ProductivityByEpoch(ctx context.Context, bc Blockchain, epochNum uint64) (uint64, map[string]uint64, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
 
@@ -427,6 +423,7 @@ func (bc *blockchain) ValidateBlock(blk *block.Block) error {
 func (bc *blockchain) Context() (context.Context, error) {
 	bc.mu.RLock()
 	defer bc.mu.RUnlock()
+
 	return bc.context(context.Background(), true, true)
 }
 
@@ -478,7 +475,7 @@ func (bc *blockchain) MintNewBlock(
 
 	newblockHeight := bc.tipHeight + 1
 	// run execution and update state trie root hash
-	ctx, err := bc.context(context.Background(), false, true)
+	ctx, err := bc.context(context.Background(), true, true)
 	if err != nil {
 		return nil, err
 	}

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -196,17 +196,13 @@ func New(
 		copts = append(copts, consensus.WithRollDPoSProtocol(rDPoSProtocol))
 		pollProtocol, err = poll.NewProtocol(
 			cfg,
-			func(contract string, height uint64, ts time.Time, params []byte) ([]byte, error) {
+			func(ctx context.Context, contract string, height uint64, ts time.Time, params []byte) ([]byte, error) {
 				ex, err := action.NewExecution(contract, 1, big.NewInt(0), 1000000, big.NewInt(0), params)
 				if err != nil {
 					return nil, err
 				}
 
 				addr, err := address.FromString(address.ZeroAddress)
-				if err != nil {
-					return nil, err
-				}
-				ctx, err := chain.Context()
 				if err != nil {
 					return nil, err
 				}
@@ -237,8 +233,8 @@ func New(
 		}
 	}
 	// TODO: rewarding protocol for standalone mode is weird, rDPoSProtocol could be passed via context
-	rewardingProtocol := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
-		return blockchain.ProductivityByEpoch(chain, epochNum)
+	rewardingProtocol := rewarding.NewProtocol(func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
+		return blockchain.ProductivityByEpoch(ctx, chain, epochNum)
 	}, rDPoSProtocol)
 	// TODO: explorer dependency deleted at #1085, need to revive by migrating to api
 	consensus, err := consensus.NewConsensus(cfg, chain, actPool, copts...)

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -186,8 +186,8 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol) {
 	)
 
 	require.NoError(rolldposProtocol.Register(registry))
-	rewardingProtocol := rewarding.NewProtocol(func(epochNum uint64) (uint64, map[string]uint64, error) {
-		return blockchain.ProductivityByEpoch(chain, epochNum)
+	rewardingProtocol := rewarding.NewProtocol(func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
+		return blockchain.ProductivityByEpoch(ctx, chain, epochNum)
 	}, rolldposProtocol)
 	require.NoError(rewardingProtocol.Register(registry))
 	acc := account.NewProtocol(rewarding.DepositGas)


### PR DESCRIPTION
Both ReadContract and ProductivityByEpoch are able to get context.Context from Protocol. This PR tries to use the existing context.Context, instead of generating one, to prevent dead lock.