### PR TITLE
move kickout code to slasher

### DIFF
--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -20,7 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
-	"github.com/iotexproject/iotex-core/action/protocol/vote"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
@@ -33,7 +32,6 @@ type governanceChainCommitteeProtocol struct {
 	initGravityChainHeight    uint64
 	addr                      address.Address
 	initialCandidatesInterval time.Duration
-	kickoutIntensity          uint32
 	sh                        *Slasher
 	indexer                   *CandidateIndexer
 }
@@ -45,7 +43,6 @@ func NewGovernanceChainCommitteeProtocol(
 	initGravityChainHeight uint64,
 	getBlockTime GetBlockTime,
 	initialCandidatesInterval time.Duration,
-	kickoutIntensity uint32,
 	sh *Slasher,
 ) (Protocol, error) {
 	if electionCommittee == nil {
@@ -67,7 +64,6 @@ func NewGovernanceChainCommitteeProtocol(
 		getBlockTime:              getBlockTime,
 		addr:                      addr,
 		initialCandidatesInterval: initialCandidatesInterval,
-		kickoutIntensity:          kickoutIntensity,
 		sh:                        sh,
 		indexer:                   candidatesIndexer,
 	}, nil
@@ -105,10 +101,7 @@ func (p *governanceChainCommitteeProtocol) CreateGenesisStates(
 		if err := setNextEpochBlacklist(sm,
 			p.indexer,
 			uint64(1),
-			&vote.Blacklist{
-				BlacklistInfos: make(map[string]uint32),
-				IntensityRate:  p.kickoutIntensity,
-			}); err != nil {
+			p.sh.EmptyBlacklist()); err != nil {
 			return err
 		}
 	}

--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -8,14 +8,12 @@ package poll
 
 import (
 	"context"
-	"math/big"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-election/committee"
 	"github.com/iotexproject/iotex-election/db"
-	"github.com/iotexproject/iotex-election/util"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -24,50 +22,31 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/action/protocol/vote"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
 
 type governanceChainCommitteeProtocol struct {
-	candidatesByHeight        CandidatesByHeight
-	getCandidates             GetCandidates
-	getKickoutList            GetKickoutList
-	getUnproductiveDelegate   GetUnproductiveDelegate
 	getBlockTime              GetBlockTime
 	electionCommittee         committee.Committee
 	initGravityChainHeight    uint64
-	numCandidateDelegates     uint64
-	numDelegates              uint64
 	addr                      address.Address
 	initialCandidatesInterval time.Duration
-	productivityByEpoch       ProductivityByEpoch
-	productivityThreshold     uint64
-	kickoutEpochPeriod        uint64
 	kickoutIntensity          uint32
-	maxKickoutPeriod          uint64
+	sh                        *Slasher
 	indexer                   *CandidateIndexer
 }
 
 // NewGovernanceChainCommitteeProtocol creates a Poll Protocol which fetch result from governance chain
 func NewGovernanceChainCommitteeProtocol(
 	candidatesIndexer *CandidateIndexer,
-	candidatesByHeight CandidatesByHeight,
-	getCandidates GetCandidates,
-	getKickoutList GetKickoutList,
-	getUnproductiveDelegate GetUnproductiveDelegate,
 	electionCommittee committee.Committee,
 	initGravityChainHeight uint64,
 	getBlockTime GetBlockTime,
-	numCandidateDelegates uint64,
-	numDelegates uint64,
 	initialCandidatesInterval time.Duration,
-	productivityByEpoch ProductivityByEpoch,
-	productivityThreshold uint64,
-	kickoutEpochPeriod uint64,
 	kickoutIntensity uint32,
-	maxKickoutPeriod uint64,
+	sh *Slasher,
 ) (Protocol, error) {
 	if electionCommittee == nil {
 		return nil, ErrNoElectionCommittee
@@ -81,24 +60,16 @@ func NewGovernanceChainCommitteeProtocol(
 	if err != nil {
 		log.L().Panic("Error when constructing the address of poll protocol", zap.Error(err))
 	}
+
 	return &governanceChainCommitteeProtocol{
-		indexer:                   candidatesIndexer,
-		candidatesByHeight:        candidatesByHeight,
-		getCandidates:             getCandidates,
-		getKickoutList:            getKickoutList,
-		getUnproductiveDelegate:   getUnproductiveDelegate,
 		electionCommittee:         electionCommittee,
 		initGravityChainHeight:    initGravityChainHeight,
 		getBlockTime:              getBlockTime,
-		numCandidateDelegates:     numCandidateDelegates,
-		numDelegates:              numDelegates,
 		addr:                      addr,
 		initialCandidatesInterval: initialCandidatesInterval,
-		productivityByEpoch:       productivityByEpoch,
-		productivityThreshold:     productivityThreshold,
-		kickoutEpochPeriod:        kickoutEpochPeriod,
 		kickoutIntensity:          kickoutIntensity,
-		maxKickoutPeriod:          maxKickoutPeriod,
+		sh:                        sh,
+		indexer:                   candidatesIndexer,
 	}, nil
 }
 
@@ -159,7 +130,7 @@ func (p *governanceChainCommitteeProtocol) CreatePreStates(ctx context.Context, 
 	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
 	if blkCtx.BlockHeight == epochLastHeight && hu.IsPost(config.Easter, nextEpochStartHeight) {
 		// if the block height is the end of epoch and next epoch is after the Easter height, calculate blacklist for kick-out and write into state DB
-		unqualifiedList, err := p.calculateKickoutBlackList(ctx, sm, epochNum+1)
+		unqualifiedList, err := p.sh.CalculateKickoutList(ctx, sm, epochNum+1)
 		if err != nil {
 			return err
 		}
@@ -239,19 +210,19 @@ func (p *governanceChainCommitteeProtocol) CalculateCandidatesByHeight(ctx conte
 }
 
 func (p *governanceChainCommitteeProtocol) Delegates(ctx context.Context, sr protocol.StateReader) (state.CandidateList, error) {
-	return p.readActiveBlockProducers(ctx, sr, false)
+	return p.sh.GetActiveBlockProducers(ctx, sr, false)
 }
 
 func (p *governanceChainCommitteeProtocol) NextDelegates(ctx context.Context, sr protocol.StateReader) (state.CandidateList, error) {
-	return p.readActiveBlockProducers(ctx, sr, true)
+	return p.sh.GetActiveBlockProducers(ctx, sr, true)
 }
 
 func (p *governanceChainCommitteeProtocol) Candidates(ctx context.Context, sr protocol.StateReader) (state.CandidateList, error) {
-	return p.readCandidates(ctx, sr, false)
+	return p.sh.GetCandidates(ctx, sr, false)
 }
 
 func (p *governanceChainCommitteeProtocol) NextCandidates(ctx context.Context, sr protocol.StateReader) (state.CandidateList, error) {
-	return p.readCandidates(ctx, sr, true)
+	return p.sh.GetCandidates(ctx, sr, true)
 }
 
 func (p *governanceChainCommitteeProtocol) ReadState(
@@ -272,7 +243,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 			epochStartHeight = rp.GetEpochHeight(epochNum)
 		}
 		if p.indexer != nil {
-			candidates, err := p.readCandidatesFromIndexer(ctx, epochStartHeight)
+			candidates, err := p.sh.GetCandidatesFromIndexer(ctx, epochStartHeight)
 			if err == nil {
 				return candidates.Serialize()
 			}
@@ -282,7 +253,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 				}
 			}
 		}
-		candidates, err := p.readCandidates(ctx, sr, false)
+		candidates, err := p.sh.GetCandidates(ctx, sr, false)
 		if err != nil {
 			return nil, err
 		}
@@ -293,7 +264,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 			epochStartHeight = rp.GetEpochHeight(epochNum)
 		}
 		if p.indexer != nil {
-			blockProducers, err := p.readBPFromIndexer(ctx, epochStartHeight)
+			blockProducers, err := p.sh.GetBPFromIndexer(ctx, epochStartHeight)
 			if err == nil {
 				return blockProducers.Serialize()
 			}
@@ -303,7 +274,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 				}
 			}
 		}
-		blockProducers, err := p.readBlockProducers(ctx, sr, false)
+		blockProducers, err := p.sh.GetBlockProducers(ctx, sr, false)
 		if err != nil {
 			return nil, err
 		}
@@ -314,7 +285,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 			epochStartHeight = rp.GetEpochHeight(epochNum)
 		}
 		if p.indexer != nil {
-			activeBlockProducers, err := p.readABPFromIndexer(ctx, epochStartHeight)
+			activeBlockProducers, err := p.sh.GetABPFromIndexer(ctx, epochStartHeight)
 			if err == nil {
 				return activeBlockProducers.Serialize()
 			}
@@ -324,7 +295,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 				}
 			}
 		}
