### PR TITLE
Update ReadState API deserialize method between bytes and uint64

### DIFF
--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -8,6 +8,7 @@ package poll
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -22,7 +23,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -200,11 +200,15 @@ func (p *governanceChainCommitteeProtocol) ReadState(
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		gravityStartheight, err := p.getGravityHeight(ctx, byteutil.BytesToUint64(args[0]))
+		nativeHeight, err := strconv.ParseUint(string(args[0]), 10, 64)
 		if err != nil {
 			return nil, err
 		}
-		return byteutil.Uint64ToBytes(gravityStartheight), nil
+		gravityStartheight, err := p.getGravityHeight(ctx, nativeHeight)
+		if err != nil {
+			return nil, err
+		}
+		return []byte(strconv.FormatUint(gravityStartheight, 10)), nil
 	default:
 		return p.sh.ReadState(ctx, sr, p.indexer, method, args...)
 	}

--- a/action/protocol/poll/slasher.go
+++ b/action/protocol/poll/slasher.go
@@ -9,6 +9,7 @@ package poll
 import (
 	"context"
 	"math/big"
+	"strconv"
 
 	"github.com/iotexproject/iotex-election/util"
 	"github.com/pkg/errors"
@@ -21,7 +22,6 @@ import (
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/crypto"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -115,7 +115,10 @@ func (sh *Slasher) ReadState(
 	epochNum := rp.GetEpochNum(blkCtx.BlockHeight) // tip
 	epochStartHeight := rp.GetEpochHeight(epochNum)
 	if len(args) != 0 {
-		epochNum = byteutil.BytesToUint64(args[0])
+		epochNum, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
 		epochStartHeight = rp.GetEpochHeight(epochNum)
 	}
 	switch string(method) {

--- a/action/protocol/rolldpos/epoch.go
+++ b/action/protocol/rolldpos/epoch.go
@@ -8,13 +8,13 @@ package rolldpos
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 const protocolID = "rolldpos"
@@ -101,39 +101,59 @@ func (p *Protocol) Handle(context.Context, action.Action, protocol.StateManager)
 func (p *Protocol) ReadState(ctx context.Context, _ protocol.StateReader, method []byte, args ...[]byte) ([]byte, error) {
 	switch string(method) {
 	case "NumCandidateDelegates":
-		return byteutil.Uint64ToBytes(p.numCandidateDelegates), nil
+		return []byte(strconv.FormatUint(p.numCandidateDelegates, 10)), nil
 	case "NumDelegates":
-		return byteutil.Uint64ToBytes(p.numDelegates), nil
+		return []byte(strconv.FormatUint(p.numDelegates, 10)), nil
 	case "NumSubEpochs":
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		numSubEpochs := p.NumSubEpochs(byteutil.BytesToUint64(args[0]))
-		return byteutil.Uint64ToBytes(numSubEpochs), nil
+		height, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		numSubEpochs := p.NumSubEpochs(height)
+		return []byte(strconv.FormatUint(numSubEpochs, 10)), nil
 	case "EpochNumber":
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		epochNumber := p.GetEpochNum(byteutil.BytesToUint64(args[0]))
-		return byteutil.Uint64ToBytes(epochNumber), nil
+		height, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		epochNumber := p.GetEpochNum(height)
+		return []byte(strconv.FormatUint(epochNumber, 10)), nil
 	case "EpochHeight":
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		epochHeight := p.GetEpochHeight(byteutil.BytesToUint64(args[0]))
-		return byteutil.Uint64ToBytes(epochHeight), nil
+		epochNumber, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		epochHeight := p.GetEpochHeight(epochNumber)
+		return []byte(strconv.FormatUint(epochHeight, 10)), nil
 	case "EpochLastHeight":
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		epochLastHeight := p.GetEpochLastBlockHeight(byteutil.BytesToUint64(args[0]))
-		return byteutil.Uint64ToBytes(epochLastHeight), nil
+		epochNumber, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		epochLastHeight := p.GetEpochLastBlockHeight(epochNumber)
+		return []byte(strconv.FormatUint(epochLastHeight, 10)), nil
 	case "SubEpochNumber":
 		if len(args) != 1 {
 			return nil, errors.Errorf("invalid number of arguments %d", len(args))
 		}
-		subEpochNumber := p.GetSubEpochNum(byteutil.BytesToUint64(args[0]))
-		return byteutil.Uint64ToBytes(subEpochNumber), nil
+		height, err := strconv.ParseUint(string(args[0]), 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		subEpochNumber := p.GetSubEpochNum(height)
+		return []byte(strconv.FormatUint(subEpochNumber, 10)), nil
 	default:
 		return nil, errors.New("corresponding method isn't found")
 	}

--- a/action/protocol/rolldpos/epoch_test.go
+++ b/action/protocol/rolldpos/epoch_test.go
@@ -2,11 +2,10 @@ package rolldpos
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 func TestEnableDardanellesSubEpoch(t *testing.T) {
@@ -71,8 +70,11 @@ func TestProtocol_ReadState(t *testing.T) {
 		"trick",
 	}
 
-	arg1 := byteutil.Uint64ToBytes(10)
-	arg2 := byteutil.Uint64ToBytes(20)
+	arg1 := []byte("10")
+	arg2 := []byte("20")
+
+	arg1Num, err := strconv.ParseUint(string(arg1), 10, 64)
+	require.NoError(err)
 
 	for i, method := range methods {
 
@@ -86,41 +88,41 @@ func TestProtocol_ReadState(t *testing.T) {
 
 		case "NumCandidateDelegates":
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.numCandidateDelegates), result)
+			require.Equal(strconv.FormatUint(p.numCandidateDelegates, 10), string(result))
 			require.NoError(err)
 
 		case "NumDelegates":
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.numDelegates), result)
+			require.Equal(strconv.FormatUint(p.numDelegates, 10), string(result))
 			require.NoError(err)
 
 		case "NumSubEpochs":
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.NumSubEpochs(byteutil.BytesToUint64(arg1))), result)
+			require.Equal(strconv.FormatUint(p.NumSubEpochs(arg1Num), 10), string(result))
 			require.NoError(err)
 
 		case "EpochNumber":
 
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.GetEpochNum(byteutil.BytesToUint64(arg1))), result)
+			require.Equal(strconv.FormatUint(p.GetEpochNum(arg1Num), 10), string(result))
 			require.NoError(err)
 
 		case "EpochHeight":
 
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.GetEpochHeight(byteutil.BytesToUint64(arg1))), result)
+			require.Equal(strconv.FormatUint(p.GetEpochHeight(arg1Num), 10), string(result))
 			require.NoError(err)
 
 		case "EpochLastHeight":
 
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.GetEpochLastBlockHeight(byteutil.BytesToUint64(arg1))), result)
+			require.Equal(strconv.FormatUint(p.GetEpochLastBlockHeight(arg1Num), 10), string(result))
 			require.NoError(err)
 
 		case "SubEpochNumber":
 
 			result, err := p.ReadState(ctx, nil, []byte(method), arg1)
