### PR TITLE
Rename rewarding protocol method name

### DIFF
--- a/action/protocol/rewarding/fund.go
+++ b/action/protocol/rewarding/fund.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/go-pkgs/hash"
+
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/action/protocol/rewarding/rewardingpb"
@@ -21,6 +22,8 @@ import (
 
 // fund stores the balance of the rewarding fund. The difference between total and available balance should be
 // equal to the unclaimed balance in all reward accounts
+// totalBalance is Rewards in the rewarding fund that has not been issued to anyone
+// unclaimedBalance is Rewards in the rewarding fund that has been issued and unclaimed
 type fund struct {
 	totalBalance     *big.Int
 	unclaimedBalance *big.Int

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -16,13 +16,14 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 const (
@@ -192,13 +193,13 @@ func (p *Protocol) ReadState(
 	args ...[]byte,
 ) ([]byte, error) {
 	switch string(method) {
-	case "AvailableBalance":
+	case "TotalUnclaimedBalance":
 		balance, err := p.AvailableBalance(ctx, sm)
 		if err != nil {
 			return nil, err
 		}
 		return []byte(balance.String()), nil
-	case "TotalBalance":
+	case "TotalAvailableBalance":
 		balance, err := p.TotalBalance(ctx, sm)
 		if err != nil {
 			return nil, err

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -395,11 +395,11 @@ func TestProtocol_Handle(t *testing.T) {
 		expect []byte
 	}{
 		{
-			input:  "AvailableBalance",
+			input:  "TotalUnclaimedBalance",
 			expect: []byte{49, 57, 57, 57, 57, 57, 48},
 		},
 		{
-			input:  "TotalBalance",
+			input:  "TotalAvailableBalance",
 			expect: []byte{49, 48, 48, 48, 48, 48, 48},
 		},
 		{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1197,7 +1197,7 @@ func TestServer_TotalBalance(t *testing.T) {
 
 	out, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("rewarding"),
-		MethodName: []byte("TotalBalance"),
+		MethodName: []byte("TotalAvailableBalance"),
 		Arguments:  nil,
 	})
 	require.NoError(t, err)
@@ -1214,7 +1214,7 @@ func TestServer_AvailableBalance(t *testing.T) {
 
 	out, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("rewarding"),
-		MethodName: []byte("AvailableBalance"),
+		MethodName: []byte("TotalUnclaimedBalance"),
 		Arguments:  nil,
 	})
 	require.NoError(t, err)

--- a/ioctl/cmd/node/nodereward.go
+++ b/ioctl/cmd/node/nodereward.go
@@ -65,7 +65,6 @@ var nodeRewardCmd = &cobra.Command{
 // TotalAvailable == Rewards in the pool that has not been issued to anyone
 // TotalUnclaimed == Rewards in the pool that has been issued to a delegate but are not claimed yet
 type rewardPoolMessage struct {
-	//rewardPoolMessageDescription string `json:rewardPoolMessageDescription`
 	TotalUnclaimed string `json:"TotalUnclaimed"`
 	TotalAvailable string `json:"TotalAvailable"`
 }
@@ -105,10 +104,10 @@ func rewardPool() error {
 	if err == nil {
 		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
-	// AvailableBalance == Rewards in the pool that has been issued and unclaimed
+	// TotalUnclaimedBalance == Rewards in the pool that has been issued and unclaimed
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("rewarding"),
-		MethodName: []byte("AvailableBalance"),
+		MethodName: []byte("TotalUnclaimedBalance"),
 	}
 	response, err := cli.ReadState(ctx, request)
 	if err != nil {
@@ -118,14 +117,14 @@ func rewardPool() error {
 		}
 		return output.NewError(output.NetworkError, "failed to invoke ReadState api", err)
 	}
-	availableRewardRau, ok := big.NewInt(0).SetString(string(response.Data), 10)
+	totalUnclaimedRewardRau, ok := big.NewInt(0).SetString(string(response.Data), 10)
 	if !ok {
 		return output.NewError(output.ConvertError, "failed to convert string into big int", err)
 	}
-	// TotalBalance == Rewards in the pool that has not been issued to anyone
+	// TotalAvailableBalance == Rewards in the pool that has not been issued to anyone
 	request = &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("rewarding"),
-		MethodName: []byte("TotalBalance"),
+		MethodName: []byte("TotalAvailableBalance"),
 	}
 	response, err = cli.ReadState(ctx, request)
 	if err != nil {
@@ -135,13 +134,13 @@ func rewardPool() error {
 		}
 		return output.NewError(output.NetworkError, "failed to invoke ReadState api", err)
 	}
-	totalRewardRau, ok := big.NewInt(0).SetString(string(response.Data), 10)
+	totalAvailableRewardRau, ok := big.NewInt(0).SetString(string(response.Data), 10)
 	if !ok {
 		return output.NewError(output.ConvertError, "failed to convert string into big int", err)
 	}
 	message := rewardPoolMessage{
-		TotalUnclaimed: util.RauToString(availableRewardRau, util.IotxDecimalNum),
-		TotalAvailable: util.RauToString(totalRewardRau, util.IotxDecimalNum),
+		TotalUnclaimed: util.RauToString(totalUnclaimedRewardRau, util.IotxDecimalNum),
+		TotalAvailable: util.RauToString(totalAvailableRewardRau, util.IotxDecimalNum),
 	}
 	fmt.Println(message.String())
 	return nil


### PR DESCRIPTION
#2012 
change "AvailableBalance" and "TotalBalance" method name to "TotalUnclaimedBalance" and "TotalAvailableBalance"  in  action/protocol/rewarding/protocol.go, and change some related codes.