### PR TITLE
remove BlockDAO() from blockchain interface

### DIFF
--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -23,7 +23,9 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/execution"
 	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/blockchain"
+	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
@@ -167,11 +169,11 @@ func TestActPool_AddActs(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[addr2] = "10"
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	require.NoError(bc.Start(context.Background()))
@@ -200,7 +202,7 @@ func TestActPool_AddActs(t *testing.T) {
 	tsf8, err := testutil.SignedTransfer(addr2, priKey2, uint64(4), big.NewInt(5), []byte{}, uint64(100000), big.NewInt(0))
 	require.NoError(err)
 
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 
 	ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{Registry: registry})
@@ -336,11 +338,11 @@ func TestActPool_PickActs(t *testing.T) {
 		cfgDefault.Genesis.InitBalanceMap[addr2] = "10"
 		sf, err := factory.NewFactory(cfgDefault, factory.InMemTrieOption())
 		require.NoError(err)
+		dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfgDefault.Chain.CompressBlock, cfgDefault.DB)
 		bc := blockchain.NewBlockchain(
 			cfgDefault,
-			nil,
+			dao,
 			sf,
-			blockchain.InMemDaoOption(),
 			blockchain.RegistryOption(registry),
 		)
 		require.NoError(bc.Start(context.Background()))
@@ -372,7 +374,7 @@ func TestActPool_PickActs(t *testing.T) {
 		tsf10, err := testutil.SignedTransfer(addr2, priKey2, uint64(5), big.NewInt(5), []byte{}, uint64(100000), big.NewInt(0))
 		require.NoError(err)
 
-		ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+		ep := execution.NewProtocol(dao.GetBlockHash)
 		require.NoError(ep.Register(registry))
 
 		ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{Registry: registry})
@@ -415,16 +417,16 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool
@@ -483,16 +485,16 @@ func TestActPool_Reset(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[addr5] = "20"
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 	require.NoError(bc.Start(context.Background()))
 
@@ -845,16 +847,16 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 	registry := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool
@@ -898,16 +900,16 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 	registry := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool
@@ -947,16 +949,16 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	registry := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(registry),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(registry))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool
@@ -1053,16 +1055,16 @@ func TestActPool_GetSize(t *testing.T) {
 	re := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		blockchain.InMemDaoOption(),
 		blockchain.RegistryOption(re),
 	)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(re))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(ep.Register(re))
 	require.NoError(bc.Start(context.Background()))
 	// Create actpool