-			require.Equal(byteutil.Uint64ToBytes(p.GetSubEpochNum(byteutil.BytesToUint64(arg1))), result)
+			require.Equal(strconv.FormatUint(p.GetSubEpochNum(arg1Num), 10), string(result))
 			require.NoError(err)
 
 		default:

--- a/api/api.go
+++ b/api/api.go
@@ -46,7 +46,6 @@ import (
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/gasstation"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
@@ -515,7 +514,7 @@ func (api *Server) GetEpochMeta(
 	}
 
 	methodName := []byte("ActiveBlockProducersByEpoch")
-	arguments := [][]byte{byteutil.Uint64ToBytes(in.EpochNumber)}
+	arguments := [][]byte{[]byte(strconv.FormatUint(in.EpochNumber, 10))}
 	height := strconv.FormatUint(epochHeight, 10)
 	data, err := api.readState(context.Background(), pp, height, methodName, arguments...)
 	if err != nil {
@@ -533,7 +532,6 @@ func (api *Server) GetEpochMeta(
 	}
 
 	methodName = []byte("BlockProducersByEpoch")
-	arguments = [][]byte{byteutil.Uint64ToBytes(in.EpochNumber)}
 	data, err = api.readState(context.Background(), pp, height, methodName, arguments...)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -1212,12 +1210,14 @@ func (api *Server) getGravityChainStartHeight(epochHeight uint64) (uint64, error
 	gravityChainStartHeight := epochHeight
 	if pp := poll.FindProtocol(api.registry); pp != nil {
 		methodName := []byte("GetGravityChainStartHeight")
-		arguments := [][]byte{byteutil.Uint64ToBytes(epochHeight)}
+		arguments := [][]byte{[]byte(strconv.FormatUint(epochHeight, 10))}
 		data, err := api.readState(context.Background(), pp, "", methodName, arguments...)
 		if err != nil {
 			return 0, err
 		}
-		gravityChainStartHeight = byteutil.BytesToUint64(data)
+		if gravityChainStartHeight, err = strconv.ParseUint(string(data), 10, 64); err != nil {
+			return 0, err
+		}
 	}
 	return gravityChainStartHeight, nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/gasstation"
 	"github.com/iotexproject/iotex-core/pkg/unit"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/systemlog"
@@ -1358,7 +1357,7 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 		res, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 			ProtocolID: []byte(test.protocolID),
 			MethodName: []byte(test.methodName),
-			Arguments:  [][]byte{byteutil.Uint64ToBytes(test.epoch)},
+			Arguments:  [][]byte{[]byte(strconv.FormatUint(test.epoch, 10))},
 		})
 		require.NoError(err)
 		var delegates state.CandidateList
@@ -1427,7 +1426,7 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 		res, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 			ProtocolID: []byte(test.protocolID),
 			MethodName: []byte(test.methodName),
-			Arguments:  [][]byte{byteutil.Uint64ToBytes(test.epoch)},
+			Arguments:  [][]byte{[]byte(strconv.FormatUint(test.epoch, 10))},
 		})
 		require.NoError(err)
 		var blockProducers state.CandidateList