-		activeBlockProducers, err := p.readActiveBlockProducers(ctx, sr, false)
+		activeBlockProducers, err := p.sh.GetActiveBlockProducers(ctx, sr, false)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +325,7 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 				}
 			}
 		}
-		kickoutList, err := p.readKickoutList(ctx, sr, false)
+		kickoutList, err := p.sh.GetKickoutList(ctx, sr, false)
 		if err != nil {
 			return nil, err
 		}
@@ -374,131 +345,6 @@ func (p *governanceChainCommitteeProtocol) ForceRegister(r *protocol.Registry) e
 	return r.ForceRegister(protocolID, p)
 }
 
-func (p *governanceChainCommitteeProtocol) readCandidates(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
-	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
-	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
-	targetHeight, err := sr.Height()
-	if err != nil {
-		return nil, err
-	}
-	// make sure it's epochStartHeight
-	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(targetHeight))
-	if readFromNext {
-		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
-		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
-	}
-	if hu.IsPre(config.Easter, targetEpochStartHeight) {
-		return p.candidatesByHeight(sr, targetEpochStartHeight)
-	}
-	// After Easter height, kick-out unqualified delegates based on productivity
-	candidates, stateHeight, err := p.getCandidates(sr, readFromNext)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get candidates at height %d after easter height", targetEpochStartHeight)
-	}
-	// to catch the corner case that since the new block is committed, shift occurs in the middle of processing the request
-	if rp.GetEpochNum(targetEpochStartHeight) < rp.GetEpochNum(stateHeight) {
-		return nil, errors.Wrap(ErrInconsistentHeight, "state factory epoch number became larger than target epoch number")
-	}
-	unqualifiedList, err := p.readKickoutList(ctx, sr, readFromNext)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get kickout list at height %d", targetEpochStartHeight)
-	}
-	// recalculate the voting power for blacklist delegates
-	return filterCandidates(candidates, unqualifiedList, targetEpochStartHeight)
-}
-
-func (p *governanceChainCommitteeProtocol) readCandidatesFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
-	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
-	candidates, err := p.indexer.CandidateList(epochStartHeight)
-	if err != nil {
-		return nil, err
-	}
-	if hu.IsPre(config.Easter, epochStartHeight) {
-		return candidates, nil
-	}
-	// After Easter height, kick-out unqualified delegates based on productivity
-	kickoutList, err := p.indexer.KickoutList(epochStartHeight)
-	if err != nil {
-		return nil, err
-	}
-	// recalculate the voting power for blacklist delegates
-	return filterCandidates(candidates, kickoutList, epochStartHeight)
-}
-
-func (p *governanceChainCommitteeProtocol) readBlockProducers(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
-	candidates, err := p.readCandidates(ctx, sr, readFromNext)
-	if err != nil {
-		return nil, err
-	}
-	return p.calculateBlockProducer(candidates)
-}
-
-func (p *governanceChainCommitteeProtocol) readBPFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
-	candidates, err := p.readCandidatesFromIndexer(ctx, epochStartHeight)
-	if err != nil {
-		return nil, err
-	}
-	return p.calculateBlockProducer(candidates)
-}
-
-func (p *governanceChainCommitteeProtocol) readActiveBlockProducers(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
-	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
-	targetHeight, err := sr.Height()
-	if err != nil {
-		return nil, err
-	}
-	// make sure it's epochStartHeight
-	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(targetHeight))
-	if readFromNext {
-		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
-		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
-	}
-	blockProducers, err := p.readBlockProducers(ctx, sr, readFromNext)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to read block producers at height %d", targetEpochStartHeight)
-	}
-	return p.calculateActiveBlockProducer(ctx, blockProducers, targetEpochStartHeight)
-}
-
-func (p *governanceChainCommitteeProtocol) readABPFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
-	blockProducers, err := p.readBPFromIndexer(ctx, epochStartHeight)
-	if err != nil {
-		return nil, err
-	}
-	return p.calculateActiveBlockProducer(ctx, blockProducers, epochStartHeight)
-}
-
-func (p *governanceChainCommitteeProtocol) readKickoutList(ctx context.Context, sr protocol.StateReader, readFromNext bool) (*vote.Blacklist, error) {
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
-	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
-	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
-	targetHeight, err := sr.Height()
-	if err != nil {
-		return nil, err
-	}
-	// make sure it's epochStartHeight
-	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochHeight(targetHeight))
-	if readFromNext {
-		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
-		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
-	}
-	if hu.IsPre(config.Easter, targetEpochStartHeight) {
-		return nil, errors.New("Before Easter, there is no blacklist in stateDB")
-	}
-	unqualifiedList, stateHeight, err := p.getKickoutList(sr, readFromNext)
-	if err != nil {
-		return nil, err
-	}
-	// to catch the corner case that since the new block is committed, shift occurs in the middle of processing the request
-	if rp.GetEpochNum(targetEpochStartHeight) < rp.GetEpochNum(stateHeight) {
-		return nil, errors.Wrap(ErrInconsistentHeight, "state factory tip epoch number became larger than target epoch number")
-	}
-	return unqualifiedList, nil
-}
-
 func (p *governanceChainCommitteeProtocol) getGravityHeight(ctx context.Context, height uint64) (uint64, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
@@ -513,226 +359,4 @@ func (p *governanceChainCommitteeProtocol) getGravityHeight(ctx context.Context,
 		zap.Time("time", blkTime),
 	)
 	return p.electionCommittee.HeightByTime(blkTime)
-}
-
-func (p *governanceChainCommitteeProtocol) calculateKickoutBlackList(
-	ctx context.Context,
-	sm protocol.StateManager,
-	epochNum uint64,
-) (*vote.Blacklist, error) {
-	bcCtx := protocol.MustGetBlockchainCtx(ctx)
-	hu := config.NewHeightUpgrade(&bcCtx.Genesis)
-	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
-	easterEpochNum := rp.GetEpochNum(hu.EasterBlockHeight())
-
-	nextBlacklist := &vote.Blacklist{
-		IntensityRate: p.kickoutIntensity,
-	}
-	upd, err := p.getUnproductiveDelegate(sm)
-	if err != nil {
-		if errors.Cause(err) == state.ErrStateNotExist {
-			if upd, err = vote.NewUnproductiveDelegate(p.kickoutEpochPeriod, p.maxKickoutPeriod); err != nil {
-				return nil, errors.Wrap(err, "failed to make new upd")
-			}
-		} else {
-			return nil, errors.Wrapf(err, "failed to read upd struct from state DB at epoch number %d", epochNum)
-		}
-	}
-	unqualifiedDelegates := make(map[string]uint32)
-	if epochNum <= easterEpochNum+p.kickoutEpochPeriod {
-		// if epoch number is smaller than easterEpochNum+K(kickout period), calculate it one-by-one (initialize).
-		log.L().Debug("Before using kick-out blacklist",
-			zap.Uint64("epochNum", epochNum),
-			zap.Uint64("easterEpochNum", easterEpochNum),
-			zap.Uint64("kickoutEpochPeriod", p.kickoutEpochPeriod),
-		)
-		existinglist := upd.DelegateList()
-		for _, listByEpoch := range existinglist {
-			for _, addr := range listByEpoch {
-				if _, ok := unqualifiedDelegates[addr]; !ok {
-					unqualifiedDelegates[addr] = 1
-				} else {
-					unqualifiedDelegates[addr]++
-				}
-			}
-		}
-		// calculate upd of epochNum-1 (latest)
-		uq, err := p.calculateUnproductiveDelegatesByEpoch(ctx, sm, epochNum-1)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to calculate current epoch upd %d", epochNum-1)
-		}
-		for _, addr := range uq {
-			if _, ok := unqualifiedDelegates[addr]; !ok {
-				unqualifiedDelegates[addr] = 1
-			} else {
-				unqualifiedDelegates[addr]++
-			}
-		}
-		if err := upd.AddRecentUPD(uq); err != nil {
-			return nil, errors.Wrap(err, "failed to add recent upd")
-		}
-		nextBlacklist.BlacklistInfos = unqualifiedDelegates
-		return nextBlacklist, setUnproductiveDelegates(sm, upd)
-	}
-	// Blacklist[N] = Blacklist[N-1] - Low-productivity-list[N-K-1] + Low-productivity-list[N-1]
-	log.L().Debug("Using kick-out blacklist",
-		zap.Uint64("epochNum", epochNum),
-		zap.Uint64("easterEpochNum", easterEpochNum),
-		zap.Uint64("kickoutEpochPeriod", p.kickoutEpochPeriod),
-	)
-	prevBlacklist, _, err := p.getKickoutList(sm, false)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to read latest kick-out list")
-	}
-	blacklistMap := prevBlacklist.BlacklistInfos
-	if blacklistMap == nil {
-		blacklistMap = make(map[string]uint32)
-	}
-	skipList := upd.ReadOldestUPD()
-	for _, addr := range skipList {
-		if _, ok := blacklistMap[addr]; !ok {
-			log.L().Fatal("skipping list element doesn't exist among one of existing map")
-			continue
-		}
-		blacklistMap[addr]--
-	}
-	addList, err := p.calculateUnproductiveDelegatesByEpoch(ctx, sm, epochNum-1)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to calculate current epoch upd %d", epochNum-1)
-	}
-	if err := upd.AddRecentUPD(addList); err != nil {
-		return nil, errors.Wrap(err, "failed to add recent upd")
-	}
-	for _, addr := range addList {
-		if _, ok := blacklistMap[addr]; ok {
-			blacklistMap[addr]++
-			continue
-		}
-		blacklistMap[addr] = 1
-	}
-
-	for addr, count := range blacklistMap {
-		if count == 0 {
-			delete(blacklistMap, addr)
-		}
-	}
-	nextBlacklist.BlacklistInfos = blacklistMap
-	return nextBlacklist, setUnproductiveDelegates(sm, upd)
-}
-
-func (p *governanceChainCommitteeProtocol) calculateUnproductiveDelegatesByEpoch(
-	ctx context.Context,
-	sr protocol.StateReader,
-	epochNum uint64,
-) ([]string, error) {
-	blkCtx := protocol.MustGetBlockCtx(ctx)
-	delegates, err := p.readActiveBlockProducers(ctx, sr, false)
-	if err != nil {
-		return nil, err
-	}
-	numBlks, produce, err := p.productivityByEpoch(ctx, epochNum)
-	if err != nil {
-		return nil, err
-	}
-	// The current block is not included, so add it
-	numBlks++
-	if _, ok := produce[blkCtx.Producer.String()]; ok {
-		produce[blkCtx.Producer.String()]++
-	} else {
-		produce[blkCtx.Producer.String()] = 1
-	}
-
-	for _, abp := range delegates {
-		if _, ok := produce[abp.Address]; !ok {
-			produce[abp.Address] = 0
-		}
-	}
-	unqualified := make([]string, 0)
-	expectedNumBlks := numBlks / uint64(len(produce))
-	for addr, actualNumBlks := range produce {
-		if actualNumBlks*100/expectedNumBlks < p.productivityThreshold {
-			unqualified = append(unqualified, addr)
-		}
-	}
-
-	return unqualified, nil
-}
-
-// filterCandidates returns filtered candidate list by given raw candidate/ kick-out list
-func filterCandidates(
-	candidates state.CandidateList,
-	unqualifiedList *vote.Blacklist,
-	epochStartHeight uint64,
-) (state.CandidateList, error) {
-	candidatesMap := make(map[string]*state.Candidate)
-	updatedVotingPower := make(map[string]*big.Int)
-	intensityRate := float64(uint32(100)-unqualifiedList.IntensityRate) / float64(100)
-	for _, cand := range candidates {
-		filterCand := cand.Clone()
-		if _, ok := unqualifiedList.BlacklistInfos[cand.Address]; ok {
-			// if it is an unqualified delegate, multiply the voting power with kick-out intensity rate
-			votingPower := new(big.Float).SetInt(filterCand.Votes)
-			filterCand.Votes, _ = votingPower.Mul(votingPower, big.NewFloat(intensityRate)).Int(nil)
-		}
-		updatedVotingPower[filterCand.Address] = filterCand.Votes
-		candidatesMap[filterCand.Address] = filterCand
-	}
-	// sort again with updated voting power
-	sorted := util.Sort(updatedVotingPower, epochStartHeight)
-	var verifiedCandidates state.CandidateList
-	for _, name := range sorted {
-		verifiedCandidates = append(verifiedCandidates, candidatesMap[name])
-	}
-
-	return verifiedCandidates, nil
-}
-
-// calculateBlockProducer calculates block producer by given candidate list
-func (p *governanceChainCommitteeProtocol) calculateBlockProducer(
-	candidates state.CandidateList,
-) (state.CandidateList, error) {
-	var blockProducers state.CandidateList
-	for i, candidate := range candidates {
-		if uint64(i) >= p.numCandidateDelegates {
-			break
-		}
-		if candidate.Votes.Cmp(big.NewInt(0)) == 0 {
-			// if the voting power is 0, exclude from being a block producer(hard kickout)
-			continue
-		}
-		blockProducers = append(blockProducers, candidate)
-	}
-	return blockProducers, nil
-}
-
-// calculateActiveBlockProducer calculates active block producer by given block producer list
-func (p *governanceChainCommitteeProtocol) calculateActiveBlockProducer(
-	ctx context.Context,
-	blockProducers state.CandidateList,
-	epochStartHeight uint64,
-) (state.CandidateList, error) {
-	var blockProducerList []string
-	blockProducerMap := make(map[string]*state.Candidate)
-	for _, bp := range blockProducers {
-		blockProducerList = append(blockProducerList, bp.Address)
-		blockProducerMap[bp.Address] = bp
-	}
-	crypto.SortCandidates(blockProducerList, epochStartHeight, crypto.CryptoSeed)
-
-	length := int(p.numDelegates)
-	if len(blockProducerList) < length {
-		// TODO: if the number of delegates is smaller than expected, should it return error or not?
-		length = len(blockProducerList)
-		log.L().Warn(
-			"the number of block producer is less than expected",
-			zap.Int("actual block producer", len(blockProducerList)),
-			zap.Uint64("expected", p.numDelegates),
-		)
-	}
-	var activeBlockProducers state.CandidateList
-	for i := 0; i < length; i++ {
-		activeBlockProducers = append(activeBlockProducers, blockProducerMap[blockProducerList[i]])
-	}
-
-	return activeBlockProducers, nil
 }

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -137,20 +137,8 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
-	p, err := NewGovernanceChainCommitteeProtocol(
-		indexer,
-		func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
-		func(protocol.StateReader, bool) ([]*state.Candidate, uint64, error) {
-			return candidates, 720, nil
-		},
-		candidatesutil.KickoutListFromDB,
-		candidatesutil.UnproductiveDelegateFromDB,
-		committee,
-		uint64(123456),
-		func(uint64) (time.Time, error) { return time.Now(), nil },
-		2,
-		2,
-		cfg.Chain.PollInitialCandidatesInterval,
+	slasher, err := NewSlasher(
+		&cfg.Genesis,
 		func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
 			switch epochNum {
 			case 1:
@@ -187,12 +175,33 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 				return 0, nil, nil
 			}
 		},
+		func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
+		func(protocol.StateReader, bool) ([]*state.Candidate, uint64, error) {
+			return candidates, 720, nil
+		},
+		candidatesutil.KickoutListFromDB,
+		candidatesutil.UnproductiveDelegateFromDB,
+		indexer,
+		2,
+		2,
 		cfg.Genesis.ProductivityThreshold,
 		cfg.Genesis.KickoutEpochPeriod,
-		cfg.Genesis.KickoutIntensityRate,
 		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-	)
