### PR TITLE
Sporadic CI test failure 2032

### DIFF
--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -356,7 +356,7 @@ func listSm2Account() ([]string, error) {
 	for _, f := range files {
 		if !f.IsDir() {
 			if strings.HasSuffix(f.Name(), ".pem") {
-				addr := strings.TrimRight(strings.TrimLeft(f.Name(), "sm2sk-"), ".pem")
+				addr := strings.TrimSuffix(strings.TrimPrefix(f.Name(), "sm2sk-"), ".pem")
 				if err := validator.ValidateAddress(addr); err == nil {
 					sm2Accounts = append(sm2Accounts, addr)
 				}


### PR DESCRIPTION
for example:
strings.TrimRight(strings.TrimLeft("sm2sk-io1tx4nf330r2ewdp8u4vt9gk5rmdnkxeajcl828m.pem", "sm2sk-"), ".pem")
return：io1tx4nf330r2ewdp8u4vt9gk5rmdnkxeajcl828