### PR TITLE
Duplicate ioctl command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ ioctl:
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_IOCTL) -v ./tools/ioctl
 
 .PHONY: xctl
-ioctl:
+xctl:
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_XCTL) -v ./tools/ioctl/xctl
 
 .PHONY: iomigrater


### PR DESCRIPTION
In Makefile, there is a duplicate ioctl command, overriding the correct command. It should be xctl.