### PR TITLE
Move hard kick-out logic to the place picking up top 36 

### DIFF
--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -382,10 +382,6 @@ func (p *governanceChainCommitteeProtocol) readCandidatesByHeight(ctx context.Co
 			votingPower := new(big.Float).SetInt(filterCand.Votes)
 			filterCand.Votes, _ = votingPower.Mul(votingPower, big.NewFloat(intensityRate)).Int(nil)
 		}
-		if filterCand.Votes.Cmp(big.NewInt(0)) == 0 {
-			// if the voting power is 0, exclude it (hard kickout)
-			continue
-		}
 		updatedVotingPower[filterCand.Address] = filterCand.Votes
 		candidatesMap[filterCand.Address] = filterCand
 	}
@@ -408,6 +404,10 @@ func (p *governanceChainCommitteeProtocol) readBlockProducersByEpoch(ctx context
 	for i, candidate := range candidates {
 		if uint64(i) >= p.numCandidateDelegates {
 			break
+		}
+		if candidate.Votes.Cmp(big.NewInt(0)) == 0 {
+			// if the voting power is 0, exclude from being a block producer(hard kickout)
+			continue
 		}
 		blockProducers = append(blockProducers, candidate)
 	}

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -210,6 +210,10 @@ func (p *Protocol) GrantEpochReward(
 			if _, ok := exemptAddrs[candidates[i].Address]; ok {
 				continue
 			}
+			if candidates[i].Votes.Cmp(big.NewInt(0)) == 0 {
+				// hard kick-out 
+				continue
+			}
 			count++
 			// If reward address doesn't exist, do nothing
 			if candidates[i].RewardAddress == "" {


### PR DESCRIPTION
Currently, because of hard kick-out, readCandidate API doesn't include hard-kicked out delegate at all, so for front-end/analytics it is confusing because they can't find those from list.

So I keep same hard kick-out logic, but we don't delete those from candidate list and just keep with 0 voting power. Instead, we exclude who's voting power is 0 when picking up top 36