### PR TITLE
fix IsEmpty bug in merkle patricia trie

### DIFF
--- a/db/trie/mptrie/merklepatriciatrie.go
+++ b/db/trie/mptrie/merklepatriciatrie.go
@@ -165,6 +165,9 @@ func (mpt *merklePatriciaTrie) SetRootHash(rootHash []byte) error {
 func (mpt *merklePatriciaTrie) IsEmpty() bool {
 	mpt.mutex.RLock()
 	defer mpt.mutex.RUnlock()
+	if mpt.async {
+		return mpt.root == nil || len(mpt.root.Children()) == 0
+	}
 
 	return mpt.isEmptyRootHash(mpt.rootHash)
 }

--- a/db/trie/mptrie/merklepatriciatrie_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_test.go
@@ -534,9 +534,18 @@ func TestCollision(t *testing.T) {
 }
 
 func Test4kEntries(t *testing.T) {
+	t.Run("test async mode", func(t *testing.T) {
+		test4kEntries(t, true)
+	})
+	t.Run("test sync mode", func(t *testing.T) {
+		test4kEntries(t, false)
+	})
+}
+
+func test4kEntries(t *testing.T, enableAsync bool) {
 	require := require.New(t)
 
-	tr, err := New(KeyLengthOption(4))
+	tr, err := New(KeyLengthOption(4), AsyncOption())
 	require.NoError(err)
 	require.NoError(tr.Start(context.Background()))
 	root, err := tr.RootHash()


### PR DESCRIPTION
in async mode, check root node instead of root hash.