-
+		cfg.Genesis.KickoutIntensityRate)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
+	p, err := NewGovernanceChainCommitteeProtocol(
+		indexer,
+		committee,
+		uint64(123456),
+		func(uint64) (time.Time, error) { return time.Now(), nil },
+		cfg.Chain.PollInitialCandidatesInterval,
+		cfg.Genesis.KickoutIntensityRate,
+		slasher)
+	if err != nil {
+		return nil, nil, nil, nil, err
+	}
 	if err := setCandidates(ctx, sm, indexer, candidates, 1); err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -197,7 +197,6 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
 		cfg.Chain.PollInitialCandidatesInterval,
-		cfg.Genesis.KickoutIntensityRate,
 		slasher)
 	if err != nil {
 		return nil, nil, nil, nil, err

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -112,7 +112,7 @@ func NewProtocol(
 	readContract ReadContract,
 	candidatesByHeight CandidatesByHeight,
 	getCandidates GetCandidates,
-	kickoutListByEpoch GetKickoutList,
+	getkickoutList GetKickoutList,
 	getUnproductiveDelegate GetUnproductiveDelegate,
 	electionCommittee committee.Committee,
 	stakingV2 *staking.Protocol,
@@ -130,25 +130,32 @@ func NewProtocol(
 		}
 		return NewLifeLongDelegatesProtocol(delegates), nil
 	}
-	var pollProtocol, governance Protocol
-	var err error
-	if governance, err = NewGovernanceChainCommitteeProtocol(
-		candidateIndexer,
+	slasher, err := NewSlasher(
+		&genesisConfig,
+		productivityByEpoch,
 		candidatesByHeight,
 		getCandidates,
-		kickoutListByEpoch,
+		getkickoutList,
 		getUnproductiveDelegate,
+		candidateIndexer,
+		genesisConfig.NumCandidateDelegates,
+		genesisConfig.NumDelegates,
+		genesisConfig.ProductivityThreshold,
+		genesisConfig.KickoutEpochPeriod,
+		genesisConfig.UnproductiveDelegateMaxCacheSize,
+		genesisConfig.KickoutIntensityRate)
+	if err != nil {
+		return nil, err
+	}
+	var pollProtocol, governance Protocol
+	if governance, err = NewGovernanceChainCommitteeProtocol(
+		candidateIndexer,
 		electionCommittee,
 		genesisConfig.GravityChainStartHeight,
 		getBlockTimeFunc,
-		genesisConfig.NumCandidateDelegates,
-		genesisConfig.NumDelegates,
 		cfg.Chain.PollInitialCandidatesInterval,
-		productivityByEpoch,
-		genesisConfig.ProductivityThreshold,
-		genesisConfig.KickoutEpochPeriod,
 		genesisConfig.KickoutIntensityRate,
-		genesisConfig.UnproductiveDelegateMaxCacheSize,
+		slasher,
 	); err != nil {
 		return nil, err
 	}

--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -154,7 +154,6 @@ func NewProtocol(
 		genesisConfig.GravityChainStartHeight,
 		getBlockTimeFunc,
 		cfg.Chain.PollInitialCandidatesInterval,
-		genesisConfig.KickoutIntensityRate,
 		slasher,
 	); err != nil {
 		return nil, err

--- a/action/protocol/poll/slasher.go
+++ b/action/protocol/poll/slasher.go
@@ -1,0 +1,412 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package poll
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/iotexproject/iotex-election/util"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
+	"github.com/iotexproject/iotex-core/action/protocol/vote"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/crypto"
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/iotexproject/iotex-core/state"
+)
+
+// Slasher is the module to slash candidates
+type Slasher struct {
+	hu                    config.HeightUpgrade
+	prodByEpoch           ProductivityByEpoch
+	candByHeight          CandidatesByHeight
+	getCandidates         GetCandidates
+	getKickoutList        GetKickoutList
+	getUnprodDelegate     GetUnproductiveDelegate
+	indexer               *CandidateIndexer
+	numCandidateDelegates uint64
+	numDelegates          uint64
+	prodThreshold         uint64
+	kickoutEpochPeriod    uint64
+	maxKickoutPeriod      uint64
+	kickoutIntensity      uint32
+}
+
+// NewSlasher returns a new Slasher
+func NewSlasher(
+	gen *genesis.Genesis,
+	productivityByEpoch ProductivityByEpoch,
+	candByHeight CandidatesByHeight,
+	getCandidates GetCandidates,
+	getKickoutList GetKickoutList,
+	getUnprodDelegate GetUnproductiveDelegate,
+	indexer *CandidateIndexer,
+	numCandidateDelegates, numDelegates, thres, koPeriod, maxKoPeriod uint64,
+	koIntensity uint32,
+) (*Slasher, error) {
+	return &Slasher{
+		hu:                    config.NewHeightUpgrade(gen),
+		prodByEpoch:           productivityByEpoch,
+		candByHeight:          candByHeight,
+		getCandidates:         getCandidates,
+		getKickoutList:        getKickoutList,
+		getUnprodDelegate:     getUnprodDelegate,
+		indexer:               indexer,
+		numCandidateDelegates: numCandidateDelegates,
+		numDelegates:          numDelegates,
+		prodThreshold:         thres,
+		kickoutEpochPeriod:    koPeriod,
+		maxKickoutPeriod:      maxKoPeriod,
+		kickoutIntensity:      koIntensity,
+	}, nil
+}
+
+// GetCandidates returns candidate list
+func (sh *Slasher) GetCandidates(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
+	targetHeight, err := sr.Height()
+	if err != nil {
+		return nil, err
+	}
+	// make sure it's epochStartHeight
+	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(targetHeight))
+	if readFromNext {
+		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
+		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
+	}
+	if sh.hu.IsPre(config.Easter, targetEpochStartHeight) {
+		return sh.candByHeight(sr, targetEpochStartHeight)
+	}
+	// After Easter height, kick-out unqualified delegates based on productivity
+	candidates, stateHeight, err := sh.getCandidates(sr, readFromNext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get candidates at height %d after easter height", targetEpochStartHeight)
+	}
+	// to catch the corner case that since the new block is committed, shift occurs in the middle of processing the request
+	if rp.GetEpochNum(targetEpochStartHeight) < rp.GetEpochNum(stateHeight) {
+		return nil, errors.Wrap(ErrInconsistentHeight, "state factory epoch number became larger than target epoch number")
+	}
+	unqualifiedList, err := sh.GetKickoutList(ctx, sr, readFromNext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get kickout list at height %d", targetEpochStartHeight)
+	}
+	// recalculate the voting power for blacklist delegates
+	return filterCandidates(candidates, unqualifiedList, targetEpochStartHeight)
+}
+
+// GetBlockProducers returns BP list
+func (sh *Slasher) GetBlockProducers(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
+	candidates, err := sh.GetCandidates(ctx, sr, readFromNext)
+	if err != nil {
+		return nil, err
+	}
+	return sh.calculateBlockProducer(candidates)
+}
+
+// GetActiveBlockProducers returns active BP list
+func (sh *Slasher) GetActiveBlockProducers(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
+	targetHeight, err := sr.Height()
+	if err != nil {
+		return nil, err
+	}
+	// make sure it's epochStartHeight
+	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(targetHeight))
+	if readFromNext {
+		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
+		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
+	}
+	blockProducers, err := sh.GetBlockProducers(ctx, sr, readFromNext)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read block producers at height %d", targetEpochStartHeight)
+	}
+	return sh.calculateActiveBlockProducer(ctx, blockProducers, targetEpochStartHeight)
+}
+
+// GetCandidatesFromIndexer returns candidate list from indexer
+func (sh *Slasher) GetCandidatesFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
+	candidates, err := sh.indexer.CandidateList(epochStartHeight)
+	if err != nil {
+		return nil, err
+	}
+	if sh.hu.IsPre(config.Easter, epochStartHeight) {
+		return candidates, nil
+	}
+	// After Easter height, kick-out unqualified delegates based on productivity
+	kickoutList, err := sh.indexer.KickoutList(epochStartHeight)
+	if err != nil {
+		return nil, err
+	}
+	// recalculate the voting power for blacklist delegates
+	return filterCandidates(candidates, kickoutList, epochStartHeight)
+}
+
+// GetBPFromIndexer returns BP list from indexer
+func (sh *Slasher) GetBPFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
+	candidates, err := sh.GetCandidatesFromIndexer(ctx, epochStartHeight)
+	if err != nil {
+		return nil, err
+	}
+	return sh.calculateBlockProducer(candidates)
+}
+
+// GetABPFromIndexer returns active BP list from indexer
+func (sh *Slasher) GetABPFromIndexer(ctx context.Context, epochStartHeight uint64) (state.CandidateList, error) {
+	blockProducers, err := sh.GetBPFromIndexer(ctx, epochStartHeight)
+	if err != nil {
+		return nil, err
+	}
+	return sh.calculateActiveBlockProducer(ctx, blockProducers, epochStartHeight)
+}
+
+// GetKickoutList returns the kick-out list at given epoch
+func (sh *Slasher) GetKickoutList(ctx context.Context, sr protocol.StateReader, readFromNext bool) (*vote.Blacklist, error) {
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
+	targetHeight, err := sr.Height()
+	if err != nil {
+		return nil, err
+	}
+	// make sure it's epochStartHeight
+	targetEpochStartHeight := rp.GetEpochHeight(rp.GetEpochHeight(targetHeight))
+	if readFromNext {
+		targetEpochNum := rp.GetEpochNum(targetEpochStartHeight) + 1
+		targetEpochStartHeight = rp.GetEpochHeight(targetEpochNum) // next epoch start height
+	}
+	if sh.hu.IsPre(config.Easter, targetEpochStartHeight) {
+		return nil, errors.New("Before Easter, there is no blacklist in stateDB")
+	}
+	unqualifiedList, stateHeight, err := sh.getKickoutList(sr, readFromNext)
+	if err != nil {
+		return nil, err
+	}
+	// to catch the corner case that since the new block is committed, shift occurs in the middle of processing the request
+	if rp.GetEpochNum(targetEpochStartHeight) < rp.GetEpochNum(stateHeight) {
+		return nil, errors.Wrap(ErrInconsistentHeight, "state factory tip epoch number became larger than target epoch number")
+	}
+	return unqualifiedList, nil
+}
+
+// CalculateKickoutList calculates kick-out list according to productivity
+func (sh *Slasher) CalculateKickoutList(
+	ctx context.Context,
+	sm protocol.StateManager,
+	epochNum uint64,
+) (*vote.Blacklist, error) {
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
+	easterEpochNum := rp.GetEpochNum(sh.hu.EasterBlockHeight())
+
+	nextBlacklist := &vote.Blacklist{
+		IntensityRate: sh.kickoutIntensity,
+	}
+	upd, err := sh.getUnprodDelegate(sm)
+	if err != nil {
+		if errors.Cause(err) == state.ErrStateNotExist {
+			if upd, err = vote.NewUnproductiveDelegate(sh.kickoutEpochPeriod, sh.maxKickoutPeriod); err != nil {
+				return nil, errors.Wrap(err, "failed to make new upd")
+			}
+		} else {
+			return nil, errors.Wrapf(err, "failed to read upd struct from state DB at epoch number %d", epochNum)
+		}
+	}
+	unqualifiedDelegates := make(map[string]uint32)
+	if epochNum <= easterEpochNum+sh.kickoutEpochPeriod {
+		// if epoch number is smaller than easterEpochNum+K(kickout period), calculate it one-by-one (initialize).
+		log.L().Debug("Before using kick-out blacklist",
+			zap.Uint64("epochNum", epochNum),
+			zap.Uint64("easterEpochNum", easterEpochNum),
+			zap.Uint64("kickoutEpochPeriod", sh.kickoutEpochPeriod),
+		)
+		existinglist := upd.DelegateList()
+		for _, listByEpoch := range existinglist {
+			for _, addr := range listByEpoch {
+				if _, ok := unqualifiedDelegates[addr]; !ok {
+					unqualifiedDelegates[addr] = 1
+				} else {
+					unqualifiedDelegates[addr]++
+				}
+			}
+		}
+		// calculate upd of epochNum-1 (latest)
+		uq, err := sh.calculateUnproductiveDelegatesByEpoch(ctx, sm, epochNum-1)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to calculate current epoch upd %d", epochNum-1)
+		}
+		for _, addr := range uq {
+			if _, ok := unqualifiedDelegates[addr]; !ok {
+				unqualifiedDelegates[addr] = 1
+			} else {
+				unqualifiedDelegates[addr]++
+			}
+		}
+		if err := upd.AddRecentUPD(uq); err != nil {
+			return nil, errors.Wrap(err, "failed to add recent upd")
+		}
+		nextBlacklist.BlacklistInfos = unqualifiedDelegates
+		return nextBlacklist, setUnproductiveDelegates(sm, upd)
+	}
+	// Blacklist[N] = Blacklist[N-1] - Low-productivity-list[N-K-1] + Low-productivity-list[N-1]
+	log.L().Debug("Using kick-out blacklist",
+		zap.Uint64("epochNum", epochNum),
+		zap.Uint64("easterEpochNum", easterEpochNum),
+		zap.Uint64("kickoutEpochPeriod", sh.kickoutEpochPeriod),
+	)
+	prevBlacklist, _, err := sh.getKickoutList(sm, false)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read latest kick-out list")
+	}
+	blacklistMap := prevBlacklist.BlacklistInfos
+	if blacklistMap == nil {
+		blacklistMap = make(map[string]uint32)
+	}
+	skipList := upd.ReadOldestUPD()
+	for _, addr := range skipList {
+		if _, ok := blacklistMap[addr]; !ok {
+			log.L().Fatal("skipping list element doesn't exist among one of existing map")
+			continue
+		}
+		blacklistMap[addr]--
+	}
+	addList, err := sh.calculateUnproductiveDelegatesByEpoch(ctx, sm, epochNum-1)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to calculate current epoch upd %d", epochNum-1)
+	}
+	if err := upd.AddRecentUPD(addList); err != nil {
+		return nil, errors.Wrap(err, "failed to add recent upd")
+	}
+	for _, addr := range addList {
+		if _, ok := blacklistMap[addr]; ok {
+			blacklistMap[addr]++
+			continue
+		}
+		blacklistMap[addr] = 1
+	}
+
+	for addr, count := range blacklistMap {
+		if count == 0 {
+			delete(blacklistMap, addr)
+		}
+	}
+	nextBlacklist.BlacklistInfos = blacklistMap
+	return nextBlacklist, setUnproductiveDelegates(sm, upd)
+}
+
+func (sh *Slasher) calculateUnproductiveDelegatesByEpoch(ctx context.Context, sr protocol.StateReader, epochNum uint64) ([]string, error) {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	delegates, err := sh.GetActiveBlockProducers(ctx, sr, false)
+	if err != nil {
+		return nil, err
+	}
+	numBlks, produce, err := sh.prodByEpoch(ctx, epochNum)
+	if err != nil {
+		return nil, err
+	}
+	// The current block is not included, so add it
+	numBlks++
+	if _, ok := produce[blkCtx.Producer.String()]; ok {
+		produce[blkCtx.Producer.String()]++
+	} else {
+		produce[blkCtx.Producer.String()] = 1
+	}
+
+	for _, abp := range delegates {
+		if _, ok := produce[abp.Address]; !ok {
+			produce[abp.Address] = 0
+		}
+	}
+	unqualified := make([]string, 0)
+	expectedNumBlks := numBlks / uint64(len(produce))
+	for addr, actualNumBlks := range produce {
+		if actualNumBlks*100/expectedNumBlks < sh.prodThreshold {
+			unqualified = append(unqualified, addr)
+		}
+	}
+	return unqualified, nil
+}
+
+// calculateBlockProducer calculates block producer by given candidate list
+func (sh *Slasher) calculateBlockProducer(candidates state.CandidateList) (state.CandidateList, error) {
+	var blockProducers state.CandidateList
+	for i, candidate := range candidates {
+		if uint64(i) >= sh.numCandidateDelegates {
+			break
+		}
+		if candidate.Votes.Cmp(big.NewInt(0)) == 0 {
+			// if the voting power is 0, exclude from being a block producer(hard kickout)
+			continue
+		}
+		blockProducers = append(blockProducers, candidate)
+	}
+	return blockProducers, nil
+}
+
+// calculateActiveBlockProducer calculates active block producer by given block producer list
+func (sh *Slasher) calculateActiveBlockProducer(
+	ctx context.Context,
+	blockProducers state.CandidateList,
+	epochStartHeight uint64,
+) (state.CandidateList, error) {
+	var blockProducerList []string
+	blockProducerMap := make(map[string]*state.Candidate)
+	for _, bp := range blockProducers {
+		blockProducerList = append(blockProducerList, bp.Address)
+		blockProducerMap[bp.Address] = bp
+	}
+	crypto.SortCandidates(blockProducerList, epochStartHeight, crypto.CryptoSeed)
+
+	length := int(sh.numDelegates)
+	if len(blockProducerList) < length {
+		// TODO: if the number of delegates is smaller than expected, should it return error or not?
+		length = len(blockProducerList)
+		log.L().Warn(
+			"the number of block producer is less than expected",
+			zap.Int("actual block producer", len(blockProducerList)),
+			zap.Uint64("expected", sh.numDelegates),
+		)
+	}
+	var activeBlockProducers state.CandidateList
+	for i := 0; i < length; i++ {
+		activeBlockProducers = append(activeBlockProducers, blockProducerMap[blockProducerList[i]])
+	}
+	return activeBlockProducers, nil
+}
+
+// filterCandidates returns filtered candidate list by given raw candidate/ kick-out list
+func filterCandidates(
+	candidates state.CandidateList,
+	unqualifiedList *vote.Blacklist,
+	epochStartHeight uint64,
+) (state.CandidateList, error) {
+	candidatesMap := make(map[string]*state.Candidate)
+	updatedVotingPower := make(map[string]*big.Int)
+	intensityRate := float64(uint32(100)-unqualifiedList.IntensityRate) / float64(100)
+	for _, cand := range candidates {
+		filterCand := cand.Clone()
+		if _, ok := unqualifiedList.BlacklistInfos[cand.Address]; ok {
+			// if it is an unqualified delegate, multiply the voting power with kick-out intensity rate
+			votingPower := new(big.Float).SetInt(filterCand.Votes)
+			filterCand.Votes, _ = votingPower.Mul(votingPower, big.NewFloat(intensityRate)).Int(nil)
+		}
+		updatedVotingPower[filterCand.Address] = filterCand.Votes
+		candidatesMap[filterCand.Address] = filterCand
+	}
+	// sort again with updated voting power
+	sorted := util.Sort(updatedVotingPower, epochStartHeight)
+	var verifiedCandidates state.CandidateList
+	for _, name := range sorted {
+		verifiedCandidates = append(verifiedCandidates, candidatesMap[name])
+	}
+	return verifiedCandidates, nil
+}

