### PR TITLE
put/commit block in order into indexer by using buffer 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -142,7 +142,7 @@ func NewServer(
 		broadcastHandler:  apiCfg.broadcastHandler,
 		cfg:               cfg,
 		registry:          registry,
-		chainListener:     NewChainListener(),
+		chainListener:     NewChainListener(cfg.BlockSync.BufferSize),
 		gs:                gasstation.NewGasStation(chain, sf.SimulateExecution, dao, cfg.API),
 		electionCommittee: apiCfg.electionCommittee,
 	}

--- a/api/listener.go
+++ b/api/listener.go
@@ -20,7 +20,7 @@ type (
 	Listener interface {
 		Start() error
 		Stop() error
-		HandleBlock(*block.Block) error
+		ReceiveBlock(*block.Block) error
 		AddResponder(Responder) error
 	}
 
@@ -33,9 +33,9 @@ type (
 )
 
 // NewChainListener returns a new blockchain chainListener
-func NewChainListener() Listener {
+func NewChainListener(bufferSize uint64) Listener {
 	return &chainListener{
-		pendingBlks: make(chan *block.Block, 4),
+		pendingBlks: make(chan *block.Block, bufferSize),
 		cancelChan:  make(chan struct{}),
 	}
 }
@@ -82,7 +82,7 @@ func (cl *chainListener) Stop() error {
 }
 
 // HandleBlock handles the block
-func (cl *chainListener) HandleBlock(blk *block.Block) error {
+func (cl *chainListener) ReceiveBlock(blk *block.Block) error {
 	cl.pendingBlks <- blk
 	return nil
 }

--- a/api/listener.go
+++ b/api/listener.go
@@ -81,7 +81,7 @@ func (cl *chainListener) Stop() error {
 	return nil
 }
 
-// HandleBlock handles the block
+// ReceiveBlock handles the block
 func (cl *chainListener) ReceiveBlock(blk *block.Block) error {
 	cl.pendingBlks <- blk
 	return nil

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -654,11 +654,9 @@ func (bc *blockchain) emitToSubscribers(blk *block.Block) {
 		return
 	}
 	for _, s := range bc.blocklistener {
-		go func(bcs BlockCreationSubscriber, b *block.Block) {
-			if err := bcs.HandleBlock(b); err != nil {
-				log.L().Error("Failed to handle new block.", zap.Error(err))
-			}
-		}(s, blk)
+		if err := s.ReceiveBlock(blk); err != nil {
+			log.L().Error("Failed to handle new block.", zap.Error(err))
+		}
 	}
 }
 

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -593,7 +593,7 @@ type MockSubscriber struct {
 	mu      sync.RWMutex
 }
 
-func (ms *MockSubscriber) HandleBlock(blk *block.Block) error {
+func (ms *MockSubscriber) ReceiveBlock(blk *block.Block) error {
 	ms.mu.Lock()
 	tsfs, _ := action.ClassifyActions(blk.Actions)
 	ms.counter += len(tsfs)

--- a/blockchain/blockcreationsubscriber.go
+++ b/blockchain/blockcreationsubscriber.go
@@ -10,5 +10,5 @@ import "github.com/iotexproject/iotex-core/blockchain/block"
 
 // BlockCreationSubscriber is an interface which will get notified when a block is created
 type BlockCreationSubscriber interface {
-	HandleBlock(*block.Block) error
+	ReceiveBlock(*block.Block) error
 }

--- a/blockchain/blockdao/indexbuilder.go
+++ b/blockchain/blockdao/indexbuilder.go
@@ -38,7 +38,7 @@ type addrIndex map[hash.Hash160]db.CountingIndex
 
 // IndexBuilder defines the index builder
 type IndexBuilder struct {
-	pendingBlks  map[uint64]*block.Block
+	pendingBlks  chan *block.Block
 	cancelChan   chan interface{}
 	timerFactory *prometheustimer.TimerFactory
 	dao          BlockDAO
@@ -46,7 +46,7 @@ type IndexBuilder struct {
 }
 
 // NewIndexBuilder instantiates an index builder
-func NewIndexBuilder(chainID uint32, dao BlockDAO, indexer blockindex.Indexer) (*IndexBuilder, error) {
+func NewIndexBuilder(chainID uint32, dao BlockDAO, indexer blockindex.Indexer, bufferSize uint64) (*IndexBuilder, error) {
 	timerFactory, err := prometheustimer.New(
 		"iotex_indexer_batch_time",
 		"Indexer batch time",
@@ -57,7 +57,7 @@ func NewIndexBuilder(chainID uint32, dao BlockDAO, indexer blockindex.Indexer) (
 		return nil, err
 	}
 	return &IndexBuilder{
-		pendingBlks:  make(map[uint64]*block.Block),
+		pendingBlks:  make(chan *block.Block, bufferSize),
 		cancelChan:   make(chan interface{}),
 		timerFactory: timerFactory,
 		dao:          dao,
@@ -90,8 +90,8 @@ func (ib *IndexBuilder) Indexer() blockindex.Indexer {
 }
 
 // HandleBlock handles the block and create the indices for the actions and receipts in it
-func (ib *IndexBuilder) HandleBlock(blk *block.Block) error {
-	ib.pendingBlks[blk.Height()] = blk
+func (ib *IndexBuilder) ReceiveBlock(blk *block.Block) error {
+	ib.pendingBlks <- blk
 	return nil
 }
 
@@ -100,36 +100,25 @@ func (ib *IndexBuilder) handler() {
 		select {
 		case <-ib.cancelChan:
 			return
-		default:
-			tipHeight, err := ib.indexer.GetBlockchainHeight()
-			if err != nil {
+		case blk := <-ib.pendingBlks:
+			timer := ib.timerFactory.NewTimer("indexBlock")
+			if err := ib.indexer.PutBlock(blk); err != nil {
 				log.L().Error(
-					"Error when get blockchain tipheight from indexer",
+					"Error when indexing the block",
+					zap.Uint64("height", blk.Height()),
 					zap.Error(err),
 				)
 			}
-			if blk, ok := ib.pendingBlks[tipHeight+1]; ok {
-				// putBlock only if the next block is in the pending blk map
-				timer := ib.timerFactory.NewTimer("indexBlock")
-				if err := ib.indexer.PutBlock(blk); err != nil {
-					log.L().Error(
-						"Error when indexing the block",
-						zap.Uint64("height", blk.Height()),
-						zap.Error(err),
-					)
-				}
-				if err := ib.indexer.Commit(); err != nil {
-					log.L().Error(
-						"Error when committing the block index",
-						zap.Uint64("height", blk.Height()),
-						zap.Error(err),
-					)
-				}
-				timer.End()
-				if blk.Height()%100 == 0 {
-					log.L().Info("<<<<<<< indexing new block", zap.Uint64("height", blk.Height()))
-				}
-				delete(ib.pendingBlks, tipHeight+1)
+			if err := ib.indexer.Commit(); err != nil {
+				log.L().Error(
+					"Error when committing the block index",
+					zap.Uint64("height", blk.Height()),
+					zap.Error(err),
+				)
+			}
+			timer.End()
+			if blk.Height()%100 == 0 {
+				log.L().Info("<<<<<<< indexing new block", zap.Uint64("height", blk.Height()))
 			}
 		}
 	}

--- a/blockchain/blockdao/indexbuilder.go
+++ b/blockchain/blockdao/indexbuilder.go
@@ -89,7 +89,7 @@ func (ib *IndexBuilder) Indexer() blockindex.Indexer {
 	return ib.indexer
 }
 
-// HandleBlock handles the block and create the indices for the actions and receipts in it
+// ReceiveBlock handles the block and create the indices for the actions and receipts in it
 func (ib *IndexBuilder) ReceiveBlock(blk *block.Block) error {
 	ib.pendingBlks <- blk
 	return nil

--- a/blockchain/blockdao/indexbuilder_test.go
+++ b/blockchain/blockdao/indexbuilder_test.go
@@ -71,7 +71,7 @@ func TestIndexer(t *testing.T) {
 		}()
 
 		ib := &IndexBuilder{
-			pendingBlks: make(chan *block.Block, 8),
+			pendingBlks: make(map[uint64]*block.Block),
 			cancelChan:  make(chan interface{}),
 			dao:         dao,
 			indexer:     indexer,

--- a/blockchain/blockdao/indexbuilder_test.go
+++ b/blockchain/blockdao/indexbuilder_test.go
@@ -71,7 +71,7 @@ func TestIndexer(t *testing.T) {
 		}()
 
 		ib := &IndexBuilder{
-			pendingBlks: make(map[uint64]*block.Block),
+			pendingBlks: make(chan *block.Block, config.Default.BlockSync.BufferSize),
 			cancelChan:  make(chan interface{}),
 			dao:         dao,
 			indexer:     indexer,
@@ -98,7 +98,7 @@ func TestIndexer(t *testing.T) {
 		// test handle 1 new block
 		require.NoError(dao.PutBlock(blks[2]))
 		require.NoError(dao.Commit())
-		ib.HandleBlock(blks[2])
+		ib.ReceiveBlock(blks[2])
 		time.Sleep(500 * time.Millisecond)
 
 		height, err = ib.indexer.GetBlockchainHeight()

--- a/blockchain/blockdao/indexbuilder_test.go
+++ b/blockchain/blockdao/indexbuilder_test.go
@@ -71,7 +71,7 @@ func TestIndexer(t *testing.T) {
 		}()
 
 		ib := &IndexBuilder{
-			pendingBlks: make(chan *block.Block, config.Default.BlockSync.BufferSize),
+			pendingBlks: make(chan *block.Block, 1),
 			cancelChan:  make(chan interface{}),
 			dao:         dao,
 			indexer:     indexer,

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -179,7 +179,7 @@ func New(
 	// config asks for a standalone indexer
 	var indexBuilder *blockdao.IndexBuilder
 	if gateway && cfg.Chain.EnableAsyncIndexWrite {
-		if indexBuilder, err = blockdao.NewIndexBuilder(chain.ChainID(), dao, indexer); err != nil {
+		if indexBuilder, err = blockdao.NewIndexBuilder(chain.ChainID(), dao, indexer, cfg.BlockSync.BufferSize); err != nil {
 			return nil, errors.Wrap(err, "failed to create index builder")
 		}
 		if err := chain.AddSubscriber(indexBuilder); err != nil {

--- a/test/mock/mock_blockchain/mock_blockchain.go
+++ b/test/mock/mock_blockchain/mock_blockchain.go
@@ -82,21 +82,6 @@ func (mr *MockBlockchainMockRecorder) BlockHeaderByHeight(height interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHeight), height)
 }
 
-// BlockHeaderByHash mocks base method
-func (m *MockBlockchain) BlockHeaderByHash(h hash.Hash256) (*block.Header, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockHeaderByHash", h)
-	ret0, _ := ret[0].(*block.Header)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockHeaderByHash indicates an expected call of BlockHeaderByHash
-func (mr *MockBlockchainMockRecorder) BlockHeaderByHash(h interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHeaderByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockHeaderByHash), h)
-}
-
 // BlockFooterByHeight mocks base method
 func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, error) {
 	m.ctrl.T.Helper()
@@ -110,21 +95,6 @@ func (m *MockBlockchain) BlockFooterByHeight(height uint64) (*block.Footer, erro
 func (mr *MockBlockchainMockRecorder) BlockFooterByHeight(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHeight", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHeight), height)
-}
-
-// BlockFooterByHash mocks base method
-func (m *MockBlockchain) BlockFooterByHash(h hash.Hash256) (*block.Footer, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockFooterByHash", h)
-	ret0, _ := ret[0].(*block.Footer)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockFooterByHash indicates an expected call of BlockFooterByHash
-func (mr *MockBlockchainMockRecorder) BlockFooterByHash(h interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockFooterByHash", reflect.TypeOf((*MockBlockchain)(nil).BlockFooterByHash), h)
 }
 
 // ChainID mocks base method

--- a/test/mock/mock_blockcreationsubscriber/mock_blockcreationsubscriber.go
+++ b/test/mock/mock_blockcreationsubscriber/mock_blockcreationsubscriber.go
@@ -33,16 +33,16 @@ func (m *MockBlockCreationSubscriber) EXPECT() *MockBlockCreationSubscriberMockR
 	return m.recorder
 }
 
-// HandleBlock mocks base method
-func (m *MockBlockCreationSubscriber) HandleBlock(arg0 *block.Block) error {
+// ReceiveBlock mocks base method
+func (m *MockBlockCreationSubscriber) ReceiveBlock(arg0 *block.Block) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleBlock", arg0)
+	ret := m.ctrl.Call(m, "ReceiveBlock", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// HandleBlock indicates an expected call of HandleBlock
-func (mr *MockBlockCreationSubscriberMockRecorder) HandleBlock(arg0 interface{}) *gomock.Call {
+// ReceiveBlock indicates an expected call of ReceiveBlock
+func (mr *MockBlockCreationSubscriberMockRecorder) ReceiveBlock(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlock", reflect.TypeOf((*MockBlockCreationSubscriber)(nil).HandleBlock), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReceiveBlock", reflect.TypeOf((*MockBlockCreationSubscriber)(nil).ReceiveBlock), arg0)
 }

--- a/test/mock/mock_blockdao/mock_blockdao.go
+++ b/test/mock/mock_blockdao/mock_blockdao.go
@@ -139,21 +139,6 @@ func (mr *MockBlockDAOMockRecorder) GetTipHeight() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTipHeight", reflect.TypeOf((*MockBlockDAO)(nil).GetTipHeight))
 }
 
-// GetTipHash mocks base method
-func (m *MockBlockDAO) GetTipHash() (hash.Hash256, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTipHash")
-	ret0, _ := ret[0].(hash.Hash256)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTipHash indicates an expected call of GetTipHash
-func (mr *MockBlockDAOMockRecorder) GetTipHash() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTipHash", reflect.TypeOf((*MockBlockDAO)(nil).GetTipHash))
-}
-
 // Header mocks base method
 func (m *MockBlockDAO) Header(arg0 hash.Hash256) (*block.Header, error) {
 	m.ctrl.T.Helper()
@@ -327,6 +312,36 @@ func (m *MockBlockDAO) KVStore() db.KVStore {
 func (mr *MockBlockDAOMockRecorder) KVStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVStore", reflect.TypeOf((*MockBlockDAO)(nil).KVStore))
+}
+
+// HeaderByHeight mocks base method
+func (m *MockBlockDAO) HeaderByHeight(arg0 uint64) (*block.Header, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HeaderByHeight", arg0)
+	ret0, _ := ret[0].(*block.Header)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HeaderByHeight indicates an expected call of HeaderByHeight
+func (mr *MockBlockDAOMockRecorder) HeaderByHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HeaderByHeight", reflect.TypeOf((*MockBlockDAO)(nil).HeaderByHeight), arg0)
+}
+
+// FooterByHeight mocks base method
+func (m *MockBlockDAO) FooterByHeight(arg0 uint64) (*block.Footer, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FooterByHeight", arg0)
+	ret0, _ := ret[0].(*block.Footer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FooterByHeight indicates an expected call of FooterByHeight
+func (mr *MockBlockDAOMockRecorder) FooterByHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FooterByHeight", reflect.TypeOf((*MockBlockDAO)(nil).FooterByHeight), arg0)
 }
 
 // MockBlockIndexer is a mock of BlockIndexer interface


### PR DESCRIPTION
because when we broadcast block we are using goroutine, the order can be different. So make a buffer to store pending blocks and make sure to put/commit block in order  