### PR TITLE
add generate did doc hash

### DIFF
--- a/ioctl/cmd/did/didgenerate.go
+++ b/ioctl/cmd/did/didgenerate.go
@@ -105,6 +105,6 @@ func generateFromSigner(signer, password string) (generatedMessage string, err e
 	}
 
 	sum := sha256.Sum256(msg)
-	generatedMessage = string(msg) + "\n\nThe sha256 hash is:" + hex.EncodeToString(sum[:])
+	generatedMessage = string(msg) + "\n\nThe hex encoded SHA256 hash of the DID doc is:" + hex.EncodeToString(sum[:])
 	return
 }

--- a/ioctl/cmd/did/didgenerate.go
+++ b/ioctl/cmd/did/didgenerate.go
@@ -7,6 +7,7 @@
 package did
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -102,6 +103,8 @@ func generateFromSigner(signer, password string) (generatedMessage string, err e
 	if err != nil {
 		return "", output.NewError(output.ConvertError, "", err)
 	}
-	generatedMessage = string(msg)
+
+	sum := sha256.Sum256(msg)
+	generatedMessage = string(msg) + "\n\nThe sha256 hash is:" + hex.EncodeToString(sum[:])
 	return
 }


### PR DESCRIPTION
```
ioctl did generate -s testaccount
Enter password #io1vdtfpzkwpyngzvx7u2mauepnzja7kd5rryp0sg:
{
  "@context": "https://www.w3.org/ns/did/v1",
  "id": "did:io:0x6356908ACe09268130DEE2b7de643314BBeb3683",
  "authentication": [
    {
      "id": "did:io:0x6356908ACe09268130DEE2b7de643314BBeb3683#owner",
      "type": "EcdsaSecp256k1VerificationKey2019",
      "controller": "did:io:0x6356908ACe09268130DEE2b7de643314BBeb3683",
      "publicKeyHex": "03ea8046cf8dc5bc9cda5f2e83e5d2d61932ad7e0e402b4f4cb65b58e9618891f5"
    }
  ]
}

The hex encoded SHA256 hash of the DID doc is:e123ae6f24d38786a071539970d7bc0d299d43d5316204fa16ba81b766278024
```