### PR TITLE
add contract compile command for ioctl

### DIFF
--- a/ioctl/cmd/contract/contract.go
+++ b/ioctl/cmd/contract/contract.go
@@ -7,9 +7,22 @@
 package contract
 
 import (
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common/compiler"
 	"github.com/spf13/cobra"
 
 	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/flag"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+)
+
+const solCompiler = "solc"
+
+// Flags
+var (
+	sourceFlag = flag.NewStringVar("source", "",
+		config.TranslateInLang(flagSourceUsage, config.UILanguage))
 )
 
 // Multi-language support
@@ -30,6 +43,14 @@ var (
 		config.English: "insecure connection for once",
 		config.Chinese: "一次不安全的连接",
 	}
+	flagSourceUsage = map[config.Language]string{
+		config.English: "set source code file path",
+		config.Chinese: "设定代码文件路径",
+	}
+	flagVersionUsage = map[config.Language]string{
+		config.English: "set solidity version",
+		config.Chinese: "设定solidity版本",
+	}
 )
 
 // ContractCmd represents the contract command
@@ -39,8 +60,35 @@ var ContractCmd = &cobra.Command{
 }
 
 func init() {
+	ContractCmd.AddCommand(ContractCompileCmd)
 	ContractCmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
 		config.ReadConfig.Endpoint, config.TranslateInLang(flagEndpointUsages, config.UILanguage))
 	ContractCmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,
 		config.TranslateInLang(flagInsecureUsages, config.UILanguage))
+}
+
+// Compile compiles smart contract from source code
+func Compile(sourceFiles ...string) (map[string]*compiler.Contract, error) {
+	solc, err := compiler.SolidityVersion(solCompiler)
+	if err != nil {
+		return nil, output.NewError(output.CompilerError, "solidity compiler not ready", err)
+	}
+	if !checkCompilerVersion(solc) {
+		return nil, output.NewError(output.CompilerError,
+			fmt.Sprintf("unsupported solc version %d.%d.%d", solc.Major, solc.Minor, solc.Patch), nil)
+	}
+
+	contracts, err := compiler.CompileSolidity(solCompiler, sourceFiles...)
+	if err != nil {
+		return nil, output.NewError(output.CompilerError, "failed to compile", err)
+	}
+	return contracts, nil
+}
+
+func checkCompilerVersion(solc *compiler.Solidity) bool {
+	// TODO: may support 0.5.0 later, need to make sure range of valid version
+	if solc.Major == 0 && solc.Minor == 4 && solc.Patch >= 24 {
+		return true
+	}
+	return false
 }