--- a/action/protocol/poll/slasher.go
+++ b/action/protocol/poll/slasher.go
@@ -70,6 +70,11 @@ func NewSlasher(
 	}, nil
 }
 
+// EmptyBlacklist returns an empty Blacklist
+func (sh *Slasher) EmptyBlacklist() *vote.Blacklist{
+	return vote.NewBlacklist(sh.kickoutIntensity)
+}
+
 // GetCandidates returns candidate list
 func (sh *Slasher) GetCandidates(ctx context.Context, sr protocol.StateReader, readFromNext bool) (state.CandidateList, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -115,7 +115,6 @@ func initConstructStakingCommittee(ctrl *gomock.Controller) (Protocol, context.C
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
 		cfg.Chain.PollInitialCandidatesInterval,
-		cfg.Genesis.KickoutIntensityRate,
 		slasher,
 	)
 	scoreThreshold, ok := new(big.Int).SetString("0", 10)

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -93,25 +93,30 @@ func initConstructStakingCommittee(ctrl *gomock.Controller) (Protocol, context.C
 	r := types.NewElectionResultForTest(time.Now())
 	committee.EXPECT().ResultByHeight(uint64(123456)).Return(r, nil).AnyTimes()
 	committee.EXPECT().HeightByTime(gomock.Any()).Return(uint64(123456), nil).AnyTimes()
+	slasher, err := NewSlasher(
+		&cfg.Genesis,
+		func(context.Context, uint64) (uint64, map[string]uint64, error) {
+			return 0, nil, nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		cfg.Genesis.NumCandidateDelegates,
+		cfg.Genesis.NumDelegates,
+		cfg.Genesis.ProductivityThreshold,
+		cfg.Genesis.KickoutEpochPeriod,
+		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		cfg.Genesis.KickoutIntensityRate)
 	gs, err := NewGovernanceChainCommitteeProtocol(
-		nil,
-		nil,
-		nil,
-		nil,
 		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
-		cfg.Genesis.NumCandidateDelegates,
-		cfg.Genesis.NumDelegates,
 		cfg.Chain.PollInitialCandidatesInterval,
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
-		},
-		cfg.Genesis.ProductivityThreshold,
-		cfg.Genesis.KickoutEpochPeriod,
 		cfg.Genesis.KickoutIntensityRate,
-		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		slasher,
 	)
 	scoreThreshold, ok := new(big.Int).SetString("0", 10)
 	if !ok {

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -173,7 +173,6 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
 		cfg.Chain.PollInitialCandidatesInterval,
-		cfg.Genesis.KickoutIntensityRate,
 		slasher,
 	)
 	require.NoError(t, err)

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -148,25 +148,33 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 	}
 	cfg := config.Default
 	committee := mock_committee.NewMockCommittee(ctrl)
-	pp, err := poll.NewGovernanceChainCommitteeProtocol(
-		nil,
+	slasher, err := poll.NewSlasher(
+		&cfg.Genesis,
+		func(context.Context, uint64) (uint64, map[string]uint64, error) {
+			return 0, nil, nil
+		},
 		func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 			return abps, nil
 		},
 		nil,
 		nil,
 		nil,
+		nil,
+		5,
+		5,
+		cfg.Genesis.ProductivityThreshold,
+		cfg.Genesis.KickoutEpochPeriod,
+		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		cfg.Genesis.KickoutIntensityRate)
+	require.NoError(t, err)
+	pp, err := poll.NewGovernanceChainCommitteeProtocol(
+		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
-		5,
-		5,
 		cfg.Chain.PollInitialCandidatesInterval,
-		nil,
-		cfg.Genesis.ProductivityThreshold,
-		cfg.Genesis.KickoutEpochPeriod,
 		cfg.Genesis.KickoutIntensityRate,
-		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		slasher,
 	)
 	require.NoError(t, err)
 	require.NoError(t, rp.Register(registry))

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -335,25 +335,33 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 	}
 	cfg := config.Default
 	committee := mock_committee.NewMockCommittee(ctrl)
