### PR TITLE
fix a bug to use stateReader Height

### DIFF
--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -486,7 +486,11 @@ func (p *governanceChainCommitteeProtocol) readCandidates(ctx context.Context, e
 	if hu.IsPre(config.Easter, epochStartHeight) {
 		return p.candidatesByHeight(p.sr, epochStartHeight)
 	}
-	tipEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(bcCtx.Tip.Height))
+	stateTipHeight, err := p.sr.Height()
+	if err != nil {
+		return nil, err
+	}
+	tipEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(stateTipHeight))
 	if epochStartHeight < tipEpochStartHeight {
 		// read historical data
 		candidates, _, err := p.getCandidates(p.sr, readFromNext, protocol.BlockHeightOption(epochStartHeight))
@@ -514,7 +518,11 @@ func (p *governanceChainCommitteeProtocol) readKickoutList(ctx context.Context, 
 	if hu.IsPre(config.Easter, epochStartHeight) {
 		return nil, errors.New("Before Easter, there is no blacklist in stateDBs")
 	}
-	tipEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(bcCtx.Tip.Height))
+	stateTipHeight, err := p.sr.Height()
+	if err != nil {
+		return nil, err
+	}
+	tipEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(stateTipHeight))
 	if epochStartHeight < tipEpochStartHeight {
 		// read historical data
 		unqualifiedList, _, err := p.getKickoutList(p.sr, readFromNext, protocol.BlockHeightOption(epochStartHeight))

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -185,7 +185,7 @@ func setCandidates(
 	}
 	if indexer != nil {
 		if err := indexer.PutCandidateList(height, &candidates); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to put candidatelist into indexer at height %d", height)
 		}
 	}
 	if preEaster {
@@ -206,7 +206,7 @@ func setNextEpochBlacklist(
 ) error {
 	if indexer != nil {
 		if err := indexer.PutKickoutList(height, blackList); err != nil {
-			return err
+			return errors.Wrapf(err, "failed to put kickoutlist into indexer at height %d", height)
 		}
 	}
 	blackListKey := candidatesutil.ConstructKey(candidatesutil.NxtKickoutKey)


### PR DESCRIPTION
we have to use stateReader's tip height
for example, in startExistingBlockchain, if the blockchain Tip is higher than state factory height and restore factory, stateFactory's tip height is the right thing to compare with 