### PR TITLE
Use DelegatesByEpoch to unify the same logic at consensus

### DIFF
--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -113,6 +113,7 @@ func (p *governanceChainCommitteeProtocol) CreatePostSystemActions(ctx context.C
 	lastBlkHeight := rp.GetEpochLastBlockHeight(epochNum)
 	epochHeight := rp.GetEpochHeight(epochNum)
 	nextEpochHeight := rp.GetEpochHeight(epochNum + 1)
+	// make sure that putpollresult action is created around half of each epoch
 	if blkCtx.BlockHeight < epochHeight+(nextEpochHeight-epochHeight)/2 {
 		return nil, nil
 	}
@@ -123,7 +124,7 @@ func (p *governanceChainCommitteeProtocol) CreatePostSystemActions(ctx context.C
 		zap.Uint64("epochHeight", epochHeight),
 		zap.Uint64("nextEpochHeight", nextEpochHeight),
 	)
-	l, err := p.DelegatesByHeight(ctx, epochHeight)
+	l, err := p.CalculateCandidatesByHeight(ctx, epochHeight)
 	if err == nil && len(l) == 0 {
 		err = errors.Wrapf(
 			ErrDelegatesNotExist,
@@ -192,7 +193,7 @@ func (p *governanceChainCommitteeProtocol) delegatesByGravityChainHeight(height 
 	return l, nil
 }
 
-func (p *governanceChainCommitteeProtocol) DelegatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
+func (p *governanceChainCommitteeProtocol) CalculateCandidatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
 	gravityHeight, err := p.getGravityHeight(ctx, height)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get gravity chain height")

--- a/action/protocol/poll/lifelong_protocol.go
+++ b/action/protocol/poll/lifelong_protocol.go
@@ -16,7 +16,9 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/state"
 )
@@ -69,7 +71,7 @@ func (p *lifeLongDelegatesProtocol) Validate(ctx context.Context, act action.Act
 	return validate(ctx, p, act)
 }
 
-func (p *lifeLongDelegatesProtocol) DelegatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
+func (p *lifeLongDelegatesProtocol) CalculateCandidatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
 	return p.delegates, nil
 }
 

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -48,8 +48,8 @@ type Protocol interface {
 	protocol.GenesisStateCreator
 	// DelegatesByEpoch returns the delegates by epoch
 	DelegatesByEpoch(context.Context, uint64) (state.CandidateList, error)
-	// DelegatesByHeight returns the delegates by chain height
-	DelegatesByHeight(context.Context, uint64) (state.CandidateList, error)
+	// CalculateCandidatesByHeight calculates candidate and returns candidates by chain height
+	CalculateCandidatesByHeight(context.Context, uint64) (state.CandidateList, error)
 	// CandidatesByHeight returns a list of delegate candidates
 	CandidatesByHeight(context.Context, uint64) (state.CandidateList, error)
 }

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -183,8 +183,9 @@ func (sc *stakingCommittee) Validate(ctx context.Context, act action.Action) err
 	return validate(ctx, sc, act)
 }
 
-func (sc *stakingCommittee) DelegatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
-	cand, err := sc.governanceStaking.DelegatesByHeight(ctx, height)
+// CalculateCandidatesByHeight calculates delegates with native staking and returns merged list
+func (sc *stakingCommittee) CalculateCandidatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
+	cand, err := sc.governanceStaking.CalculateCandidatesByHeight(ctx, height)
 	if err != nil {
 		return nil, err
 	}
@@ -214,10 +215,12 @@ func (sc *stakingCommittee) DelegatesByHeight(ctx context.Context, height uint64
 	return sc.mergeDelegates(cand, nativeVotes, bcCtx.Tip.Timestamp), nil
 }
 
+// DelegatesByEpoch returns exact number of delegates according to epoch number
 func (sc *stakingCommittee) DelegatesByEpoch(ctx context.Context, epochNum uint64) (state.CandidateList, error) {
 	return sc.governanceStaking.DelegatesByEpoch(ctx, epochNum)
 }
 
