### PR TITLE
[db] improve indexer write speed using common batch

### DIFF
--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -265,7 +265,7 @@ func (p *Protocol) handle(ctx context.Context, act action.Action, csm CandidateS
 	}
 
 	if receiptErr, ok := err.(ReceiptError); ok {
-		log.L().Info("Non-critical error when processing staking action", zap.Error(err))
+		log.L().Debug("Non-critical error when processing staking action", zap.Error(err))
 		return p.settleAction(ctx, csm, receiptErr.ReceiptStatus(), rLog.Build(ctx, err))
 	}
 	return nil, err

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 
+	"github.com/iotexproject/iotex-core/db/batch"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/testutil"
 )
@@ -71,10 +72,18 @@ func TestCountingIndex(t *testing.T) {
 		index, err = GetCountingIndex(kv, bucket)
 		require.NoError(err)
 		// write another 100 entries
-		for i := 200; i < 300; i++ {
+		for i := 200; i < 250; i++ {
 			h := hash.Hash160b([]byte(strconv.Itoa(i)))
 			require.NoError(index.Add(h[:], false))
 		}
+		require.EqualValues(250, index.Size())
+		// use external batch
+		require.NoError(index.UseBatch(batch.NewBatch()))
+		for i := 250; i < 300; i++ {
+			h := hash.Hash160b([]byte(strconv.Itoa(i)))
+			require.NoError(index.Add(h[:], true))
+		}
+		require.NoError(index.Commit())
 		require.EqualValues(300, index.Size())
 
 		_, err = index.Range(248, 0)

--- a/db/kvstore_impl.go
+++ b/db/kvstore_impl.go
@@ -144,3 +144,13 @@ func (m *memKVStore) GetBucketByPrefix(namespace []byte) ([][]byte, error) {
 func (m *memKVStore) GetKeyByPrefix(namespace, prefix []byte) ([][]byte, error) {
 	return nil, nil
 }
+
+// CommitWithFillPercent commits the batch using fill percent, if underlying KVStore is capable
+func CommitWithFillPercent(kvstore KVStore, b batch.KVStoreBatch, percent float64) error {
+	if kvFillPercent, ok := kvstore.(KVStoreWithBucketFillPercent); ok {
+		// set an aggressive fill percent
+		// b/c counting index only appends, further inserts to the bucket would never split the page
+		return kvFillPercent.WriteBatchWithFillPercent(b, percent)
+	}
+	return kvstore.WriteBatch(b)
+}

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -518,7 +518,7 @@ func (sf *factory) PutBlock(ctx context.Context, blk *block.Block) error {
 		// regenerate workingset
 		_, err = ws.Process(ctx, blk.RunnableActions().Actions())
 		if err != nil {
-			log.L().Panic("Failed to update state.", zap.Error(err))
+			log.L().Error("Failed to update state.", zap.Error(err))
 			return err
 		}
 	}

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -356,7 +356,7 @@ func (sdb *stateDB) PutBlock(ctx context.Context, blk *block.Block) error {
 	if !isExist {
 		_, err = ws.Process(ctx, blk.RunnableActions().Actions())
 		if err != nil {
-			log.L().Panic("Failed to update state.", zap.Error(err))
+			log.L().Error("Failed to update state.", zap.Error(err))
 			return err
 		}
 	}


### PR DESCRIPTION
when indexing a block (assume 1 transfer), it usually need to update 5 account/states: total block, total action, sender, receiver, grantreward

each account/state is represented by a counting index, so it ends up 5 calls of db.WriteBatch()

these writes can be combined into a single batch, hence only calling db.WriteBatch() 1 time

indexer.PutBlock() time reduced 50~70% according to test, here's the running time to index 3 blocks in test:

before:
==== 210.572331ms
==== 151.561612ms
==== 134.105388ms

after
==== 124.215178ms
==== 64.461701ms
==== 45.41873ms
