### PR TITLE
fix test cleanup fail on Windows

### DIFF
--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -14,9 +14,10 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
@@ -32,8 +33,10 @@ func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -66,7 +69,7 @@ func TestCreateContract(t *testing.T) {
 		}).AnyTimes()
 
 	addr := identityset.Address(28)
-	_, err := accountutil.LoadOrCreateAccount(sm, addr.String())
+	_, err = accountutil.LoadOrCreateAccount(sm, addr.String())
 	require.NoError(err)
 	hu := config.NewHeightUpgrade(&cfg.Genesis)
 	stateDB := NewStateDBAdapter(sm, 0, hu.IsPre(config.Aleutian, 0), hash.ZeroHash256)
@@ -96,8 +99,9 @@ func TestCreateContract(t *testing.T) {
 }
 
 func TestLoadStoreCommit(t *testing.T) {
+	require := require.New(t)
+
 	testLoadStoreCommit := func(cfg config.Config, t *testing.T) {
-		require := require.New(t)
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		sm, err := initMockStateManager(ctrl)
@@ -202,8 +206,10 @@ func TestLoadStoreCommit(t *testing.T) {
 		}
 	}
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 	}()
@@ -214,8 +220,10 @@ func TestLoadStoreCommit(t *testing.T) {
 		testLoadStoreCommit(cfg, t)
 	})
 
-	testTrieFile, _ = ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err = ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath2 := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 	defer func() {
 		testutil.CleanupPath(t, testTriePath2)
 	}()

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -7,9 +7,7 @@
 package evm
 
 import (
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -33,10 +31,8 @@ func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -206,10 +202,8 @@ func TestLoadStoreCommit(t *testing.T) {
 		}
 	}
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 	}()
@@ -220,10 +214,8 @@ func TestLoadStoreCommit(t *testing.T) {
 		testLoadStoreCommit(cfg, t)
 	})
 
-	testTrieFile, err = ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath2, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath2 := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 	defer func() {
 		testutil.CleanupPath(t, testTriePath2)
 	}()

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -457,18 +457,12 @@ func TestProtocol_Handle(t *testing.T) {
 			delete(cfg.Plugins, config.GatewayPlugin)
 		}()
 
-		testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+		testTriePath, err := testutil.PathOfTempFile("trie")
 		require.NoError(err)
-		testTriePath := testTrieFile.Name()
-		require.NoError(testTrieFile.Close())
-		testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+		testDBPath, err := testutil.PathOfTempFile("db")
 		require.NoError(err)
-		testDBPath := testDBFile.Name()
-		require.NoError(testDBFile.Close())
-		testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+		testIndexPath, err := testutil.PathOfTempFile("index")
 		require.NoError(err)
-		testIndexPath := testIndexFile.Name()
-		require.NoError(testIndexFile.Close())
 
 		cfg.Plugins[config.GatewayPlugin] = true
 		cfg.Chain.TrieDBPath = testTriePath

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -53,7 +53,7 @@ type ExpectedBalance struct {
 	RawBalance string `json:"rawBalance"`
 }
 
-// GensisBlockHeight defines an gensis blockHeight
+// GenesisBlockHeight defines an genesis blockHeight
 type GenesisBlockHeight struct {
 	IsBering bool `json:"isBering"`
 }
@@ -457,12 +457,18 @@ func TestProtocol_Handle(t *testing.T) {
 			delete(cfg.Plugins, config.GatewayPlugin)
 		}()
 
-		testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+		testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+		require.NoError(err)
 		testTriePath := testTrieFile.Name()
-		testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+		require.NoError(testTrieFile.Close())
+		testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+		require.NoError(err)
 		testDBPath := testDBFile.Name()
-		testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+		require.NoError(testDBFile.Close())
+		testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+		require.NoError(err)
 		testIndexPath := testIndexFile.Name()