--- a/ioctl/cmd/contract/contractcompile.go
+++ b/ioctl/cmd/contract/contractcompile.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+)
+
+var (
+	abiOut string
+	binOut string
+)
+
+// Multi-language support
+var (
+	contractCompileCmdUses = map[config.Language]string{
+		config.English: "compile CONTRACT_NAME --abi-out ABI_PATH --bin-out BIN_PATH",
+		config.Chinese: "compile 合约名 --abi-out ABI路径 --bin-out BIN路径",
+	}
+	contractCompileCmdShorts = map[config.Language]string{
+		config.English: "Compile smart contract of IoTeX blockchain from source code",
+		config.Chinese: "编译IoTeX区块链的智能合约代码",
+	}
+	flagAbiOutUsage = map[config.Language]string{
+		config.English: "set abi file output path",
+		config.Chinese: "设置abi文件输出路径",
+	}
+	flagBinOutUsage = map[config.Language]string{
+		config.English: "set bin file output path",
+		config.Chinese: "设置bin文件输出路径",
+	}
+)
+
+// ContractCompileCmd represents the contract compile command
+var ContractCompileCmd = &cobra.Command{
+	Use:   config.TranslateInLang(contractCompileCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(contractCompileCmdShorts, config.UILanguage),
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		err := compile(args)
+		return output.PrintError(err)
+	},
+}
+
+func init() {
+	sourceFlag.RegisterCommand(ContractCompileCmd)
+	sourceFlag.MarkFlagRequired(ContractCompileCmd)
+	ContractCompileCmd.Flags().StringVar(&abiOut, "abi-out", "",
+		config.TranslateInLang(flagAbiOutUsage, config.UILanguage))
+	ContractCompileCmd.Flags().StringVar(&binOut, "bin-out", "",
+		config.TranslateInLang(flagBinOutUsage, config.UILanguage))
+	ContractCompileCmd.MarkFlagRequired("abi-out")
+	ContractCompileCmd.MarkFlagRequired("bin-out")
+}
+
+func compile(args []string) error {
+	contractName := sourceFlag.Value().(string) + ":" + args[0]
+
+	contracts, err := Compile(sourceFlag.Value().(string))
+	if err != nil {
+		return output.NewError(0, "failed to compile", err)
+	}
+
+	contract, ok := contracts[contractName]
+	if !ok {
+		return output.NewError(output.CompilerError, fmt.Sprintf("failed to get contract from %s", contractName), nil)
+	}
+
+	abiByte, err := json.Marshal(contract.Info.AbiDefinition)
+	if err != nil {
+		return output.NewError(output.SerializationError, "failed to marshal abi", err)
+	}
+
+	if err := ioutil.WriteFile(abiOut, abiByte, 0600); err != nil {
+		return output.NewError(output.WriteFileError, "failed to write abi file", err)
+	}
+	// bin file starts with "0x" prefix
+	if err := ioutil.WriteFile(binOut, []byte(contract.Code), 0600); err != nil {
+		return output.NewError(output.WriteFileError, "failed to write bin file", err)
+	}
+	return nil
+}

--- a/ioctl/cmd/root.go
+++ b/ioctl/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/cmd/action"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/bc"
+	"github.com/iotexproject/iotex-core/ioctl/cmd/contract"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/node"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/update"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/version"
@@ -71,6 +72,7 @@ func NewIoctl() *cobra.Command {
 	rootCmd.AddCommand(node.NodeCmd)
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(update.UpdateCmd)
+	rootCmd.AddCommand(contract.ContractCmd)
 
 	rootCmd.PersistentFlags().StringVarP(&output.Format, "output-format", "o", "",
 		config.TranslateInLang(flagOutputFormatUsages, config.UILanguage))
@@ -93,6 +95,7 @@ func NewXctl() *cobra.Command {
 	rootCmd.AddCommand(action.Xrc20Cmd)
 	rootCmd.AddCommand(bc.BCCmd)
 	rootCmd.AddCommand(version.VersionCmd)
+	rootCmd.AddCommand(contract.ContractCmd)
 	// TODO: add xctl's UpdateCmd
 
 	rootCmd.PersistentFlags().StringVarP(&output.Format, "output-format", "o", "",

--- a/ioctl/flag/flag.go
+++ b/ioctl/flag/flag.go
@@ -67,6 +67,21 @@ func NewStringVarP(
 	}
 }
 
+// NewStringVar creates a new stringVar flag
+func NewStringVar(
+	label string,
+	defaultValue string,
+	description string,
+) Flag {
+	return &stringVarP{
+		flagBase: flagBase{
+			label:       label,
+			description: description,
+		},
+		defaultValue: defaultValue,
+	}
+}
+
 func (f *stringVarP) Value() interface{} {
 	return f.value
 }

--- a/ioctl/output/format.go
+++ b/ioctl/output/format.go
@@ -53,6 +53,8 @@ const (
 	ConfigError
 	// InstantiationError used when an error during instantiation
 	InstantiationError
+	// CompilerError used when an error occurs when using the solidity compiler
+	CompilerError
 )
 
 // MessageType marks the type of output message


### PR DESCRIPTION
This command needs local solc to complete. A contract prepare command is needed to install solc.