### PR TITLE
add candidateIndexer to store candidate/kickoutlist for API call

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,8 @@ clean:
 	$(ECHO_V)rm -rf *chain*.db
 	$(ECHO_V)rm -rf *trie*.db
 	$(ECHO_V)rm -rf *index*.db
+	$(ECHO_V)rm -rf *systemlog*.db
+	$(ECHO_V)rm -rf *candidate.index*.db
 	$(ECHO_V)rm -rf $(COV_REPORT) $(COV_HTML) $(LINT_LOG)
 	$(ECHO_V)find . -name $(COV_OUT) -delete
 	$(ECHO_V)find . -name $(TESTBED_COV_OUT) -delete
@@ -169,6 +171,7 @@ reboot:
 	$(ECHO_V)rm -rf *chain*.db
 	$(ECHO_V)rm -rf *trie*.db
 	$(ECHO_V)rm -rf *index*.db
+	$(ECHO_V)rm -rf *candidate.index*.db
 	$(ECHO_V)rm -rf ./e2etest/*chain*.db
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_SERVER) -v ./$(BUILD_TARGET_SERVER)
 	./bin/$(BUILD_TARGET_SERVER) -plugin=gateway
@@ -177,7 +180,7 @@ reboot:
 run:
 	$(ECHO_V)rm -rf ./e2etest/*chain*.db
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_SERVER) -v ./$(BUILD_TARGET_SERVER)
-	./bin/$(BUILD_TARGET_SERVER) -plugin=gateway
+	./bin/$(BUILD_TARGET_SERVER) -plugin=gateway -plugin=candidategateway
 
 .PHONY: docker
 docker:
@@ -188,6 +191,7 @@ minicluster:
 	$(ECHO_V)rm -rf *chain*.db
 	$(ECHO_V)rm -rf *trie*.db
 	$(ECHO_V)rm -rf *index*.db
+	$(ECHO_V)rm -rf *candidate.index*.db
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_MINICLUSTER) -v ./tools/minicluster
 	./bin/$(BUILD_TARGET_MINICLUSTER)
 
@@ -196,6 +200,7 @@ nightlybuild:
 	$(ECHO_V)rm -rf *chain*.db
 	$(ECHO_V)rm -rf *trie*.db
 	$(ECHO_V)rm -rf *index*.db
+	$(ECHO_V)rm -rf *candidate.index*.db
 	$(GOBUILD) -ldflags "$(PackageFlags)" -o ./bin/$(BUILD_TARGET_MINICLUSTER) -v ./tools/minicluster
 	./bin/$(BUILD_TARGET_MINICLUSTER) -timeout=14400 -fp-token=true
 

--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package poll
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/action/protocol/vote"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+	"github.com/iotexproject/iotex-core/state"
+)
+
+var (
+	CandidateNamespace = "candidates"
+	KickoutNamespace   = "kickout"
+	ErrIndexerNotExist = errors.New("not exist in DB")
+)
+
+type CandidateIndexer struct {
+	mutex   sync.RWMutex
+	kvStore db.KVStore
+}
+
+// NewCandidateIndexer creates a new CandidateIndexer
+func NewCandidateIndexer(kv db.KVStore) (*CandidateIndexer, error) {
+	if kv == nil {
+		return nil, errors.New("empty kvStore")
+	}
+	x := CandidateIndexer{
+		kvStore: kv,
+	}
+	return &x, nil
+}
+
+func (cd *CandidateIndexer) PutCandidate(height uint64, candidates *state.CandidateList) error {
+	cd.mutex.Lock()
+	defer cd.mutex.Unlock()
+	candidatesByte, err := candidates.Serialize()
+	if err != nil {
+		return err
+	}
+	return cd.kvStore.Put(CandidateNamespace, byteutil.Uint64ToBytes(height), candidatesByte)
+}
+
+func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blacklist) error {
+	cd.mutex.Lock()
+	defer cd.mutex.Unlock()
+	kickoutListByte, err := kickoutList.Serialize()
+	if err != nil {
+		return err
+	}
+	return cd.kvStore.Put(KickoutNamespace, byteutil.Uint64ToBytes(height), kickoutListByte)
+}
+
+func (cd *CandidateIndexer) GetCandidate(height uint64) (state.CandidateList, error) {
+	cd.mutex.RLock()
+	defer cd.mutex.RUnlock()
+	candidates := &state.CandidateList{}
+	bytes, err := cd.kvStore.Get(CandidateNamespace, byteutil.Uint64ToBytes(height))
+	if err != nil {
+		if errors.Cause(err) == db.ErrNotExist {
+			return nil, ErrIndexerNotExist
+		}
+		return nil, err
+	}
+	if err := candidates.Deserialize(bytes); err != nil {
+		return nil, err
+	}
+	return *candidates, nil
+}
+
+func (cd *CandidateIndexer) GetKickoutList(height uint64) (*vote.Blacklist, error) {
+	cd.mutex.RLock()
+	defer cd.mutex.RUnlock()
+	bl := &vote.Blacklist{}
+	bytes, err := cd.kvStore.Get(KickoutNamespace, byteutil.Uint64ToBytes(height))
+	if err != nil {
+		if errors.Cause(err) == db.ErrNotExist {
+			return nil, ErrIndexerNotExist
+		}
+		return nil, err
+	}
+	if err := bl.Deserialize(bytes); err != nil {
+		return nil, err
+	}
+	return bl, nil
+}

--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -43,8 +43,8 @@ func NewCandidateIndexer(kv db.KVStore) (*CandidateIndexer, error) {
 	return &x, nil
 }
 
-// PutCandidate puts candidate list into indexer
-func (cd *CandidateIndexer) PutCandidate(height uint64, candidates *state.CandidateList) error {
+// PutCandidateList puts candidate list into indexer
+func (cd *CandidateIndexer) PutCandidateList(height uint64, candidates *state.CandidateList) error {
 	cd.mutex.Lock()
 	defer cd.mutex.Unlock()
 	candidatesByte, err := candidates.Serialize()
@@ -65,8 +65,8 @@ func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blac
 	return cd.kvStore.Put(KickoutNamespace, byteutil.Uint64ToBytes(height), kickoutListByte)
 }
 
-// GetCandidate gets candidate list from indexer given epoch start height
-func (cd *CandidateIndexer) GetCandidate(height uint64) (state.CandidateList, error) {
+// CandidateList gets candidate list from indexer given epoch start height
+func (cd *CandidateIndexer) CandidateList(height uint64) (state.CandidateList, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()
 	candidates := &state.CandidateList{}
@@ -83,8 +83,8 @@ func (cd *CandidateIndexer) GetCandidate(height uint64) (state.CandidateList, er
 	return *candidates, nil
 }
 
-// GetKickoutList gets kickout list from indexer given epoch start height
-func (cd *CandidateIndexer) GetKickoutList(height uint64) (*vote.Blacklist, error) {
+// KickoutList gets kickout list from indexer given epoch start height
+func (cd *CandidateIndexer) KickoutList(height uint64) (*vote.Blacklist, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()
 	bl := &vote.Blacklist{}

--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -18,11 +18,15 @@ import (
 )
 
 var (
+	// CandidateNamespace is a namespace to store raw candidate
 	CandidateNamespace = "candidates"
-	KickoutNamespace   = "kickout"
+	// KickoutNamespace is a namespace to store kickoutlist
+	KickoutNamespace = "kickout"
+	// ErrIndexerNotExist is an error that shows not exist in candidate indexer DB
 	ErrIndexerNotExist = errors.New("not exist in DB")
 )
 
+// CandidateIndexer is an indexer to store candidate/blacklist by given height
 type CandidateIndexer struct {
 	mutex   sync.RWMutex
 	kvStore db.KVStore
@@ -39,6 +43,7 @@ func NewCandidateIndexer(kv db.KVStore) (*CandidateIndexer, error) {
 	return &x, nil
 }
 
+// PutCandidate puts candidate list into indexer
 func (cd *CandidateIndexer) PutCandidate(height uint64, candidates *state.CandidateList) error {
 	cd.mutex.Lock()
 	defer cd.mutex.Unlock()
@@ -49,6 +54,7 @@ func (cd *CandidateIndexer) PutCandidate(height uint64, candidates *state.Candid
 	return cd.kvStore.Put(CandidateNamespace, byteutil.Uint64ToBytes(height), candidatesByte)
 }
 
+// PutKickoutList puts kickout list into indexer
 func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blacklist) error {
 	cd.mutex.Lock()
 	defer cd.mutex.Unlock()
@@ -59,6 +65,7 @@ func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blac
 	return cd.kvStore.Put(KickoutNamespace, byteutil.Uint64ToBytes(height), kickoutListByte)
 }
 
+// GetCandidate gets candidate list from indexer given epoch start height
 func (cd *CandidateIndexer) GetCandidate(height uint64) (state.CandidateList, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()
@@ -76,6 +83,7 @@ func (cd *CandidateIndexer) GetCandidate(height uint64) (state.CandidateList, er
 	return *candidates, nil
 }
 
+// GetKickoutList gets kickout list from indexer given epoch start height
 func (cd *CandidateIndexer) GetKickoutList(height uint64) (*vote.Blacklist, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()

--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -11,9 +11,11 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action/protocol/vote"
 	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
@@ -62,6 +64,7 @@ func (cd *CandidateIndexer) PutCandidateList(height uint64, candidates *state.Ca
 	if err != nil {
 		return err
 	}
+	log.L().Debug("put candidatelist into candidate indexer", zap.Uint64("height", height))
 	return cd.kvStore.Put(CandidateNamespace, byteutil.Uint64ToBytes(height), candidatesByte)
 }
 
@@ -73,6 +76,7 @@ func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blac
 	if err != nil {
 		return err
 	}
+	log.L().Debug("put kickout list into candidate indexer", zap.Uint64("height", height))
 	return cd.kvStore.Put(KickoutNamespace, byteutil.Uint64ToBytes(height), kickoutListByte)
 }
 
@@ -80,6 +84,7 @@ func (cd *CandidateIndexer) PutKickoutList(height uint64, kickoutList *vote.Blac
 func (cd *CandidateIndexer) CandidateList(height uint64) (state.CandidateList, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()
+	log.L().Debug("get candidatelist from candidate indexer", zap.Uint64("height", height))
 	candidates := &state.CandidateList{}
 	bytes, err := cd.kvStore.Get(CandidateNamespace, byteutil.Uint64ToBytes(height))
 	if err != nil {
@@ -98,6 +103,7 @@ func (cd *CandidateIndexer) CandidateList(height uint64) (state.CandidateList, e
 func (cd *CandidateIndexer) KickoutList(height uint64) (*vote.Blacklist, error) {
 	cd.mutex.RLock()
 	defer cd.mutex.RUnlock()
+	log.L().Debug("get kickoutlist from candidate indexer", zap.Uint64("height", height))
 	bl := &vote.Blacklist{}
 	bytes, err := cd.kvStore.Get(KickoutNamespace, byteutil.Uint64ToBytes(height))
 	if err != nil {

--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -7,6 +7,7 @@
 package poll
 
 import (
+	"context"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -41,6 +42,16 @@ func NewCandidateIndexer(kv db.KVStore) (*CandidateIndexer, error) {
 		kvStore: kv,
 	}
 	return &x, nil
+}
+
+// Start starts the indexer
+func (cd *CandidateIndexer) Start(ctx context.Context) error {
+	return cd.kvStore.Start(ctx)
+}
+
+// Stop stops the indexer
+func (cd *CandidateIndexer) Stop(ctx context.Context) error {
+	return cd.kvStore.Stop(ctx)
 }
 
 // PutCandidateList puts candidate list into indexer

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/vote"
 	"github.com/iotexproject/iotex-core/action/protocol/vote/candidatesutil"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/db/batch"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/test/identityset"

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -122,7 +122,12 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 			RewardAddress: "rewardAddress4",
 		},
 	}
+	indexer, err := NewCandidateIndexer(db.NewMemKVStore())
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	p, err := NewGovernanceChainCommitteeProtocol(
+		indexer,
 		func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 		func(protocol.StateReader, bool, ...protocol.StateOption) ([]*state.Candidate, uint64, error) {
 			return candidates, 720, nil
@@ -172,7 +177,7 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
 	)
 
-	if err := setCandidates(ctx, sm, candidates, 1); err != nil {
+	if err := setCandidates(ctx, sm, indexer, candidates, 1); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	return p, ctx, sm, r, err
@@ -558,7 +563,7 @@ func TestCandidatesByHeight(t *testing.T) {
 		BlacklistInfos: blackListMap,
 		IntensityRate:  50,
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList))
 	filteredCandidates, err := p.CandidatesByHeight(ctx, 721)
 	require.NoError(err)
 	require.Equal(4, len(filteredCandidates))
@@ -577,7 +582,7 @@ func TestCandidatesByHeight(t *testing.T) {
 		BlacklistInfos: blackListMap,
 		IntensityRate:  0,
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList))
 	filteredCandidates, err = p.CandidatesByHeight(ctx, 721)
 	require.NoError(err)
 	require.Equal(4, len(filteredCandidates))
@@ -606,7 +611,7 @@ func TestDelegatesByEpoch(t *testing.T) {
 		BlacklistInfos: blackListMap,
 		IntensityRate:  90,
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList))
 
 	delegates, err := p.DelegatesByEpoch(ctx, 2)
 	require.NoError(err)
@@ -623,7 +628,7 @@ func TestDelegatesByEpoch(t *testing.T) {
 		BlacklistInfos: blackListMap2,
 		IntensityRate:  90,
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList2))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList2))
 	delegates2, err := p.DelegatesByEpoch(ctx, 2)
 	require.NoError(err)
 	require.Equal(2, len(delegates2))
@@ -640,7 +645,7 @@ func TestDelegatesByEpoch(t *testing.T) {
 		BlacklistInfos: blackListMap3,
 		IntensityRate:  90,
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList3))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList3))
 
 	delegates3, err := p.DelegatesByEpoch(ctx, 2)
 	require.NoError(err)
@@ -669,7 +674,7 @@ func TestDelegatesByEpoch(t *testing.T) {
 		BlacklistInfos: blackListMap5,
 		IntensityRate:  100, // hard kickout
 	}
-	require.NoError(setNextEpochBlacklist(sm, blackList5))
+	require.NoError(setNextEpochBlacklist(sm, nil, 721, blackList5))
 
 	delegates5, err := p.DelegatesByEpoch(ctx, 2)
 	require.NoError(err)

--- a/action/protocol/poll/lifelong_protocol.go
+++ b/action/protocol/poll/lifelong_protocol.go
@@ -60,11 +60,11 @@ func (p *lifeLongDelegatesProtocol) CreateGenesisStates(
 		return errors.Errorf("Cannot create genesis state for height %d", blkCtx.BlockHeight)
 	}
 	log.L().Info("Creating genesis states for lifelong delegates protocol")
-	return setCandidates(ctx, sm, p.delegates, uint64(1))
+	return setCandidates(ctx, sm, nil, p.delegates, uint64(1))
 }
 
 func (p *lifeLongDelegatesProtocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	return handle(ctx, act, sm, p.addr.String())
+	return handle(ctx, act, sm, nil, p.addr.String())
 }
 
 func (p *lifeLongDelegatesProtocol) Validate(ctx context.Context, act action.Action) error {

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -106,6 +106,7 @@ func MustGetProtocol(registry *protocol.Registry) Protocol {
 // NewProtocol instantiates a rewarding protocol instance.
 func NewProtocol(
 	cfg config.Config,
+	candidateIndexer *CandidateIndexer,
 	readContract ReadContract,
 	candidatesByHeight CandidatesByHeight,
 	getCandidates GetCandidates,
@@ -133,6 +134,7 @@ func NewProtocol(
 	var pollProtocol, governance Protocol
 	var err error
 	if governance, err = NewGovernanceChainCommitteeProtocol(
+		candidateIndexer,
 		candidatesByHeight,
 		getCandidates,
 		kickoutListByEpoch,

--- a/action/protocol/poll/protocol_test.go
+++ b/action/protocol/poll/protocol_test.go
@@ -32,6 +32,7 @@ func TestNewProtocol(t *testing.T) {
 	cfg.Genesis.ScoreThreshold = "1200000"
 	p, err := NewProtocol(
 		cfg,
+		nil,
 		func(context.Context, string, []byte, bool) ([]byte, error) { return nil, nil },
 		nil,
 		nil,

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -98,6 +98,7 @@ func initConstructStakingCommittee(ctrl *gomock.Controller) (Protocol, context.C
 		nil,
 		nil,
 		nil,
+		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -45,7 +45,7 @@ func validateDelegates(cs state.CandidateList) error {
 	return nil
 }
 
-func handle(ctx context.Context, act action.Action, sm protocol.StateManager, protocolAddr string) (*action.Receipt, error) {
+func handle(ctx context.Context, act action.Action, sm protocol.StateManager, indexer *CandidateIndexer, protocolAddr string) (*action.Receipt, error) {
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 
@@ -55,7 +55,7 @@ func handle(ctx context.Context, act action.Action, sm protocol.StateManager, pr
 	}
 	zap.L().Debug("Handle PutPollResult Action", zap.Uint64("height", r.Height()))
 
-	if err := setCandidates(ctx, sm, r.Candidates(), r.Height()); err != nil {
+	if err := setCandidates(ctx, sm, indexer, r.Candidates(), r.Height()); err != nil {
 		return nil, errors.Wrap(err, "failed to set candidates")
 	}
 	return &action.Receipt{
@@ -150,6 +150,7 @@ func createPostSystemActions(ctx context.Context, p Protocol) ([]action.Envelope
 func setCandidates(
 	ctx context.Context,
 	sm protocol.StateManager,
+	indexer *CandidateIndexer,
 	candidates state.CandidateList,
 	height uint64, // epoch start height
 ) error {
@@ -182,6 +183,11 @@ func setCandidates(
 			zap.String("score", candidate.Votes.String()),
 		)
 	}
+	if indexer != nil {
+		if err := indexer.PutCandidate(height, &candidates); err != nil {
+			return err
+		}
+	}
 	if preEaster {
 		_, err := sm.PutState(&candidates, protocol.LegacyKeyOption(candidatesutil.ConstructLegacyKey(height)))
 		return err
@@ -194,8 +200,15 @@ func setCandidates(
 // setNextEpochBlacklist sets the blacklist for kick-out with next key
 func setNextEpochBlacklist(
 	sm protocol.StateManager,
+	indexer *CandidateIndexer,
+	height uint64,
 	blackList *vote.Blacklist,
 ) error {
+	if indexer != nil {
+		if err := indexer.PutKickoutList(height, blackList); err != nil {
+			return err
+		}
+	}
 	blackListKey := candidatesutil.ConstructKey(candidatesutil.NxtKickoutKey)
 	_, err := sm.PutState(blackList, protocol.KeyOption(blackListKey[:]), protocol.NamespaceOption(protocol.SystemNamespace))
 	return err

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -184,7 +184,7 @@ func setCandidates(
 		)
 	}
 	if indexer != nil {
-		if err := indexer.PutCandidate(height, &candidates); err != nil {
+		if err := indexer.PutCandidateList(height, &candidates); err != nil {
 			return err
 		}
 	}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -984,6 +984,7 @@ func TestServer_GetChainMeta(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				nil,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
@@ -1249,7 +1250,10 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 			cfg.Genesis.Delegates = delegates
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
+			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
+			require.NoError(err)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
@@ -1312,7 +1316,10 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 			cfg.Genesis.Delegates = delegates
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
+			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
+			require.NoError(err)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
@@ -1377,7 +1384,10 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 			cfg.Genesis.Delegates = delegates
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else {
+			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
+			require.NoError(err)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
@@ -1467,7 +1477,10 @@ func TestServer_GetEpochMeta(t *testing.T) {
 		} else if test.pollProtocolType == "governanceChainCommittee" {
 			committee := mock_committee.NewMockCommittee(ctrl)
 			mbc := mock_blockchain.NewMockBlockchain(ctrl)
+			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
+			require.NoError(err)
 			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 					return []*state.Candidate{
 						{
@@ -1523,7 +1536,7 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			require.NoError(pol.ForceRegister(svr.registry))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)
 
-			mbc.EXPECT().TipHeight().Return(uint64(4)).Times(2)
+			mbc.EXPECT().TipHeight().Return(uint64(4)).Times(3)
 			ctx := protocol.WithBlockchainCtx(
 				context.Background(),
 				protocol.BlockchainCtx{

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -112,6 +112,7 @@ type (
 )
 
 // ProductivityByEpoch returns the map of the number of blocks produced per delegate in an epoch
+// TODO: move to poll protocol and implement reading current epoch meta from state factory -- now only reading current epoch productivity
 func ProductivityByEpoch(ctx context.Context, bc Blockchain, epochNum uint64) (uint64, map[string]uint64, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
@@ -125,6 +126,7 @@ func ProductivityByEpoch(ctx context.Context, bc Blockchain, epochNum uint64) (u
 	if epochNum == currentEpochNum {
 		epochEndHeight = bcCtx.Tip.Height
 	} else {
+		// TODO: delete, won't happen
 		epochEndHeight = rp.GetEpochLastBlockHeight(epochNum)
 	}
 	numBlks := epochEndHeight - epochStartHeight + 1
@@ -138,6 +140,8 @@ func ProductivityByEpoch(ctx context.Context, bc Blockchain, epochNum uint64) (u
 	for _, bp := range activeConsensusBlockProducers {
 		produce[bp.Address] = 0
 	}
+	// TODO: because now this function is only getting current epoch data, (not history)
+	// change to get from bc indexer before easter and after easter(backward compatiblility), read from state factory(cache layer)
 	for i := uint64(0); i < numBlks; i++ {
 		header, err := bc.BlockHeaderByHeight(epochStartHeight + i)
 		if err != nil {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -150,9 +150,9 @@ func New(
 	}
 	// create indexers
 	var (
-		indexers       []blockdao.BlockIndexer
-		indexer        blockindex.Indexer
-		systemLogIndex *systemlog.Indexer
+		indexers         []blockdao.BlockIndexer
+		indexer          blockindex.Indexer
+		systemLogIndex   *systemlog.Indexer
 		candidateIndexer *poll.CandidateIndexer
 	)
 	_, gateway := cfg.Plugins[config.GatewayPlugin]
@@ -174,7 +174,7 @@ func New(
 		}
 		indexers = append(indexers, systemLogIndex)
 
-		// create candidate indexer 
+		// create candidate indexer
 		cfg.DB.DbPath = cfg.Chain.CandidateIndexDBPath
 		candidateIndexer, err = poll.NewCandidateIndexer(db.NewBoltDB(cfg.DB))
 		if err != nil {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -8,7 +8,6 @@ package chainservice
 
 import (
 	"context"
-	"fmt"
 	"math/big"
 	"time"
 
@@ -193,7 +192,6 @@ func New(
 		kvStore = db.NewMemKVStore()
 	} else {
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		fmt.Println("blockdao db path", cfg.DB.DbPath)
 		kvStore = db.NewBoltDB(cfg.DB)
 	}
 	var dao blockdao.BlockDAO
@@ -458,6 +456,11 @@ func (cs *ChainService) Stop(ctx context.Context) error {
 	}
 	if err := cs.chain.Stop(ctx); err != nil {
 		return errors.Wrap(err, "error when stopping blockchain")
+	}
+	if cs.candidateIndexer != nil {
+		if err := cs.candidateIndexer.Stop(ctx); err != nil {
+			return errors.Wrap(err, "error when stopping candidate indexer")
+		}
 	}
 	return nil
 }

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -58,9 +58,10 @@ type ChainService struct {
 	blockdao          blockdao.BlockDAO
 	electionCommittee committee.Committee
 	// TODO: explorer dependency deleted at #1085, need to api related params
-	api          *api.Server
-	indexBuilder *blockindex.IndexBuilder
-	registry     *protocol.Registry
+	api              *api.Server
+	indexBuilder     *blockindex.IndexBuilder
+	candidateIndexer *poll.CandidateIndexer
+	registry         *protocol.Registry
 }
 
 type optionParams struct {
@@ -385,6 +386,7 @@ func New(
 		consensus:         consensus,
 		electionCommittee: electionCommittee,
 		indexBuilder:      indexBuilder,
+		candidateIndexer:  candidateIndexer,
 		api:               apiSvr,
 		registry:          registry,
 	}, nil
@@ -395,6 +397,11 @@ func (cs *ChainService) Start(ctx context.Context) error {
 	if cs.electionCommittee != nil {
 		if err := cs.electionCommittee.Start(ctx); err != nil {
 			return errors.Wrap(err, "error when starting election committee")
+		}
+	}
+	if cs.candidateIndexer != nil {
+		if err := cs.candidateIndexer.Start(ctx); err != nil {
+			return errors.Wrap(err, "error when starting candidate indexer")
 		}
 	}
 	if err := cs.chain.Start(ctx); err != nil {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -8,6 +8,7 @@ package chainservice
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -174,7 +175,10 @@ func New(
 			return nil, err
 		}
 		indexers = append(indexers, systemLogIndex)
+	}
 
+	_, candidateGateway := cfg.Plugins[config.CandidateGatewayPlugin]
+	if candidateGateway {
 		// create candidate indexer
 		cfg.DB.DbPath = cfg.Chain.CandidateIndexDBPath
 		candidateIndexer, err = poll.NewCandidateIndexer(db.NewBoltDB(cfg.DB))
@@ -182,12 +186,14 @@ func New(
 			return nil, err
 		}
 	}
+
 	// create BlockDAO
 	var kvStore db.KVStore
 	if ops.isTesting {
 		kvStore = db.NewMemKVStore()
 	} else {
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
+		fmt.Println("blockdao db path", cfg.DB.DbPath)
 		kvStore = db.NewBoltDB(cfg.DB)
 	}
 	var dao blockdao.BlockDAO

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -176,7 +176,7 @@ func New(
 		indexers = append(indexers, systemLogIndex)
 	}
 
-	_, candidateGateway := cfg.Plugins[config.CandidateGatewayPlugin]
+	_, candidateGateway := cfg.Plugins[config.HistoricalCandidatePlugin]
 	if candidateGateway {
 		// create candidate indexer
 		cfg.DB.DbPath = cfg.Chain.CandidateIndexDBPath

--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,8 @@ const (
 const (
 	// GatewayPlugin is the plugin of accepting user API requests and serving blockchain data to users
 	GatewayPlugin = iota
+	// CandidateGatewayPlugin is the plugin of accepting user API requests and serving blockchain data to users related to candidate/delegate info
+	CandidateGatewayPlugin
 )
 
 type strs []string
@@ -441,6 +443,8 @@ func New(validates ...Validate) (Config, error) {
 		switch strings.ToLower(plugin) {
 		case "gateway":
 			cfg.Plugins[GatewayPlugin] = nil
+		case "candidategateway":
+			cfg.Plugins[CandidateGatewayPlugin] = nil
 		default:
 			return Config{}, errors.Errorf("Plugin %s is not supported", plugin)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -58,8 +58,8 @@ const (
 const (
 	// GatewayPlugin is the plugin of accepting user API requests and serving blockchain data to users
 	GatewayPlugin = iota
-	// CandidateGatewayPlugin is the plugin of accepting user API requests and serving blockchain data to users related to candidate/delegate info
-	CandidateGatewayPlugin
+	// HistoricalCandidatePlugin is the plugin of accepting user API requests and serving blockchain data to users related to candidate/delegate info
+	HistoricalCandidatePlugin
 )
 
 type strs []string
@@ -444,7 +444,7 @@ func New(validates ...Validate) (Config, error) {
 		case "gateway":
 			cfg.Plugins[GatewayPlugin] = nil
 		case "candidategateway":
-			cfg.Plugins[CandidateGatewayPlugin] = nil
+			cfg.Plugins[HistoricalCandidatePlugin] = nil
 		default:
 			return Config{}, errors.Errorf("Plugin %s is not supported", plugin)
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -103,15 +103,16 @@ var (
 			PrivateNetworkPSK: "",
 		},
 		Chain: Chain{
-			ChainDBPath:     "./chain.db",
-			TrieDBPath:      "./trie.db",
-			IndexDBPath:     "./index.db",
-			ID:              1,
-			Address:         "",
-			ProducerPrivKey: generateRandomKey(SigP256k1),
-			SignatureScheme: []string{SigP256k1},
-			EmptyGenesis:    false,
-			GravityChainDB:  DB{DbPath: "./poll.db", NumRetries: 10},
+			ChainDBPath:          "./chain.db",
+			TrieDBPath:           "./trie.db",
+			IndexDBPath:          "./index.db",
+			CandidateIndexDBPath: "./candidate.index.db",
+			ID:                   1,
+			Address:              "",
+			ProducerPrivKey:      generateRandomKey(SigP256k1),
+			SignatureScheme:      []string{SigP256k1},
+			EmptyGenesis:         false,
+			GravityChainDB:       DB{DbPath: "./poll.db", NumRetries: 10},
 			Committee: committee.Config{
 				GravityChainAPIs: []string{},
 			},
@@ -224,16 +225,17 @@ type (
 
 	// Chain is the config struct for blockchain package
 	Chain struct {
-		ChainDBPath     string           `yaml:"chainDBPath"`
-		TrieDBPath      string           `yaml:"trieDBPath"`
-		IndexDBPath     string           `yaml:"indexDBPath"`
-		ID              uint32           `yaml:"id"`
-		Address         string           `yaml:"address"`
-		ProducerPrivKey string           `yaml:"producerPrivKey"`
-		SignatureScheme []string         `yaml:"signatureScheme"`
-		EmptyGenesis    bool             `yaml:"emptyGenesis"`
-		GravityChainDB  DB               `yaml:"gravityChainDB"`
-		Committee       committee.Config `yaml:"committee"`
+		ChainDBPath          string           `yaml:"chainDBPath"`
+		TrieDBPath           string           `yaml:"trieDBPath"`
+		IndexDBPath          string           `yaml:"indexDBPath"`
+		CandidateIndexDBPath string           `yaml:"candidateIndexDBPath"`
+		ID                   uint32           `yaml:"id"`
+		Address              string           `yaml:"address"`
+		ProducerPrivKey      string           `yaml:"producerPrivKey"`
+		SignatureScheme      []string         `yaml:"signatureScheme"`
+		EmptyGenesis         bool             `yaml:"emptyGenesis"`
+		GravityChainDB       DB               `yaml:"gravityChainDB"`
+		Committee            committee.Config `yaml:"committee"`
 
 		EnableTrielessStateDB bool `yaml:"enableTrielessStateDB"`
 		// EnableArchiveMode is only meaningful when EnableTrielessStateDB is false

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -266,6 +266,8 @@ func TestLocalTransfer(t *testing.T) {
 	require.NoError(err)
 	testSystemLogPath, err := testutil.PathOfTempFile("systemlog")
 	require.NoError(err)
+	testCandidateIndexPath, err := testutil.PathOfTempFile("candidateIndex")
+	require.NoError(err)
 
 	defer func() {
 		testutil.CleanupPath(t, testTriePath)
@@ -276,7 +278,7 @@ func TestLocalTransfer(t *testing.T) {
 
 	networkPort := 4689
 	apiPort := testutil.RandomPort()
-	cfg, err := newTransferConfig(testDBPath, testTriePath, testIndexPath, testSystemLogPath, networkPort, apiPort)
+	cfg, err := newTransferConfig(testDBPath, testTriePath, testIndexPath, testSystemLogPath, testCandidateIndexPath, networkPort, apiPort)
 	defer func() {
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -497,8 +499,9 @@ func getLocalKey(i int) crypto.PrivateKey {
 func newTransferConfig(
 	chainDBPath,
 	trieDBPath,
-	indexDBPath,
+	indexDBPath string,
 	systemLogDBPath string,
+	candidateIndexDBPath string,
 	networkPort,
 	apiPort int,
 ) (config.Config, error) {
@@ -511,6 +514,7 @@ func newTransferConfig(
 	cfg.Chain.TrieDBPath = trieDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
 	cfg.System.SystemLogDBPath = systemLogDBPath
+	cfg.Chain.CandidateIndexDBPath = candidateIndexDBPath
 	cfg.Chain.EnableAsyncIndexWrite = true
 	cfg.ActPool.MinGasPriceStr = "0"
 	cfg.Consensus.Scheme = config.StandaloneScheme

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -261,6 +261,7 @@ func testCandidates(sf Factory, t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -92,7 +92,7 @@ func main() {
 		dbFilePaths = append(dbFilePaths, consensusDBPath)
 		systemLogDBPath := fmt.Sprintf("./systemlog%d.db", i+1)
 		dbFilePaths = append(dbFilePaths, systemLogDBPath)
-		candidateIndexDBPath := fmt.Sprintf("./candidateIndex%d.db", i+1)
+		candidateIndexDBPath := fmt.Sprintf("./candidate.index%d.db", i+1)
 		dbFilePaths = append(dbFilePaths, candidateIndexDBPath)
 		networkPort := 4689 + i
 		apiPort := 14014 + i

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -92,12 +92,15 @@ func main() {
 		dbFilePaths = append(dbFilePaths, consensusDBPath)
 		systemLogDBPath := fmt.Sprintf("./systemlog%d.db", i+1)
 		dbFilePaths = append(dbFilePaths, systemLogDBPath)
+		candidateIndexDBPath := fmt.Sprintf("./candidateIndex%d.db", i+1)
+		dbFilePaths = append(dbFilePaths, candidateIndexDBPath)
 		networkPort := 4689 + i
 		apiPort := 14014 + i
 		config := newConfig(chainAddrs[i].PriKey, networkPort, apiPort)
 		config.Chain.ChainDBPath = chainDBPath
 		config.Chain.TrieDBPath = trieDBPath
 		config.Chain.IndexDBPath = indexDBPath
+		config.Chain.CandidateIndexDBPath = candidateIndexDBPath
 		config.Consensus.RollDPoS.ConsensusDBPath = consensusDBPath
 		config.System.SystemLogDBPath = systemLogDBPath
 		if i == 0 {


### PR DESCRIPTION
Because archive mode takes too much time, add indexer to store candidate/blacklist for API call (ReadState and GetEpochMeta) 

1. implement candidateIndexer and if exists, read from indexer at ReadState() in poll.Protocol 
2. Refactor ```productivityByEpoch``` to distinguish API purpose and protocol purpose
(DelegatesByEpoch is only for protocol purpose -- related to tip) 

I will refactor ```productivityByEpoch``` in next PR to only keep current epoch data in state factory and move into poll protocol  