### PR TITLE
revert namespace naming changes to make them consistent with v0.11

### DIFF
--- a/action/protocol/poll/candidateindexer.go
+++ b/action/protocol/poll/candidateindexer.go
@@ -24,7 +24,7 @@ var (
 	// CandidateNamespace is a namespace to store raw candidate
 	CandidateNamespace = "candidates"
 	// ProbationNamespace is a namespace to store probationlist
-	ProbationNamespace = "probation"
+	ProbationNamespace = "kickout"
 	// ErrIndexerNotExist is an error that shows not exist in candidate indexer DB
 	ErrIndexerNotExist = errors.New("not exist in DB")
 )

--- a/action/protocol/vote/candidatesutil/candidatesutil.go
+++ b/action/protocol/vote/candidatesutil/candidatesutil.go
@@ -33,10 +33,10 @@ const CurCandidateKey = "CurrentCandidateList."
 const NxtCandidateKey = "NextCandidateList."
 
 // CurProbationKey is the key of current probation list
-const CurProbationKey = "CurrentProbationKey."
+const CurProbationKey = "CurrentKickoutKey."
 
 // NxtProbationKey is the key of next probation list
-const NxtProbationKey = "NextProbationKey."
+const NxtProbationKey = "NextKickoutKey."
 
 // UnproductiveDelegateKey is the key of unproductive Delegate struct
 const UnproductiveDelegateKey = "UnproductiveDelegateKey."


### PR DESCRIPTION
rename kickout to probation diff: https://github.com/iotexproject/iotex-core/pull/2071

include some changes not in v0.11(https://github.com/iotexproject/iotex-core/tree/v0.11.1) like name space change and key change. this diff revert those changes.