### PR TITLE
fix blockdao deadlock bug

### DIFF
--- a/test/mock/mock_blockdao/mock_blockdao.go
+++ b/test/mock/mock_blockdao/mock_blockdao.go
@@ -258,35 +258,6 @@ func (mr *MockBlockDAOMockRecorder) DeleteBlockToTarget(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBlockToTarget", reflect.TypeOf((*MockBlockDAO)(nil).DeleteBlockToTarget), arg0)
 }
 
-// IndexFile mocks base method
-func (m *MockBlockDAO) IndexFile(arg0 uint64, arg1 []byte) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IndexFile", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// IndexFile indicates an expected call of IndexFile
-func (mr *MockBlockDAOMockRecorder) IndexFile(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexFile", reflect.TypeOf((*MockBlockDAO)(nil).IndexFile), arg0, arg1)
-}
-
-// GetFileIndex mocks base method
-func (m *MockBlockDAO) GetFileIndex(arg0 uint64) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFileIndex", arg0)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetFileIndex indicates an expected call of GetFileIndex
-func (mr *MockBlockDAOMockRecorder) GetFileIndex(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileIndex", reflect.TypeOf((*MockBlockDAO)(nil).GetFileIndex), arg0)
-}
-
 // KVStore mocks base method
 func (m *MockBlockDAO) KVStore() db.KVStore {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
fix 2 bugs 
1. deadlock issue
2. In GetTopDB() in case of ```index the height --> file index mapping``` it should put index(top+1) 

For dead lock issue, the blockdao mutex is not for general usage but for creating new files/ rangeIndex files. But while previous refactoring, in the ```putBlock(), DeleteBlockToTarget()```, we lock/unlock mutex wrongly. 