-	pp, err := poll.NewGovernanceChainCommitteeProtocol(
-		nil,
+	slasher, err := poll.NewSlasher(
+		&cfg.Genesis,
+		func(context.Context, uint64) (uint64, map[string]uint64, error) {
+			return 0, nil, nil
+		},
 		func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 			return abps, nil
 		},
 		nil,
 		nil,
 		nil,
+		nil,
+		2,
+		2,
+		cfg.Genesis.ProductivityThreshold,
+		cfg.Genesis.KickoutEpochPeriod,
+		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		cfg.Genesis.KickoutIntensityRate)
+	require.NoError(t, err)
+	pp, err := poll.NewGovernanceChainCommitteeProtocol(
+		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
-		2,
-		2,
 		cfg.Chain.PollInitialCandidatesInterval,
-		nil,
-		cfg.Genesis.ProductivityThreshold,
-		cfg.Genesis.KickoutEpochPeriod,
 		cfg.Genesis.KickoutIntensityRate,
-		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		slasher,
 	)
 	require.NoError(t, err)
 	require.NoError(t, rp.Register(registry))

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -360,7 +360,6 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
 		cfg.Chain.PollInitialCandidatesInterval,
-		cfg.Genesis.KickoutIntensityRate,
 		slasher,
 	)
 	require.NoError(t, err)