--- a/api/api.go
+++ b/api/api.go
@@ -142,7 +142,7 @@ func NewServer(
 		cfg:               cfg,
 		registry:          registry,
 		chainListener:     NewChainListener(),
-		gs:                gasstation.NewGasStation(chain, sf, dao, cfg.API),
+		gs:                gasstation.NewGasStation(chain, sf.SimulateExecution, dao, cfg.API),
 		electionCommittee: apiCfg.electionCommittee,
 	}
 	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok {

--- a/api/api.go
+++ b/api/api.go
@@ -142,7 +142,7 @@ func NewServer(
 		cfg:               cfg,
 		registry:          registry,
 		chainListener:     NewChainListener(),
-		gs:                gasstation.NewGasStation(chain, sf, cfg.API),
+		gs:                gasstation.NewGasStation(chain, sf, dao, cfg.API),
 		electionCommittee: apiCfg.electionCommittee,
 	}
 	if _, ok := cfg.Plugins[config.GatewayPlugin]; ok {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -779,7 +779,7 @@ func TestServer_GetAction(t *testing.T) {
 		require.Equal(test.nonce, act.Action.GetCore().GetNonce())
 		require.Equal(test.senderPubKey, hex.EncodeToString(act.Action.SenderPubKey))
 		if !test.checkPending {
-			blk, err := svr.bc.BlockDAO().GetBlockByHeight(test.blkNumber)
+			blk, err := svr.dao.GetBlockByHeight(test.blkNumber)
 			require.NoError(err)
 			timeStamp := blk.ConvertToBlockHeaderPb().GetCore().GetTimestamp()
 			blkHash := blk.HashBlock()
@@ -1774,7 +1774,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 	}()
 
 	acc := account.NewProtocol(rewarding.DepositGas)
-	evm := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	evm := execution.NewProtocol(dao.GetBlockHash)
 	p := poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 	rolldposProtocol := rolldpos.NewProtocol(
 		genesis.Default.NumCandidateDelegates,
@@ -1876,7 +1876,7 @@ func createServer(cfg config.Config, needActPool bool) (*Server, error) {
 		indexer:        indexer,
 		ap:             ap,
 		cfg:            cfg,
-		gs:             gasstation.NewGasStation(bc, sf, cfg.API),
+		gs:             gasstation.NewGasStation(bc, sf, dao, cfg.API),
 		registry:       registry,
 		hasActionIndex: true,
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1876,7 +1876,7 @@ func createServer(cfg config.Config, needActPool bool) (*Server, error) {
 		indexer:        indexer,
 		ap:             ap,
 		cfg:            cfg,
-		gs:             gasstation.NewGasStation(bc, sf, dao, cfg.API),
+		gs:             gasstation.NewGasStation(bc, sf.SimulateExecution, dao, cfg.API),
 		registry:       registry,
 		hasActionIndex: true,
 	}

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -69,8 +69,6 @@ type Blockchain interface {
 	BlockFooterByHeight(height uint64) (*block.Footer, error)
 	// BlockFooterByHash return block footer by hash
 	BlockFooterByHash(h hash.Hash256) (*block.Footer, error)
-	// BlockDAO returns the block dao
-	BlockDAO() blockdao.BlockDAO
 	// ChainID returns the chain ID
 	ChainID() uint32
 	// ChainAddress returns chain address on parent chain, the root chain return empty.
@@ -267,10 +265,6 @@ func NewBlockchain(cfg config.Config, dao blockdao.BlockDAO, sf factory.Factory,
 		chain.lifecycle.Add(chain.sf)
 	}
 	return chain
-}
-
-func (bc *blockchain) BlockDAO() blockdao.BlockDAO {
-	return bc.dao
 }
 
 func (bc *blockchain) ChainID() uint32 {

--- a/blockchain/blockvalidator_test.go
+++ b/blockchain/blockvalidator_test.go
@@ -25,7 +25,9 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/execution"
 	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -261,7 +263,8 @@ func TestWrongAddress(t *testing.T) {
 	registry := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(t, err)
-	bc := NewBlockchain(cfg, nil, sf, InMemDaoOption(), RegistryOption(registry))
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
+	bc := NewBlockchain(cfg, dao, sf, RegistryOption(registry))
 	require.NoError(t, bc.Start(ctx))
 	require.NotNil(t, bc)
 	defer func() {
@@ -270,7 +273,7 @@ func TestWrongAddress(t *testing.T) {
 	}()
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(t, ep.Register(registry))
 
 	ctx = protocol.WithBlockchainCtx(
@@ -334,7 +337,8 @@ func TestBlackListAddress(t *testing.T) {
 	registry := protocol.NewRegistry()
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(t, err)
-	bc := NewBlockchain(cfg, nil, sf, InMemDaoOption(), RegistryOption(registry))
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
+	bc := NewBlockchain(cfg, dao, sf, RegistryOption(registry))
 	require.NoError(t, bc.Start(ctx))
 	require.NotNil(t, bc)
 	defer func() {
@@ -344,7 +348,7 @@ func TestBlackListAddress(t *testing.T) {
 
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, acc.Register(registry))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(dao.GetBlockHash)
 	require.NoError(t, ep.Register(registry))
 
 	ctx = protocol.WithBlockchainCtx(

--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/consensus"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
@@ -71,6 +72,7 @@ type blockSyncer struct {
 	buf              *blockBuffer
 	worker           *syncWorker
 	bc               blockchain.Blockchain
+	dao              blockdao.BlockDAO
 	unicastHandler   UnicastOutbound
 	neighborsHandler Neighbors
 }
@@ -79,6 +81,7 @@ type blockSyncer struct {
 func NewBlockSyncer(
 	cfg config.Config,
 	chain blockchain.Blockchain,
+	dao blockdao.BlockDAO,
 	ap actpool.ActPool,
 	cs consensus.Consensus,
 	opts ...Option,
@@ -99,6 +102,7 @@ func NewBlockSyncer(
 	}
 	bs := &blockSyncer{
 		bc:               chain,
+		dao:              dao,
 		buf:              buf,
 		unicastHandler:   bsCfg.unicastHandler,
 		neighborsHandler: bsCfg.neighborsHandler,
@@ -174,7 +178,7 @@ func (bs *blockSyncer) ProcessSyncRequest(ctx context.Context, peer peerstore.Pe
 		)
 	}
 	for i := sync.Start; i <= end; i++ {
-		blk, err := bs.bc.BlockDAO().GetBlockByHeight(i)
+		blk, err := bs.dao.GetBlockByHeight(i)
 		if err != nil {
 			return err
 		}

--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/consensus"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
@@ -30,6 +29,11 @@ type (
 	// Neighbors returns the neighbors' addresses
 	Neighbors func(ctx context.Context) ([]peerstore.PeerInfo, error)
 )
+
+// BlockDAO represents the block data access object
+type BlockDAO interface {
+	GetBlockByHeight(uint64) (*block.Block, error)
+}
 
 // Config represents the config to setup blocksync
 type Config struct {
@@ -72,7 +76,7 @@ type blockSyncer struct {
 	buf              *blockBuffer
 	worker           *syncWorker
 	bc               blockchain.Blockchain
-	dao              blockdao.BlockDAO
+	dao              BlockDAO
 	unicastHandler   UnicastOutbound
 	neighborsHandler Neighbors
 }
@@ -81,7 +85,7 @@ type blockSyncer struct {
 func NewBlockSyncer(
 	cfg config.Config,
 	chain blockchain.Blockchain,
-	dao blockdao.BlockDAO,
+	dao BlockDAO,
 	ap actpool.ActPool,
 	cs consensus.Consensus,
 	opts ...Option,

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -29,7 +29,9 @@ import (
 	"github.com/iotexproject/iotex-core/actpool"
 	bc "github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
@@ -69,7 +71,6 @@ func TestNewBlockSyncer(t *testing.T) {
 	)
 	dao := mock_blockdao.NewMockBlockDAO(ctrl)
 	dao.EXPECT().GetBlockByHeight(gomock.Any()).AnyTimes().Return(blk, nil)
-	mBc.EXPECT().BlockDAO().Return(dao).AnyTimes()
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
@@ -78,7 +79,7 @@ func TestNewBlockSyncer(t *testing.T) {
 
 	cs := mock_consensus.NewMockConsensus(ctrl)
 
-	bs, err := NewBlockSyncer(cfg, mBc, ap, cs, opts...)
+	bs, err := NewBlockSyncer(cfg, mBc, dao, ap, cs, opts...)
 	assert.Nil(err)
 	assert.NotNil(bs)
 }
@@ -127,7 +128,6 @@ func TestBlockSyncerProcessSyncRequest(t *testing.T) {
 	)
 	dao := mock_blockdao.NewMockBlockDAO(ctrl)
 	dao.EXPECT().GetBlockByHeight(gomock.Any()).AnyTimes().Return(blk, nil)
-	mBc.EXPECT().BlockDAO().Return(dao).AnyTimes()
 	mBc.EXPECT().TipHeight().AnyTimes().Return(uint64(0))
 	cfg, err := newTestConfig()
 	require.NoError(err)
@@ -135,7 +135,7 @@ func TestBlockSyncerProcessSyncRequest(t *testing.T) {
 	assert.NoError(err)
 	cs := mock_consensus.NewMockConsensus(ctrl)
 
-	bs, err := NewBlockSyncer(cfg, mBc, ap, cs, opts...)
+	bs, err := NewBlockSyncer(cfg, mBc, dao, ap, cs, opts...)
 	assert.NoError(err)
 
 	pbBs := &iotexrpc.BlockSync{
@@ -157,7 +157,6 @@ func TestBlockSyncerProcessSyncRequestError(t *testing.T) {
 	sf := mock_factory.NewMockFactory(ctrl)
 	dao := mock_blockdao.NewMockBlockDAO(ctrl)
 	dao.EXPECT().GetBlockByHeight(uint64(1)).Return(nil, errors.New("some error")).Times(1)
-	chain.EXPECT().BlockDAO().Return(dao).Times(1)
 	chain.EXPECT().ChainID().Return(uint32(1)).AnyTimes()
 	chain.EXPECT().TipHeight().Return(uint64(10)).Times(1)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool, actpool.EnableExperimentalActions())
@@ -165,7 +164,7 @@ func TestBlockSyncerProcessSyncRequestError(t *testing.T) {
 	require.NoError(err)
 	cs := mock_consensus.NewMockConsensus(ctrl)
 
-	bs, err := NewBlockSyncer(cfg, chain, ap, cs, opts...)
+	bs, err := NewBlockSyncer(cfg, chain, dao, ap, cs, opts...)
 	require.NoError(err)
 	pbBs := &iotexrpc.BlockSync{
 		Start: 1,
@@ -188,11 +187,11 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	require.NoError(rp.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	chain := bc.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		bc.InMemDaoOption(),
 		bc.RegistryOption(registry),
 	)
 	chain.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(sf.AccountState))
@@ -205,7 +204,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	cs.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(1)
 	cs.EXPECT().Calibrate(uint64(1)).Times(1)
 
-	bs, err := NewBlockSyncer(cfg, chain, ap, cs, opts...)
+	bs, err := NewBlockSyncer(cfg, chain, dao, ap, cs, opts...)
 	require.NoError(err)
 
 	defer func() {
@@ -249,11 +248,11 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	require.NoError(rp.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	chain1 := bc.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		bc.InMemDaoOption(),
 		bc.RegistryOption(registry),
 	)
 	require.NotNil(chain1)
@@ -266,18 +265,18 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	cs1.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(3)
 	cs1.EXPECT().Calibrate(gomock.Any()).Times(3)
 
-	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
+	bs1, err := NewBlockSyncer(cfg, chain1, dao, ap1, cs1, opts...)
 	require.NoError(err)
 	registry2 := protocol.NewRegistry()
 	require.NoError(acc.Register(registry2))
 	require.NoError(rp.Register(registry2))
 	sf2, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao2 := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	chain2 := bc.NewBlockchain(
 		cfg,
-		nil,
+		dao2,
 		sf2,
-		bc.InMemDaoOption(),
 		bc.RegistryOption(registry2),
 	)
 	require.NotNil(chain2)
@@ -289,7 +288,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	cs2 := mock_consensus.NewMockConsensus(ctrl)
 	cs2.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(3)
 	cs2.EXPECT().Calibrate(gomock.Any()).Times(3)
-	bs2, err := NewBlockSyncer(cfg, chain2, ap2, cs2, opts...)
+	bs2, err := NewBlockSyncer(cfg, chain2, dao2, ap2, cs2, opts...)
 	require.NoError(err)
 
 	defer func() {
@@ -349,11 +348,11 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	require.NoError(rolldposProtocol.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	chain1 := bc.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		sf,
-		bc.InMemDaoOption(),
 		bc.RegistryOption(registry),
 	)
 	chain1.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(sf.AccountState))
@@ -365,18 +364,18 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	cs1 := mock_consensus.NewMockConsensus(ctrl)
 	cs1.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(3)
 	cs1.EXPECT().Calibrate(gomock.Any()).Times(3)
-	bs1, err := NewBlockSyncer(cfg, chain1, ap1, cs1, opts...)
+	bs1, err := NewBlockSyncer(cfg, chain1, dao, ap1, cs1, opts...)
 	require.NoError(err)
 	registry2 := protocol.NewRegistry()
 	require.NoError(acc.Register(registry2))
 	require.NoError(rolldposProtocol.Register(registry2))
 	sf2, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
+	dao2 := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
 	chain2 := bc.NewBlockchain(
 		cfg,
-		nil,
+		dao2,
 		sf2,
-		bc.InMemDaoOption(),
 		bc.RegistryOption(registry2),
 	)
 	chain2.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(sf2.AccountState))
@@ -388,7 +387,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	cs2 := mock_consensus.NewMockConsensus(ctrl)
 	cs2.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(3)
 	cs2.EXPECT().Calibrate(gomock.Any()).Times(3)
-	bs2, err := NewBlockSyncer(cfg, chain2, ap2, cs2, opts...)
+	bs2, err := NewBlockSyncer(cfg, chain2, dao2, ap2, cs2, opts...)
 	require.NoError(err)
 
 	defer func() {
@@ -441,7 +440,8 @@ func TestBlockSyncerSync(t *testing.T) {
 	require.NoError(rp.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption())
 	require.NoError(err)
-	chain := bc.NewBlockchain(cfg, nil, sf, bc.InMemDaoOption(), bc.RegistryOption(registry))
+	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), nil, cfg.Chain.CompressBlock, cfg.DB)
+	chain := bc.NewBlockchain(cfg, dao, sf, bc.RegistryOption(registry))
 	require.NoError(chain.Start(ctx))
 	require.NotNil(chain)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool, actpool.EnableExperimentalActions())
@@ -451,7 +451,7 @@ func TestBlockSyncerSync(t *testing.T) {
 	cs.EXPECT().ValidateBlockFooter(gomock.Any()).Return(nil).Times(2)
 	cs.EXPECT().Calibrate(gomock.Any()).Times(2)
 
-	bs, err := NewBlockSyncer(cfg, chain, ap, cs, opts...)
+	bs, err := NewBlockSyncer(cfg, chain, dao, ap, cs, opts...)
 	require.NotNil(bs)
 	require.NoError(err)
 	require.NoError(bs.Start(ctx))

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -50,6 +50,7 @@ type ChainService struct {
 	consensus         consensus.Consensus
 	chain             blockchain.Blockchain
 	factory           factory.Factory
+	blockdao          blockdao.BlockDAO
 	electionCommittee committee.Committee
 	// TODO: explorer dependency deleted at #1085, need to api related params
 	api          *api.Server
@@ -253,6 +254,7 @@ func New(
 	bs, err := blocksync.NewBlockSyncer(
 		cfg,
 		chain,
+		dao,
 		actPool,
 		consensus,
 		blocksync.WithUnicastOutBound(func(ctx context.Context, peer peerstore.PeerInfo, msg proto.Message) error {
@@ -299,7 +301,7 @@ func New(
 			)
 	}
 	accountProtocol := account.NewProtocol(rewarding.DepositGas)
-	executionProtocol := execution.NewProtocol(chain.BlockDAO().GetBlockHash)
+	executionProtocol := execution.NewProtocol(dao.GetBlockHash)
 	if accountProtocol != nil {
 		if err = accountProtocol.Register(registry); err != nil {
 			return nil, err
@@ -330,6 +332,7 @@ func New(
 		actpool:           actPool,
 		chain:             chain,
 		factory:           sf,
+		blockdao:          dao,
 		blocksync:         bs,
 		consensus:         consensus,
 		electionCommittee: electionCommittee,
@@ -448,6 +451,11 @@ func (cs *ChainService) Blockchain() blockchain.Blockchain {
 // StateFactory returns the state factory
 func (cs *ChainService) StateFactory() factory.Factory {
 	return cs.factory
+}
+
+// BlockDAO returns the blockdao
+func (cs *ChainService) BlockDAO() blockdao.BlockDAO {
+	return cs.blockdao
 }
 
 // ActionPool returns the Action pool

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -386,24 +386,26 @@ func TestLocalSync(t *testing.T) {
 	chainID := cfg.Chain.ID
 	bc := svr.ChainService(chainID).Blockchain()
 	sf := svr.ChainService(chainID).StateFactory()
+	dao := svr.ChainService(chainID).BlockDAO()
 	require.NotNil(bc)
 	require.NotNil(sf)
+	require.NotNil(dao)
 	require.NotNil(svr.P2PAgent())
 	require.NoError(addTestingTsfBlocks(bc))
 
-	blk, err := bc.BlockDAO().GetBlockByHeight(1)
+	blk, err := dao.GetBlockByHeight(1)
 	require.NoError(err)
 	hash1 := blk.HashBlock()
-	blk, err = bc.BlockDAO().GetBlockByHeight(2)
+	blk, err = dao.GetBlockByHeight(2)
 	require.NoError(err)
 	hash2 := blk.HashBlock()
-	blk, err = bc.BlockDAO().GetBlockByHeight(3)
+	blk, err = dao.GetBlockByHeight(3)
 	require.NoError(err)
 	hash3 := blk.HashBlock()
-	blk, err = bc.BlockDAO().GetBlockByHeight(4)
+	blk, err = dao.GetBlockByHeight(4)
 	require.NoError(err)
 	hash4 := blk.HashBlock()
-	blk, err = bc.BlockDAO().GetBlockByHeight(5)
+	blk, err = dao.GetBlockByHeight(5)
 	require.NoError(err)
 	hash5 := blk.HashBlock()
 	require.NotNil(svr.P2PAgent())
@@ -447,23 +449,23 @@ func TestLocalSync(t *testing.T) {
 	)
 	require.NoError(err)
 	check := testutil.CheckCondition(func() (bool, error) {
-		blk1, err := cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(1)
+		blk1, err := cli.ChainService(chainID).BlockDAO().GetBlockByHeight(1)
 		if err != nil {
 			return false, nil
 		}
-		blk2, err := cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(2)
+		blk2, err := cli.ChainService(chainID).BlockDAO().GetBlockByHeight(2)
 		if err != nil {
 			return false, nil
 		}
-		blk3, err := cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(3)
+		blk3, err := cli.ChainService(chainID).BlockDAO().GetBlockByHeight(3)
 		if err != nil {
 			return false, nil
 		}
-		blk4, err := cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(4)
+		blk4, err := cli.ChainService(chainID).BlockDAO().GetBlockByHeight(4)
 		if err != nil {
 			return false, nil
 		}
-		blk5, err := cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(5)
+		blk5, err := cli.ChainService(chainID).BlockDAO().GetBlockByHeight(5)
 		if err != nil {
 			return false, nil
 		}
@@ -476,19 +478,19 @@ func TestLocalSync(t *testing.T) {
 	require.NoError(testutil.WaitUntil(time.Millisecond*100, time.Second*60, check))
 
 	// verify 4 received blocks
-	blk, err = cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(1)
+	blk, err = cli.ChainService(chainID).BlockDAO().GetBlockByHeight(1)
 	require.NoError(err)
 	require.Equal(hash1, blk.HashBlock())
-	blk, err = cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(2)
+	blk, err = cli.ChainService(chainID).BlockDAO().GetBlockByHeight(2)
 	require.NoError(err)
 	require.Equal(hash2, blk.HashBlock())
-	blk, err = cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(3)
+	blk, err = cli.ChainService(chainID).BlockDAO().GetBlockByHeight(3)
 	require.NoError(err)
 	require.Equal(hash3, blk.HashBlock())
-	blk, err = cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(4)
+	blk, err = cli.ChainService(chainID).BlockDAO().GetBlockByHeight(4)
 	require.NoError(err)
 	require.Equal(hash4, blk.HashBlock())
-	blk, err = cli.ChainService(chainID).Blockchain().BlockDAO().GetBlockByHeight(5)
+	blk, err = cli.ChainService(chainID).BlockDAO().GetBlockByHeight(5)
 	require.NoError(err)
 	require.Equal(hash5, blk.HashBlock())
 	t.Log("4 blocks received correctly")
@@ -518,8 +520,10 @@ func TestStartExistingBlockchain(t *testing.T) {
 	chainID := cfg.Chain.ID
 	bc := svr.ChainService(chainID).Blockchain()
 	sf := svr.ChainService(chainID).StateFactory()
+	dao := svr.ChainService(chainID).BlockDAO()
 	require.NotNil(bc)
 	require.NotNil(sf)
+	require.NotNil(dao)
 
 	defer func() {
 		require.NoError(svr.Stop(ctx))
@@ -540,9 +544,10 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.NoError(err)
 	require.NoError(svr.Start(ctx))
 	bc = svr.ChainService(chainID).Blockchain()
+	dao = svr.ChainService(chainID).BlockDAO()
 	// Recover to height 3 from empty state DB
 	testutil.CleanupPath(t, testTriePath)
-	require.NoError(bc.BlockDAO().DeleteBlockToTarget(3))
+	require.NoError(dao.DeleteBlockToTarget(3))
 	require.NoError(svr.Stop(ctx))
 	svr, err = itx.NewServer(cfg)
 	require.NoError(err)
@@ -550,13 +555,14 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.NoError(svr.Start(ctx))
 	bc = svr.ChainService(chainID).Blockchain()
 	sf = svr.ChainService(chainID).StateFactory()
+	dao = svr.ChainService(chainID).BlockDAO()
 	height, _ = sf.Height()
 	require.Equal(bc.TipHeight(), height)
 	require.Equal(uint64(3), height)
 
 	// Recover to height 2 from an existing state DB with Height 3
 	testutil.CleanupPath(t, testTriePath)
-	require.NoError(bc.BlockDAO().DeleteBlockToTarget(2))
+	require.NoError(dao.DeleteBlockToTarget(2))
 	require.NoError(svr.Stop(ctx))
 	svr, err = itx.NewServer(cfg)
 	require.NoError(err)

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -119,7 +119,7 @@ func TestBlockReward(t *testing.T) {
 	assert.True(t, balance.Cmp(big.NewInt(0).Mul(blockReward, big.NewInt(5))) <= 0)
 
 	for i := 1; i <= 5; i++ {
-		blk, err := svr.ChainService(1).Blockchain().BlockDAO().GetBlockByHeight(uint64(i))
+		blk, err := svr.ChainService(1).BlockDAO().GetBlockByHeight(uint64(i))
 		require.NoError(t, err)
 		ok := false
 		var gr *action.GrantReward

--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -7,33 +7,45 @@
 package gasstation
 
 import (
+	"context"
 	"math/big"
 	"sort"
 
+	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/action/protocol/execution/evm"
 	"github.com/iotexproject/iotex-core/blockchain"
-	"github.com/iotexproject/iotex-core/blockchain/blockdao"
+	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
+// BlockDAO represents the block data access object
+type BlockDAO interface {
+	GetBlockHash(uint64) (hash.Hash256, error)
+	GetBlockByHeight(uint64) (*block.Block, error)
+}
+
+// SimulateFunc is function that simulate execution
+type SimulateFunc func(context.Context, address.Address, *action.Execution, evm.GetBlockHash) ([]byte, *action.Receipt, error)
+
 // GasStation provide gas related api
 type GasStation struct {
-	bc  blockchain.Blockchain
-	sf  factory.Factory
-	dao blockdao.BlockDAO
-	cfg config.API
+	bc        blockchain.Blockchain
+	simulator SimulateFunc
+	dao       BlockDAO
+	cfg       config.API
 }
 
 // NewGasStation creates a new gas station
-func NewGasStation(bc blockchain.Blockchain, sf factory.Factory, dao blockdao.BlockDAO, cfg config.API) *GasStation {
+func NewGasStation(bc blockchain.Blockchain, simulator SimulateFunc, dao BlockDAO, cfg config.API) *GasStation {
 	return &GasStation{
-		bc:  bc,
-		sf:  sf,
-		dao: dao,
-		cfg: cfg,
+		bc:        bc,
+		simulator: simulator,
+		dao:       dao,
+		cfg:       cfg,
 	}
 }
 
@@ -110,7 +122,7 @@ func (gs *GasStation) EstimateGasForAction(actPb *iotextypes.Action) (uint64, er
 		if err != nil {
 			return 0, err
 		}
-		_, receipt, err := gs.sf.SimulateExecution(ctx, callerAddr, sc, gs.dao.GetBlockHash)
+		_, receipt, err := gs.simulator(ctx, callerAddr, sc, gs.dao.GetBlockHash)
 		if err != nil {
 			return 0, err
 		}

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -103,7 +103,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, sf, blkMemDao, cfg.API)
+	gs := NewGasStation(bc, sf.SimulateExecution, blkMemDao, cfg.API)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -160,7 +160,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, sf, blkMemDao, cfg.API)
+	gs := NewGasStation(bc, sf.SimulateExecution, blkMemDao, cfg.API)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -181,7 +181,7 @@ func TestEstimateGasForAction(t *testing.T) {
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, sf)
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
-	gs := NewGasStation(bc, sf, blkMemDao, config.Default.API)
+	gs := NewGasStation(bc, sf.SimulateExecution, blkMemDao, config.Default.API)
 	require.NotNil(gs)
 	ret, err := gs.EstimateGasForAction(act)
 	require.NoError(err)

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -35,7 +35,7 @@ import (
 
 func TestNewGasStation(t *testing.T) {
 	require := require.New(t)
-	require.NotNil(NewGasStation(nil, nil, config.Default.API))
+	require.NotNil(NewGasStation(nil, nil, nil, config.Default.API))
 }
 func TestSuggestGasPriceForUserAction(t *testing.T) {
 	ctx := context.Background()
@@ -53,7 +53,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	blkRegistryOption := blockchain.RegistryOption(registry)
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, sf, blkRegistryOption)
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(sf.AccountState))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(blkMemDao.GetBlockHash)
 	require.NoError(t, ep.Register(registry))
 	rewardingProtocol := rewarding.NewProtocol(nil, rp)
 	require.NoError(t, rewardingProtocol.Register(registry))
@@ -103,7 +103,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, sf, cfg.API)
+	gs := NewGasStation(bc, sf, blkMemDao, cfg.API)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -128,7 +128,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	blkRegistryOption := blockchain.RegistryOption(registry)
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, sf, blkRegistryOption)
 	bc.Validator().AddActionEnvelopeValidators(protocol.NewGenericValidator(sf.AccountState))
-	ep := execution.NewProtocol(bc.BlockDAO().GetBlockHash)
+	ep := execution.NewProtocol(blkMemDao.GetBlockHash)
 	require.NoError(t, ep.Register(registry))
 	rewardingProtocol := rewarding.NewProtocol(nil, rp)
 	require.NoError(t, rewardingProtocol.Register(registry))
@@ -160,7 +160,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, sf, cfg.API)
+	gs := NewGasStation(bc, sf, blkMemDao, cfg.API)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -181,7 +181,7 @@ func TestEstimateGasForAction(t *testing.T) {
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, sf)
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
-	gs := NewGasStation(bc, sf, config.Default.API)
+	gs := NewGasStation(bc, sf, blkMemDao, config.Default.API)
 	require.NotNil(gs)
 	ret, err := gs.EstimateGasForAction(act)
 	require.NoError(err)

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -11,7 +11,6 @@ import (
 	action "github.com/iotexproject/iotex-core/action"
 	blockchain "github.com/iotexproject/iotex-core/blockchain"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
-	blockdao "github.com/iotexproject/iotex-core/blockchain/blockdao"
 	genesis "github.com/iotexproject/iotex-core/blockchain/genesis"
 	reflect "reflect"
 	time "time"
@@ -126,20 +125,6 @@ func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error
 func (mr *MockBlockchainMockRecorder) BlockFooterByHash(h interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHash), h)
-}
-
-// BlockDAO mocks base method
-func (m *MockBlockchain) BlockDAO() blockdao.BlockDAO {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockDAO")
-	ret0, _ := ret[0].(blockdao.BlockDAO)
-	return ret0
-}
-
-// BlockDAO indicates an expected call of BlockDAO
-func (mr *MockBlockchainMockRecorder) BlockDAO() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockDAO", reflect.TypeOf((*MockBlockchain)(nil).BlockDAO))
 }
 
 // ChainID mocks base method


### PR DESCRIPTION
following to PR #1783, remove BlockDAO() from blockchain interface and use dao directly (not through bc) 