### PR TITLE
Use statemanager in contract

### DIFF
--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -20,8 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
-	"github.com/iotexproject/iotex-core/db/batch"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
@@ -33,9 +31,6 @@ func TestExecuteContractFailure(t *testing.T) {
 	defer ctrl.Finish()
 
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
-	flusher, err := db.NewKVStoreFlusher(db.NewMemKVStore(), batch.NewCachedBatch())
-	require.NoError(t, err)
-	sm.EXPECT().GetDB().Return(flusher.KVStoreWithBuffer()).AnyTimes()
 	sm.EXPECT().State(gomock.Any(), gomock.Any()).Return(uint64(0), state.ErrStateNotExist).AnyTimes()
 	sm.EXPECT().PutState(gomock.Any(), gomock.Any()).Return(uint64(0), nil).AnyTimes()
 	sm.EXPECT().Snapshot().Return(1).AnyTimes()
@@ -75,9 +70,6 @@ func TestConstantinople(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
-	flusher, err := db.NewKVStoreFlusher(db.NewMemKVStore(), batch.NewCachedBatch())
-	require.NoError(err)
-	sm.EXPECT().GetDB().Return(flusher.KVStoreWithBuffer()).AnyTimes()
 
 	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
 		Caller: identityset.Address(27),

--- a/action/protocol/execution/evm/kvstorefortrie.go
+++ b/action/protocol/execution/evm/kvstorefortrie.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package evm
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/db/trie"
+	"github.com/iotexproject/iotex-core/state"
+)
+
+type kvStoreForTrie struct {
+	nsOpt protocol.StateOption
+	sm    protocol.StateManager
+}
+
+func newKVStoreForTrieWithStateManager(ns string, sm protocol.StateManager) trie.KVStore {
+	return &kvStoreForTrie{nsOpt: protocol.NamespaceOption(ns), sm: sm}
+}
+
+func (kv *kvStoreForTrie) Start(context.Context) error {
+	return nil
+}
+
+func (kv *kvStoreForTrie) Stop(context.Context) error {
+	return nil
+}
+
+func (kv *kvStoreForTrie) Put(key []byte, value []byte) error {
+	var sb SerializableBytes
+	if err := sb.Deserialize(value); err != nil {
+		return err
+	}
+	_, err := kv.sm.PutState(sb, protocol.KeyOption(key), kv.nsOpt)
+
+	return err
+}
+
+func (kv *kvStoreForTrie) Delete(key []byte) error {
+	_, err := kv.sm.DelState(protocol.KeyOption(key), kv.nsOpt)
+	switch errors.Cause(err) {
+	case state.ErrStateNotExist:
+		return errors.Wrapf(db.ErrNotExist, "failed to find key %x", key)
+	}
+	return err
+}
+
+func (kv *kvStoreForTrie) Get(key []byte) ([]byte, error) {
+	var value SerializableBytes
+	_, err := kv.sm.State(&value, protocol.KeyOption(key), kv.nsOpt)
+	switch errors.Cause(err) {
+	case state.ErrStateNotExist:
+		return nil, errors.Wrapf(db.ErrNotExist, "failed to find key %x", key)
+	}
+	return value, err
+}

--- a/action/protocol/execution/evm/serializablebytes.go
+++ b/action/protocol/execution/evm/serializablebytes.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package evm
+
+// SerializableBytes defines a type of serializable bytes
+type SerializableBytes []byte
+
+// Serialize copies and return bytes
+func (sb SerializableBytes) Serialize() ([]byte, error) {
+	data := make([]byte, len(sb))
+	copy(data, sb)
+
+	return data, nil
+}
+
+// Deserialize copies data into bytes
+func (sb *SerializableBytes) Deserialize(data []byte) error {
+	*sb = make([]byte, len(data))
+	copy(*sb, data)
+
+	return nil
+}

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -67,26 +67,15 @@ func (eb *ExpectedBalance) Balance() *big.Int {
 	return balance
 }
 
-type codeType struct {
-	value []byte
-}
-
-func (c *codeType) Deserialize(data []byte) error {
-	c.value = make([]byte, len(data))
-	copy(c.value, data)
-
-	return nil
-}
-
 func readCode(sr protocol.StateReader, addr []byte) ([]byte, error) {
-	var c codeType
+	var c evm.SerializableBytes
 	account, err := accountutil.LoadAccount(sr, hash.BytesToHash160(addr))
 	if err != nil {
 		return nil, err
 	}
 	_, err = sr.State(&c, protocol.NamespaceOption(evm.CodeKVNameSpace), protocol.KeyOption(account.CodeHash[:]))
 
-	return c.value, err
+	return c[:], err
 }
 
 type Log struct {

--- a/action/protocol/managers.go
+++ b/action/protocol/managers.go
@@ -3,8 +3,6 @@ package protocol
 import (
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
-
-	"github.com/iotexproject/iotex-core/db"
 )
 
 // NamespaceOption creates an option for given namesapce
@@ -80,7 +78,5 @@ type (
 		// General state
 		PutState(interface{}, ...StateOption) (uint64, error)
 		DelState(...StateOption) (uint64, error)
-		// TODO: delete GetDB
-		GetDB() db.KVStore
 	}
 )

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -662,32 +662,32 @@ func TestConstantinople(t *testing.T) {
 			},
 			{
 				setHash,
-				"cb0f7895c1fa4f179c0c109835b160d9d1852fce526e12c6b443e86257cadb48",
+				"06c0b7f6aa7accf4c82dfec228ea35d459ab63d255f1b856013072d2aa5b83b5",
 				setTopic,
 			},
 			{
 				shrHash,
-				"c1337e26e157426dd0af058ed37e329d25dd3e34ed606994a6776b59f988f458",
+				"afd1c8bcd37a198bbd6de886a643945fba26ca332798a1dea61630ffa999837f",
 				shrTopic,
 			},
 			{
 				shlHash,
-				"cf5c2050a261fa7eca45f31a184c6cd1dc737c7fc3088a0983f659b08985521c",
+				"1c26fe8b8053cfeaed542a103029b297fd6562c0c0f7cd8c69371b4a6de0dcd7",
 				shlTopic,
 			},
 			{
 				sarHash,
-				"5d76bd9e4be3a60c00761fd141da6bd9c07ab73f472f537845b65679095b0570",
+				"19768e710b1cd742a25ab809d3fec638107be086e8a0bc645b80772701d2a9f4",
 				sarTopic,
 			},
 			{
 				extHash,
-				"c5fd9f372b89265f2423737a6d7b680e9759a4a715b22b04ccf875460c310015",
+				"e9764901f0a4fc0e62300ce822672c8c998ab78e0aed91dfd89f9368a7c89915",
 				extTopic,
 			},
 			{
 				crt2Hash,
-				"53632287a97e4e118302f2d9b54b3f97f62d3533286c4d4eb955627b3602d3b0",
+				"a6f0a7bb940f62020a54e3cc597bb8806c3ce8494d12b9b2a5afce496bdbae9c",
 				crt2Topic,
 			},
 		}
