### PR TITLE
move handler goroutine logic from subscriber to blockchain

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -142,7 +142,7 @@ func NewServer(
 		broadcastHandler:  apiCfg.broadcastHandler,
 		cfg:               cfg,
 		registry:          registry,
-		chainListener:     NewChainListener(cfg.BlockSync.BufferSize),
+		chainListener:     NewChainListener(),
 		gs:                gasstation.NewGasStation(chain, sf.SimulateExecution, dao, cfg.API),
 		electionCommittee: apiCfg.electionCommittee,
 	}

--- a/api/listener.go
+++ b/api/listener.go
@@ -26,23 +26,23 @@ type (
 
 	// chainListener implements the Listener interface
 	chainListener struct {
-		pendingBlks chan *block.Block
-		cancelChan  chan struct{}
-		streamMap   sync.Map // all registered <Responder, chan error>
+		//pendingBlks chan *block.Block
+		//cancelChan  chan struct{}
+		streamMap sync.Map // all registered <Responder, chan error>
 	}
 )
 
 // NewChainListener returns a new blockchain chainListener
-func NewChainListener(bufferSize uint64) Listener {
+func NewChainListener() Listener {
 	return &chainListener{
-		pendingBlks: make(chan *block.Block, bufferSize),
-		cancelChan:  make(chan struct{}),
+		//pendingBlks: make(chan *block.Block, bufferSize),
+		//cancelChan:  make(chan struct{}),
 	}
 }
 
 // Start starts the chainListener
 func (cl *chainListener) Start() error {
-	go func() {
+	/*go func() {
 		for {
 			select {
 			case <-cl.cancelChan:
@@ -71,19 +71,39 @@ func (cl *chainListener) Start() error {
 				})
 			}
 		}
-	}()
+	}()*/
 	return nil
 }
 
 // Stop stops the block chainListener
 func (cl *chainListener) Stop() error {
-	close(cl.cancelChan)
+	//close(cl.cancelChan)
+	// notify all responders to exit
+	cl.streamMap.Range(func(key, _ interface{}) bool {
+		r, ok := key.(Responder)
+		if !ok {
+			log.S().Panic("streamMap stores a key which is not a Responder")
+		}
+		r.Exit()
+		cl.streamMap.Delete(key)
+		return true
+	})
 	return nil
 }
 
 // ReceiveBlock handles the block
 func (cl *chainListener) ReceiveBlock(blk *block.Block) error {
-	cl.pendingBlks <- blk
+	// pass the block to every responder
+	cl.streamMap.Range(func(key, _ interface{}) bool {
+		r, ok := key.(Responder)
+		if !ok {
+			log.S().Panic("streamMap stores a key which is not a Responder")
+		}
+		if err := r.Respond(blk); err != nil {
+			cl.streamMap.Delete(key)
+		}
+		return true
+	})
 	return nil
 }
 

--- a/api/listener.go
+++ b/api/listener.go
@@ -26,58 +26,22 @@ type (
 
 	// chainListener implements the Listener interface
 	chainListener struct {
-		//pendingBlks chan *block.Block
-		//cancelChan  chan struct{}
 		streamMap sync.Map // all registered <Responder, chan error>
 	}
 )
 
 // NewChainListener returns a new blockchain chainListener
 func NewChainListener() Listener {
-	return &chainListener{
-		//pendingBlks: make(chan *block.Block, bufferSize),
-		//cancelChan:  make(chan struct{}),
-	}
+	return &chainListener{}
 }
 
 // Start starts the chainListener
 func (cl *chainListener) Start() error {
-	/*go func() {
-		for {
-			select {
-			case <-cl.cancelChan:
-				// notify all responders to exit
-				cl.streamMap.Range(func(key, _ interface{}) bool {
-					r, ok := key.(Responder)
-					if !ok {
-						log.S().Panic("streamMap stores a key which is not a Responder")
-					}
-					r.Exit()
-					cl.streamMap.Delete(key)
-					return true
-				})
-				return
-			case blk := <-cl.pendingBlks:
-				// pass the block to every responder
-				cl.streamMap.Range(func(key, _ interface{}) bool {
-					r, ok := key.(Responder)
-					if !ok {
-						log.S().Panic("streamMap stores a key which is not a Responder")
-					}
-					if err := r.Respond(blk); err != nil {
-						cl.streamMap.Delete(key)
-					}
-					return true
-				})
-			}
-		}
-	}()*/
 	return nil
 }
 
 // Stop stops the block chainListener
 func (cl *chainListener) Stop() error {
-	//close(cl.cancelChan)
 	// notify all responders to exit
 	cl.streamMap.Range(func(key, _ interface{}) bool {
 		r, ok := key.(Responder)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -458,7 +458,7 @@ func (bc *blockchain) AddSubscriber(s BlockCreationSubscriber) error {
 	}
 	pendingBlksChan := make(chan *block.Block, bc.config.BlockSync.BufferSize)
 	cancelChan := make(chan interface{})
-	// create subscriber handler thread to handle pending blocks 
+	// create subscriber handler thread to handle pending blocks
 	go bc.handler(cancelChan, pendingBlksChan, s)
 
 	bc.blocklistener = append(bc.blocklistener, s)

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -626,7 +626,7 @@ func (bc *blockchain) emitToSubscribers(blk *block.Block) {
 	if bc.blocklistener == nil {
 		return
 	}
-	for i, _ := range bc.blocklistener {
+	for i := range bc.blocklistener {
 		bc.blocklistenerBuffer[i] <- blk
 	}
 }

--- a/blockchain/blockcreationsubscriber.go
+++ b/blockchain/blockcreationsubscriber.go
@@ -6,16 +6,94 @@
 
 package blockchain
 
-import "github.com/iotexproject/iotex-core/blockchain/block"
+import (
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/pkg/log"
+)
 
 // BlockCreationSubscriber is an interface which will get notified when a block is created
 type BlockCreationSubscriber interface {
 	ReceiveBlock(*block.Block) error
 }
 
-// pubSub includes Subscriber, buffered channel for storing the pending blocks and cancel channel to end the handler thread
+// PubSubManager is an interface which handles multi-thread publisher and subscribers
+type PubSubManager interface {
+	AddBlockListener(BlockCreationSubscriber) error
+	RemoveBlockListener(BlockCreationSubscriber) error
+	SendBlockToSubscribers(*block.Block)
+}
+
+// pubSubElem includes Subscriber, buffered channel for storing the pending blocks and cancel channel to end the handler thread
+type pubSubElem struct {
+	listener          BlockCreationSubscriber
+	pendingBlksBuffer chan *block.Block
+	cancel            chan interface{}
+}
+
+// pubSub defines array of blockListener to handle multi-thread publish/subscribe
 type pubSub struct {
-	Blocklistener       BlockCreationSubscriber
-	BlocklistenerBuffer chan *block.Block
-	BlocklistenerCancel chan interface{}
+	blocklisteners       []*pubSubElem
+	pendingBlkBufferSize uint64
+}
+
+// NewPubSub creates new pubSub struct with buffersize for pendingBlock buffer channel
+func NewPubSub(bufferSize uint64) PubSubManager {
+	return &pubSub{
+		blocklisteners:       make([]*pubSubElem, 0),
+		pendingBlkBufferSize: bufferSize,
+	}
+}
+
+// AddBlockListener creates new pubSubElem subscriber and append it to blocklisteners
+func (ps *pubSub) AddBlockListener(s BlockCreationSubscriber) error {
+	pendingBlksChan := make(chan *block.Block, ps.pendingBlkBufferSize)
+	cancelChan := make(chan interface{})
+	// create subscriber handler thread to handle pending blocks
+	go ps.handler(cancelChan, pendingBlksChan, s)
+
+	pubSubElem := &pubSubElem{
+		listener:          s,
+		pendingBlksBuffer: pendingBlksChan,
+		cancel:            cancelChan,
+	}
+	ps.blocklisteners = append(ps.blocklisteners, pubSubElem)
+
+	return nil
+}
+
+// RemoveBlockListener looks up blocklisteners and if exists, close the cancel channel and pop out the element
+func (ps *pubSub) RemoveBlockListener(s BlockCreationSubscriber) error {
+	for i, elem := range ps.blocklisteners {
+		if elem.listener == s {
+			close(elem.cancel)
+			ps.blocklisteners = append(ps.blocklisteners[:i], ps.blocklisteners[i+1:]...)
+			log.L().Info("Successfully unsubscribe block creation.")
+			return nil
+		}
+	}
+	return errors.New("cannot find subscription")
+}
+
+// SendBlockToSubscribers sends block to every subscriber by using buffer channel
+func (ps *pubSub) SendBlockToSubscribers(blk *block.Block) {
+	for _, elem := range ps.blocklisteners {
+		elem.pendingBlksBuffer <- blk
+	}
+	return
+}
+
+func (ps *pubSub) handler(cancelChan <-chan interface{}, pendingBlks <-chan *block.Block, s BlockCreationSubscriber) {
+	for {
+		select {
+		case <-cancelChan:
+			return
+		case blk := <-pendingBlks:
+			if err := s.ReceiveBlock(blk); err != nil {
+				log.L().Error("Failed to handle new block.", zap.Error(err))
+			}
+		}
+	}
 }

--- a/blockchain/blockcreationsubscriber.go
+++ b/blockchain/blockcreationsubscriber.go
@@ -12,3 +12,10 @@ import "github.com/iotexproject/iotex-core/blockchain/block"
 type BlockCreationSubscriber interface {
 	ReceiveBlock(*block.Block) error
 }
+
+// pubSub includes Subscriber, buffered channel for storing the pending blocks and cancel channel to end the handler thread
+type pubSub struct {
+	Blocklistener       BlockCreationSubscriber
+	BlocklistenerBuffer chan *block.Block
+	BlocklistenerCancel chan interface{}
+}

--- a/blockchain/blockdao/indexbuilder.go
+++ b/blockchain/blockdao/indexbuilder.go
@@ -104,7 +104,7 @@ func (ib *IndexBuilder) ReceiveBlock(blk *block.Block) error {
 	}
 	timer.End()
 	if blk.Height()%100 == 0 {
-		log.L().Info("<<<<<<< indexing new block", zap.Uint64("height", blk.Height()))
+		log.L().Info("indexing new block", zap.Uint64("height", blk.Height()))
 	}
 	return nil
 }

--- a/blockchain/blockdao/indexbuilder.go
+++ b/blockchain/blockdao/indexbuilder.go
@@ -38,8 +38,6 @@ type addrIndex map[hash.Hash160]db.CountingIndex
 
 // IndexBuilder defines the index builder
 type IndexBuilder struct {
-	//pendingBlks  chan *block.Block
-	//cancelChan   chan interface{}
 	timerFactory *prometheustimer.TimerFactory
 	dao          BlockDAO
 	indexer      blockindex.Indexer
@@ -57,8 +55,6 @@ func NewIndexBuilder(chainID uint32, dao BlockDAO, indexer blockindex.Indexer) (
 		return nil, err
 	}
 	return &IndexBuilder{
-		//pendingBlks:  make(chan *block.Block, bufferSize),
-		//cancelChan:   make(chan interface{}),
 		timerFactory: timerFactory,
 		dao:          dao,
 		indexer:      indexer,
@@ -74,13 +70,11 @@ func (ib *IndexBuilder) Start(ctx context.Context) error {
 		return err
 	}
 	// start handler to index incoming new block
-	//go ib.handler()
 	return nil
 }
 
 // Stop stops the index builder
 func (ib *IndexBuilder) Stop(ctx context.Context) error {
-	//close(ib.cancelChan)
 	return ib.indexer.Stop(ctx)
 }
 
@@ -115,36 +109,6 @@ func (ib *IndexBuilder) ReceiveBlock(blk *block.Block) error {
 	return nil
 }
 
-/*
-func (ib *IndexBuilder) handler() {
-	for {
-		select {
-		case <-ib.cancelChan:
-			return
-		case blk := <-ib.pendingBlks:
-			timer := ib.timerFactory.NewTimer("indexBlock")
-			if err := ib.indexer.PutBlock(blk); err != nil {
-				log.L().Error(
-					"Error when indexing the block",
-					zap.Uint64("height", blk.Height()),
-					zap.Error(err),
-				)
-			}
-			if err := ib.indexer.Commit(); err != nil {
-				log.L().Error(
-					"Error when committing the block index",
-					zap.Uint64("height", blk.Height()),
-					zap.Error(err),
-				)
-			}
-			timer.End()
-			if blk.Height()%100 == 0 {
-				log.L().Info("indexing new block", zap.Uint64("height", blk.Height()))
-			}
-		}
-	}
-}
-*/
 func (ib *IndexBuilder) init() error {
 	startHeight, err := ib.indexer.GetBlockchainHeight()
 	if err != nil {

--- a/blockchain/blockdao/indexbuilder_test.go
+++ b/blockchain/blockdao/indexbuilder_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
-	//"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
@@ -71,8 +70,6 @@ func TestIndexer(t *testing.T) {
 		}()
 
 		ib := &IndexBuilder{
-			//pendingBlks: make(chan *block.Block, 1),
-			//cancelChan:  make(chan interface{}),
 			dao:     dao,
 			indexer: indexer,
 		}
@@ -93,7 +90,6 @@ func TestIndexer(t *testing.T) {
 		height, err := ib.indexer.GetBlockchainHeight()
 		require.NoError(err)
 		require.EqualValues(2, height)
-		//go ib.handler()
 
 		// test handle 1 new block
 		require.NoError(dao.PutBlock(blks[2]))

--- a/blockchain/blockdao/indexbuilder_test.go
+++ b/blockchain/blockdao/indexbuilder_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
-	"github.com/iotexproject/iotex-core/blockchain/block"
+	//"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
@@ -71,10 +71,10 @@ func TestIndexer(t *testing.T) {
 		}()
 
 		ib := &IndexBuilder{
-			pendingBlks: make(chan *block.Block, 1),
-			cancelChan:  make(chan interface{}),
-			dao:         dao,
-			indexer:     indexer,
+			//pendingBlks: make(chan *block.Block, 1),
+			//cancelChan:  make(chan interface{}),
+			dao:     dao,
+			indexer: indexer,
 		}
 		defer ib.Stop(context.Background())
 
@@ -93,7 +93,7 @@ func TestIndexer(t *testing.T) {
 		height, err := ib.indexer.GetBlockchainHeight()
 		require.NoError(err)
 		require.EqualValues(2, height)
-		go ib.handler()
+		//go ib.handler()
 
 		// test handle 1 new block
 		require.NoError(dao.PutBlock(blks[2]))

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -179,7 +179,7 @@ func New(
 	// config asks for a standalone indexer
 	var indexBuilder *blockdao.IndexBuilder
 	if gateway && cfg.Chain.EnableAsyncIndexWrite {
-		if indexBuilder, err = blockdao.NewIndexBuilder(chain.ChainID(), dao, indexer, cfg.BlockSync.BufferSize); err != nil {
+		if indexBuilder, err = blockdao.NewIndexBuilder(chain.ChainID(), dao, indexer); err != nil {
 			return nil, errors.Wrap(err, "failed to create index builder")
 		}
 		if err := chain.AddSubscriber(indexBuilder); err != nil {
@@ -379,6 +379,9 @@ func (cs *ChainService) Start(ctx context.Context) error {
 // Stop stops the server
 func (cs *ChainService) Stop(ctx context.Context) error {
 	if cs.indexBuilder != nil {
+		if err := cs.chain.RemoveSubscriber(cs.indexBuilder); err != nil {
+			return errors.Wrap(err, "failed to unsubscribe indexBuilder")
+		}
 		if err := cs.indexBuilder.Stop(ctx); err != nil {
 			return errors.Wrap(err, "error when stopping index builder")
 		}


### PR DESCRIPTION
Because each subscriber has same handler logic using goroutine, move this logic to blockchain.go
And when addsubscriber/removesubscriber, create the handler thread and kill it. 