### PR TITLE
Add multistage build to decrease image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5-stretch
+FROM golang:1.13.5-stretch as build
 
 WORKDIR apps/iotex-core
 
@@ -12,12 +12,13 @@ RUN go mod download
 COPY . .
 
 RUN mkdir -p $GOPATH/pkg/linux_amd64/github.com/iotexproject/ && \
-    make clean build-all && \
-    cp ./bin/server /usr/local/bin/iotex-server  && \
-    cp ./bin/actioninjectorv2 /usr/local/bin/iotex-actioninjectorv2 && \
-    cp ./bin/addrgen /usr/local/bin/iotex-addrgen && \
-    cp ./bin/ioctl /usr/local/bin/ioctl && \
-    mkdir -p /etc/iotex/ && \
-    rm -rf apps/iotex-core/
+    make clean build-all
+
+FROM debian:stretch
+RUN mkdir -p /etc/iotex/
+COPY --from=build /go/apps/iotex-core/bin/server /usr/local/bin/iotex-server
+COPY --from=build /go/apps/iotex-core/bin/actioninjectorv2 /usr/local/bin/iotex-actioninjectorv2
+COPY --from=build /go/apps/iotex-core/bin/addrgen /usr/local/bin/iotex-addrgen
+COPY --from=build /go/apps/iotex-core/bin/ioctl /usr/local/bin/ioctl
 
 CMD [ "iotex-server"]


### PR DESCRIPTION
SSIA. Here is size difference of unpacked images, ~10 times smaller
```shell
docker images
REPOSITORY                                 TAG                 IMAGE ID            CREATED              SIZE
iot                                        0                   b8d834a3b050        2 minutes ago       189MB
iotex/iotex-core                           v1.0.0              74efb029ceb6        6 weeks ago         1.82GB
```