@@ -1496,7 +1495,7 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 		res, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 			ProtocolID: []byte(test.protocolID),
 			MethodName: []byte(test.methodName),
-			Arguments:  [][]byte{byteutil.Uint64ToBytes(test.epoch)},
+			Arguments:  [][]byte{[]byte(strconv.FormatUint(test.epoch, 10))},
 		})
 		require.NoError(err)
 		var activeBlockProducers state.CandidateList
@@ -1517,7 +1516,9 @@ func TestServer_ReadRollDPoSMeta(t *testing.T) {
 			MethodName: []byte(test.methodName),
 		})
 		require.NoError(err)
-		require.Equal(test.result, byteutil.BytesToUint64(res.Data))
+		result, err := strconv.ParseUint(string(res.Data), 10, 64)
+		require.NoError(err)
+		require.Equal(test.result, result)
 	}
 }
 
@@ -1531,10 +1532,12 @@ func TestServer_ReadEpochCtx(t *testing.T) {
 		res, err := svr.ReadState(context.Background(), &iotexapi.ReadStateRequest{
 			ProtocolID: []byte(test.protocolID),
 			MethodName: []byte(test.methodName),
-			Arguments:  [][]byte{byteutil.Uint64ToBytes(test.argument)},
+			Arguments:  [][]byte{[]byte(strconv.FormatUint(test.argument, 10))},
 		})
 		require.NoError(err)
-		require.Equal(test.result, byteutil.BytesToUint64(res.Data))
+		result, err := strconv.ParseUint(string(res.Data), 10, 64)
+		require.NoError(err)
+		require.Equal(test.result, result)
 	}
 }
 

--- a/ioctl/cmd/bc/bc.go
+++ b/ioctl/cmd/bc/bc.go
@@ -8,6 +8,7 @@ package bc
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/spf13/cobra"
@@ -20,7 +21,6 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 // Multi-language support
@@ -124,7 +124,7 @@ func GetProbationList(epochNum uint64) (*iotexapi.ReadStateResponse, error) {
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("poll"),
 		MethodName: []byte("ProbationListByEpoch"),
-		Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 	}
 	ctx := context.Background()
 

--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -26,7 +26,6 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -234,7 +233,7 @@ func nextDelegates() error {
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("poll"),
 		MethodName: []byte("ActiveBlockProducersByEpoch"),
-		Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 	}
 	abpResponse, err := cli.ReadState(ctx, request)
 	if err != nil {
@@ -256,7 +255,7 @@ func nextDelegates() error {
 	request = &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("poll"),
 		MethodName: []byte("BlockProducersByEpoch"),
-		Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 	}
 	bpResponse, err := cli.ReadState(ctx, request)
 	if err != nil {

--- a/ioctl/newcmd/bc/bc.go
+++ b/ioctl/newcmd/bc/bc.go
@@ -8,6 +8,7 @@ package bc
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -19,7 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 // Multi-language support
@@ -133,7 +133,7 @@ func GetProbationList(epochNum uint64, client ioctl.Client) (*iotexapi.ReadState
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("poll"),
 		MethodName: []byte("ProbationListByEpoch"),
-		Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 	}
 
 	response, err := apiServiceClient.ReadState(context.Background(), request)

--- a/ioctl/newcmd/node/nodedelegate.go
+++ b/ioctl/newcmd/node/nodedelegate.go
@@ -20,7 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/newcmd/bc"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -114,7 +113,7 @@ func NewNodeDelegateCmd(c ioctl.Client) *cobra.Command {
 					&iotexapi.ReadStateRequest{
 						ProtocolID: []byte("poll"),
 						MethodName: []byte("ActiveBlockProducersByEpoch"),
-						Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+						Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 					},
 				)
 
@@ -140,7 +139,7 @@ func NewNodeDelegateCmd(c ioctl.Client) *cobra.Command {
 					&iotexapi.ReadStateRequest{
 						ProtocolID: []byte("poll"),
 						MethodName: []byte("BlockProducersByEpoch"),
-						Arguments:  [][]byte{byteutil.Uint64ToBytes(epochNum)},
+						Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
 					},
 				)
 


### PR DESCRIPTION
 In API side, we decided not to use golang byteutil.BytesToUint64 but to use strconv.Parse/Format to support more general usage. 