--- a/action/protocol/vote/blacklist.go
+++ b/action/protocol/vote/blacklist.go
@@ -21,6 +21,14 @@ type Blacklist struct {
 	IntensityRate  uint32
 }
 
+// NewBlacklist returns a new Blacklist
+func NewBlacklist(intensity uint32) *Blacklist {
+	return &Blacklist{
+		BlacklistInfos: make(map[string]uint32),
+		IntensityRate:  intensity,
+	}
+}
+
 // Serialize serializes map of blacklist to bytes
 func (bl *Blacklist) Serialize() ([]byte, error) {
 	return proto.Marshal(bl.Proto())

--- a/action/protocol/vote/candidatesutil/candidatesutil.go
+++ b/action/protocol/vote/candidatesutil/candidatesutil.go
@@ -163,7 +163,7 @@ func ConstructKey(key string) hash.Hash256 {
 	return hash.Hash256b(bytesKey)
 }
 
-// LoadAndAddCandidates loads candidates from trie and adds a new candidate	// KickoutListFromDB returns array of kickout list at current epoch
+// LoadAndAddCandidates loads candidates from trie and adds a new candidate
 func LoadAndAddCandidates(sm protocol.StateManager, blkHeight uint64, addr string) error {
 	candidateMap, err := GetMostRecentCandidateMap(sm, blkHeight)
 	if err != nil {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -978,26 +978,30 @@ func TestServer_GetChainMeta(t *testing.T) {
 			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
 		} else if test.pollProtocolType == "governanceChainCommittee" {
 			committee := mock_committee.NewMockCommittee(ctrl)
+			slasher, _ := poll.NewSlasher(
+				&cfg.Genesis,
+				func(context.Context, uint64) (uint64, map[string]uint64, error) {
+					return 0, nil, nil
+				},
+				nil,
+				nil,
+				nil,
+				nil,
+				nil,
+				cfg.Genesis.NumCandidateDelegates,
+				cfg.Genesis.NumDelegates,
+				cfg.Genesis.ProductivityThreshold,
+				cfg.Genesis.KickoutEpochPeriod,
+				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.Genesis.KickoutIntensityRate)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				nil,
-				nil,
-				nil,
-				nil,
 				nil,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
 				cfg.Chain.PollInitialCandidatesInterval,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
-				},
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.KickoutEpochPeriod,
 				cfg.Genesis.KickoutIntensityRate,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-			)
+				slasher)
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epoch.GravityChainStartHeight, nil)
 		}
 
