### PR TITLE
[db] better fix to remove LRU cache from boltDB

### DIFF
--- a/db/kvstore.go
+++ b/db/kvstore.go
@@ -47,8 +47,8 @@ type (
 	// KVStoreWithBucketFillPercent is KVStore with option to set bucket fill percent
 	KVStoreWithBucketFillPercent interface {
 		KVStore
-		// SetBucketFillPercent sets specified fill percent for a bucket
-		SetBucketFillPercent(string, float64) error
+		// WriteBatchWithFillPercent
+		WriteBatchWithFillPercent(batch.KVStoreBatch, float64) error
 	}
 
 	// KVStoreForRangeIndex is KVStore for range index

--- a/db/mock_kvstore.go
+++ b/db/mock_kvstore.go
@@ -492,18 +492,18 @@ func (mr *MockKVStoreWithBucketFillPercentMockRecorder) Filter(arg0, arg1, arg2,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Filter", reflect.TypeOf((*MockKVStoreWithBucketFillPercent)(nil).Filter), arg0, arg1, arg2, arg3)
 }
 
-// SetBucketFillPercent mocks base method
-func (m *MockKVStoreWithBucketFillPercent) SetBucketFillPercent(arg0 string, arg1 float64) error {
+// WriteBatchWithFillPercent mocks base method
+func (m *MockKVStoreWithBucketFillPercent) WriteBatchWithFillPercent(arg0 batch.KVStoreBatch, arg1 float64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetBucketFillPercent", arg0, arg1)
+	ret := m.ctrl.Call(m, "WriteBatchWithFillPercent", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// SetBucketFillPercent indicates an expected call of SetBucketFillPercent
-func (mr *MockKVStoreWithBucketFillPercentMockRecorder) SetBucketFillPercent(arg0, arg1 interface{}) *gomock.Call {
+// WriteBatchWithFillPercent indicates an expected call of WriteBatchWithFillPercent
+func (mr *MockKVStoreWithBucketFillPercentMockRecorder) WriteBatchWithFillPercent(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetBucketFillPercent", reflect.TypeOf((*MockKVStoreWithBucketFillPercent)(nil).SetBucketFillPercent), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteBatchWithFillPercent", reflect.TypeOf((*MockKVStoreWithBucketFillPercent)(nil).WriteBatchWithFillPercent), arg0, arg1)
 }
 
 // MockKVStoreForRangeIndex is a mock of KVStoreForRangeIndex interface


### PR DESCRIPTION
the correct fix is to let index (which can use the FillPercent feature) to call a different interface WriteBatchWithFillPercent(percent), other writes (like putBlock) still use normal WriteBatch()

thus we remove the need of an LRU cache to save these index's address
