### PR TITLE
fix using wrong epoch data

### DIFF
--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -173,11 +173,6 @@ func delegates() error {
 }
 
 func delegatesV2(pb *vote.ProbationList, epochMeta *iotexapi.GetEpochMetaResponse, message *delegatesMessage) error {
-	chainMeta, err := bc.GetChainMeta()
-	if err != nil {
-		return output.NewError(0, "failed to get chain meta", err)
-	}
-	epochNum = chainMeta.Epoch.Num
 	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
 	if err != nil {
 		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
@@ -195,7 +190,7 @@ func delegatesV2(pb *vote.ProbationList, epochMeta *iotexapi.GetEpochMetaRespons
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("poll"),
 		MethodName: []byte("ActiveBlockProducersByEpoch"),
-		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochNum, 10))},
+		Arguments:  [][]byte{[]byte(strconv.FormatUint(epochMeta.EpochData.Num, 10))},
 		Height:     strconv.FormatUint(epochMeta.EpochData.Height, 10),
 	}
 	abpResponse, err := cli.ReadState(ctx, request)


### PR DESCRIPTION
work on #2260 
The new command is like this:
```

ioctl node delegate -e 10518

Epoch: 10518,  Start block height: 5756041,Total blocks produced in epoch: 720

Address                                     Name           Rank   Alias   Status   Blocks   ProbatedStatus    Votes
io108h7sa5sap44e244hz649zyk5y4rqzsvnpzxh5   royalland         1           active   30                       133593082.452736305852276477
io1puxw08ze2jnv5x4943ly273tkyth56p9k6ssv9   huobiwallet       2                    0                        108755999.652091904181493681
io1kr85xacgvhg9l4hj4atr243sw540g6cssajqrz   droute            3           active   30                       99647818.571951801495599143
io10reczcaelglh5xmkay65h9vw3e5dp82e8vw0rz   metanyx           4           active   30                       95594084.222405831870426017
io1ddjluttkzljqfgdtcz9eu3r3s832umy7ylx0ts   longz             5           active   30                       87540079.968446930844643657
io1hgxksz37qtqq9n5n6lkkc9qhaajdklhvkh5969   coredev           6           active   30                       83229193.546847710821931108
io1456knehzn9qup8unxlf4q06empz8lqxtp6v5vh   pubxpayments      7           active   30                       79951004.688775243414456542
io14u5d66rt465ykm7t2847qllj0reml27q30kr75   iosg              8           active   30                       76937465.659582599709133835
io13672hgsdr7d8nu5jndyageygel3r5nwyzqwlhl   hofancrypto       9                    0                        74903898.996324110895694484
io1kugyfdkdss7acy0y9x8fmfjd5qyxfcye3gxt99   consensusnet     10           active   30                       73331707.663491271727788546
io1mcyk4aqmwgn7zjx0n9ggdtpm9x6y9pkdze3u39   airfoil          11           active   30                       73221183.735159647168054597
io18tnk59jqdjgpdzz4hq4dl0dwwjkv7gg20fygqn   hashbuy          12           active   30                       70114093.805410802873245521
io1u4pev9u5as7ujpk29wpsrc95m8kuhec3pmuk72   hashquark        13           active   30                       67081468.63750536011429164
io1tfke5nfwryte6nultpmqefadgm0dsahm2gm63k   iotexlab         14                    0                        65167605.000638141258440881
io195mh6ftwz5vnagw984fj4hj8awty3ue2gh457f   ducapital        15           active   30                       64308502.41299150053246187
io12fa96hxh9ata23gwp5pfxztzaawvwl2sk5xmdg   hotbit           16           active   30                       62960967.434006595375425177
io1qnec80ark9shjc6uzk45dhm8s50dpc27sjuver   gamefantasy      17           active   30                       61873376.586025896584730372
io1zy9q4myp3jezxdsv82z3f865ruamhqm7a6mggh   capitmu          18                    0                        59285710.137615180097288739
io1e5vwdmpkf2hpu2266hx9syu0ursqgqwv0kzrxm   enlightiv        19           active   30                       57948116.772364034059432693
io1tf7tu2xt6mpk8s70ahugsx20jqgu9eg6v48qlk   pnp              20                    0                        56949205.032660962557139338
io1y5yafr6y48ck234hudvnslszutma9vhdy4l2au   satoshi          21           active   30                       52218941.430710054211953825
io13q2am9nedrd3n746lsj6qan4pymcpgm94vvx2c   iotexcore        22                    0                        50280950.636094110089265017
io1l42qgv8328h8x7pde35w3szh59elhw8nwmcy6j   cryptozoo        23           active   30                       50247694.489406257824187562
io17cmrextyfeu4gddwd89g5qncedsnc553dhz7xa   infstones        24           active   30                       47399663.468897338812177268
io1cw8x7ruxeqqcklmlxc5yxqfu2txd2hgv8rt6j7   draperdragon     25                    0                        46386211.233752621202613858
io1lcpdct3sr7lg53x23aylungmmdrn5jq0vlnclu   elitex           26                    0                        42641015.427246514096732479
io1ha87fd54jmgmes5eswsyd52gwm0qjxnnsqlyl0   mrtrump          27           active   30                       41711270.673373436655474659
io1kzejlwftmsckwmnragvcfej67l73l7gy8y6q4k   coingecko        28           active   30                       41347909.781745028856165971
io1et7zkzc76m9twa4gn5xht3urt9mwj05qvdtj66   iotxplorerio     29                    0                        41123030.249680856494892225
io1n3llm0zzlles6pvpzugzajyzyjehztztxf2rff   ratels           30                    0                        40652725.468064348569455336
io1fra0fx6akacny9asewt7vyvggqq4rtq3eznccr   iotexteam        31           active   30                       39829882.567055125400384879
io1qqaswtu7rcevahucpfxc0zxx088pylwtxnkrrl   cpc              32                    0                        39623449.327748944609596485
io1scyl386axa5meexmd4h7ruxpkdf5ds2m2x0tpf   cobo             33           active   30                       37291292.019791584810495689
io13xdhg9du56khumz3sg6a3ma5q5kjx7vdlx48x8   blockboost       34           active   30                       36790324.966568859952733207
io1lqm3jwspjdapzj7lv4uu5rvquag4p6r86cu0pc   bcf              35                    0                        36432506.927077092410655712
io1ztqalgh0zl9309a48k7wjwyump6agq24cf4zdq   blockfolio       36           active   30                       36103248.442966071312438261
```