@@ -1250,26 +1254,30 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
-			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				indexer,
+			slasher, _ := poll.NewSlasher(
+				&cfg.Genesis,
+				func(context.Context, uint64) (uint64, map[string]uint64, error) {
+					return 0, nil, nil
+				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
 				nil,
+				indexer,
+				cfg.Genesis.NumCandidateDelegates,
+				cfg.Genesis.NumDelegates,
+				cfg.Genesis.ProductivityThreshold,
+				cfg.Genesis.KickoutEpochPeriod,
+				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.Genesis.KickoutIntensityRate)
+			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
 				cfg.Chain.PollInitialCandidatesInterval,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
-				},
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.KickoutEpochPeriod,
 				cfg.Genesis.KickoutIntensityRate,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-			)
+				slasher)
 		}
 		svr, err := createServer(cfg, false)
 		require.NoError(err)
@@ -1315,26 +1323,31 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
-			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				indexer,
+			slasher, _ := poll.NewSlasher(
+				&cfg.Genesis,
+				func(context.Context, uint64) (uint64, map[string]uint64, error) {
+					return 0, nil, nil
+				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
 				nil,
+				indexer,
+				test.numCandidateDelegates,
+				cfg.Genesis.NumDelegates,
+				cfg.Genesis.ProductivityThreshold,
+				cfg.Genesis.KickoutEpochPeriod,
+				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.Genesis.KickoutIntensityRate)
+
+			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				test.numCandidateDelegates,
-				cfg.Genesis.NumDelegates,
 				cfg.Chain.PollInitialCandidatesInterval,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
-				},
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.KickoutEpochPeriod,
 				cfg.Genesis.KickoutIntensityRate,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-			)
