### PR TITLE
change readstate API to display bucket withdrawn status on ioctl 

### DIFF
--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -52,8 +52,9 @@ const (
 
 // Errors
 var (
-	ErrTypeAssertion = errors.New("failed type assertion")
-	TotalBucketKey   = append([]byte{_const}, []byte("totalBucket")...)
+	ErrTypeAssertion   = errors.New("failed type assertion")
+	ErrWithdrawnBucket = errors.New("the bucket is already withdrawn")
+	TotalBucketKey     = append([]byte{_const}, []byte("totalBucket")...)
 )
 
 type (
@@ -344,7 +345,7 @@ func (p *Protocol) ReadState(ctx context.Context, sr protocol.StateReader, metho
 	case iotexapi.ReadStakingDataMethod_BUCKETS_BY_CANDIDATE:
 		resp, err = readStateBucketsByCandidate(ctx, sr, center, r.GetBucketsByCandidate())
 	case iotexapi.ReadStakingDataMethod_BUCKETS_BY_INDEXES:
-		resp, err = readStateBucketByIndex(ctx, sr, r.GetBucketsByIndexes())
+		resp, err = readStateBucketByIndices(ctx, sr, r.GetBucketsByIndexes())
 	case iotexapi.ReadStakingDataMethod_CANDIDATES:
 		resp, err = readStateCandidates(ctx, center, r.GetCandidates())
 	case iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME:

--- a/action/protocol/staking/read_state.go
+++ b/action/protocol/staking/read_state.go
@@ -79,7 +79,7 @@ func readStateBucketsByCandidate(ctx context.Context, sr protocol.StateReader, c
 	return toIoTeXTypesVoteBucketList(buckets)
 }
 
-func readStateBucketByIndex(ctx context.Context, sr protocol.StateReader,
+func readStateBucketByIndices(ctx context.Context, sr protocol.StateReader,
 	req *iotexapi.ReadStakingDataRequest_VoteBucketsByIndexes) (*iotextypes.VoteBucketList, error) {
 	buckets, err := getBucketsWithIndices(sr, BucketIndices(req.GetIndex()))
 	if err != nil {

--- a/ioctl/cmd/bc/bcbucket.go
+++ b/ioctl/cmd/bc/bcbucket.go
@@ -130,6 +130,9 @@ func getBucket(arg string) error {
 	if err != nil {
 		return err
 	}
+	if bucketpb == nil {
+		return errors.New("The bucket has been withdrawn")
+	}
 	bucket, err := newBucket(bucketpb)
 	if err != nil {
 		return err


### PR DESCRIPTION
works on #2201 
Change ReadState API side to return not error but nil result if it's withdrawn, and handle on ioctl the client side to show withdrawn bucket status. 