### PR TITLE
[staking] remove CandidateView interface

### DIFF
--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -323,12 +323,3 @@ func delCandidate(sm protocol.StateManager, name address.Address) error {
 	_, err := sm.DelState(protocol.NamespaceOption(CandidateNameSpace), protocol.KeyOption(name.Bytes()))
 	return err
 }
-
-func getCandidateByName(cv CandidateView, name string) (*Candidate, error) {
-	for _, cand := range cv.All() {
-		if cand.Name == name {
-			return cand, nil
-		}
-	}
-	return nil, nil
-}

--- a/action/protocol/staking/candidate_center_test.go
+++ b/action/protocol/staking/candidate_center_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 // testEqual verifies m contains exactly the list
-func testEqual(m CandidateView, l CandidateList) bool {
+func testEqual(m CandidateCenter, l CandidateList) bool {
 	for _, v := range l {
 		d := m.GetByOwner(v.Owner)
 		if d == nil {
@@ -69,9 +69,7 @@ func testEqualAllCommitAbort(r *require.Assertions, m CandidateCenter, old Candi
 
 	// test commit
 	r.NoError(delta.Deserialize(ser))
-	diff, err := NewCandidateView(delta)
-	r.NoError(err)
-	r.NoError(m.SetDelta(diff))
+	r.NoError(m.SetDelta(delta))
 	r.NoError(m.Commit())
 	r.NoError(m.Commit()) // commit is idempotent
 	r.Equal(size+increase, m.Size())
@@ -105,9 +103,7 @@ func TestCandCenter(t *testing.T) {
 	r.NotNil(list)
 	r.Equal(len(list), m.Size())
 	r.True(testEqual(m, list))
-	delta, err := NewCandidateView(list)
-	r.NoError(err)
-	r.NoError(m.SetDelta(delta))
+	r.NoError(m.SetDelta(list))
 	r.NoError(m.Commit())
 	r.Equal(len(testCandidates), m.Size())
 	r.True(testEqual(m, list))
@@ -207,10 +203,9 @@ func TestCandCenter(t *testing.T) {
 	list = m.All()
 	r.Equal(len(list), m.Size())
 	r.True(testEqual(m, list))
-	delta, err = NewCandidateView(m.Delta())
-	r.NoError(err)
+	delta := m.Delta()
 	// 4 updates + 4 new
-	r.Equal(8, delta.Size())
+	r.Equal(8, len(delta))
 	r.Equal(len(testCandidates)+4, m.Size())
 
 	// SetDelta using one's own Delta() does not change a thing

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -114,7 +114,7 @@ func loadCandidatesFromSR(sr protocol.StateReader) (CandidateList, error) {
 	return cands, nil
 }
 
-func retrieveDeltaFromSM(sm protocol.StateManager) (CandidateView, error) {
+func retrieveDeltaFromSM(sm protocol.StateManager) (CandidateList, error) {
 	v, err := sm.Unload(protocolID)
 	if err != nil {
 		if errors.Cause(err) == protocol.ErrNoName {
@@ -133,5 +133,5 @@ func retrieveDeltaFromSM(sm protocol.StateManager) (CandidateView, error) {
 	if err := l.Deserialize(ser); err != nil {
 		return nil, errors.Wrap(err, "failed to retrieveDeltaFromSM")
 	}
-	return NewCandidateView(l)
+	return l, nil
 }

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -37,18 +37,14 @@ func (m *candCenter) deleteForTestOnly(owner address.Address) {
 
 	if _, hit := m.base.getByOwner(owner.String()); hit {
 		m.base.delete(owner)
-		if !m.change.ContainsOwner(owner) {
+		if !m.change.containsOwner(owner) {
 			m.size--
 			return
 		}
 	}
 
-	if m.change.ContainsOwner(owner) {
-		cv, ok := m.change.(*candChange)
-		if !ok {
-			panic("wrong type of CandidateView, expecting *candChange")
-		}
-		cv.delete(owner)
+	if m.change.containsOwner(owner) {
+		m.change.delete(owner)
 		m.size--
 	}
 }

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -400,13 +400,8 @@ func createCandCenter(sr protocol.StateReader, height uint64) (CandidateCenter, 
 		return nil, err
 	}
 
-	delta, err := NewCandidateView(all)
-	if err != nil {
-		return nil, err
-	}
-
 	center := NewCandidateCenter()
-	if err := center.SetDelta(delta); err != nil {
+	if err := center.SetDelta(all); err != nil {
 		return nil, err
 	}
 	if err := center.Commit(); err != nil {

--- a/action/protocol/staking/read_state.go
+++ b/action/protocol/staking/read_state.go
@@ -54,12 +54,9 @@ func readStateBucketsByVoter(ctx context.Context, sr protocol.StateReader,
 	return toIoTeXTypesVoteBucketList(buckets)
 }
 
-func readStateBucketsByCandidate(ctx context.Context, sr protocol.StateReader, cv CandidateView,
+func readStateBucketsByCandidate(ctx context.Context, sr protocol.StateReader, cc CandidateCenter,
 	req *iotexapi.ReadStakingDataRequest_VoteBucketsByCandidate) (*iotextypes.VoteBucketList, error) {
-	c, err := getCandidateByName(cv, req.GetCandName())
-	if err != nil {
-		return nil, err
-	}
+	c := cc.GetByName(req.GetCandName())
 	if c == nil {
 		return &iotextypes.VoteBucketList{}, nil
 	}
@@ -82,21 +79,18 @@ func readStateBucketsByCandidate(ctx context.Context, sr protocol.StateReader, c
 	return toIoTeXTypesVoteBucketList(buckets)
 }
 
-func readStateCandidates(ctx context.Context, cv CandidateView,
+func readStateCandidates(ctx context.Context, cc CandidateCenter,
 	req *iotexapi.ReadStakingDataRequest_Candidates) (*iotextypes.CandidateListV2, error) {
 	offset := int(req.GetPagination().GetOffset())
 	limit := int(req.GetPagination().GetLimit())
-	candidates := getPageOfCandidates(cv.All(), offset, limit)
+	candidates := getPageOfCandidates(cc.All(), offset, limit)
 
 	return toIoTeXTypesCandidateListV2(candidates), nil
 }
 
-func readStateCandidateByName(ctx context.Context, cv CandidateView,
+func readStateCandidateByName(ctx context.Context, cc CandidateCenter,
 	req *iotexapi.ReadStakingDataRequest_CandidateByName) (*iotextypes.CandidateV2, error) {
-	c, err := getCandidateByName(cv, req.GetCandName())
-	if err != nil {
-		return nil, err
-	}
+	c := cc.GetByName(req.GetCandName())
 	if c == nil {
 		return &iotextypes.CandidateV2{}, nil
 	}


### PR DESCRIPTION
CandidateCenter is still widely used

after we finish moving CandidateCenter to state factory + remove LRU, we can revisit if it's possible to remove it