### PR TITLE
add ioctl did command to generate did document 2228

### DIFF
--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -108,6 +108,7 @@ func decodeBytecode() ([]byte, error) {
 	return hex.DecodeString(util.TrimHexPrefix(bytecodeFlag.Value().(string)))
 }
 
+// Signer returns signer's address
 func Signer() (address string, err error) {
 	return util.GetAddress(signerFlag.Value().(string))
 }

--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -108,7 +108,7 @@ func decodeBytecode() ([]byte, error) {
 	return hex.DecodeString(util.TrimHexPrefix(bytecodeFlag.Value().(string)))
 }
 
-func signer() (address string, err error) {
+func Signer() (address string, err error) {
 	return util.GetAddress(signerFlag.Value().(string))
 }
 
@@ -311,7 +311,7 @@ func Execute(contract string, amount *big.Int, bytecode []byte) error {
 	if err != nil {
 		return output.NewError(0, "failed to get gas price", err)
 	}
-	signer, err := signer()
+	signer, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signer address", err)
 	}
@@ -343,7 +343,7 @@ func Execute(contract string, amount *big.Int, bytecode []byte) error {
 
 // Read reads smart contract on IoTeX blockchain
 func Read(contract address.Address, amount *big.Int, bytecode []byte) (string, error) {
-	caller, err := signer()
+	caller, err := Signer()
 	if err != nil {
 		caller = address.ZeroAddress
 	}

--- a/ioctl/cmd/action/actionclaim.go
+++ b/ioctl/cmd/action/actionclaim.go
@@ -52,7 +52,7 @@ func claim(args []string) error {
 	if len(args) == 2 {
 		payload = []byte(args[1])
 	}
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signer address", err)
 	}

--- a/ioctl/cmd/action/actiondeposit.go
+++ b/ioctl/cmd/action/actiondeposit.go
@@ -53,7 +53,7 @@ func deposit(args []string) error {
 	if len(args) == 2 {
 		payload = []byte(args[1])
 	}
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signer address", err)
 	}

--- a/ioctl/cmd/action/actiontransfer.go
+++ b/ioctl/cmd/action/actiontransfer.go
@@ -62,7 +62,7 @@ func transfer(args []string) error {
 			return output.NewError(output.ConvertError, "failed to decode data", err)
 		}
 	}
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2Transfer.go
+++ b/ioctl/cmd/action/stake2Transfer.go
@@ -69,7 +69,7 @@ func stake2Transfer(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2Withdraw.go
+++ b/ioctl/cmd/action/stake2Withdraw.go
@@ -61,7 +61,7 @@ func stake2Withdraw(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2add.go
+++ b/ioctl/cmd/action/stake2add.go
@@ -69,7 +69,7 @@ func stake2Add(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2change.go
+++ b/ioctl/cmd/action/stake2change.go
@@ -67,7 +67,7 @@ func stake2Change(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2create.go
+++ b/ioctl/cmd/action/stake2create.go
@@ -77,7 +77,7 @@ func stake2Create(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2reclaim.go
+++ b/ioctl/cmd/action/stake2reclaim.go
@@ -57,7 +57,7 @@ func stake2Reclaim(args []string) error {
 		return output.NewError(output.ConvertError, "failed to convert bucket index", nil)
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2register.go
+++ b/ioctl/cmd/action/stake2register.go
@@ -86,7 +86,7 @@ func register(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2release.go
+++ b/ioctl/cmd/action/stake2release.go
@@ -64,7 +64,7 @@ func stake2Release(args []string) error {
 	if err != nil {
 		return output.NewError(0, "failed to get gas price", err)
 	}
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signer address", err)
 	}

--- a/ioctl/cmd/action/stake2renew.go
+++ b/ioctl/cmd/action/stake2renew.go
@@ -69,7 +69,7 @@ func stake2Renew(args []string) error {
 		}
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/stake2update.go
+++ b/ioctl/cmd/action/stake2update.go
@@ -60,7 +60,7 @@ func stake2Update(args []string) error {
 		return output.NewError(output.AddressError, "failed to get reward address", err)
 	}
 
-	sender, err := signer()
+	sender, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signed address", err)
 	}

--- a/ioctl/cmd/action/xrc20allowance.go
+++ b/ioctl/cmd/action/xrc20allowance.go
@@ -42,7 +42,7 @@ var xrc20AllowanceCmd = &cobra.Command{
 }
 
 func allowance(arg string) error {
-	caller, err := signer()
+	caller, err := Signer()
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get signer address", err)
 	}

--- a/ioctl/cmd/did/did.go
+++ b/ioctl/cmd/did/did.go
@@ -31,5 +31,5 @@ var DIDCmd = &cobra.Command{
 }
 
 func init() {
-	DIDCmd.AddCommand(generateCmd)
+	DIDCmd.AddCommand(didGenerateCmd)
 }

--- a/ioctl/cmd/did/did.go
+++ b/ioctl/cmd/did/did.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+)
+
+// Multi-language support
+var (
+	DIDCmdShorts = map[config.Language]string{
+		config.English: "Generate DID document",
+		config.Chinese: "产生DID document",
+	}
+	DIDCmdUses = map[config.Language]string{
+		config.English: "did",
+		config.Chinese: "did",
+	}
+)
+
+// DIDCmd represents the DID command
+var DIDCmd = &cobra.Command{
+	Use:   config.TranslateInLang(DIDCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(DIDCmdShorts, config.UILanguage),
+}
+
+func init() {
+	DIDCmd.AddCommand(generateCmd)
+}

--- a/ioctl/cmd/did/diddoc.go
+++ b/ioctl/cmd/did/diddoc.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+const (
+	DIDPrefix   = "did:io:"
+	DIDAuthType = "Secp256k1VerificationKey2018"
+	DIDOwner    = "#owner"
+)
+
+type (
+	authenticationStruct struct {
+		Id           string `json:"id,omitempty"`
+		Type         string `json:"type,omitempty"`
+		Controller   string `json:"controller,omitempty"`
+		PublicKeyHex string `json:"publicKeyHex,omitempty"`
+	}
+	DIDDoc struct {
+		Context        string                 `json:"@context,omitempty"`
+		Id             string                 `json:"id,omitempty"`
+		Authentication []authenticationStruct `json:"authentication,omitempty"`
+	}
+)
+
+func newDIDDoc() *DIDDoc {
+	return &DIDDoc{
+		Context: "https://www.w3.org/ns/did/v1",
+	}
+}

--- a/ioctl/cmd/did/diddoc.go
+++ b/ioctl/cmd/did/diddoc.go
@@ -7,9 +7,12 @@
 package did
 
 const (
-	DIDPrefix   = "did:io:"
+	// DIDPrefix is the prefix string
+	DIDPrefix = "did:io:"
+	// DIDAuthType is the authentication type
 	DIDAuthType = "Secp256k1VerificationKey2018"
-	DIDOwner    = "#owner"
+	// DIDOwner is the suffix string
+	DIDOwner = "#owner"
 )
 
 type (
@@ -19,6 +22,7 @@ type (
 		Controller   string `json:"controller,omitempty"`
 		PublicKeyHex string `json:"publicKeyHex,omitempty"`
 	}
+	// DIDDoc is the DID document struct
 	DIDDoc struct {
 		Context        string                 `json:"@context,omitempty"`
 		Id             string                 `json:"id,omitempty"`

--- a/ioctl/cmd/did/diddoc.go
+++ b/ioctl/cmd/did/diddoc.go
@@ -10,7 +10,7 @@ const (
 	// DIDPrefix is the prefix string
 	DIDPrefix = "did:io:"
 	// DIDAuthType is the authentication type
-	DIDAuthType = "Secp256k1VerificationKey2018"
+	DIDAuthType = "EcdsaSecp256k1VerificationKey2019"
 	// DIDOwner is the suffix string
 	DIDOwner = "#owner"
 )

--- a/ioctl/cmd/did/diddoc.go
+++ b/ioctl/cmd/did/diddoc.go
@@ -17,21 +17,21 @@ const (
 
 type (
 	authenticationStruct struct {
-		Id           string `json:"id,omitempty"`
+		ID           string `json:"id,omitempty"`
 		Type         string `json:"type,omitempty"`
 		Controller   string `json:"controller,omitempty"`
 		PublicKeyHex string `json:"publicKeyHex,omitempty"`
 	}
-	// DIDDoc is the DID document struct
-	DIDDoc struct {
+	// Doc is the DID document struct
+	Doc struct {
 		Context        string                 `json:"@context,omitempty"`
-		Id             string                 `json:"id,omitempty"`
+		ID             string                 `json:"id,omitempty"`
 		Authentication []authenticationStruct `json:"authentication,omitempty"`
 	}
 )
 
-func newDIDDoc() *DIDDoc {
-	return &DIDDoc{
+func newDIDDoc() *Doc {
+	return &Doc{
 		Context: "https://www.w3.org/ns/did/v1",
 	}
 }

--- a/ioctl/cmd/did/didgenerate.go
+++ b/ioctl/cmd/did/didgenerate.go
@@ -81,7 +81,7 @@ func generateFromSigner(signer, password string) (generatedMessage string, err e
 	if err != nil {
 		return "", output.NewError(output.AddressError, "", err)
 	}
-	doc.Id = DIDPrefix + ethAddress.String()
+	doc.ID = DIDPrefix + ethAddress.String()
 	uncompressed := pri.PublicKey().HexString()
 	x := uncompressed[2:66]
 	last := uncompressed[129:]
@@ -96,9 +96,9 @@ func generateFromSigner(signer, password string) (generatedMessage string, err e
 		compressed = "03" + x
 	}
 	authentication := authenticationStruct{
-		Id:           doc.Id + DIDOwner,
+		ID:           doc.ID + DIDOwner,
 		Type:         DIDAuthType,
-		Controller:   doc.Id,
+		Controller:   doc.ID,
 		PublicKeyHex: compressed,
 	}
 	doc.Authentication = append(doc.Authentication, authentication)

--- a/ioctl/cmd/did/didgenerate.go
+++ b/ioctl/cmd/did/didgenerate.go
@@ -97,6 +97,8 @@ func generateFromSigner(signer, password string) (generatedMessage string, err e
 		} else {
 			authentication.PublicKeyHex = "03" + authentication.PublicKeyHex
 		}
+	} else {
+		return "", output.NewError(output.CryptoError, "invalid public key", nil)
 	}
 
 	doc.Authentication = append(doc.Authentication, authentication)

--- a/ioctl/cmd/did/didgenerate.go
+++ b/ioctl/cmd/did/didgenerate.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl/cmd/account"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+var signer string
+
+// Multi-language support
+var (
+	generateCmdShorts = map[config.Language]string{
+		config.English: "Generate DID document using private key from wallet",
+		config.Chinese: "用钱包中的私钥产生DID document",
+	}
+	generateCmdUses = map[config.Language]string{
+		config.English: "generate [-s SIGNER]",
+		config.Chinese: "generate [-s 签署人]",
+	}
+	flagSignerUsages = map[config.Language]string{
+		config.English: "choose a signing account",
+		config.Chinese: "选择一个签名账户",
+	}
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   config.TranslateInLang(generateCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(generateCmdShorts, config.UILanguage),
+	Args:  cobra.ExactArgs(0),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		err := generate()
+		return output.PrintError(err)
+	},
+}
+
+func init() {
+	generateCmd.Flags().StringVarP(&signer, "signer", "s", "", config.TranslateInLang(flagSignerUsages, config.UILanguage))
+}
+
+func generate() error {
+	addr, err := util.GetAddress(signer)
+	if err != nil {
+		return output.NewError(output.InputError, "failed to get signer addr", err)
+	}
+	fmt.Printf("Enter password #%s:\n", addr)
+	password, err := util.ReadSecretFromStdin()
+	if err != nil {
+		return output.NewError(output.InputError, "failed to get password", err)
+	}
+	generatedMessage, err := generateFromSigner(addr, password)
+	if err != nil {
+		return output.NewError(output.KeystoreError, "failed to sign message", err)
+	}
+	output.PrintResult(generatedMessage)
+	return nil
+}
+
+func generateFromSigner(signer, password string) (generatedMessage string, err error) {
+	pri, err := account.LocalAccountToPrivateKey(signer, password)
+	if err != nil {
+		return
+	}
+	doc := newDIDDoc()
+	ethAddress, err := util.IoAddrToEvmAddr(signer)
+	if err != nil {
+		return "", output.NewError(output.AddressError, "", err)
+	}
+	doc.Id = DIDPrefix + ethAddress.String()
+	uncompressed := pri.PublicKey().HexString()
+	x := uncompressed[2:66]
+	last := uncompressed[129:]
+	lastNum, err := strconv.ParseInt(last, 16, 64)
+	if err != nil {
+		return "", output.NewError(output.ConvertError, "", err)
+	}
+	var compressed string
+	if lastNum%2 == 0 {
+		compressed = "02" + x
+	} else {
+		compressed = "03" + x
+	}
+	authentication := authenticationStruct{
+		Id:           doc.Id + DIDOwner,
+		Type:         DIDAuthType,
+		Controller:   doc.Id,
+		PublicKeyHex: compressed,
+	}
+	doc.Authentication = append(doc.Authentication, authentication)
+	msg, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return "", output.NewError(output.ConvertError, "", err)
+	}
+	generatedMessage = string(msg)
+	return
+}

--- a/ioctl/cmd/root.go
+++ b/ioctl/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/cmd/alias"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/bc"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/contract"
+	"github.com/iotexproject/iotex-core/ioctl/cmd/did"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/node"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/update"
 	"github.com/iotexproject/iotex-core/ioctl/cmd/version"
@@ -72,7 +73,7 @@ func NewIoctl() *cobra.Command {
 	rootCmd.AddCommand(version.VersionCmd)
 	rootCmd.AddCommand(update.UpdateCmd)
 	rootCmd.AddCommand(contract.ContractCmd)
-
+	rootCmd.AddCommand(did.DIDCmd)
 	rootCmd.PersistentFlags().StringVarP(&output.Format, "output-format", "o", "",
 		config.TranslateInLang(flagOutputFormatUsages, config.UILanguage))
 


### PR DESCRIPTION
work on #2228 

using:
`ioctl did generate -s yy`
`Enter password #io1ladc7y0scpcs768xvusqn6r7thavafe8wyxypa:`
```
{
  "@context": "https://www.w3.org/ns/did/v1",
  "id": "did:io:0xff5b8f11f0c0710F68e6672009e87e5DFacea727",
  "authentication": [
    {
      "id": "did:io:0xff5b8f11f0c0710F68e6672009e87e5DFacea727#owner",
      "type": "EcdsaSecp256k1VerificationKey2019",
      "controller": "did:io:0xff5b8f11f0c0710F68e6672009e87e5DFacea727",
      "publicKeyHex": "033f8dc3224ed5d2212e0b89093044294c55a286a29417e20393a82a682517d6f1"
    }
  ]
}
```