### PR TITLE
move epoch related concept out of blockchain

### DIFF
--- a/action/protocol/poll/protocol.go
+++ b/action/protocol/poll/protocol.go
@@ -64,8 +64,8 @@ type GetUnproductiveDelegate func(protocol.StateReader) (*vote.UnproductiveDeleg
 // GetBlockTime defines a function to get block creation time
 type GetBlockTime func(uint64) (time.Time, error)
 
-// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
-type ProductivityByEpoch func(context.Context, uint64) (uint64, map[string]uint64, error)
+// Productivity returns the number of produced blocks per producer
+type Productivity func(uint64, uint64) (map[string]uint64, error)
 
 // Protocol defines the protocol of handling votes
 type Protocol interface {
@@ -125,7 +125,7 @@ func NewProtocol(
 	electionCommittee committee.Committee,
 	stakingV2 *staking.Protocol,
 	getBlockTimeFunc GetBlockTime,
-	productivityByEpoch ProductivityByEpoch,
+	productivity Productivity,
 ) (Protocol, error) {
 	genesisConfig := cfg.Genesis
 	if cfg.Consensus.Scheme != config.RollDPoSScheme {
@@ -145,7 +145,7 @@ func NewProtocol(
 		}
 		slasher, err := NewSlasher(
 			&genesisConfig,
-			productivityByEpoch,
+			productivity,
 			candidatesByHeight,
 			getCandidates,
 			getkickoutList,

--- a/action/protocol/poll/protocol_test.go
+++ b/action/protocol/poll/protocol_test.go
@@ -39,8 +39,8 @@ func TestNewProtocol(t *testing.T) {
 		committee,
 		nil,
 		func(uint64) (time.Time, error) { return time.Now(), nil },
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		},
 	)
 	require.NoError(err)

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -95,8 +95,8 @@ func initConstructStakingCommittee(ctrl *gomock.Controller) (Protocol, context.C
 	committee.EXPECT().HeightByTime(gomock.Any()).Return(uint64(123456), nil).AnyTimes()
 	slasher, err := NewSlasher(
 		&cfg.Genesis,
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		},
 		nil,
 		nil,

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -39,21 +39,21 @@ var (
 	exemptKey                   = []byte("xpt")
 )
 
-// ProductivityByEpoch returns the number of produced blocks per delegate in an epoch
-type ProductivityByEpoch func(context.Context, uint64) (uint64, map[string]uint64, error)
+// Productivity returns the number of produced blocks per producer
+type Productivity func(uint64, uint64) (map[string]uint64, error)
 
 // Protocol defines the protocol of the rewarding fund and the rewarding process. It allows the admin to config the
 // reward amount, users to donate tokens to the fund, block producers to grant them block and epoch reward and,
 // beneficiaries to claim the balance into their personal account.
 type Protocol struct {
-	productivityByEpoch ProductivityByEpoch
-	keyPrefix           []byte
-	addr                address.Address
+	productivity Productivity
+	keyPrefix    []byte
+	addr         address.Address
 }
 
 // NewProtocol instantiates a rewarding protocol instance.
 func NewProtocol(
-	productivityByEpoch ProductivityByEpoch,
+	productivity Productivity,
 ) *Protocol {
 	h := hash.Hash160b([]byte(protocolID))
 	addr, err := address.FromBytes(h[:])
@@ -61,9 +61,9 @@ func NewProtocol(
 		log.L().Panic("Error when constructing the address of rewarding protocol", zap.Error(err))
 	}
 	return &Protocol{
-		productivityByEpoch: productivityByEpoch,
-		keyPrefix:           h[:],
-		addr:                addr,
+		productivity: productivity,
+		keyPrefix:    h[:],
+		addr:         addr,
 	}
 }
 

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -76,9 +76,8 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 		genesis.Default.NumSubEpochs,
 	)
 	p := NewProtocol(
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return uint64(19),
-				map[string]uint64{
+		func(uint64, uint64) (map[string]uint64, error) {
+			return map[string]uint64{
 					identityset.Address(27).String(): 3,
 					identityset.Address(28).String(): 7,
 					identityset.Address(29).String(): 1,
@@ -150,8 +149,8 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 	committee := mock_committee.NewMockCommittee(ctrl)
 	slasher, err := poll.NewSlasher(
 		&cfg.Genesis,
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		},
 		func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 			return abps, nil
@@ -236,6 +235,9 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 			Genesis:    ge,
 			Registry:   registry,
 			Candidates: candidates,
+			Tip: protocol.TipInfo{
+				Height: 20,
+			},
 		},
 	)
 	blockReward, err := p.BlockReward(ctx, sm)
@@ -310,8 +312,8 @@ func TestProtocol_Handle(t *testing.T) {
 	)
 	require.NoError(t, rp.Register(registry))
 	p := NewProtocol(
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		})
 	require.NoError(t, p.Register(registry))
 	// Test for ForceRegister

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -163,7 +163,7 @@ func (p *Protocol) GrantEpochReward(
 	epochStartHeight := rp.GetEpochHeight(epochNum)
 	if hu.IsPre(config.Easter, epochStartHeight) {
 		// Get unqualified delegate list
-		if uqd, err = p.unqualifiedDelegates(ctx, sm, epochNum, a.productivityThreshold); err != nil {
+		if uqd, err = p.unqualifiedDelegates(ctx, sm, rp, epochNum, a.productivityThreshold); err != nil {
 			return nil, err
 		}
 	}
@@ -426,6 +426,7 @@ func (p *Protocol) splitEpochReward(
 func (p *Protocol) unqualifiedDelegates(
 	ctx context.Context,
 	sm protocol.StateManager,
+	rp *rolldpos.Protocol,
 	epochNum uint64,
 	productivityThreshold uint64,
 ) (map[string]bool, error) {
@@ -436,7 +437,7 @@ func (p *Protocol) unqualifiedDelegates(
 		return nil, err
 	}
 	unqualifiedDelegates := make(map[string]bool, 0)
-	numBlks, produce, err := p.productivityByEpoch(ctx, epochNum)
+	numBlks, produce, err := rp.ProductivityByEpoch(epochNum, bcCtx.Tip.Height, p.productivity)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -308,9 +308,8 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 	sm.EXPECT().Height().Return(uint64(1), nil).AnyTimes()
 
 	p := NewProtocol(
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return uint64(19),
-				map[string]uint64{
+		func(uint64, uint64) (map[string]uint64, error) {
+			return map[string]uint64{
 					identityset.Address(0).String(): 9,
 					identityset.Address(1).String(): 10,
 				},
@@ -337,8 +336,8 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 	committee := mock_committee.NewMockCommittee(ctrl)
 	slasher, err := poll.NewSlasher(
 		&cfg.Genesis,
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		},
 		func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 			return abps, nil
@@ -403,6 +402,9 @@ func TestProtocol_NoRewardAddr(t *testing.T) {
 			Genesis:    ge,
 			Candidates: abps,
 			Registry:   registry,
+			Tip: protocol.TipInfo{
+				Height: 1,
+			},
 		},
 	)
 

--- a/api/api.go
+++ b/api/api.go
@@ -1432,7 +1432,11 @@ func (api *Server) getProductivityByEpoch(
 	epochNum uint64,
 	abps state.CandidateList,
 ) (uint64, map[string]uint64, error) {
-	numBlks, produce, err := blockchain.ProductivityByEpoch(ctx, api.bc, epochNum)
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	rp := rolldpos.MustGetProtocol(bcCtx.Registry)
+	num, produce, err := rp.ProductivityByEpoch(epochNum, bcCtx.Tip.Height, func(start uint64, end uint64) (map[string]uint64, error) {
+		return blockchain.Productivity(api.bc, start, end)
+	})
 	if err != nil {
 		return 0, nil, status.Error(codes.NotFound, err.Error())
 	}
@@ -1442,5 +1446,5 @@ func (api *Server) getProductivityByEpoch(
 			produce[abp.Address] = 0
 		}
 	}
-	return numBlks, produce, nil
+	return num, produce, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -980,8 +980,8 @@ func TestServer_GetChainMeta(t *testing.T) {
 			committee := mock_committee.NewMockCommittee(ctrl)
 			slasher, _ := poll.NewSlasher(
 				&cfg.Genesis,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
+				func(uint64, uint64) (map[string]uint64, error) {
+					return nil, nil
 				},
 				nil,
 				nil,
@@ -1255,8 +1255,8 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 			require.NoError(err)
 			slasher, _ := poll.NewSlasher(
 				&cfg.Genesis,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
+				func(uint64, uint64) (map[string]uint64, error) {
+					return nil, nil
 				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
@@ -1323,8 +1323,8 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 			require.NoError(err)
 			slasher, _ := poll.NewSlasher(
 				&cfg.Genesis,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
+				func(uint64, uint64) (map[string]uint64, error) {
+					return nil, nil
 				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
@@ -1391,8 +1391,8 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 			require.NoError(err)
 			slasher, _ := poll.NewSlasher(
 				&cfg.Genesis,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
+				func(uint64, uint64) (map[string]uint64, error) {
+					return nil, nil
 				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) { return candidates, nil },
 				nil,
@@ -1482,8 +1482,8 @@ func TestServer_GetEpochMeta(t *testing.T) {
 			require.NoError(err)
 			slasher, _ := poll.NewSlasher(
 				&cfg.Genesis,
-				func(context.Context, uint64) (uint64, map[string]uint64, error) {
-					return 0, nil, nil
+				func(uint64, uint64) (map[string]uint64, error) {
+					return nil, nil
 				},
 				func(protocol.StateReader, uint64) ([]*state.Candidate, error) {
 					return []*state.Candidate{
@@ -1844,8 +1844,8 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 		rolldpos.EnableDardanellesSubEpoch(cfg.Genesis.DardanellesBlockHeight, cfg.Genesis.DardanellesNumSubEpochs),
 	)
 	r := rewarding.NewProtocol(
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		})
 
 	if err := rolldposProtocol.Register(registry); err != nil {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -291,8 +291,8 @@ func New(
 				}
 				return header.Timestamp(), nil
 			},
-			func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
-				return blockchain.ProductivityByEpoch(ctx, chain, epochNum)
+			func(start, end uint64) (map[string]uint64, error) {
+				return blockchain.Productivity(chain, start, end)
 			},
 		)
 		if err != nil {
@@ -304,8 +304,8 @@ func New(
 	}
 	// TODO: rewarding protocol for standalone mode is weird, rDPoSProtocol could be passed via context
 	rewardingProtocol := rewarding.NewProtocol(
-		func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
-			return blockchain.ProductivityByEpoch(ctx, chain, epochNum)
+		func(start uint64, end uint64) (map[string]uint64, error) {
+			return blockchain.Productivity(chain, start, end)
 		})
 	// TODO: explorer dependency deleted at #1085, need to revive by migrating to api
 	consensus, err := consensus.NewConsensus(cfg, chain, sf, actPool, copts...)

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -194,8 +194,8 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, *rolldpos.
 
 	require.NoError(rolldposProtocol.Register(registry))
 	rewardingProtocol := rewarding.NewProtocol(
-		func(ctx context.Context, epochNum uint64) (uint64, map[string]uint64, error) {
-			return blockchain.ProductivityByEpoch(ctx, chain, epochNum)
+		func(start uint64, end uint64) (map[string]uint64, error) {
+			return blockchain.Productivity(chain, start, end)
 		},
 	)
 	require.NoError(rewardingProtocol.Register(registry))

--- a/go.sum
+++ b/go.sum
@@ -163,6 +163,7 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.3.2/go.mod h1:R6WIWVfZAnpSo8llzEs
 github.com/iotexproject/iotex-election v0.2.11 h1:opQk5DVVtem2u6tIO/wFND4qX9QqpL8Pb/hiPG3fuFw=
 github.com/iotexproject/iotex-election v0.2.11/go.mod h1:y5niif2oeYT1MVS4WOIqNgSlDCpmGWjR8clafzrOg6E=
 github.com/iotexproject/iotex-proto v0.2.1-0.20190814190638-f74c55ffedf5/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
+github.com/iotexproject/iotex-proto v0.2.5 h1:SYdl9Lqb0LYfFf3sfw92fN8GY3bthfCvGmltz+2uvDQ=
 github.com/iotexproject/iotex-proto v0.2.5/go.mod h1:962P5o0qlB5sqRT07TJBMX31i2u309kzDqqwCg+cGz0=
 github.com/iotexproject/iotex-proto v0.2.6-0.20200313212651-3c29eadd68ba h1:06z8oNwLjs9ap/q4tE9ORx9r2zkccoeWfklGcG1Fk+8=
 github.com/iotexproject/iotex-proto v0.2.6-0.20200313212651-3c29eadd68ba/go.mod h1:xKA4yUbg208k1j3+t10Pe7IzT6uHcP+/4rsDanF4Q58=

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -259,8 +259,8 @@ func testCandidates(sf Factory, t *testing.T) {
 	cfg := config.Default
 	slasher, err := poll.NewSlasher(
 		&cfg.Genesis,
-		func(context.Context, uint64) (uint64, map[string]uint64, error) {
-			return 0, nil, nil
+		func(uint64, uint64) (map[string]uint64, error) {
+			return nil, nil
 		},
 		nil,
 		nil,


### PR DESCRIPTION
Move epoch out of ProductivityByEpoch in blockchain.go, and rename it to Productivity