+		require.NoError(testIndexFile.Close())
 
 		cfg.Plugins[config.GatewayPlugin] = true
 		cfg.Chain.TrieDBPath = testTriePath

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -9,9 +9,7 @@ package api
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -1868,18 +1866,12 @@ func newConfig(t *testing.T) config.Config {
 	r := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	r.NoError(err)
-	testTriePath := testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	r.NoError(err)
-	testDBPath := testDBFile.Name()
-	r.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	r.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	r.NoError(testIndexFile.Close())
 
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.TrieDBPath = testTriePath

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,10 +18,14 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-election/test/mock/mock_committee"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
@@ -49,9 +53,6 @@ import (
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
 	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 	"github.com/iotexproject/iotex-core/testutil"
-	"github.com/iotexproject/iotex-election/test/mock/mock_committee"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 const lld = "lifeLongDelegates"
@@ -710,7 +711,7 @@ var (
 
 func TestServer_GetAccount(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, true)
 	require.NoError(err)
@@ -734,7 +735,7 @@ func TestServer_GetAccount(t *testing.T) {
 
 func TestServer_GetActions(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -760,7 +761,7 @@ func TestServer_GetActions(t *testing.T) {
 
 func TestServer_GetAction(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, true)
 	require.NoError(err)
@@ -798,7 +799,7 @@ func TestServer_GetAction(t *testing.T) {
 
 func TestServer_GetActionsByAddress(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -846,7 +847,7 @@ func TestServer_GetActionsByAddress(t *testing.T) {
 
 func TestServer_GetUnconfirmedActionsByAddress(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, true)
 	require.NoError(err)
@@ -874,7 +875,7 @@ func TestServer_GetUnconfirmedActionsByAddress(t *testing.T) {
 
 func TestServer_GetActionsByBlock(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -905,7 +906,7 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 
 func TestServer_GetBlockMetas(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -939,7 +940,7 @@ func TestServer_GetBlockMetas(t *testing.T) {
 
 func TestServer_GetBlockMeta(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -975,7 +976,7 @@ func TestServer_GetChainMeta(t *testing.T) {
 
 	var pol poll.Protocol
 	for _, test := range getChainMetaTests {
-		cfg := newConfig()
+		cfg := newConfig(t)
 		if test.pollProtocolType == lld {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else if test.pollProtocolType == "governanceChainCommittee" {
@@ -1054,7 +1055,7 @@ func TestServer_SendAction(t *testing.T) {
 
 func TestServer_GetReceiptByAction(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -1072,7 +1073,7 @@ func TestServer_GetReceiptByAction(t *testing.T) {
 
 func TestServer_ReadContract(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -1097,7 +1098,7 @@ func TestServer_ReadContract(t *testing.T) {
 
 func TestServer_SuggestGasPrice(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	for _, test := range suggestGasPriceTests {
 		cfg.API.GasStation.DefaultGas = test.defaultGasPrice
@@ -1111,7 +1112,7 @@ func TestServer_SuggestGasPrice(t *testing.T) {
 
 func TestServer_EstimateGasForAction(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -1133,7 +1134,7 @@ func TestServer_EstimateGasForAction(t *testing.T) {
 
 func TestServer_EstimateActionGasConsumption(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
 
@@ -1168,7 +1169,7 @@ func TestServer_EstimateActionGasConsumption(t *testing.T) {
 }
 
 func TestServer_ReadUnclaimedBalance(t *testing.T) {
-	cfg := newConfig()
+	cfg := newConfig(t)
 	cfg.Consensus.Scheme = config.RollDPoSScheme
 	svr, err := createServer(cfg, false)
 	require.NoError(t, err)
@@ -1191,7 +1192,7 @@ func TestServer_ReadUnclaimedBalance(t *testing.T) {
 }
 
 func TestServer_TotalBalance(t *testing.T) {
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(t, err)
@@ -1208,7 +1209,7 @@ func TestServer_TotalBalance(t *testing.T) {
 }
 
 func TestServer_AvailableBalance(t *testing.T) {
-	cfg := newConfig()
+	cfg := newConfig(t)
 	cfg.Consensus.Scheme = config.RollDPoSScheme
 	svr, err := createServer(cfg, false)
 	require.NoError(t, err)
@@ -1226,7 +1227,7 @@ func TestServer_AvailableBalance(t *testing.T) {
 
 func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1289,7 +1290,7 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 
 func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1351,7 +1352,7 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 
 func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1417,7 +1418,7 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 
 func TestServer_ReadRollDPoSMeta(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	for _, test := range readRollDPoSMetaTests {
 		svr, err := createServer(cfg, false)
@@ -1433,7 +1434,7 @@ func TestServer_ReadRollDPoSMeta(t *testing.T) {
 
 func TestServer_ReadEpochCtx(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	for _, test := range readEpochCtxTests {
 		svr, err := createServer(cfg, false)
@@ -1450,7 +1451,7 @@ func TestServer_ReadEpochCtx(t *testing.T) {
 
 func TestServer_GetEpochMeta(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -1581,7 +1582,7 @@ func TestServer_GetEpochMeta(t *testing.T) {
 
 func TestServer_GetRawBlocks(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -1609,7 +1610,7 @@ func TestServer_GetRawBlocks(t *testing.T) {
 
 func TestServer_GetLogs(t *testing.T) {
 	require := require.New(t)
-	cfg := newConfig()
+	cfg := newConfig(t)
 
 	svr, err := createServer(cfg, false)
 	require.NoError(err)
@@ -1863,15 +1864,22 @@ func setupActPool(sf factory.Factory, cfg config.ActPool) (actpool.ActPool, erro
 	return ap, nil
 }
 
-func newConfig() config.Config {
+func newConfig(t *testing.T) config.Config {
+	r := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	r.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	r.NoError(testIndexFile.Close())
 
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.TrieDBPath = testTriePath

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -19,11 +19,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -614,8 +615,8 @@ func (ms *MockSubscriber) Counter() int {
 }
 
 func TestConstantinople(t *testing.T) {
+	require := require.New(t)
 	testValidateBlockchain := func(cfg config.Config, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 
 		// Create a blockchain from scratch
@@ -745,12 +746,19 @@ func TestConstantinople(t *testing.T) {
 	}
 
 	cfg := config.Default
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
+
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 		testutil.CleanupPath(t, testDBPath)
@@ -775,8 +783,8 @@ func TestConstantinople(t *testing.T) {
 }
 
 func TestLoadBlockchainfromDB(t *testing.T) {
+	require := require.New(t)
 	testValidateBlockchain := func(cfg config.Config, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 
 		// Create a blockchain from scratch
@@ -985,12 +993,19 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		}
 	}
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
+
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 		testutil.CleanupPath(t, testDBPath)
@@ -1007,12 +1022,19 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		testValidateBlockchain(cfg, t)
 	})
 
-	testTrieFile, _ = ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err = ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath2 := testTrieFile.Name()
-	testDBFile, _ = ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err = ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath2 := testDBFile.Name()
-	testIndexFile2, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile2, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath2 := testIndexFile2.Name()
+	require.NoError(testIndexFile2.Close())
+
 	defer func() {
 		testutil.CleanupPath(t, testTriePath2)
 		testutil.CleanupPath(t, testDBPath2)
@@ -1039,12 +1061,18 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 func TestBlockchainInitialCandidate(t *testing.T) {
 	require := require.New(t)
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -1113,12 +1141,19 @@ func TestBlocks(t *testing.T) {
 	require := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
+
 	a := identityset.Address(28).String()
 	priKeyA := identityset.PrivateKey(28)
 	c := identityset.Address(29).String()
@@ -1183,12 +1218,19 @@ func TestActions(t *testing.T) {
 		context.Background(),
 		protocol.BlockchainCtx{Genesis: cfg.Genesis, Registry: registry},
 	)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
 
 	a := identityset.Address(28).String()
 	priKeyA := identityset.PrivateKey(28)
@@ -1460,15 +1502,23 @@ func BalanceOfContract(contract, genesisAccount string, kv db.KVStore, t *testin
 	return big.NewInt(0).SetBytes(ret)
 }
 
-func newChain(t *testing.T, statetx bool) (Blockchain, factory.Factory, db.KVStore, blockdao.BlockDAO) {
+func newChain(t *testing.T, stateTX bool) (Blockchain, factory.Factory, db.KVStore, blockdao.BlockDAO) {
 	require := require.New(t)
 	cfg := config.Default
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
+
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = testIndexPath
@@ -1478,8 +1528,7 @@ func newChain(t *testing.T, statetx bool) (Blockchain, factory.Factory, db.KVSto
 	cfg.Genesis.EnableGravityChainVoting = false
 	var sf factory.Factory
 	kv := db.NewMemKVStore()
-	var err error
-	if statetx {
+	if stateTX {
 		sf, err = factory.NewStateDB(cfg, factory.PrecreatedStateDBOption(kv))
 		require.NoError(err)
 	} else {
@@ -1524,7 +1573,7 @@ func newChain(t *testing.T, statetx bool) (Blockchain, factory.Factory, db.KVSto
 	genesisPriKey := identityset.PrivateKey(27)
 	a := identityset.Address(28).String()
 	b := identityset.Address(29).String()
-	// make a transfer from genesisAccount to a and b,because statetx cannot store data in height 0
+	// make a transfer from genesisAccount to a and b,because stateTX cannot store data in height 0
 	tsf, err := testutil.SignedTransfer(a, genesisPriKey, 1, big.NewInt(100), []byte{}, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))
 	require.NoError(err)
 	tsf2, err := testutil.SignedTransfer(b, genesisPriKey, 2, big.NewInt(100), []byte{}, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -10,9 +10,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"sync"
 	"testing"
 	"time"
@@ -746,18 +744,12 @@ func TestConstantinople(t *testing.T) {
 	}
 
 	cfg := config.Default
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
@@ -993,18 +985,12 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		}
 	}
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
@@ -1022,18 +1008,12 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		testValidateBlockchain(cfg, t)
 	})
 
-	testTrieFile, err = ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath2, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath2 := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err = ioutil.TempFile(os.TempDir(), "db")
+	testDBPath2, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath2 := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile2, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath2, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath2 := testIndexFile2.Name()
-	require.NoError(testIndexFile2.Close())
 
 	defer func() {
 		testutil.CleanupPath(t, testTriePath2)
@@ -1061,18 +1041,12 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 func TestBlockchainInitialCandidate(t *testing.T) {
 	require := require.New(t)
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -1141,18 +1115,12 @@ func TestBlocks(t *testing.T) {
 	require := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	a := identityset.Address(28).String()
 	priKeyA := identityset.PrivateKey(28)
@@ -1219,18 +1187,12 @@ func TestActions(t *testing.T) {
 		protocol.BlockchainCtx{Genesis: cfg.Genesis, Registry: registry},
 	)
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	a := identityset.Address(28).String()
 	priKeyA := identityset.PrivateKey(28)
@@ -1506,18 +1468,12 @@ func newChain(t *testing.T, stateTX bool) (Blockchain, factory.Factory, db.KVSto
 	require := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -3,7 +3,6 @@ package blockdao
 import (
 	"context"
 	"hash/fnv"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"testing"
@@ -239,10 +238,8 @@ func TestBlockDAO(t *testing.T) {
 		testBlockDao(db.NewMemKVStore(), t)
 	})
 	path := "test-kv-store"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 
 	cfg := config.Default.DB
 	t.Run("Bolt DB for blocks", func(t *testing.T) {
@@ -271,14 +268,10 @@ func BenchmarkBlockCache(b *testing.B) {
 	test := func(cacheSize int, b *testing.B) {
 		b.StopTimer()
 		path := "test-kv-store"
-		testFile, err := ioutil.TempFile(os.TempDir(), path)
+		testPath, err := testutil.PathOfTempFile(path)
 		require.NoError(b, err)
-		testPath := testFile.Name()
-		require.NoError(b, testFile.Close())
-		indexFile, err := ioutil.TempFile(os.TempDir(), path)
+		indexPath, err := testutil.PathOfTempFile(path)
 		require.NoError(b, err)
-		indexPath := indexFile.Name()
-		require.NoError(b, indexFile.Close())
 		cfg := config.DB{
 			NumRetries: 1,
 		}

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -9,8 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -82,6 +83,7 @@ func getTestBlocks(t *testing.T) []*block.Block {
 }
 
 func TestBlockDAO(t *testing.T) {
+	require := require.New(t)
 
 	blks := getTestBlocks(t)
 	t1Hash := blks[0].Actions[0].Hash()
@@ -152,8 +154,6 @@ func TestBlockDAO(t *testing.T) {
 	}
 
 	testBlockDao := func(kvStore db.KVStore, t *testing.T) {
-		require := require.New(t)
-
 		ctx := context.Background()
 		dao := NewBlockDAO(kvStore, []BlockIndexer{}, false, config.Default.DB)
 		require.NoError(dao.Start(ctx))
@@ -205,8 +205,6 @@ func TestBlockDAO(t *testing.T) {
 	}
 
 	testDeleteDao := func(kvStore db.KVStore, t *testing.T) {
-		require := require.New(t)
-
 		ctx := context.Background()
 		dao := NewBlockDAO(kvStore, []BlockIndexer{}, false, config.Default.DB)
 		require.NoError(dao.Start(ctx))
@@ -241,9 +239,10 @@ func TestBlockDAO(t *testing.T) {
 		testBlockDao(db.NewMemKVStore(), t)
 	})
 	path := "test-kv-store"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
+	require.NoError(testFile.Close())
 
 	cfg := config.Default.DB
 	t.Run("Bolt DB for blocks", func(t *testing.T) {
@@ -272,10 +271,14 @@ func BenchmarkBlockCache(b *testing.B) {
 	test := func(cacheSize int, b *testing.B) {
 		b.StopTimer()
 		path := "test-kv-store"
-		testFile, _ := ioutil.TempFile(os.TempDir(), path)
+		testFile, err := ioutil.TempFile(os.TempDir(), path)
+		require.NoError(b, err)
 		testPath := testFile.Name()
-		indexFile, _ := ioutil.TempFile(os.TempDir(), path)
+		require.NoError(b, testFile.Close())
+		indexFile, err := ioutil.TempFile(os.TempDir(), path)
+		require.NoError(b, err)
 		indexPath := indexFile.Name()
+		require.NoError(b, indexFile.Close())
 		cfg := config.DB{
 			NumRetries: 1,
 		}
@@ -296,7 +299,6 @@ func BenchmarkBlockCache(b *testing.B) {
 		}()
 		prevHash := hash.ZeroHash256
 		numBlks := 8640
-		var err error
 		for i := 1; i <= numBlks; i++ {
 			actions := make([]action.SealedEnvelope, 10)
 			for j := 0; j < 10; j++ {

--- a/blockindex/indexbuilder_test.go
+++ b/blockindex/indexbuilder_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
@@ -21,6 +22,7 @@ import (
 )
 
 func TestIndexBuilder(t *testing.T) {
+	require := require.New(t)
 
 	blks := getTestBlocks(t)
 
@@ -59,7 +61,6 @@ func TestIndexBuilder(t *testing.T) {
 	}
 
 	testIndexer := func(kvStore db.KVStore, indexer Indexer, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 		dao := blockdao.NewBlockDAO(kvStore, nil, false, config.Default.DB)
 		require.NoError(dao.Start(ctx))
@@ -148,16 +149,18 @@ func TestIndexBuilder(t *testing.T) {
 
 	t.Run("In-memory KV indexer", func(t *testing.T) {
 		indexer, err := NewIndexer(db.NewMemKVStore(), hash.ZeroHash256)
-		require.NoError(t, err)
+		require.NoError(err)
 		testIndexer(db.NewMemKVStore(), indexer, t)
 	})
 	path := "test-indexer"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
-	indexFile, _ := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(testFile.Close())
+	indexFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	indexPath := indexFile.Name()
-	require.NoError(t, indexFile.Close())
+	require.NoError(indexFile.Close())
 	cfg := config.Default.DB
 	t.Run("Bolt DB indexer", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -168,7 +171,7 @@ func TestIndexBuilder(t *testing.T) {
 		}()
 		cfg.DbPath = indexPath
 		indexer, err := NewIndexer(db.NewBoltDB(cfg), hash.ZeroHash256)
-		require.NoError(t, err)
+		require.NoError(err)
 		cfg.DbPath = testPath
 		testIndexer(db.NewBoltDB(cfg), indexer, t)
 	})

--- a/blockindex/indexbuilder_test.go
+++ b/blockindex/indexbuilder_test.go
@@ -2,9 +2,7 @@ package blockindex
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -153,14 +151,10 @@ func TestIndexBuilder(t *testing.T) {
 		testIndexer(db.NewMemKVStore(), indexer, t)
 	})
 	path := "test-indexer"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
-	indexFile, err := ioutil.TempFile(os.TempDir(), path)
+	indexPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	indexPath := indexFile.Name()
-	require.NoError(indexFile.Close())
 	cfg := config.Default.DB
 	t.Run("Bolt DB indexer", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)

--- a/blockindex/indexer_test.go
+++ b/blockindex/indexer_test.go
@@ -9,9 +9,7 @@ package blockindex
 import (
 	"context"
 	"hash/fnv"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -315,10 +313,8 @@ func TestIndexer(t *testing.T) {
 		testIndexer(db.NewMemKVStore(), t)
 	})
 	path := "test-indexer"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 

--- a/blockindex/indexer_test.go
+++ b/blockindex/indexer_test.go
@@ -14,9 +14,10 @@ import (
 	"os"
 	"testing"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -87,6 +88,8 @@ func getTestBlocks(t *testing.T) []*block.Block {
 }
 
 func TestIndexer(t *testing.T) {
+	require := require.New(t)
+
 	blks := getTestBlocks(t)
 	t1Hash := blks[0].Actions[0].Hash()
 	t4Hash := blks[0].Actions[1].Hash()
@@ -156,7 +159,6 @@ func TestIndexer(t *testing.T) {
 	}
 
 	testIndexer := func(kvStore db.KVStore, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 		indexer, err := NewIndexer(kvStore, hash.ZeroHash256)
 		require.NoError(err)
@@ -242,7 +244,6 @@ func TestIndexer(t *testing.T) {
 	}
 
 	testDelete := func(kvStore db.KVStore, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 		indexer, err := NewIndexer(kvStore, hash.ZeroHash256)
 		require.NoError(err)
@@ -314,8 +315,10 @@ func TestIndexer(t *testing.T) {
 		testIndexer(db.NewMemKVStore(), t)
 	})
 	path := "test-indexer"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
+	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -8,8 +8,6 @@ package blocksync
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -496,16 +494,14 @@ func TestBlockSyncerSync(t *testing.T) {
 }
 
 func newTestConfig() (config.Config, error) {
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	if err != nil {
 		return config.Config{}, err
 	}
-	testTriePath := testTrieFile.Name()
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	if err != nil {
 		return config.Config{}, err
 	}
-	testDBPath := testDBFile.Name()
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -13,8 +13,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/crypto"
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -139,12 +140,18 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol, poll.Pr
 	require := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = testIndexPath

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -8,8 +8,6 @@ package rolldpos
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 	"time"
 
@@ -140,18 +138,12 @@ func makeChain(t *testing.T) (blockchain.Blockchain, *rolldpos.Protocol, poll.Pr
 	require := require.New(t)
 	cfg := config.Default
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = testIndexPath

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -14,10 +14,12 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/go-pkgs/hash"
+
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
@@ -138,8 +140,10 @@ func TestCountingIndex(t *testing.T) {
 	})
 
 	path := "test-iterate.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -178,7 +182,7 @@ func TestBulk(t *testing.T) {
 			}
 			require.NoError(tenant.Commit())
 			tenant.Close()
-			fmt.Printf("write tenant %d:\n", i)
+			log.L().Info(fmt.Sprintf("write tenant %d:\n", i))
 		}
 	}
 
@@ -217,7 +221,7 @@ func TestCheckBulk(t *testing.T) {
 				h := hash.Hash160b([]byte(strconv.Itoa(i)))
 				require.Equal(h[:], value[i])
 			}
-			fmt.Printf("verify tenant: %d\n", i)
+			log.L().Info(fmt.Sprintf("verify tenant: %d\n", i))
 		}
 	}
 

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -9,8 +9,6 @@ package db
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strconv"
 	"testing"
 
@@ -140,10 +138,8 @@ func TestCountingIndex(t *testing.T) {
 	})
 
 	path := "test-iterate.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)

--- a/db/db_bolt_test.go
+++ b/db/db_bolt_test.go
@@ -8,21 +8,21 @@ package db
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func BenchmarkBoltDB_Get(b *testing.B) {
 	runBenchmark := func(b *testing.B, size int) {
-		path, err := ioutil.TempFile("", "boltdb")
+		path, err := testutil.PathOfTempFile("boltdb")
 		require.NoError(b, err)
 		db := boltDB{
-			path:   path.Name(),
+			path:   path,
 			config: config.Default.DB,
 		}
 		db.Start(context.Background())

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -9,8 +9,6 @@ package db
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -63,10 +61,8 @@ func TestKVStorePutGet(t *testing.T) {
 	})
 
 	path := "test-kv-store.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -117,10 +113,8 @@ func TestBatchRollback(t *testing.T) {
 	}
 
 	path := "test-batch-rollback.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -235,10 +229,8 @@ func TestDBBatch(t *testing.T) {
 	}
 
 	path := "test-batch-commit.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -289,10 +281,8 @@ func TestCacheKV(t *testing.T) {
 	})
 
 	path := "test-cache-kv.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -328,10 +318,8 @@ func TestDeleteBucket(t *testing.T) {
 	}
 
 	path := "test-delete.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -430,10 +418,8 @@ func TestFilter(t *testing.T) {
 	}
 
 	path := "test-filter.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -13,10 +13,11 @@ import (
 	"os"
 	"testing"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db/batch"
@@ -62,8 +63,10 @@ func TestKVStorePutGet(t *testing.T) {
 	})
 
 	path := "test-kv-store.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -114,8 +117,10 @@ func TestBatchRollback(t *testing.T) {
 	}
 
 	path := "test-batch-rollback.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -230,8 +235,10 @@ func TestDBBatch(t *testing.T) {
 	}
 
 	path := "test-batch-commit.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -282,8 +289,10 @@ func TestCacheKV(t *testing.T) {
 	})
 
 	path := "test-cache-kv.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -319,8 +328,10 @@ func TestDeleteBucket(t *testing.T) {
 	}
 
 	path := "test-delete.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)
@@ -330,9 +341,9 @@ func TestDeleteBucket(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	testFunc := func(kv KVStore, t *testing.T) {
-		require := require.New(t)
+	require := require.New(t)
 
+	testFunc := func(kv KVStore, t *testing.T) {
 		require.NoError(kv.Start(context.Background()))
 		defer func() {
 			require.NoError(kv.Stop(context.Background()))
@@ -419,8 +430,10 @@ func TestFilter(t *testing.T) {
 	}
 
 	path := "test-filter.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
+	require.NoError(testFile.Close())
 	cfg.DbPath = testPath
 	t.Run("Bolt DB", func(t *testing.T) {
 		testutil.CleanupPath(t, testPath)

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -34,8 +34,10 @@ func TestRangeIndex(t *testing.T) {
 	}
 
 	path := "test-indexer"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
+	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)
@@ -160,8 +162,10 @@ func TestRangeIndex2(t *testing.T) {
 	require := require.New(t)
 
 	path := "test-ranger"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
+	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -8,9 +8,7 @@ package db
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,10 +32,8 @@ func TestRangeIndex(t *testing.T) {
 	}
 
 	path := "test-indexer"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)
@@ -162,10 +158,8 @@ func TestRangeIndex2(t *testing.T) {
 	require := require.New(t)
 
 	path := "test-ranger"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 	cfg := config.Default.DB
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)

--- a/db/sql/sqlite3_test.go
+++ b/db/sql/sqlite3_test.go
@@ -7,9 +7,9 @@
 package sql
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
+
+	"github.com/iotexproject/iotex-core/testutil"
 
 	"github.com/stretchr/testify/require"
 
@@ -22,10 +22,8 @@ const (
 
 func TestSQLite3StorePutGet(t *testing.T) {
 	testRDSStorePutGet := TestStorePutGet
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg := config.SQLITE3{
 		SQLite3File: testPath,
 	}
@@ -36,10 +34,8 @@ func TestSQLite3StorePutGet(t *testing.T) {
 
 func TestSQLite3StoreTransaction(t *testing.T) {
 	testSQLite3StoreTransaction := TestStoreTransaction
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testPath := testFile.Name()
-	require.NoError(t, testFile.Close())
 	cfg := config.SQLITE3{
 		SQLite3File: testPath,
 	}

--- a/db/sql/sqlite3_test.go
+++ b/db/sql/sqlite3_test.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/iotex-core/config"
 )
 
@@ -20,8 +22,10 @@ const (
 
 func TestSQLite3StorePutGet(t *testing.T) {
 	testRDSStorePutGet := TestStorePutGet
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg := config.SQLITE3{
 		SQLite3File: testPath,
 	}
@@ -32,8 +36,10 @@ func TestSQLite3StorePutGet(t *testing.T) {
 
 func TestSQLite3StoreTransaction(t *testing.T) {
 	testSQLite3StoreTransaction := TestStoreTransaction
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(t, err)
 	testPath := testFile.Name()
+	require.NoError(t, testFile.Close())
 	cfg := config.SQLITE3{
 		SQLite3File: testPath,
 	}

--- a/db/trie/trie_test.go
+++ b/db/trie/trie_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/go-pkgs/hash"
+
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/db/batch"
@@ -45,8 +46,6 @@ var (
 		[]byte("egg"), []byte("fox"), []byte("cow"), []byte("ant"),
 	}
 )
-
-const testTriePath = "trie.test"
 
 func TestEmptyTrie(t *testing.T) {
 	require := require.New(t)
@@ -425,8 +424,11 @@ func TestHistoryTrie(t *testing.T) {
 	AccountKVNamespace := "Account"
 	AccountTrieRootKey := "accountTrieRoot"
 	path := "test-history-trie.bolt"
-	testFile, _ := ioutil.TempFile(os.TempDir(), path)
+	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	require.NoError(err)
 	testPath := testFile.Name()
+	require.NoError(testFile.Close())
+
 	cfg.DbPath = testPath
 	opts := []db.KVStoreFlusherOption{
 		db.FlushTranslateOption(func(wi *batch.WriteInfo) *batch.WriteInfo {

--- a/db/trie/trie_test.go
+++ b/db/trie/trie_test.go
@@ -8,11 +8,11 @@ package trie
 
 import (
 	"context"
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/iotexproject/iotex-core/testutil"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -424,10 +424,8 @@ func TestHistoryTrie(t *testing.T) {
 	AccountKVNamespace := "Account"
 	AccountTrieRootKey := "accountTrieRoot"
 	path := "test-history-trie.bolt"
-	testFile, err := ioutil.TempFile(os.TempDir(), path)
+	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testPath := testFile.Name()
-	require.NoError(testFile.Close())
 
 	cfg.DbPath = testPath
 	opts := []db.KVStoreFlusherOption{

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -30,7 +30,7 @@ import (
 func TestLocalActPool(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := newActPoolConfig()
+	cfg, err := newActPoolConfig(t)
 	require.NoError(err)
 
 	// create server
@@ -44,7 +44,7 @@ func TestLocalActPool(t *testing.T) {
 	require.NotNil(svr.ChainService(chainID).ActionPool())
 
 	// create client
-	cfg, err = newActPoolConfig()
+	cfg, err = newActPoolConfig(t)
 	require.NoError(err)
 	cfg.Network.BootstrapNodes = []string{validNetworkAddr(svr.P2PAgent().Self())}
 	cli := p2p.NewAgent(
@@ -102,7 +102,7 @@ func TestLocalActPool(t *testing.T) {
 func TestPressureActPool(t *testing.T) {
 	require := require.New(t)
 
-	cfg, err := newActPoolConfig()
+	cfg, err := newActPoolConfig(t)
 	require.NoError(err)
 
 	// create server
@@ -114,7 +114,7 @@ func TestPressureActPool(t *testing.T) {
 	require.NotNil(svr.ChainService(chainID).ActionPool())
 
 	// create client
-	cfg, err = newActPoolConfig()
+	cfg, err = newActPoolConfig(t)
 	require.NoError(err)
 	cfg.Network.BootstrapNodes = []string{validNetworkAddr(svr.P2PAgent().Self())}
 	cli := p2p.NewAgent(
@@ -159,15 +159,23 @@ func TestPressureActPool(t *testing.T) {
 	require.NoError(err)
 }
 
-func newActPoolConfig() (config.Config, error) {
+func newActPoolConfig(t *testing.T) (config.Config, error) {
+	r := require.New(t)
+
 	cfg := config.Default
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	r.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	r.NoError(testIndexFile.Close())
 
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -8,16 +8,15 @@ package e2etest
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/crypto"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/crypto"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/config"
@@ -164,18 +163,12 @@ func newActPoolConfig(t *testing.T) (config.Config, error) {
 
 	cfg := config.Default
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	r.NoError(err)
-	testTriePath := testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	r.NoError(err)
-	testDBPath := testDBFile.Name()
-	r.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	r.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	r.NoError(testIndexFile.Close())
 
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -8,9 +8,7 @@ package e2etest
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -52,18 +50,12 @@ func TestLocalCommit(t *testing.T) {
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	testDBPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	indexDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	indexDBPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	indexDBPath := indexDBFile.Name()
-	require.NoError(indexDBFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
@@ -166,18 +158,12 @@ func TestLocalCommit(t *testing.T) {
 	require.EqualValues(5, bc.TipHeight())
 
 	// create local chain
-	testTrieFile2, err := ioutil.TempFile(os.TempDir(), triePath2)
+	testTriePath2, err := testutil.PathOfTempFile(triePath2)
 	require.NoError(err)
-	testTriePath2 := testTrieFile2.Name()
-	require.NoError(testTrieFile2.Close())
-	testDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	testDBPath2, err := testutil.PathOfTempFile(dBPath2)
 	require.NoError(err)
-	testDBPath2 := testDBFile2.Name()
-	require.NoError(testDBFile2.Close())
-	indexDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	indexDBPath2, err := testutil.PathOfTempFile(dBPath2)
 	require.NoError(err)
-	indexDBPath2 := indexDBFile2.Name()
-	require.NoError(indexDBFile2.Close())
 	cfg.Chain.TrieDBPath = testTriePath2
 	cfg.Chain.ChainDBPath = testDBPath2
 	cfg.Chain.IndexDBPath = indexDBPath2
@@ -388,18 +374,12 @@ func TestLocalSync(t *testing.T) {
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	testDBPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	indexDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	indexDBPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	indexDBPath := indexDBFile.Name()
-	require.NoError(indexDBFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
@@ -437,18 +417,12 @@ func TestLocalSync(t *testing.T) {
 	hash5 := blk.HashBlock()
 	require.NotNil(svr.P2PAgent())
 
-	testDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	testDBPath2, err := testutil.PathOfTempFile(dBPath2)
 	require.NoError(err)
-	testDBPath2 := testDBFile2.Name()
-	require.NoError(testDBFile2.Close())
-	testTrieFile2, err := ioutil.TempFile(os.TempDir(), triePath2)
+	testTriePath2, err := testutil.PathOfTempFile(triePath2)
 	require.NoError(err)
-	testTriePath2 := testTrieFile2.Name()
-	require.NoError(testTrieFile2.Close())
-	indexDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	indexDBPath2, err := testutil.PathOfTempFile(dBPath2)
 	require.NoError(err)
-	indexDBPath2 := indexDBFile2.Name()
-	require.NoError(indexDBFile2.Close())
 
 	cfg, err = newTestConfig()
 	require.NoError(err)
@@ -533,18 +507,12 @@ func TestLocalSync(t *testing.T) {
 func TestStartExistingBlockchain(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
-	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	testDBPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	testIndexPath, err := testutil.PathOfTempFile(dBPath)
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 	// Disable block reward to make bookkeeping easier
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -567,31 +535,38 @@ func TestStartExistingBlockchain(t *testing.T) {
 
 	defer func() {
 		require.NoError(svr.Stop(ctx))
+		testutil.CleanupPath(t, testTriePath)
+		testutil.CleanupPath(t, testDBPath)
+		testutil.CleanupPath(t, testIndexPath)
 	}()
 
 	require.NoError(addTestingTsfBlocks(bc))
 	require.Equal(uint64(5), bc.TipHeight())
 
+	require.NoError(svr.Stop(ctx))
 	// Delete state db and recover to tip
 	testutil.CleanupPath(t, testTriePath)
-	require.NoError(svr.Stop(ctx))
+
 	require.NoError(svr.ChainService(cfg.Chain.ID).Blockchain().Start(ctx))
 	height, _ := svr.ChainService(cfg.Chain.ID).StateFactory().Height()
 	require.Equal(bc.TipHeight(), height)
 	require.Equal(uint64(5), height)
 	require.NoError(svr.ChainService(cfg.Chain.ID).Blockchain().Stop(ctx))
+
+	// Recover to height 3 from empty state DB
+	testutil.CleanupPath(t, testTriePath)
 	svr, err = itx.NewServer(cfg)
 	require.NoError(err)
 	require.NoError(svr.Start(ctx))
 	bc = svr.ChainService(chainID).Blockchain()
 	dao = svr.ChainService(chainID).BlockDAO()
-	// Recover to height 3 from empty state DB
-	testutil.CleanupPath(t, testTriePath)
 	require.NoError(dao.DeleteBlockToTarget(3))
 	require.NoError(svr.Stop(ctx))
+
+	// Build states from height 1 to 3
+	testutil.CleanupPath(t, testTriePath)
 	svr, err = itx.NewServer(cfg)
 	require.NoError(err)
-	// Build states from height 1 to 3
 	require.NoError(svr.Start(ctx))
 	bc = svr.ChainService(chainID).Blockchain()
 	sf = svr.ChainService(chainID).StateFactory()
@@ -601,9 +576,9 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.Equal(uint64(3), height)
 
 	// Recover to height 2 from an existing state DB with Height 3
-	testutil.CleanupPath(t, testTriePath)
 	require.NoError(dao.DeleteBlockToTarget(2))
 	require.NoError(svr.Stop(ctx))
+	testutil.CleanupPath(t, testTriePath)
 	svr, err = itx.NewServer(cfg)
 	require.NoError(err)
 	// Build states from height 1 to 2

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -16,10 +16,11 @@ import (
 	"time"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/crypto"
 	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	multiaddr "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/crypto"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
@@ -51,12 +52,18 @@ func TestLocalCommit(t *testing.T) {
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	indexDBFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(testDBFile.Close())
+	indexDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	indexDBPath := indexDBFile.Name()
+	require.NoError(indexDBFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
@@ -159,12 +166,18 @@ func TestLocalCommit(t *testing.T) {
 	require.EqualValues(5, bc.TipHeight())
 
 	// create local chain
-	testTrieFile2, _ := ioutil.TempFile(os.TempDir(), triePath2)
+	testTrieFile2, err := ioutil.TempFile(os.TempDir(), triePath2)
+	require.NoError(err)
 	testTriePath2 := testTrieFile2.Name()
-	testDBFile2, _ := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(testTrieFile2.Close())
+	testDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(err)
 	testDBPath2 := testDBFile2.Name()
-	indexDBFile2, _ := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(testDBFile2.Close())
+	indexDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(err)
 	indexDBPath2 := indexDBFile2.Name()
+	require.NoError(indexDBFile2.Close())
 	cfg.Chain.TrieDBPath = testTriePath2
 	cfg.Chain.ChainDBPath = testDBPath2
 	cfg.Chain.IndexDBPath = indexDBPath2
@@ -375,12 +388,18 @@ func TestLocalSync(t *testing.T) {
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	indexDBFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(testDBFile.Close())
+	indexDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	indexDBPath := indexDBFile.Name()
+	require.NoError(indexDBFile.Close())
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
@@ -418,12 +437,18 @@ func TestLocalSync(t *testing.T) {
 	hash5 := blk.HashBlock()
 	require.NotNil(svr.P2PAgent())
 
-	testDBFile2, _ := ioutil.TempFile(os.TempDir(), dBPath2)
+	testDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(err)
 	testDBPath2 := testDBFile2.Name()
-	testTrieFile2, _ := ioutil.TempFile(os.TempDir(), triePath2)
+	require.NoError(testDBFile2.Close())
+	testTrieFile2, err := ioutil.TempFile(os.TempDir(), triePath2)
+	require.NoError(err)
 	testTriePath2 := testTrieFile2.Name()
-	indexDBFile2, _ := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(testTrieFile2.Close())
+	indexDBFile2, err := ioutil.TempFile(os.TempDir(), dBPath2)
+	require.NoError(err)
 	indexDBPath2 := indexDBFile2.Name()
+	require.NoError(indexDBFile2.Close())
 
 	cfg, err = newTestConfig()
 	require.NoError(err)
@@ -508,12 +533,18 @@ func TestLocalSync(t *testing.T) {
 func TestStartExistingBlockchain(t *testing.T) {
 	require := require.New(t)
 	ctx := context.Background()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	testDBFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(testDBFile.Close())
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(testTrieFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), dBPath)
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
 	// Disable block reward to make bookkeeping easier
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -17,11 +17,12 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
-	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/iotexproject/iotex-core/action"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
@@ -259,12 +260,18 @@ func TestLocalTransfer(t *testing.T) {
 
 	require := require.New(t)
 
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	require.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	require.NoError(err)
 	testIndexPath := testIndexFile.Name()
+	require.NoError(testIndexFile.Close())
 
 	networkPort := 4689
 	apiPort := testutil.RandomPort()

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -264,10 +264,19 @@ func TestLocalTransfer(t *testing.T) {
 	require.NoError(err)
 	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
+	testSystemLogPath, err := testutil.PathOfTempFile("systemlog")
+	require.NoError(err)
+
+	defer func() {
+		testutil.CleanupPath(t, testTriePath)
+		testutil.CleanupPath(t, testDBPath)
+		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPath(t, testSystemLogPath)
+	}()
 
 	networkPort := 4689
 	apiPort := testutil.RandomPort()
-	cfg, err := newTransferConfig(testDBPath, testTriePath, testIndexPath, networkPort, apiPort)
+	cfg, err := newTransferConfig(testDBPath, testTriePath, testIndexPath, testSystemLogPath, networkPort, apiPort)
 	defer func() {
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -488,7 +497,8 @@ func getLocalKey(i int) crypto.PrivateKey {
 func newTransferConfig(
 	chainDBPath,
 	trieDBPath,
-	indexDBPath string,
+	indexDBPath,
+	systemLogDBPath string,
 	networkPort,
 	apiPort int,
 ) (config.Config, error) {
@@ -500,6 +510,7 @@ func newTransferConfig(
 	cfg.Chain.ChainDBPath = chainDBPath
 	cfg.Chain.TrieDBPath = trieDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
+	cfg.System.SystemLogDBPath = systemLogDBPath
 	cfg.Chain.EnableAsyncIndexWrite = true
 	cfg.ActPool.MinGasPriceStr = "0"
 	cfg.Consensus.Scheme = config.StandaloneScheme

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -9,10 +9,8 @@ package e2etest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
-	"os"
 	"testing"
 	"time"
 
@@ -260,18 +258,12 @@ func TestLocalTransfer(t *testing.T) {
 
 	require := require.New(t)
 
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	require.NoError(err)
-	testDBPath := testDBFile.Name()
-	require.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	require.NoError(testIndexFile.Close())
 
 	networkPort := 4689
 	apiPort := testutil.RandomPort()

--- a/e2etest/native_staking_test.go
+++ b/e2etest/native_staking_test.go
@@ -2,9 +2,7 @@ package e2etest
 
 import (
 	"context"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -50,8 +48,9 @@ var (
 )
 
 func TestNativeStaking(t *testing.T) {
+	require := require.New(t)
+
 	testNativeStaking := func(cfg config.Config, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 
 		// Create a new blockchain
@@ -245,16 +244,19 @@ func TestNativeStaking(t *testing.T) {
 	}
 
 	cfg := config.Default
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
-	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
-	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
-	testIndexPath := testIndexFile.Name()
+	testTriePath, err := testutil.PathOfTempFile("trie")
+	require.NoError(err)
+	testDBPath, err := testutil.PathOfTempFile("db")
+	require.NoError(err)
+	testIndexPath, err := testutil.PathOfTempFile("index")
+	require.NoError(err)
+	testSystemLogPath, err := testutil.PathOfTempFile("systemlog")
+	require.NoError(err)
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 		testutil.CleanupPath(t, testDBPath)
 		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPath(t, testSystemLogPath)
 		// clear the gateway
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -262,6 +264,7 @@ func TestNativeStaking(t *testing.T) {
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = testIndexPath
+	cfg.System.SystemLogDBPath = testSystemLogPath
 	cfg.Consensus.Scheme = config.NOOPScheme
 	cfg.Chain.EnableAsyncIndexWrite = false
 

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -3,7 +3,6 @@ package e2etest
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -21,6 +20,8 @@ import (
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 
 	"github.com/iotexproject/iotex-core/action"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
@@ -36,8 +37,6 @@ import (
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 type claimTestCaseID int
@@ -61,22 +60,14 @@ const (
 
 func TestBlockReward(t *testing.T) {
 	r := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	testTriePath, err := testutil.PathOfTempFile("trie")
 	r.NoError(err)
-	testTriePath := testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
-	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	testDBPath, err := testutil.PathOfTempFile("db")
 	r.NoError(err)
-	testDBPath := testDBFile.Name()
-	r.NoError(testDBFile.Close())
-	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	testIndexPath, err := testutil.PathOfTempFile("index")
 	r.NoError(err)
-	testIndexPath := testIndexFile.Name()
-	r.NoError(testIndexFile.Close())
-	testConsensusFile, err := ioutil.TempFile(os.TempDir(), "cons")
+	testConsensusPath, err := testutil.PathOfTempFile("cons")
 	r.NoError(err)
-	testConsensusPath := testConsensusFile.Name()
-	r.NoError(testConsensusFile.Close())
 
 	cfg := config.Default
 	cfg.Consensus.Scheme = config.RollDPoSScheme

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -13,13 +13,14 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/iotexproject/go-pkgs/crypto"
-	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
 
 	"github.com/iotexproject/iotex-core/action"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
@@ -59,14 +60,23 @@ const (
 )
 
 func TestBlockReward(t *testing.T) {
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
+	r := require.New(t)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), "trie")
+	r.NoError(err)
 	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(testTrieFile.Close())
+	testDBFile, err := ioutil.TempFile(os.TempDir(), "db")
+	r.NoError(err)
 	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(testDBFile.Close())
+	testIndexFile, err := ioutil.TempFile(os.TempDir(), "index")
+	r.NoError(err)
 	testIndexPath := testIndexFile.Name()
-	testConsensusFile, _ := ioutil.TempFile(os.TempDir(), "cons")
+	r.NoError(testIndexFile.Close())
+	testConsensusFile, err := ioutil.TempFile(os.TempDir(), "cons")
+	r.NoError(err)
 	testConsensusPath := testConsensusFile.Name()
+	r.NoError(testConsensusFile.Close())
 
 	cfg := config.Default
 	cfg.Consensus.Scheme = config.RollDPoSScheme

--- a/e2etest/staking_test.go
+++ b/e2etest/staking_test.go
@@ -18,9 +18,10 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
@@ -35,8 +36,9 @@ import (
 )
 
 func TestStakingContract(t *testing.T) {
+	require := require.New(t)
+
 	testReadContract := func(cfg config.Config, t *testing.T) {
-		require := require.New(t)
 		ctx := context.Background()
 
 		// Create a new blockchain

--- a/e2etest/staking_test.go
+++ b/e2etest/staking_test.go
@@ -10,9 +10,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -179,14 +177,14 @@ func TestStakingContract(t *testing.T) {
 	}
 
 	cfg := config.Default
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), "trie")
-	testTriePath := testTrieFile.Name()
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), "db")
-	testDBPath := testDBFile.Name()
-	testIndexFile, _ := ioutil.TempFile(os.TempDir(), "index")
-	testIndexPath := testIndexFile.Name()
-	testSystemLogFile, _ := ioutil.TempFile(os.TempDir(), "index")
-	testSystemLogPath := testSystemLogFile.Name()
+	testTriePath, err := testutil.PathOfTempFile("trie")
+	require.NoError(err)
+	testDBPath, err := testutil.PathOfTempFile("db")
+	require.NoError(err)
+	testIndexPath, err := testutil.PathOfTempFile("index")
+	require.NoError(err)
+	testSystemLogPath,err:=testutil.PathOfTempFile("systemlog")
+	require.NoError(err)
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
 		testutil.CleanupPath(t, testDBPath)

--- a/ioctl/cmd/account/account_test.go
+++ b/ioctl/cmd/account/account_test.go
@@ -8,11 +8,13 @@ package account
 
 import (
 	"crypto/ecdsa"
-	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/iotexproject/iotex-core/testutil"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/stretchr/testify/require"
@@ -31,8 +33,8 @@ const (
 func TestAccount(t *testing.T) {
 	r := require.New(t)
 
-	testWallet, err := ioutil.TempDir(os.TempDir(), testPath)
-	r.NoError(err)
+	testWallet := filepath.Join(os.TempDir(), testPath)
+	defer testutil.CleanupPath(t, testWallet)
 	config.ReadConfig.Wallet = testWallet
 
 	ks := keystore.NewKeyStore(config.ReadConfig.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)

--- a/ioctl/cmd/account/account_test.go
+++ b/ioctl/cmd/account/account_test.go
@@ -14,8 +14,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/iotexproject/iotex-core/testutil"
-
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/stretchr/testify/require"
 
@@ -24,6 +22,7 @@ import (
 	"github.com/iotexproject/iotex-address/address"
 
 	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 const (

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -9,7 +9,6 @@ package factory
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
 	"os"
@@ -62,10 +61,8 @@ func randStringRunes(n int) string {
 
 func TestSnapshot(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -95,10 +92,8 @@ func TestSnapshot(t *testing.T) {
 
 func TestSDBSnapshot(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(err)
-	testStateDBPath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -320,10 +315,8 @@ func testCandidates(sf Factory, t *testing.T) {
 }
 
 func TestState(t *testing.T) {
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -334,51 +327,42 @@ func TestState(t *testing.T) {
 
 func TestHistoryState(t *testing.T) {
 	r := require.New(t)
+	var err error
 	// using factory and enable history
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
-	r.NoError(err)
 	cfg := config.Default
-	cfg.Chain.TrieDBPath = testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
+	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
+	r.NoError(err)
 	cfg.Chain.EnableArchiveMode = true
 	sf, err := NewFactory(cfg, DefaultTrieOption())
 	r.NoError(err)
 	testHistoryState(sf, t, false, cfg.Chain.EnableArchiveMode)
 
 	// using stateDB and enable history
-	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	cfg.Chain.TrieDBPath = testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
 	sf, err = NewStateDB(cfg, DefaultStateDBOption())
 	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 
 	// using factory and disable history
-	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	cfg.Chain.TrieDBPath = testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
 	cfg.Chain.EnableArchiveMode = false
 	sf, err = NewFactory(cfg, DefaultTrieOption())
 	r.NoError(err)
 	testHistoryState(sf, t, false, cfg.Chain.EnableArchiveMode)
 
 	// using stateDB and disable history
-	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	cfg.Chain.TrieDBPath = testTrieFile.Name()
-	r.NoError(testTrieFile.Close())
 	sf, err = NewStateDB(cfg, DefaultStateDBOption())
 	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 }
 
 func TestSDBState(t *testing.T) {
-	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
-	testDBPath := testDBFile.Name()
-	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -538,10 +522,8 @@ func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 }
 
 func TestNonce(t *testing.T) {
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -550,10 +532,8 @@ func TestNonce(t *testing.T) {
 	testNonce(sf, t)
 }
 func TestSDBNonce(t *testing.T) {
-	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
-	testDBPath := testDBFile.Name()
-	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -635,10 +615,8 @@ func testNonce(sf Factory, t *testing.T) {
 }
 
 func TestLoadStoreHeight(t *testing.T) {
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -649,9 +627,8 @@ func TestLoadStoreHeight(t *testing.T) {
 }
 
 func TestLoadStoreHeightInMem(t *testing.T) {
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
-	testTriePath := testTrieFile.Name()
-	require.NoError(t, testTrieFile.Close())
+	testTriePath, err := testutil.PathOfTempFile(triePath)
+	require.NoError(t, err)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -661,10 +638,8 @@ func TestLoadStoreHeightInMem(t *testing.T) {
 }
 
 func TestSDBLoadStoreHeight(t *testing.T) {
-	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
-	testDBPath := testDBFile.Name()
-	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -675,10 +650,8 @@ func TestSDBLoadStoreHeight(t *testing.T) {
 }
 
 func TestSDBLoadStoreHeightInMem(t *testing.T) {
-	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
-	testDBPath := testDBFile.Name()
-	require.NoError(t, testDBFile.Close())
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
 	db, err := NewStateDB(cfg, InMemStateDBOption())
@@ -725,10 +698,8 @@ func testLoadStoreHeight(sf Factory, t *testing.T) {
 
 func TestRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -756,10 +727,8 @@ func TestRunActions(t *testing.T) {
 
 func TestSTXRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(err)
-	testStateDBPath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -838,10 +807,8 @@ func testCommit(factory Factory, registry *protocol.Registry, t *testing.T) {
 
 func TestPickAndRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -869,10 +836,8 @@ func TestPickAndRunActions(t *testing.T) {
 
 func TestSTXPickAndRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(err)
-	testStateDBPath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -948,10 +913,8 @@ func testNewBlockBuilder(factory Factory, registry *protocol.Registry, t *testin
 
 func TestSimulateExecution(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(err)
-	testTriePath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -979,10 +942,8 @@ func TestSimulateExecution(t *testing.T) {
 
 func TestSTXSimulateExecution(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(err)
-	testStateDBPath := testTrieFile.Name()
-	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -18,12 +18,13 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-election/test/mock/mock_committee"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
@@ -61,8 +62,10 @@ func randStringRunes(n int) string {
 
 func TestSnapshot(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -92,8 +95,10 @@ func TestSnapshot(t *testing.T) {
 
 func TestSDBSnapshot(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(err)
 	testStateDBPath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -315,8 +320,10 @@ func testCandidates(sf Factory, t *testing.T) {
 }
 
 func TestState(t *testing.T) {
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(t, err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -326,41 +333,52 @@ func TestState(t *testing.T) {
 }
 
 func TestHistoryState(t *testing.T) {
+	r := require.New(t)
 	// using factory and enable history
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	r.NoError(err)
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTrieFile.Name()
+	r.NoError(testTrieFile.Close())
 	cfg.Chain.EnableArchiveMode = true
 	sf, err := NewFactory(cfg, DefaultTrieOption())
-	require.NoError(t, err)
+	r.NoError(err)
 	testHistoryState(sf, t, false, cfg.Chain.EnableArchiveMode)
 
-	// using statedb and enable history
-	testTrieFile, _ = ioutil.TempFile(os.TempDir(), triePath)
+	// using stateDB and enable history
+	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	r.NoError(err)
 	cfg.Chain.TrieDBPath = testTrieFile.Name()
+	r.NoError(testTrieFile.Close())
 	sf, err = NewStateDB(cfg, DefaultStateDBOption())
-	require.NoError(t, err)
+	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 
 	// using factory and disable history
-	testTrieFile, _ = ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	r.NoError(err)
 	cfg.Chain.TrieDBPath = testTrieFile.Name()
+	r.NoError(testTrieFile.Close())
 	cfg.Chain.EnableArchiveMode = false
 	sf, err = NewFactory(cfg, DefaultTrieOption())
-	require.NoError(t, err)
+	r.NoError(err)
 	testHistoryState(sf, t, false, cfg.Chain.EnableArchiveMode)
 
-	// using statedb and disable history
-	testTrieFile, _ = ioutil.TempFile(os.TempDir(), triePath)
+	// using stateDB and disable history
+	testTrieFile, err = ioutil.TempFile(os.TempDir(), triePath)
+	r.NoError(err)
 	cfg.Chain.TrieDBPath = testTrieFile.Name()
+	r.NoError(testTrieFile.Close())
 	sf, err = NewStateDB(cfg, DefaultStateDBOption())
-	require.NoError(t, err)
+	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 }
 
 func TestSDBState(t *testing.T) {
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(t, err)
 	testDBPath := testDBFile.Name()
+	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -520,8 +538,10 @@ func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 }
 
 func TestNonce(t *testing.T) {
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(t, err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -530,8 +550,10 @@ func TestNonce(t *testing.T) {
 	testNonce(sf, t)
 }
 func TestSDBNonce(t *testing.T) {
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(t, err)
 	testDBPath := testDBFile.Name()
+	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -613,52 +635,54 @@ func testNonce(sf Factory, t *testing.T) {
 }
 
 func TestLoadStoreHeight(t *testing.T) {
-	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(t, err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(t, testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
 	statefactory, err := NewFactory(cfg, DefaultTrieOption())
-	require.NoError(err)
+	require.NoError(t, err)
 
 	testLoadStoreHeight(statefactory, t)
 }
 
 func TestLoadStoreHeightInMem(t *testing.T) {
-	require := require.New(t)
-
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
 	testTriePath := testTrieFile.Name()
+	require.NoError(t, testTrieFile.Close())
+
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
 	statefactory, err := NewFactory(cfg, InMemTrieOption())
-	require.NoError(err)
+	require.NoError(t, err)
 	testLoadStoreHeight(statefactory, t)
 }
 
 func TestSDBLoadStoreHeight(t *testing.T) {
-	require := require.New(t)
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(t, err)
 	testDBPath := testDBFile.Name()
+	require.NoError(t, testDBFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
 	db, err := NewStateDB(cfg, DefaultStateDBOption())
-	require.NoError(err)
+	require.NoError(t, err)
 
 	testLoadStoreHeight(db, t)
 }
 
 func TestSDBLoadStoreHeightInMem(t *testing.T) {
-	require := require.New(t)
-
-	testDBFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testDBFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(t, err)
 	testDBPath := testDBFile.Name()
+	require.NoError(t, testDBFile.Close())
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
 	db, err := NewStateDB(cfg, InMemStateDBOption())
-	require.NoError(err)
+	require.NoError(t, err)
 
 	testLoadStoreHeight(db, t)
 }
@@ -701,8 +725,10 @@ func testLoadStoreHeight(sf Factory, t *testing.T) {
 
 func TestRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -730,8 +756,10 @@ func TestRunActions(t *testing.T) {
 
 func TestSTXRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(err)
 	testStateDBPath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -810,8 +838,10 @@ func testCommit(factory Factory, registry *protocol.Registry, t *testing.T) {
 
 func TestPickAndRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -839,8 +869,10 @@ func TestPickAndRunActions(t *testing.T) {
 
 func TestSTXPickAndRunActions(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(err)
 	testStateDBPath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath
@@ -916,8 +948,10 @@ func testNewBlockBuilder(factory Factory, registry *protocol.Registry, t *testin
 
 func TestSimulateExecution(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), triePath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), triePath)
+	require.NoError(err)
 	testTriePath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -945,8 +979,10 @@ func TestSimulateExecution(t *testing.T) {
 
 func TestSTXSimulateExecution(t *testing.T) {
 	require := require.New(t)
-	testTrieFile, _ := ioutil.TempFile(os.TempDir(), stateDBPath)
+	testTrieFile, err := ioutil.TempFile(os.TempDir(), stateDBPath)
+	require.NoError(err)
 	testStateDBPath := testTrieFile.Name()
+	require.NoError(testTrieFile.Close())
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testStateDBPath

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/util/fileutil"
 )
 
+// PathOfTempFile returns path of a new temporary file
 func PathOfTempFile(dirName string) (string, error) {
 	tempFile, err := ioutil.TempFile(os.TempDir(), dirName)
 	if err != nil {

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -7,11 +7,20 @@
 package testutil
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/iotexproject/iotex-core/pkg/util/fileutil"
 )
+
+func PathOfTempFile(dirName string) (string, error) {
+	tempFile, err := ioutil.TempFile(os.TempDir(), dirName)
+	if err != nil {
+		return "", err
+	}
+	return tempFile.Name(), tempFile.Close()
+}
 
 // CleanupPath detects the existence of test DB file and removes it if found
 func CleanupPath(t *testing.T, path string) {


### PR DESCRIPTION
`os.TempFile()` creates and occupies new file on Windows. Many test cleanups fails on Windows due to those occupations. Thus, I close all those files after created in this PR.