+				slasher)
 		}
 		svr, err := createServer(cfg, false)
 		require.NoError(err)
@@ -1379,26 +1392,30 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
-			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
-				indexer,
+			slasher, _ := poll.NewSlasher(
+				&cfg.Genesis,
+				func(context.Context, uint64) (uint64, map[string]uint64, error) {
+					return 0, nil, nil
+				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
 				nil,
 				nil,
+				indexer,
+				cfg.Genesis.NumCandidateDelegates,
+				test.numDelegates,
+				cfg.Genesis.ProductivityThreshold,
+				cfg.Genesis.KickoutEpochPeriod,
+				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.Genesis.KickoutIntensityRate)
+			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Genesis.NumCandidateDelegates,
-				test.numDelegates,
 				cfg.Chain.PollInitialCandidatesInterval,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
-				},
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.KickoutEpochPeriod,
 				cfg.Genesis.KickoutIntensityRate,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-			)
+				slasher)
 		}
 		svr, err := createServer(cfg, false)
 		require.NoError(err)
@@ -1467,8 +1484,11 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			mbc := mock_blockchain.NewMockBlockchain(ctrl)
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
-			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
-				indexer,
+			slasher, _ := poll.NewSlasher(
+				&cfg.Genesis,
+				func(context.Context, uint64) (uint64, map[string]uint64, error) {
+					return 0, nil, nil
+				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 					return []*state.Candidate{
 						{
@@ -1506,20 +1526,21 @@ func TestServer_GetEpochMeta(t *testing.T) {
 				nil,
 				nil,
 				nil,
+				indexer,
+				cfg.Genesis.NumCandidateDelegates,
+				cfg.Genesis.NumDelegates,
+				cfg.Genesis.ProductivityThreshold,
+				cfg.Genesis.KickoutEpochPeriod,
+				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.Genesis.KickoutIntensityRate)
+			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
+				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
 				cfg.Chain.PollInitialCandidatesInterval,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
-				},
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.KickoutEpochPeriod,
 				cfg.Genesis.KickoutIntensityRate,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-			)
+				slasher)
 			require.NoError(pol.ForceRegister(svr.registry))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1000,7 +1000,6 @@ func TestServer_GetChainMeta(t *testing.T) {
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
 				cfg.Chain.PollInitialCandidatesInterval,
-				cfg.Genesis.KickoutIntensityRate,
 				slasher)
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epoch.GravityChainStartHeight, nil)
 		}
@@ -1276,7 +1275,6 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
 				cfg.Chain.PollInitialCandidatesInterval,
-				cfg.Genesis.KickoutIntensityRate,
 				slasher)
 		}
 		svr, err := createServer(cfg, false)
@@ -1346,7 +1344,6 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
 				cfg.Chain.PollInitialCandidatesInterval,
-				cfg.Genesis.KickoutIntensityRate,
 				slasher)
 		}
 		svr, err := createServer(cfg, false)
@@ -1414,7 +1411,6 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
 				cfg.Chain.PollInitialCandidatesInterval,
-				cfg.Genesis.KickoutIntensityRate,
 				slasher)
 		}
 		svr, err := createServer(cfg, false)
@@ -1539,7 +1535,6 @@ func TestServer_GetEpochMeta(t *testing.T) {
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
 				cfg.Chain.PollInitialCandidatesInterval,
-				cfg.Genesis.KickoutIntensityRate,
 				slasher)
 			require.NoError(pol.ForceRegister(svr.registry))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -280,7 +280,6 @@ func testCandidates(sf Factory, t *testing.T) {
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
 		cfg.Chain.PollInitialCandidatesInterval,
-		cfg.Genesis.KickoutIntensityRate,
 		slasher,
 	)
 	require.NoError(t, err)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -256,23 +256,32 @@ func testCandidates(sf Factory, t *testing.T) {
 
 	registry := protocol.NewRegistry()
 	require.NoError(t, registry.Register("rolldpos", rolldpos.NewProtocol(36, 36, 20)))
+	cfg := config.Default
+	slasher, err := poll.NewSlasher(
+		&cfg.Genesis,
+		func(context.Context, uint64) (uint64, map[string]uint64, error) {
+			return 0, nil, nil
+		},
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		cfg.Genesis.NumCandidateDelegates,
+		cfg.Genesis.NumDelegates,
+		cfg.Genesis.ProductivityThreshold,
+		cfg.Genesis.KickoutEpochPeriod,
+		cfg.Genesis.UnproductiveDelegateMaxCacheSize,
+		cfg.Genesis.KickoutIntensityRate)
+	require.NoError(t, err)
 	p, err := poll.NewGovernanceChainCommitteeProtocol(
-		nil,
-		nil,
-		nil,
-		nil,
 		nil,
 		committee,
 		uint64(123456),
 		func(uint64) (time.Time, error) { return time.Now(), nil },
-		config.Default.Genesis.NumCandidateDelegates,
-		config.Default.Genesis.NumDelegates,
-		config.Default.Chain.PollInitialCandidatesInterval,
-		nil,
-		config.Default.Genesis.ProductivityThreshold,
-		config.Default.Genesis.KickoutEpochPeriod,
-		config.Default.Genesis.KickoutIntensityRate,
-		config.Default.Genesis.UnproductiveDelegateMaxCacheSize,
+		cfg.Chain.PollInitialCandidatesInterval,
+		cfg.Genesis.KickoutIntensityRate,
+		slasher,
 	)
 	require.NoError(t, err)
 	require.NoError(t, registry.Register("poll", p))
@@ -280,7 +289,7 @@ func testCandidates(sf Factory, t *testing.T) {
 
 	// TODO: investigate why registry cannot be added in the Blockchain Ctx
 	ctx := protocol.WithBlockCtx(protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{
-		Genesis: config.Default.Genesis,
+		Genesis: cfg.Genesis,
 	}), protocol.BlockCtx{
 		BlockHeight: 0,
 		Producer:    identityset.Address(27),
@@ -297,7 +306,7 @@ func testCandidates(sf Factory, t *testing.T) {
 		SignAndBuild(identityset.PrivateKey(27))
 	require.NoError(t, err)
 	require.NoError(t, sf.Commit(protocol.WithBlockCtx(protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{
-		Genesis:  config.Default.Genesis,
+		Genesis:  cfg.Genesis,
 		Registry: registry,
 	}), protocol.BlockCtx{
 		BlockHeight: 1,


### PR DESCRIPTION
think of poll protocol as 2 parts:
1. governance (with staking V1 after Cook) or staking V2 (after Fairbank) gives out candidates list
2. slasher gives out kick-out list (after Easter)

staking_committee (and new staking_command) can then use slasher