@@ -1438,7 +1438,8 @@ func BalanceOfContract(contract, genesisAccount string, kv db.KVStore, t *testin
 		trie.KVStoreOption(dbForTrie),
 		trie.KeyLengthOption(len(hash.Hash256{})),
 		trie.HashFuncOption(func(data []byte) []byte {
-			return trie.DefaultHashFunc(append(addrHash[:], data...))
+			h := hash.Hash256b(append(addrHash[:], data...))
+			return h[:]
 		}),
 	}
 	options = append(options, trie.RootHashOption(root[:]))

--- a/db/kvstore.go
+++ b/db/kvstore.go
@@ -13,8 +13,8 @@ import (
 )
 
 type (
-	// KVStore is the interface of KV store.
-	KVStore interface {
+	// KVStoreBasic is the interface of basic KV store.
+	KVStoreBasic interface {
 		lifecycle.StartStopper
 
 		// Put insert or update a record identified by (namespace, key)
@@ -23,6 +23,11 @@ type (
 		Get(string, []byte) ([]byte, error)
 		// Delete deletes a record by (namespace, key)
 		Delete(string, []byte) error
+	}
+
+	// KVStore is a KVStore with WriteBatch API
+	KVStore interface {
+		KVStoreBasic
 		// WriteBatch commits a batch
 		WriteBatch(batch.KVStoreBatch) error
 	}

--- a/db/kvstore4trie.go
+++ b/db/kvstore4trie.go
@@ -33,11 +33,11 @@ func init() {
 type KVStoreForTrie struct {
 	lc     lifecycle.Lifecycle
 	bucket string
-	dao    KVStore
+	dao    KVStoreBasic
 }
 
 // NewKVStoreForTrie creates a new KVStoreForTrie
-func NewKVStoreForTrie(bucket string, dao KVStore) (*KVStoreForTrie, error) {
+func NewKVStoreForTrie(bucket string, dao KVStoreBasic) (*KVStoreForTrie, error) {
 	s := &KVStoreForTrie{
 		bucket: bucket,
 		dao:    dao,

--- a/db/mock_kvstore_test.go
+++ b/db/mock_kvstore_test.go
@@ -11,6 +11,100 @@ import (
 	reflect "reflect"
 )
 
+// MockKVStoreBasic is a mock of KVStoreBasic interface
+type MockKVStoreBasic struct {
+	ctrl     *gomock.Controller
+	recorder *MockKVStoreBasicMockRecorder
+}
+
+// MockKVStoreBasicMockRecorder is the mock recorder for MockKVStoreBasic
+type MockKVStoreBasicMockRecorder struct {
+	mock *MockKVStoreBasic
+}
+
+// NewMockKVStoreBasic creates a new mock instance
+func NewMockKVStoreBasic(ctrl *gomock.Controller) *MockKVStoreBasic {
+	mock := &MockKVStoreBasic{ctrl: ctrl}
+	mock.recorder = &MockKVStoreBasicMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockKVStoreBasic) EXPECT() *MockKVStoreBasicMockRecorder {
+	return m.recorder
+}
+
+// Start mocks base method
+func (m *MockKVStoreBasic) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start
+func (mr *MockKVStoreBasicMockRecorder) Start(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockKVStoreBasic)(nil).Start), arg0)
+}
+
+// Stop mocks base method
+func (m *MockKVStoreBasic) Stop(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stop", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Stop indicates an expected call of Stop
+func (mr *MockKVStoreBasicMockRecorder) Stop(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockKVStoreBasic)(nil).Stop), arg0)
+}
+
+// Put mocks base method
+func (m *MockKVStoreBasic) Put(arg0 string, arg1, arg2 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Put", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Put indicates an expected call of Put
+func (mr *MockKVStoreBasicMockRecorder) Put(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Put", reflect.TypeOf((*MockKVStoreBasic)(nil).Put), arg0, arg1, arg2)
+}
+
+// Get mocks base method
+func (m *MockKVStoreBasic) Get(arg0 string, arg1 []byte) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockKVStoreBasicMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockKVStoreBasic)(nil).Get), arg0, arg1)
+}
+
+// Delete mocks base method
+func (m *MockKVStoreBasic) Delete(arg0 string, arg1 []byte) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockKVStoreBasicMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockKVStoreBasic)(nil).Delete), arg0, arg1)
+}
+
 // MockKVStore is a mock of KVStore interface
 type MockKVStore struct {
 	ctrl     *gomock.Controller

--- a/db/trie/branchroottrie.go
+++ b/db/trie/branchroottrie.go
@@ -141,6 +141,9 @@ func (tr *branchRootTrie) DB() KVStore {
 }
 
 func (tr *branchRootTrie) deleteNodeFromDB(tn Node) error {
+	if tr.root == tn && bytes.Equal(tr.rootHash, tr.emptyRootHash()) {
+		return nil
+	}
 	return tr.kvStore.Delete(tr.nodeHash(tn))
 }
 

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 IoTeX Foundation
+// Copyright (c) 2020 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -338,11 +338,7 @@ func (sf *factory) flusherOptions(ctx context.Context, height uint64) []db.KVSto
 			if wi.Namespace() != evm.CodeKVNameSpace {
 				return false
 			}
-			// TODO: Change to MustGetBlockchainCtx after deleting NewWorkingSet API
-			bcCtx, ok := protocol.GetBlockchainCtx(ctx)
-			if !ok {
-				return false
-			}
+			bcCtx := protocol.MustGetBlockchainCtx(ctx)
 			hu := config.NewHeightUpgrade(&bcCtx.Genesis)
 			return hu.IsPre(config.Easter, height)
 		}),

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 IoTeX Foundation
+// Copyright (c) 2020 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -338,11 +338,7 @@ func (sdb *stateDB) State(s interface{}, opts ...protocol.StateOption) (uint64, 
 
 func (sdb *stateDB) flusherOptions(ctx context.Context, height uint64) []db.KVStoreFlusherOption {
 	opts := []db.KVStoreFlusherOption{}
-	bcCtx, ok := protocol.GetBlockchainCtx(ctx)
-	if !ok {
-		// TODO: Change to MustGetBlockchainCtx after deleting NewWorkingSet API
-		return opts
-	}
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
 	if hu.IsPost(config.Easter, height) {
 		return opts

--- a/state/factory/twolayertrie.go
+++ b/state/factory/twolayertrie.go
@@ -102,5 +102,6 @@ func (tlt *TwoLayerTrie) Delete(layerOneKey []byte, layerTwoKey []byte) error {
 	if !layerTwo.IsEmpty() {
 		return tlt.layerOne.Upsert(layerOneKey, layerTwo.RootHash())
 	}
+
 	return tlt.layerOne.Delete(layerOneKey)
 }

--- a/state/factory/twolayertrie.go
+++ b/state/factory/twolayertrie.go
@@ -66,7 +66,7 @@ func (tlt *TwoLayerTrie) Get(layerOneKey []byte, layerTwoKey []byte) ([]byte, er
 	return layerTwo.Get(layerTwoKey)
 }
 
-// Upsert upserts an item
+// Upsert upserts an item in layer two
 func (tlt *TwoLayerTrie) Upsert(layerOneKey []byte, layerTwoKey []byte, value []byte) error {
 	layerTwo, err := tlt.layerTwoTrie(layerOneKey, len(layerTwoKey))
 	if err != nil {

--- a/state/factory/twolayertrie.go
+++ b/state/factory/twolayertrie.go
@@ -52,7 +52,7 @@ func (tlt *TwoLayerTrie) SetRootHash(rh []byte) error {
 	return tlt.layerOne.SetRootHash(rh)
 }
 
-// Get returns the layer two value
+// Get returns the value in layer two
 func (tlt *TwoLayerTrie) Get(layerOneKey []byte, layerTwoKey []byte) ([]byte, error) {
 	layerTwo, err := tlt.layerTwoTrie(layerOneKey, len(layerTwoKey))
 	if err != nil {

--- a/state/factory/twolayertrie.go
+++ b/state/factory/twolayertrie.go
@@ -84,7 +84,7 @@ func (tlt *TwoLayerTrie) Upsert(layerOneKey []byte, layerTwoKey []byte, value []
 	return tlt.layerOne.Upsert(layerOneKey, layerTwo.RootHash())
 }
 
-// Delete deletes an item
+// Delete deletes an item in layer two
 func (tlt *TwoLayerTrie) Delete(layerOneKey []byte, layerTwoKey []byte) error {
 	layerTwo, err := tlt.layerTwoTrie(layerOneKey, len(layerTwoKey))
 	if err != nil {

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -37,18 +37,17 @@ type (
 	workingSet struct {
 		height       uint64
 		finalized    bool
-		getStateFunc func(string, []byte, interface{}) error
-		putStateFunc func(string, []byte, interface{}) error
-		delStateFunc func(string, []byte) error
-		snapshotFunc func() int
-		revertFunc   func(int) error
+		commitFunc   func(uint64) error
 		dbFunc       func() db.KVStore
+		delStateFunc func(string, []byte) error
 		digestFunc   func() hash.Hash256
 		finalizeFunc func(uint64) error
-		commitFunc   func(uint64) error
+		getStateFunc func(string, []byte, interface{}) error
+		putStateFunc func(string, []byte, interface{}) error
+		revertFunc   func(int) error
+		snapshotFunc func() int
 	}
 
-	// for unit test purpose
 	workingSetCreator interface {
 		newWorkingSet(context.Context, uint64) (*workingSet, error)
 	}

--- a/test/mock/mock_chainmanager/mock_chainmanager.go
+++ b/test/mock/mock_chainmanager/mock_chainmanager.go
@@ -7,7 +7,6 @@ package mock_chainmanager
 import (
 	gomock "github.com/golang/mock/gomock"
 	protocol "github.com/iotexproject/iotex-core/action/protocol"
-	db "github.com/iotexproject/iotex-core/db"
 	reflect "reflect"
 )
 
@@ -192,18 +191,4 @@ func (m *MockStateManager) DelState(arg0 ...protocol.StateOption) (uint64, error
 func (mr *MockStateManagerMockRecorder) DelState(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelState", reflect.TypeOf((*MockStateManager)(nil).DelState), arg0...)
-}
-
-// GetDB mocks base method
-func (m *MockStateManager) GetDB() db.KVStore {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDB")
-	ret0, _ := ret[0].(db.KVStore)
-	return ret0
-}
-
-// GetDB indicates an expected call of GetDB
-func (mr *MockStateManagerMockRecorder) GetDB() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDB", reflect.TypeOf((*MockStateManager)(nil).GetDB))
 }


### PR DESCRIPTION
based on #1894, jump to the last commit please.

Eventually, we delete statemanager.GetDB, and use StateManager itself to simulate the DB.Get/Put/Delete.