### PR TITLE
fix kvstorefortrie bug

### DIFF
--- a/action/protocol/execution/evm/kvstorefortrie.go
+++ b/action/protocol/execution/evm/kvstorefortrie.go
@@ -48,7 +48,7 @@ func (kv *kvStoreForTrie) Delete(key []byte) error {
 	_, err := kv.sm.DelState(protocol.KeyOption(key), kv.nsOpt)
 	switch errors.Cause(err) {
 	case state.ErrStateNotExist:
-		return errors.Wrapf(db.ErrNotExist, "failed to find key %x", key)
+		return nil
 	}
 	return err
 }

--- a/db/trie/branchroottrie.go
+++ b/db/trie/branchroottrie.go
@@ -141,9 +141,6 @@ func (tr *branchRootTrie) DB() KVStore {
 }
 
 func (tr *branchRootTrie) deleteNodeFromDB(tn Node) error {
-	if tr.root == tn && bytes.Equal(tr.rootHash, tr.emptyRootHash()) {
-		return nil
-	}
 	return tr.kvStore.Delete(tr.nodeHash(tn))
 }
 


### PR DESCRIPTION
To be consistent with our kv store implementation: when a key does not exist, delete will return nil