### PR TITLE
make to compare epochnumber arguments in case of not using indexer in readstate

### DIFF
--- a/action/protocol/poll/slasher.go
+++ b/action/protocol/poll/slasher.go
@@ -144,8 +144,11 @@ func (sh *Slasher) ReadState(
 		if err != nil {
 			return nil, uint64(0), err
 		}
-		if epochNum != epochNumArg {
-			return nil, uint64(0), errors.New("Slasher ReadState arg epochNumber should be same as state reader height, need to set argument/height consistently")
+		if indexer == nil {
+			// consistency check between sr.height and epochNumArg in case of using state reader(not indexer)
+			if epochNum != epochNumArg {
+				return nil, uint64(0), errors.New("Slasher ReadState arg epochNumber should be same as state reader height, need to set argument/height consistently")
+			}
 		}
 		epochStartHeight = rp.GetEpochHeight(epochNum)
 	}


### PR DESCRIPTION
Currently, we are checking sr.height and epoch number argument to be same in readstate().
Since we don't need to check in case of using indexer(b/c not using sr), make to skip this comparison if we are using indexer. 