+// CandidatesByHeight returns candidate list from state factory according to height
 func (sc *stakingCommittee) CandidatesByHeight(ctx context.Context, height uint64) (state.CandidateList, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	rp := rolldpos.MustGetProtocol(bcCtx.Registry)

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -79,7 +79,7 @@ func validate(ctx context.Context, p Protocol, act action.Action) error {
 	if err := validateDelegates(proposedDelegates); err != nil {
 		return err
 	}
-	ds, err := p.DelegatesByHeight(ctx, blkCtx.BlockHeight)
+	ds, err := p.CalculateCandidatesByHeight(ctx, blkCtx.BlockHeight)
 	if err != nil {
 		return err
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -463,7 +463,7 @@ var (
 		},
 	}
 
-	readDelegatesByEpochTests = []struct {
+	readCandidatesByEpochTests = []struct {
 		// Arguments
 		protocolID   string
 		protocolType string
@@ -475,14 +475,14 @@ var (
 		{
 			protocolID:   "poll",
 			protocolType: lld,
-			methodName:   "DelegatesByEpoch",
+			methodName:   "CandidatesByEpoch",
 			epoch:        1,
 			numDelegates: 3,
 		},
 		{
 			protocolID:   "poll",
 			protocolType: "governanceChainCommittee",
-			methodName:   "DelegatesByEpoch",
+			methodName:   "CandidatesByEpoch",
 			epoch:        1,
 			numDelegates: 2,
 		},
@@ -1213,7 +1213,7 @@ func TestServer_AvailableBalance(t *testing.T) {
 	assert.Equal(t, unit.ConvertIotxToRau(199999936), val)
 }
 
-func TestServer_ReadDelegatesByEpoch(t *testing.T) {
+func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
 
@@ -1233,7 +1233,7 @@ func TestServer_ReadDelegatesByEpoch(t *testing.T) {
 		},
 	}
 
-	for _, test := range readDelegatesByEpochTests {
+	for _, test := range readCandidatesByEpochTests {
 		var pol poll.Protocol
 		if test.protocolType == lld {
 			cfg.Genesis.Delegates = delegates

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -104,7 +104,7 @@ func NewConsensus(
 			SetActPool(ap).
 			SetClock(clock).
 			SetBroadcast(ops.broadcastHandler).
-			SetCandidatesByHeightFunc(ops.pp.CandidatesByHeight).
+			SetDelegatesByEpochFunc(ops.pp.DelegatesByEpoch).
 			RegisterProtocol(ops.rp)
 		// TODO: explorer dependency deleted here at #1085, need to revive by migrating to api
 		cs.scheme, err = bd.Build()

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -18,7 +18,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -163,7 +162,7 @@ func (r *RollDPoS) Calibrate(height uint64) {
 // ValidateBlockFooter validates the signatures in the block footer
 func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 	height := blk.Height()
-	round, err := r.ctx.RoundCalc().NewRound(height, r.ctx.BlockInterval(height), blk.Timestamp(), nil)
+	round, err := r.ctx.roundCalc.NewRound(height, r.ctx.BlockInterval(height), blk.Timestamp(), nil)
 	if err != nil {
 		return err
 	}
@@ -196,29 +195,9 @@ func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 	var metrics scheme.ConsensusMetrics
 	height := r.ctx.chain.TipHeight()
-	round, err := r.ctx.RoundCalc().NewRound(height+1, r.ctx.BlockInterval(height), r.ctx.clock.Now(), nil)
+	round, err := r.ctx.roundCalc.NewRound(height+1, r.ctx.BlockInterval(height), r.ctx.clock.Now(), nil)
 	if err != nil {
 		return metrics, errors.Wrap(err, "error when calculating round")
-	}
-	// Get all candidates
-	rp := r.ctx.roundCalc.rp
-	re := protocol.NewRegistry()
-	if err := rp.Register(re); err != nil {
-		return metrics, errors.Wrap(err, "failed to register rolldpos protocol")
-	}
-	ctx := protocol.WithBlockchainCtx(
-		context.Background(),
-		protocol.BlockchainCtx{
-			Registry: re,
-		},
-	)
-	candidates, err := r.ctx.roundCalc.candidatesByHeightFunc(ctx, height)
-	if err != nil {
-		return metrics, errors.Wrap(err, "error when getting all candidates")
-	}
-	candidateAddresses := make([]string, len(candidates))
-	for i, c := range candidates {
-		candidateAddresses[i] = c.Address
 	}
 
 	return scheme.ConsensusMetrics{
@@ -226,7 +205,6 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 		LatestHeight:        height,
 		LatestDelegates:     round.Delegates(),
 		LatestBlockProducer: round.proposer,
-		Candidates:          candidateAddresses,
 	}, nil
 }
 
@@ -266,8 +244,8 @@ type Builder struct {
 	broadcastHandler scheme.Broadcast
 	clock            clock.Clock
 	// TODO: explorer dependency deleted at #1085, need to add api params
-	rp                     *rolldpos.Protocol
-	candidatesByHeightFunc CandidatesByHeightFunc
+	rp                   *rolldpos.Protocol
+	delegatesByEpochFunc DelegatesByEpochFunc
 }
 
 // NewRollDPoSBuilder instantiates a Builder instance
@@ -317,11 +295,11 @@ func (b *Builder) SetClock(clock clock.Clock) *Builder {
 	return b
 }
 
-// SetCandidatesByHeightFunc sets candidatesByHeightFunc
-func (b *Builder) SetCandidatesByHeightFunc(
-	candidatesByHeightFunc CandidatesByHeightFunc,
+// SetDelegatesByEpochFunc sets delegatesByEpochFunc
+func (b *Builder) SetDelegatesByEpochFunc(
+	delegatesByEpochFunc DelegatesByEpochFunc,
 ) *Builder {
-	b.candidatesByHeightFunc = candidatesByHeightFunc
+	b.delegatesByEpochFunc = delegatesByEpochFunc
 	return b
 }
 
@@ -356,7 +334,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.actPool,
 		b.rp,
 		b.broadcastHandler,
-		b.candidatesByHeightFunc,
+		b.delegatesByEpochFunc,
 		b.encodedAddr,
 		b.priKey,
 		b.clock,

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -259,6 +259,10 @@ func (ctx *rollDPoSCtx) CheckBlockProposer(
 	return nil
 }
 
+func (ctx *rollDPoSCtx) RoundCalc() *roundCalculator {	
+	return ctx.roundCalc	
+}
+
 /////////////////////////////////////
 // Context of consensusFSM interfaces
 /////////////////////////////////////

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -72,7 +72,7 @@ func init() {
 	prometheus.MustRegister(consensusHeightMtc)
 }
 
-// CandidatesByHeightFunc defines a function to overwrite candidates
+// DelegatesByEpochFunc defines a function to overwrite candidates
 type DelegatesByEpochFunc func(context.Context, uint64) (state.CandidateList, error)
 type rollDPoSCtx struct {
 	consensusfsm.ConsensusConfig

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -73,7 +73,7 @@ func init() {
 }
 
 // CandidatesByHeightFunc defines a function to overwrite candidates
-type CandidatesByHeightFunc func(context.Context, uint64) (state.CandidateList, error)
+type DelegatesByEpochFunc func(context.Context, uint64) (state.CandidateList, error)
 type rollDPoSCtx struct {
 	consensusfsm.ConsensusConfig
 
@@ -103,7 +103,7 @@ func newRollDPoSCtx(
 	actPool actpool.ActPool,
 	rp *rolldpos.Protocol,
 	broadcastHandler scheme.Broadcast,
-	candidatesByHeightFunc CandidatesByHeightFunc,
+	delegatesByEpochFunc DelegatesByEpochFunc,
 	encodedAddr string,
 	priKey crypto.PrivateKey,
 	clock clock.Clock,
@@ -118,8 +118,8 @@ func newRollDPoSCtx(
 	if clock == nil {
 		return nil, errors.New("clock cannot be nil")
 	}
-	if candidatesByHeightFunc == nil {
-		return nil, errors.New("canidates by height function cannot be nil")
+	if delegatesByEpochFunc == nil {
+		return nil, errors.New("delegates by epoch function cannot be nil")
 	}
 	if cfg.AcceptBlockTTL(0)+cfg.AcceptProposalEndorsementTTL(0)+cfg.AcceptLockEndorsementTTL(0)+cfg.CommitTTL(0) > cfg.BlockInterval(0) {
 		return nil, errors.Errorf(
@@ -136,11 +136,11 @@ func newRollDPoSCtx(
 		eManagerDB = db.NewBoltDB(consensusDBConfig)
 	}
 	roundCalc := &roundCalculator{
-		candidatesByHeightFunc: candidatesByHeightFunc,
-		chain:                  chain,
-		rp:                     rp,
-		timeBasedRotation:      timeBasedRotation,
-		beringHeight:           beringHeight,
+		delegatesByEpochFunc: delegatesByEpochFunc,
+		chain:                chain,
+		rp:                   rp,
+		timeBasedRotation:    timeBasedRotation,
+		beringHeight:         beringHeight,
 	}
 	return &rollDPoSCtx{
 		ConsensusConfig:   cfg,
@@ -177,6 +177,7 @@ func (ctx *rollDPoSCtx) Stop(c context.Context) error {
 	return nil
 }
 
+// CheckVoteEndorser checks if the endorsement's endorser is a valid delegate at the given height
 func (ctx *rollDPoSCtx) CheckVoteEndorser(
 	height uint64,
 	vote *ConsensusVote,
@@ -195,6 +196,7 @@ func (ctx *rollDPoSCtx) CheckVoteEndorser(
 	return nil
 }
 
+// CheckBlockProposer checks the block proposal
 func (ctx *rollDPoSCtx) CheckBlockProposer(
 	height uint64,
 	proposal *blockProposal,
@@ -257,12 +259,8 @@ func (ctx *rollDPoSCtx) CheckBlockProposer(
 	return nil
 }
 
-func (ctx *rollDPoSCtx) RoundCalc() *roundCalculator {
-	return ctx.roundCalc
-}
-
 /////////////////////////////////////
-// ConsensusFSM interfaces
+// Context of consensusFSM interfaces
 /////////////////////////////////////
 
 func (ctx *rollDPoSCtx) NewConsensusEvent(

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -32,7 +32,7 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg := config.Default
 	dbConfig := config.Default.DB
 	dbConfig.DbPath = config.Default.Consensus.RollDPoS.ConsensusDBPath
-	b, _, _, _ := makeChain(t)
+	b, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
 		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, nil, nil, nil, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0)
@@ -82,7 +82,7 @@ func TestRollDPoSCtx(t *testing.T) {
 func TestCheckVoteEndorser(t *testing.T) {
 	require := require.New(t)
 	cfg := config.Default
-	b, _, _, pp := makeChain(t)
+	b, _, pp := makeChain(t)
 	rp := rolldpos.NewProtocol(
 		config.Default.Genesis.NumCandidateDelegates,
 		config.Default.Genesis.NumDelegates,
@@ -109,7 +109,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 func TestCheckBlockProposer(t *testing.T) {
 	require := require.New(t)
 	cfg := config.Default
-	b, _, rp, pp := makeChain(t)
+	b, rp, pp := makeChain(t)
 	c := clock.New()
 	cfg.Genesis.BlockInterval = time.Second * 20
 	rctx, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), config.Default.DB, true, time.Second, true, b, nil, rp, nil, pp.DelegatesByEpoch, "", nil, c, config.Default.Genesis.BeringBlockHeight)

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -102,7 +102,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 	require.Error(rctx.CheckVoteEndorser(0, nil, en))
 
 	// case 3:normal
-	en = endorsement.NewEndorsement(time.Now(), identityset.PrivateKey(11).PublicKey(), nil)
+	en = endorsement.NewEndorsement(time.Now(), identityset.PrivateKey(10).PublicKey(), nil)
 	require.NoError(rctx.CheckVoteEndorser(1, nil, en))
 }
 

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -8,6 +8,7 @@ package rolldpos
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -15,18 +16,18 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/endorsement"
 )
 
 type roundCalculator struct {
-	chain                  ChainManager
-	timeBasedRotation      bool
-	rp                     *rolldpos.Protocol
-	candidatesByHeightFunc CandidatesByHeightFunc
-	beringHeight           uint64
+	chain                ChainManager
+	timeBasedRotation    bool
+	rp                   *rolldpos.Protocol
+	delegatesByEpochFunc DelegatesByEpochFunc
+	beringHeight         uint64
 }
 
+// UpdateRound updates previous roundCtx
 func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInterval time.Duration, now time.Time, toleratedOvertime time.Duration) (*roundCtx, error) {
 	epochNum := round.EpochNum()
 	epochStartHeight := round.EpochStartHeight()
@@ -40,6 +41,7 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 		}
 	default:
 		if height >= round.NextEpochStartHeight() {
+			// update the epoch
 			epochNum = c.rp.GetEpochNum(height)
 			epochStartHeight = c.rp.GetEpochHeight(epochNum)
 			var err error
@@ -91,6 +93,7 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 	}, nil
 }
 
+// Proposer returns the block producer of the round
 func (c *roundCalculator) Proposer(height uint64, blockInterval time.Duration, roundStartTime time.Time) string {
 	round, err := c.newRound(height, blockInterval, roundStartTime, nil, 0)
 	if err != nil {
@@ -114,6 +117,7 @@ func (c *roundCalculator) IsDelegate(addr string, height uint64) bool {
 	return false
 }
 
+// RoundInfo returns information of round by the given height and current time
 func (c *roundCalculator) RoundInfo(
 	height uint64,
 	blockInterval time.Duration,
@@ -164,9 +168,9 @@ func (c *roundCalculator) roundInfo(
 	return roundNum, roundStartTime, nil
 }
 
+// Delegates returns list of delegates at given height
 func (c *roundCalculator) Delegates(height uint64) ([]string, error) {
-	epochStartHeight := c.rp.GetEpochHeight(c.rp.GetEpochNum(height))
-	numDelegates := c.rp.NumDelegates()
+	epochNum := c.rp.GetEpochNum(height)
 	re := protocol.NewRegistry()
 	if err := c.rp.Register(re); err != nil {
 		return nil, err
@@ -177,33 +181,19 @@ func (c *roundCalculator) Delegates(height uint64) ([]string, error) {
 			Registry: re,
 		},
 	)
-	candidates, err := c.candidatesByHeightFunc(ctx, epochStartHeight)
+	candidatesList, err := c.delegatesByEpochFunc(ctx, epochNum)
 	if err != nil {
-		return nil, errors.Wrapf(
-			err,
-			"failed to get candidates on height %d",
-			epochStartHeight,
-		)
-	}
-	if len(candidates) < int(numDelegates) {
-		return nil, errors.Errorf(
-			"# of candidates %d is less than from required number %d",
-			len(candidates),
-			numDelegates,
-		)
+		return nil, errors.Wrapf(err, "failed to get delegate by epoch %d", epochNum)
 	}
 	addrs := []string{}
-	for i, candidate := range candidates {
-		if uint64(i) >= c.rp.NumCandidateDelegates() {
-			break
-		}
+	for _, candidate := range candidatesList {
 		addrs = append(addrs, candidate.Address)
 	}
-	crypto.SortCandidates(addrs, epochStartHeight, crypto.CryptoSeed)
 
-	return addrs[:numDelegates], nil
+	return addrs, nil
 }
 
+// NewRoundWithToleration starts new round with tolerated over time
 func (c *roundCalculator) NewRoundWithToleration(
 	height uint64,
 	blockInterval time.Duration,
@@ -214,6 +204,7 @@ func (c *roundCalculator) NewRoundWithToleration(
 	return c.newRound(height, blockInterval, now, eManager, toleratedOvertime)
 }
 
+// NewRound starts new round and returns roundCtx
 func (c *roundCalculator) NewRound(
 	height uint64,
 	blockInterval time.Duration,
@@ -240,17 +231,21 @@ func (c *roundCalculator) newRound(
 		epochNum = c.rp.GetEpochNum(height)
 		epochStartHeight := c.rp.GetEpochHeight(epochNum)
 		if delegates, err = c.Delegates(epochStartHeight); err != nil {
+			fmt.Println("aaa")
 			return
 		}
 		if roundNum, roundStartTime, err = c.roundInfo(height, blockInterval, now, toleratedOvertime); err != nil {
+			fmt.Println("bbb")
 			return
 		}
 		if proposer, err = c.calculateProposer(height, roundNum, delegates); err != nil {
+			fmt.Println("ccc")
 			return
 		}
 	}
 	if eManager == nil {
 		if eManager, err = newEndorsementManager(nil); err != nil {
+			fmt.Println("ddd")
 			return nil, err
 		}
 	}
@@ -273,6 +268,7 @@ func (c *roundCalculator) newRound(
 	return round, nil
 }
 
+// calculateProposer calulates proposer according to height and round number
 func (c *roundCalculator) calculateProposer(
 	height uint64,
 	round uint32,
@@ -280,6 +276,9 @@ func (c *roundCalculator) calculateProposer(
 ) (proposer string, err error) {
 	numDelegates := c.rp.NumDelegates()
 	if numDelegates != uint64(len(delegates)) {
+		fmt.Println("expected", numDelegates)
+		fmt.Println("real", len(delegates))
+		fmt.Println("qwer")
 		err = errors.New("invalid delegate list")
 		return
 	}

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -8,7 +8,6 @@ package rolldpos
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -231,21 +230,17 @@ func (c *roundCalculator) newRound(
 		epochNum = c.rp.GetEpochNum(height)
 		epochStartHeight := c.rp.GetEpochHeight(epochNum)
 		if delegates, err = c.Delegates(epochStartHeight); err != nil {
-			fmt.Println("aaa")
 			return
 		}
 		if roundNum, roundStartTime, err = c.roundInfo(height, blockInterval, now, toleratedOvertime); err != nil {
-			fmt.Println("bbb")
 			return
 		}
 		if proposer, err = c.calculateProposer(height, roundNum, delegates); err != nil {
-			fmt.Println("ccc")
 			return
 		}
 	}
 	if eManager == nil {
 		if eManager, err = newEndorsementManager(nil); err != nil {
-			fmt.Println("ddd")
 			return nil, err
 		}
 	}
@@ -276,9 +271,6 @@ func (c *roundCalculator) calculateProposer(
 ) (proposer string, err error) {
 	numDelegates := c.rp.NumDelegates()
 	if numDelegates != uint64(len(delegates)) {
-		fmt.Println("expected", numDelegates)
-		fmt.Println("real", len(delegates))
-		fmt.Println("qwer")
 		err = errors.New("invalid delegate list")
 		return
 	}

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -22,12 +22,10 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/poll"
 	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
-	"github.com/iotexproject/iotex-core/action/protocol/vote/candidatesutil"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/unit"
-	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
@@ -93,8 +91,6 @@ func TestNewRound(t *testing.T) {
 func TestDelegates(t *testing.T) {
 	require := require.New(t)
 	rc := makeRoundCalculator(t)
-	_, err := rc.Delegates(361)
-	require.Error(err)
 
 	dels, err := rc.Delegates(4)
 	require.NoError(err)
@@ -138,7 +134,7 @@ func TestRoundInfo(t *testing.T) {
 	require.True(roundStartTime.Equal(time.Unix(1562382393, 0)))
 }
 
-func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.Protocol) {
+func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.Protocol, poll.Protocol) {
 	require := require.New(t)
 	cfg := config.Default
 
@@ -213,12 +209,10 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.
 	}
 	require.Equal(uint64(50), chain.TipHeight())
 	require.NoError(err)
-	return chain, sf, rolldposProtocol
+	return chain, sf, rolldposProtocol, pp
 }
 
 func makeRoundCalculator(t *testing.T) *roundCalculator {
-	bc, sf, rp := makeChain(t)
-	return &roundCalculator{bc, true, rp, func(ctx context.Context, height uint64) (state.CandidateList, error) {
-		return candidatesutil.CandidatesByHeight(sf, rp.GetEpochHeight(rp.GetEpochNum(height)))
-	}, 0}
+	bc, _, rp, pp := makeChain(t)
+	return &roundCalculator{bc, true, rp, pp.DelegatesByEpoch, 0}
 }

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -134,7 +134,7 @@ func TestRoundInfo(t *testing.T) {
 	require.True(roundStartTime.Equal(time.Unix(1562382393, 0)))
 }
 
-func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.Protocol, poll.Protocol) {
+func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol, poll.Protocol) {
 	require := require.New(t)
 	cfg := config.Default
 
@@ -209,10 +209,10 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.
 	}
 	require.Equal(uint64(50), chain.TipHeight())
 	require.NoError(err)
-	return chain, sf, rolldposProtocol, pp
+	return chain, rolldposProtocol, pp
 }
 
 func makeRoundCalculator(t *testing.T) *roundCalculator {
-	bc, _, rp, pp := makeChain(t)
+	bc, rp, pp := makeChain(t)
 	return &roundCalculator{bc, true, rp, pp.DelegatesByEpoch, 0}
 }

--- a/consensus/scheme/scheme.go
+++ b/consensus/scheme/scheme.go
@@ -47,5 +47,4 @@ type ConsensusMetrics struct {
 	LatestHeight        uint64
 	LatestDelegates     []string
 	LatestBlockProducer string
-	Candidates          []string
 }


### PR DESCRIPTION
1. In roundCalculator, instead of using candidatesByHeightFunc, use DelegatesByEpochFunc from poll protocol so that we can unify same logic 

2. refactor poll protocol 
- change name from DelegatesByHeight to CalculateCandidatesByHeight which is used for putpollresult
- clarity method/variable name since delegate/candidate is confusing 