### PR TITLE
improve hot contract and add benchmark test

### DIFF
--- a/action/protocol/execution/evm/contract.go
+++ b/action/protocol/execution/evm/contract.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/db/trie"
 	"github.com/iotexproject/iotex-core/db/trie/mptrie"
+	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -37,7 +38,6 @@ type (
 		SetCode(hash.Hash256, []byte)
 		SelfState() *state.Account
 		Commit() error
-		RootHash() hash.Hash256
 		LoadRoot() error
 		Iterator() (trie.Iterator, error)
 		Snapshot() Contract
@@ -85,18 +85,7 @@ func (c *contract) SetState(key hash.Hash256, value []byte) error {
 		c.GetState(key)
 	}
 	c.dirtyState = true
-	err := c.trie.Upsert(key[:], value)
-	if err != nil {
-		return err
-	}
-	rh, err := c.trie.RootHash()
-	if err != nil {
-		return err
-	}
-	// TODO (zhi): confirm whether we should update the root on err
-	c.Account.Root = hash.BytesToHash256(rh)
-
-	return nil
+	return c.trie.Upsert(key[:], value)
 }
 
 // GetCode gets the contract's byte-code
@@ -147,11 +136,6 @@ func (c *contract) Commit() error {
 	return nil
 }
 
-// RootHash returns storage trie's root hash
-func (c *contract) RootHash() hash.Hash256 {
-	return c.Account.Root
-}
-
 // LoadRoot loads storage trie's root
 func (c *contract) LoadRoot() error {
 	return c.trie.SetRootHash(c.Account.Root[:])
@@ -159,6 +143,11 @@ func (c *contract) LoadRoot() error {
 
 // Snapshot takes a snapshot of the contract object
 func (c *contract) Snapshot() Contract {
+	rh, err := c.trie.RootHash()
+	if err != nil {
+		log.L().Fatal("failed to calculate root hash")
+	}
+	c.Account.Root = hash.BytesToHash256(rh)
 	return &contract{
 		Account:    c.Account.Clone(),
 		dirtyCode:  c.dirtyCode,

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -270,7 +270,6 @@ func TestSnapshot(t *testing.T) {
 		require.NoError(c1.SetState(k1b, v1[:]))
 		require.Equal(big.NewInt(12), c1.SelfState().Balance)
 		require.Equal(big.NewInt(5), c2.SelfState().Balance)
-		require.NotEqual(c1.RootHash(), c2.RootHash())
 	}
 	t.Run("sync mode", func(t *testing.T) {
 		testfunc(false)

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"math/big"
 	"os"
@@ -212,7 +213,7 @@ func NewSmartContractTest(t *testing.T, file string) {
 	sct.run(require)
 }
 
-func runExecution(
+func readExecution(
 	bc blockchain.Blockchain,
 	sf factory.Factory,
 	dao blockdao.BlockDAO,
@@ -236,48 +237,92 @@ func runExecution(
 	if err != nil {
 		return nil, nil, err
 	}
-	if ecfg.ReadOnly { // read
-		addr, err := address.FromBytes(ecfg.PrivateKey().PublicKey().Hash())
-		if err != nil {
-			return nil, nil, err
-		}
-		ctx, err := bc.Context()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		return sf.SimulateExecution(ctx, addr, exec, dao.GetBlockHash)
-	}
-	builder := &action.EnvelopeBuilder{}
-	elp := builder.SetAction(exec).
-		SetNonce(exec.Nonce()).
-		SetGasLimit(ecfg.GasLimit()).
-		SetGasPrice(ecfg.GasPrice()).
-		Build()
-	selp, err := action.Sign(elp, ecfg.PrivateKey())
+	addr, err := address.FromBytes(ecfg.PrivateKey().PublicKey().Hash())
 	if err != nil {
 		return nil, nil, err
 	}
-	if err := ap.Add(context.Background(), selp); err != nil {
+	ctx, err := bc.Context()
+	if err != nil {
 		return nil, nil, err
+	}
+
+	return sf.SimulateExecution(ctx, addr, exec, dao.GetBlockHash)
+}
+
+func runExecutions(
+	bc blockchain.Blockchain,
+	sf factory.Factory,
+	dao blockdao.BlockDAO,
+	ap actpool.ActPool,
+	ecfgs []*ExecutionConfig,
+	contractAddrs []string,
+) ([]*action.Receipt, error) {
+	nonces := map[string]uint64{}
+	hashes := []hash.Hash256{}
+	for i, ecfg := range ecfgs {
+		log.S().Info(ecfg.Comment)
+		var nonce uint64
+		var ok bool
+		executor := ecfg.Executor().String()
+		if nonce, ok = nonces[executor]; !ok {
+			state, err := accountutil.AccountState(sf, executor)
+			if err != nil {
+				return nil, err
+			}
+			nonce = state.Nonce
+		}
+		nonce = nonce + 1
+		nonces[executor] = nonce
+		exec, err := action.NewExecution(
+			contractAddrs[i],
+			nonce,
+			ecfg.Amount(),
+			ecfg.GasLimit(),
+			ecfg.GasPrice(),
+			ecfg.ByteCode(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		builder := &action.EnvelopeBuilder{}
+		elp := builder.SetAction(exec).
+			SetNonce(exec.Nonce()).
+			SetGasLimit(ecfg.GasLimit()).
+			SetGasPrice(ecfg.GasPrice()).
+			Build()
+		selp, err := action.Sign(elp, ecfg.PrivateKey())
+		if err != nil {
+			return nil, err
+		}
+		if err := ap.Add(context.Background(), selp); err != nil {
+			return nil, err
+		}
+		hashes = append(hashes, exec.Hash())
 	}
 	blk, err := bc.MintNewBlock(testutil.TimestampNow())
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if err := bc.CommitBlock(blk); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	receipt, err := dao.GetReceiptByActionHash(exec.Hash(), blk.Height())
+	receipts := []*action.Receipt{}
+	for _, hash := range hashes {
+		receipt, err := dao.GetReceiptByActionHash(hash, blk.Height())
+		if err != nil {
+			return nil, err
+		}
+		receipts = append(receipts, receipt)
+	}
 
-	return nil, receipt, err
+	return receipts, nil
 }
 
 func (sct *SmartContractTest) prepareBlockchain(
 	ctx context.Context,
+	cfg config.Config,
 	r *require.Assertions,
 ) (blockchain.Blockchain, factory.Factory, blockdao.BlockDAO, actpool.ActPool) {
-	cfg := config.Default
 	defer func() {
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -338,8 +383,10 @@ func (sct *SmartContractTest) deployContracts(
 		if contract.AppendContractAddress {
 			contract.ContractAddressToAppend = contractAddresses[contract.ContractIndexToAppend]
 		}
-		_, receipt, err := runExecution(bc, sf, dao, ap, &contract, action.EmptyAddress)
+		receipts, err := runExecutions(bc, sf, dao, ap, []*ExecutionConfig{&contract}, []string{action.EmptyAddress})
 		r.NoError(err)
+		r.Equal(1, len(receipts))
+		receipt := receipts[0]
 		r.NotNil(receipt)
 		if sct.InitGenesis.IsBering {
 			// if it is post bering, it compares the status with expected status
@@ -376,7 +423,7 @@ func (sct *SmartContractTest) deployContracts(
 func (sct *SmartContractTest) run(r *require.Assertions) {
 	// prepare blockchain
 	ctx := context.Background()
-	bc, sf, dao, ap := sct.prepareBlockchain(ctx, r)
+	bc, sf, dao, ap := sct.prepareBlockchain(ctx, config.Default, r)
 	defer func() {
 		r.NoError(bc.Stop(ctx))
 	}()
@@ -393,9 +440,25 @@ func (sct *SmartContractTest) run(r *require.Assertions) {
 		if exec.AppendContractAddress {
 			exec.ContractAddressToAppend = contractAddresses[exec.ContractIndexToAppend]
 		}
-		retval, receipt, err := runExecution(bc, sf, dao, ap, &exec, contractAddr)
-		r.NoError(err)
-		r.NotNil(receipt)
+		var retval []byte
+		var receipt *action.Receipt
+		var err error
+		if exec.ReadOnly {
+			retval, receipt, err = readExecution(bc, sf, dao, ap, &exec, contractAddr)
+			r.NoError(err)
+			expected := exec.ExpectedReturnValue()
+			if len(expected) == 0 {
+				r.Equal(0, len(retval))
+			} else {
+				r.Equal(expected, retval)
+			}
+		} else {
+			receipts, err := runExecutions(bc, sf, dao, ap, []*ExecutionConfig{&exec}, []string{contractAddr})
+			r.NoError(err)
+			r.Equal(1, len(receipts))
+			receipt = receipts[0]
+			r.NotNil(receipt)
+		}
 
 		if sct.InitGenesis.IsBering {
 			// if it is post bering, it compares the status with expected status
@@ -409,14 +472,6 @@ func (sct *SmartContractTest) run(r *require.Assertions) {
 		}
 		if exec.ExpectedGasConsumed() != 0 {
 			r.Equal(exec.ExpectedGasConsumed(), receipt.GasConsumed, i)
-		}
-		if exec.ReadOnly {
-			expected := exec.ExpectedReturnValue()
-			if len(expected) == 0 {
-				r.Equal(0, len(retval))
-			} else {
-				r.Equal(expected, retval)
-			}
 		}
 		for _, expectedBalance := range exec.ExpectedBalances {
 			account := expectedBalance.Account
@@ -781,5 +836,91 @@ func TestMaxTime(t *testing.T) {
 
 	t.Run("max-time-2", func(t *testing.T) {
 		NewSmartContractTest(t, "testdata/maxtime2.json")
+	})
+}
+
+func benchmarkHotContract(b *testing.B, async bool) {
+	sct := SmartContractTest{
+		InitBalances: []ExpectedBalance{
+			{
+				Account:    "io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms",
+				RawBalance: "1000000000000000000000000000",
+			},
+		},
+		Deployments: []ExecutionConfig{
+			{
+				ContractIndex: 0,
+				RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+				RawByteCode:   "608060405234801561001057600080fd5b506040516040806108018339810180604052810190808051906020019092919080519060200190929190505050816004819055508060058190555050506107a58061005c6000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680631249c58b1461007d57806327e235e31461009457806353277879146100eb5780636941b84414610142578063810ad50514610199578063a9059cbb14610223575b600080fd5b34801561008957600080fd5b50610092610270565b005b3480156100a057600080fd5b506100d5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610475565b6040518082815260200191505060405180910390f35b3480156100f757600080fd5b5061012c600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061048d565b6040518082815260200191505060405180910390f35b34801561014e57600080fd5b50610183600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104a5565b6040518082815260200191505060405180910390f35b3480156101a557600080fd5b506101da600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104bd565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34801561022f57600080fd5b5061026e600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190505050610501565b005b436004546000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054011115151561032a576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260108152602001807f746f6f20736f6f6e20746f206d696e740000000000000000000000000000000081525060200191505060405180910390fd5b436000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550600554600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600081548092919060010191905055503373ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167fec61728879a33aa50b55e1f4789dcfc1c680f30a24d7b8694a9f874e242a97b46005546040518082815260200191505060405180910390a3565b60016020528060005260406000206000915090505481565b60026020528060005260406000206000915090505481565b60006020528060005260406000206000915090505481565b60036020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156105b8576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260148152602001807f696e73756666696369656e742062616c616e636500000000000000000000000081525060200191505060405180910390fd5b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555080600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555060408051908101604052803373ffffffffffffffffffffffffffffffffffffffff16815260200182815250600360008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008201518160000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550602082015181600101559050508173ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fec61728879a33aa50b55e1f4789dcfc1c680f30a24d7b8694a9f874e242a97b4836040518082815260200191505060405180910390a350505600a165627a7a7230582047e5e1380e66d6b109548617ae59ff7baf70ee2d4a6734559b8fc5cabca0870b0029000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000186a0",
+				RawAmount:     "0",
+				RawGasLimit:   50000000,
+				RawGasPrice:   "0",
+			},
+		},
+	}
+	r := require.New(b)
+	ctx := context.Background()
+	cfg := config.Default
+	cfg.Genesis.NumSubEpochs = uint64(b.N)
+	if async {
+		cfg.Genesis.GreenlandBlockHeight = 0
+	} else {
+		cfg.Genesis.GreenlandBlockHeight = 10000000000
+	}
+	bc, sf, dao, ap := sct.prepareBlockchain(ctx, cfg, r)
+	defer func() {
+		r.NoError(bc.Stop(ctx))
+	}()
+	contractAddresses := sct.deployContracts(bc, sf, dao, ap, r)
+	r.Equal(1, len(contractAddresses))
+	contractAddr := contractAddresses[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		receipts, err := runExecutions(
+			bc, sf, dao, ap, []*ExecutionConfig{
+				{
+					RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+					RawByteCode:   "1249c58b",
+					RawAmount:     "0",
+					RawGasLimit:   5000000,
+					RawGasPrice:   "0",
+					Failed:        false,
+					Comment:       "mint token",
+				},
+			},
+			[]string{contractAddr},
+		)
+		r.NoError(err)
+		r.Equal(1, len(receipts))
+		r.Equal(uint64(1), receipts[0].Status)
+		ecfgs := []*ExecutionConfig{}
+		contractAddrs := []string{}
+		for j := 0; j < 100; j++ {
+			ecfgs = append(ecfgs, &ExecutionConfig{
+				RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+				RawByteCode:   fmt.Sprintf("a9059cbb000000000000000000000000123456789012345678900987%016x0000000000000000000000000000000000000000000000000000000000000039", 100*i+j),
+				RawAmount:     "0",
+				RawGasLimit:   5000000,
+				RawGasPrice:   "0",
+				Failed:        false,
+				Comment:       "send token",
+			})
+			contractAddrs = append(contractAddrs, contractAddr)
+		}
+		receipts, err = runExecutions(bc, sf, dao, ap, ecfgs, contractAddrs)
+		r.NoError(err)
+		for _, receipt := range receipts {
+			r.Equal(uint64(1), receipt.Status)
+		}
+	}
+	b.StopTimer()
+}
+
+func BenchmarkHotContract(b *testing.B) {
+	b.Run("async mode", func(b *testing.B) {
+		benchmarkHotContract(b, true)
+	})
+	b.Run("sync mode", func(b *testing.B) {
+		benchmarkHotContract(b, false)
 	})
 }


### PR DESCRIPTION
1. Move root hash calculation into snapshot and commit, @koseoyoung is testing the change on Mainnet, it has been height 5.1M/5.8M
2. Add benchmark test
async      10         462033771 ns/op
sync      10         580280197 ns/op
async      20         507928689 ns/op
sync      20         641516703 ns/op
async      40         593998320 ns/op
sync      40         767366155 ns/op
async      80         708751901 ns/op
sync      80         884618497 ns/op
test result shows that the improvement is more significant as contract gets more complicated