### PR TITLE
introduce cache/hash node in mptrie

### DIFF
--- a/db/trie/mptrie/branchnode.go
+++ b/db/trie/mptrie/branchnode.go
@@ -17,99 +17,116 @@ import (
 const radix = 256
 
 type branchNode struct {
-	mpt    *merklePatriciaTrie
-	hashes map[byte][]byte
-	isRoot bool
-	ser    []byte
+	cacheNode
+	children map[byte]node
+	isRoot   bool
 }
 
 func newBranchNode(
 	mpt *merklePatriciaTrie,
 	children map[byte]node,
-) (*branchNode, error) {
-	bnode := &branchNode{mpt: mpt, hashes: map[byte][]byte{}}
-	for i, n := range children {
-		if n == nil {
-			continue
-		}
-		bnode.hashes[i] = mpt.nodeHash(n)
+) (node, error) {
+	if children == nil || len(children) == 0 {
+		return nil, errors.New("branch node children cannot be empty")
 	}
-	if len(bnode.hashes) != 0 {
-		if err := mpt.putNode(bnode); err != nil {
-			return nil, err
-		}
+	bnode := &branchNode{
+		cacheNode: cacheNode{
+			mpt: mpt,
+		},
+		children: children,
+	}
+	bnode.cacheNode.serializable = bnode
+
+	if len(bnode.children) != 0 {
+		return bnode.store()
 	}
 	return bnode, nil
 }
 
-func newBranchNodeFromProtoPb(mpt *merklePatriciaTrie, pb *triepb.BranchPb) *branchNode {
-	b, err := newBranchNode(mpt, nil)
-	if err != nil {
-		panic(err)
+func newEmptyRootBranchNode(mpt *merklePatriciaTrie) *branchNode {
+	bnode := &branchNode{
+		cacheNode: cacheNode{
+			mpt: mpt,
+		},
+		children: make(map[byte]node),
+		isRoot:   true,
 	}
-	for _, n := range pb.Branches {
-		b.hashes[byte(n.Index)] = n.Path
-	}
-	return b
+	bnode.cacheNode.serializable = bnode
+
+	return bnode
 }
 
-func (b *branchNode) markAsRoot() {
+func newBranchNodeFromProtoPb(mpt *merklePatriciaTrie, pb *triepb.BranchPb) *branchNode {
+	bnode := &branchNode{
+		cacheNode: cacheNode{
+			mpt: mpt,
+		},
+		children: make(map[byte]node),
+	}
+	for _, n := range pb.Branches {
+		bnode.children[byte(n.Index)] = newHashNode(mpt, n.Path)
+	}
+	bnode.cacheNode.serializable = bnode
+	return bnode
+}
+
+func (b *branchNode) MarkAsRoot() {
 	b.isRoot = true
 }
 
-func (b *branchNode) children() ([]node, error) {
+func (b *branchNode) Children() []node {
 	trieMtc.WithLabelValues("branchNode", "children").Inc()
 	children := []node{}
-	for i := range b.hashes {
-		if c, err := b.child(i); err != nil {
-			return nil, err
-		} else if c != nil {
-			children = append(children, c)
-		}
+	for _, child := range b.children {
+		children = append(children, child)
 	}
 
-	return children, nil
+	return children
 }
 
-func (b *branchNode) delete(key keyType, offset uint8) (node, error) {
+func (b *branchNode) Delete(key keyType, offset uint8) (node, error) {
 	trieMtc.WithLabelValues("branchNode", "delete").Inc()
 	offsetKey := key[offset]
 	child, err := b.child(offsetKey)
 	if err != nil {
 		return nil, err
 	}
-	newChild, err := child.delete(key, offset+1)
+	newChild, err := child.Delete(key, offset+1)
 	if err != nil {
 		return nil, err
 	}
 	if newChild != nil || b.isRoot {
-		return b.updateChild(offsetKey, newChild)
+		return b.updateChild(offsetKey, newChild, false)
 	}
-	switch len(b.hashes) {
+	switch len(b.children) {
 	case 1:
 		panic("branch shouldn't have 0 child after deleting")
 	case 2:
-		if err := b.mpt.deleteNode(b); err != nil {
+		if err := b.delete(); err != nil {
 			return nil, err
 		}
 		var orphan node
 		var orphanKey byte
-		for i, h := range b.hashes {
+		for i, n := range b.children {
 			if i != offsetKey {
 				orphanKey = i
-				if orphan, err = b.mpt.loadNode(h); err != nil {
-					return nil, err
-				}
+				orphan = n
 				break
 			}
 		}
 		if orphan == nil {
 			panic("unexpected branch status")
 		}
+		if hn, ok := orphan.(*hashNode); ok {
+			if orphan, err = hn.LoadNode(); err != nil {
+				return nil, err
+			}
+		}
 		switch node := orphan.(type) {
 		case *extensionNode:
 			return node.updatePath(
 				append([]byte{orphanKey}, node.path...),
+				false,
 			)
 		case *leafNode:
 			return node, nil
@@ -117,18 +134,18 @@ func (b *branchNode) delete(key keyType, offset uint8) (node, error) {
 			return newExtensionNode(b.mpt, []byte{orphanKey}, node)
 		}
 	default:
-		return b.updateChild(offsetKey, newChild)
+		return b.updateChild(offsetKey, newChild, false)
 	}
 }
 
-func (b *branchNode) upsert(key keyType, offset uint8, value []byte) (node, error) {
+func (b *branchNode) Upsert(key keyType, offset uint8, value []byte) (node, error) {
 	trieMtc.WithLabelValues("branchNode", "upsert").Inc()
 	var newChild node
 	offsetKey := key[offset]
 	child, err := b.child(offsetKey)
 	switch errors.Cause(err) {
 	case nil:
-		newChild, err = child.upsert(key, offset+1, value)
+		newChild, err = child.Upsert(key, offset+1, value) // look for next key offset
 	case trie.ErrNotExist:
 		newChild, err = newLeafNode(b.mpt, key, value)
 	}
@@ -136,69 +153,68 @@ func (b *branchNode) upsert(key keyType, offset uint8, value []byte) (node, erro
 		return nil, err
 	}
 
-	return b.updateChild(offsetKey, newChild)
+	return b.updateChild(offsetKey, newChild, true)
 }
 
-func (b *branchNode) search(key keyType, offset uint8) node {
+func (b *branchNode) Search(key keyType, offset uint8) (node, error) {
 	trieMtc.WithLabelValues("branchNode", "search").Inc()
 	child, err := b.child(key[offset])
-	if errors.Cause(err) == trie.ErrNotExist {
-		return nil
+	if err != nil {
+		return nil, err
 	}
-	return child.search(key, offset+1)
+	return child.Search(key, offset+1)
 }
 
-func (b *branchNode) serialize() []byte {
+func (b *branchNode) proto() (proto.Message, error) {
 	trieMtc.WithLabelValues("branchNode", "serialize").Inc()
-	if b.ser != nil {
-		return b.ser
-	}
 	nodes := []*triepb.BranchNodePb{}
 	for index := 0; index < radix; index++ {
-		if h, ok := b.hashes[byte(index)]; ok {
+		if c, ok := b.children[byte(index)]; ok {
+			h, err := c.Hash()
+			if err != nil {
+				return nil, err
+			}
 			nodes = append(nodes, &triepb.BranchNodePb{Index: uint32(index), Path: h})
 		}
 	}
-	pb := &triepb.NodePb{
+	return &triepb.NodePb{
 		Node: &triepb.NodePb_Branch{
 			Branch: &triepb.BranchPb{Branches: nodes},
 		},
-	}
-	ser, err := proto.Marshal(pb)
-	if err != nil {
-		panic("failed to marshal a branch node")
-	}
-	b.ser = ser
-
-	return b.ser
+	}, nil
 }
 
 func (b *branchNode) child(key byte) (node, error) {
-	h, ok := b.hashes[key]
+	c, ok := b.children[key]
 	if !ok {
 		return nil, trie.ErrNotExist
 	}
-	child, err := b.mpt.loadNode(h)
-	if err != nil {
-		return nil, errors.Errorf("failed to fetch node for key %x", h)
-	}
-	return child, nil
+
+	return c, nil
 }
 
-func (b *branchNode) updateChild(key byte, child node) (*branchNode, error) {
-	if err := b.mpt.deleteNode(b); err != nil {
+func (b *branchNode) updateChild(key byte, child node, hashnode bool) (node, error) {
+	if err := b.delete(); err != nil {
 		return nil, err
 	}
-	b.ser = nil
+	// update branchnode with new child
 	if child == nil {
-		delete(b.hashes, key)
+		delete(b.children, key)
 	} else {
-		b.hashes[key] = b.mpt.nodeHash(child)
+		b.children[key] = child
 	}
-	if !b.isRoot || len(b.hashes) != 0 {
-		if err := b.mpt.putNode(b); err != nil {
+	if len(b.children) != 0 {
+		hn, err := b.store()
+		if err != nil {
+			return nil, err
+		}
+		if !b.isRoot && hashnode {
+			return hn, nil // return hashnode
+		}
+	} else {
+		if err := b.calculateCache(); err != nil {
 			return nil, err
 		}
 	}
-	return b, nil
+	return b, nil // return branchnode
 }

--- a/db/trie/mptrie/cachenode.go
+++ b/db/trie/mptrie/cachenode.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2020 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package mptrie
+
+import (
+	"github.com/golang/protobuf/proto"
+)
+
+type cacheNode struct {
+	serializable
+	mpt     *merklePatriciaTrie
+	hashVal []byte
+	ser     []byte
+}
+
+func (cn *cacheNode) Hash() ([]byte, error) {
+	return cn.hash()
+}
+
+func (cn *cacheNode) hash() ([]byte, error) {
+	if cn.hashVal != nil {
+		return cn.hashVal, nil
+	}
+	if err := cn.calculateCache(); err != nil {
+		return nil, err
+	}
+	return cn.hashVal, nil
+}
+
+func (cn *cacheNode) delete() error {
+	h, err := cn.hash()
+	if err != nil {
+		return err
+	}
+	if err := cn.mpt.deleteNode(h); err != nil {
+		return err
+	}
+	cn.hashVal = nil
+	cn.ser = nil
+
+	return nil
+}
+
+func (cn *cacheNode) store() (node, error) {
+	ser, err := cn.serialize()
+	if err != nil {
+		return nil, err
+	}
+	h, err := cn.hash()
+	if err != nil {
+		return nil, err
+	}
+	if err := cn.mpt.putNode(h, ser); err != nil {
+		return nil, err
+	}
+	return newHashNode(cn.mpt, h), nil
+}
+
+func (cn *cacheNode) calculateCache() error {
+	pb, err := cn.proto()
+	if err != nil {
+		return err
+	}
+	ser, err := proto.Marshal(pb)
+	if err != nil {
+		return err
+	}
+	cn.ser = ser
+	cn.hashVal = cn.mpt.hashFunc(ser)
+	return nil
+}
+
+func (cn *cacheNode) serialize() ([]byte, error) {
+	if cn.ser != nil {
+		return cn.ser, nil
+	}
+	if err := cn.calculateCache(); err != nil {
+		return nil, err
+	}
+
+	return cn.ser, nil
+}

--- a/db/trie/mptrie/hashnode.go
+++ b/db/trie/mptrie/hashnode.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package mptrie
+
+type hashNode struct {
+	node
+	mpt     *merklePatriciaTrie
+	hashVal []byte
+}
+
+func newHashNode(mpt *merklePatriciaTrie, ha []byte) *hashNode {
+	return &hashNode{mpt: mpt, hashVal: ha}
+}
+
+func (h *hashNode) Delete(key keyType, offset uint8) (node, error) {
+	n, err := h.loadNode()
+	if err != nil {
+		return nil, err
+	}
+
+	if n, err = n.Delete(key, offset); err != nil {
+		return nil, err
+	}
+
+	return h.toHashNode(n)
+}
+
+func (h *hashNode) Upsert(key keyType, offset uint8, value []byte) (node, error) {
+	n, err := h.loadNode()
+	if err != nil {
+		return nil, err
+	}
+
+	if n, err = n.Upsert(key, offset, value); err != nil {
+		return nil, err
+	}
+
+	return h.toHashNode(n)
+}
+
+func (h *hashNode) Search(key keyType, offset uint8) (node, error) {
+	node, err := h.loadNode()
+	if err != nil {
+		return nil, err
+	}
+
+	return node.Search(key, offset)
+}
+
+func (h *hashNode) LoadNode() (node, error) {
+	return h.loadNode()
+}
+
+func (h *hashNode) loadNode() (node, error) {
+	return h.mpt.loadNode(h.hashVal)
+}
+
+func (h *hashNode) toHashNode(n node) (node, error) {
+	if ln, ok := n.(*leafNode); ok {
+		return ln.ToHashNode()
+	}
+	return n, nil
+}
+
+func (h *hashNode) Hash() ([]byte, error) {
+	return h.hashVal, nil
+}

--- a/db/trie/mptrie/merklepatriciatrie.go
+++ b/db/trie/mptrie/merklepatriciatrie.go
@@ -38,14 +38,14 @@ type (
 	HashFunc func([]byte) []byte
 
 	merklePatriciaTrie struct {
-		mutex       sync.RWMutex
-		keyLength   int
-		root        branch
-		rootHash    []byte
-		rootKey     string
-		kvStore     trie.KVStore
-		hashFunc    HashFunc
-		multithread bool
+		mutex         sync.RWMutex
+		keyLength     int
+		root          branch
+		rootHash      []byte
+		rootKey       string
+		kvStore       trie.KVStore
+		hashFunc      HashFunc
+		emptyRootHash []byte
 	}
 )
 
@@ -105,9 +105,6 @@ func New(options ...Option) (trie.Trie, error) {
 			return nil, err
 		}
 	}
-	if t.rootHash == nil {
-		t.rootHash = t.emptyRootHash()
-	}
 	if t.kvStore == nil {
 		t.kvStore = trie.NewMemKVStore()
 	}
@@ -118,6 +115,15 @@ func New(options ...Option) (trie.Trie, error) {
 func (mpt *merklePatriciaTrie) Start(ctx context.Context) error {
 	mpt.mutex.Lock()
 	defer mpt.mutex.Unlock()
+
+	emptyRootHash, err := newEmptyRootBranchNode(mpt).Hash()
+	if err != nil {
+		return err
+	}
+	mpt.emptyRootHash = emptyRootHash
+	if mpt.rootHash == nil {
+		mpt.rootHash = mpt.emptyRootHash
+	}
 
 	return mpt.setRootHash(mpt.rootHash)
 }
@@ -138,32 +144,42 @@ func (mpt *merklePatriciaTrie) SetRootHash(rootHash []byte) error {
 }
 
 func (mpt *merklePatriciaTrie) IsEmpty() bool {
+	mpt.mutex.RLock()
+	defer mpt.mutex.RUnlock()
+
 	return mpt.isEmptyRootHash(mpt.rootHash)
 }
 
 func (mpt *merklePatriciaTrie) Get(key []byte) ([]byte, error) {
+	mpt.mutex.RLock()
+	defer mpt.mutex.RUnlock()
+
 	trieMtc.WithLabelValues("root", "Get").Inc()
 	kt, err := mpt.checkKeyType(key)
 	if err != nil {
 		return nil, err
 	}
-	t := mpt.root.search(kt, 0)
-	if t == nil {
-		return nil, trie.ErrNotExist
+	t, err := mpt.root.Search(kt, 0)
+	if err != nil {
+		return nil, err
 	}
 	if l, ok := t.(leaf); ok {
 		return l.Value(), nil
 	}
+
 	return nil, trie.ErrInvalidTrie
 }
 
 func (mpt *merklePatriciaTrie) Delete(key []byte) error {
+	mpt.mutex.Lock()
+	defer mpt.mutex.Unlock()
+
 	trieMtc.WithLabelValues("root", "Delete").Inc()
 	kt, err := mpt.checkKeyType(key)
 	if err != nil {
 		return err
 	}
-	newRoot, err := mpt.root.delete(kt, 0)
+	newRoot, err := mpt.root.Delete(kt, 0)
 	if err != nil {
 		return errors.Wrapf(trie.ErrNotExist, "key %x does not exist", kt)
 	}
@@ -171,18 +187,20 @@ func (mpt *merklePatriciaTrie) Delete(key []byte) error {
 	if !ok {
 		panic("unexpected new root")
 	}
-	mpt.resetRoot(bn)
 
-	return nil
+	return mpt.resetRoot(bn)
 }
 
 func (mpt *merklePatriciaTrie) Upsert(key []byte, value []byte) error {
+	mpt.mutex.Lock()
+	defer mpt.mutex.Unlock()
+
 	trieMtc.WithLabelValues("root", "Upsert").Inc()
 	kt, err := mpt.checkKeyType(key)
 	if err != nil {
 		return err
 	}
-	newRoot, err := mpt.root.upsert(kt, 0, value)
+	newRoot, err := mpt.root.Upsert(kt, 0, value)
 	if err != nil {
 		return err
 	}
@@ -190,49 +208,43 @@ func (mpt *merklePatriciaTrie) Upsert(key []byte, value []byte) error {
 	if !ok {
 		panic("unexpected new root")
 	}
-	mpt.resetRoot(bn)
 
-	return nil
+	return mpt.resetRoot(bn)
 }
 
 func (mpt *merklePatriciaTrie) isEmptyRootHash(h []byte) bool {
-	return bytes.Equal(h, mpt.emptyRootHash())
-}
-
-func (mpt *merklePatriciaTrie) emptyRootHash() []byte {
-	bn, err := newBranchNode(mpt, nil)
-	if err != nil {
-		panic(err)
-	}
-	return mpt.nodeHash(bn)
+	return bytes.Equal(h, mpt.emptyRootHash)
 }
 
 func (mpt *merklePatriciaTrie) setRootHash(rootHash []byte) error {
-	root := mpt.emptyRoot()
-	emptyRootHash := mpt.nodeHash(root)
-	if len(rootHash) == 0 || bytes.Equal(rootHash, emptyRootHash) {
-		rootHash = emptyRootHash
-	} else {
-		node, err := mpt.loadNode(rootHash)
-		if err != nil {
-			return err
-		}
-		var ok bool
-		if root, ok = node.(branch); !ok {
-			return errors.Wrapf(trie.ErrInvalidTrie, "root should be a branch")
-		}
+	if len(rootHash) == 0 || mpt.isEmptyRootHash(rootHash) {
+		emptyRoot := newEmptyRootBranchNode(mpt)
+		mpt.resetRoot(emptyRoot)
+		return nil
 	}
-	mpt.resetRoot(root)
+	node, err := mpt.loadNode(rootHash)
+	if err != nil {
+		return err
+	}
+	root, ok := node.(branch)
+	if !ok {
+		return errors.Wrapf(trie.ErrInvalidTrie, "root should be a branch")
+	}
+	root.MarkAsRoot()
 
-	return nil
+	return mpt.resetRoot(root)
 }
 
-func (mpt *merklePatriciaTrie) resetRoot(newRoot branch) {
+func (mpt *merklePatriciaTrie) resetRoot(newRoot branch) error {
 	mpt.root = newRoot
-	mpt.root.markAsRoot()
-	h := mpt.nodeHash(newRoot)
+	h, err := newRoot.Hash()
+	if err != nil {
+		return err
+	}
 	mpt.rootHash = make([]byte, len(h))
 	copy(mpt.rootHash, h)
+
+	return nil
 }
 
 func (mpt *merklePatriciaTrie) checkKeyType(key []byte) (keyType, error) {
@@ -245,29 +257,12 @@ func (mpt *merklePatriciaTrie) checkKeyType(key []byte) (keyType, error) {
 	return kt, nil
 }
 
-func (mpt *merklePatriciaTrie) nodeHash(tn node) []byte {
-	if tn == nil {
-		panic("unexpected nil node to hash")
-	}
-	return mpt.hashFunc(tn.serialize())
+func (mpt *merklePatriciaTrie) deleteNode(key []byte) error {
+	return mpt.kvStore.Delete(key)
 }
 
-func (mpt *merklePatriciaTrie) emptyRoot() branch {
-	bn, err := newBranchNode(mpt, nil)
-	if err != nil {
-		panic(err)
-	}
-	return bn
-}
-
-func (mpt *merklePatriciaTrie) deleteNode(tn node) error {
-	return mpt.kvStore.Delete(mpt.nodeHash(tn))
-}
-
-func (mpt *merklePatriciaTrie) putNode(tn node) error {
-	h := mpt.nodeHash(tn)
-	s := tn.serialize()
-	return mpt.kvStore.Put(h, s)
+func (mpt *merklePatriciaTrie) putNode(key []byte, value []byte) error {
+	return mpt.kvStore.Put(key, value)
 }
 
 func (mpt *merklePatriciaTrie) loadNode(key []byte) (node, error) {
@@ -288,5 +283,6 @@ func (mpt *merklePatriciaTrie) loadNode(key []byte) (node, error) {
 	if pbExtend := pb.GetExtend(); pbExtend != nil {
 		return newExtensionNodeFromProtoPb(mpt, pbExtend), nil
 	}
+
 	return nil, errors.New("invalid node type")
 }

--- a/db/trie/mptrie/twolayertrie.go
+++ b/db/trie/mptrie/twolayertrie.go
@@ -52,7 +52,13 @@ func (tlt *twoLayerTrie) layerTwoTrie(key []byte, layerTwoTrieKeyLen int) (trie.
 	if err != nil {
 		return nil, err
 	}
-	return lt, lt.Start(context.Background())
+	if err := lt.Start(context.Background()); err != nil {
+		return nil, err
+	}
+
+	tlt.layerTwo[hk] = lt
+
+	return lt, nil
 }
 
 func (tlt *twoLayerTrie) Start(ctx context.Context) error {


### PR DESCRIPTION
This is the last 3rd PR for splitting PR #2107 

1. introduce cache/hash node in mptrie. From what I understood the zhi's PR, the cachenode is holding common things(serialzed stream and hash of the node). Also, while trie operation, having hash node as a field enables reducing unncessary loading by only holding meta data (hash) and load the node if necessary. We can think of hashnode is a wrapper to make the nodes light. 
2. fix a 2layertrie bug 


It doesn't include "cancel out" improvement in this PR 