### PR TITLE
wrap get staking and rewarding protocol balance in GetAccount api 2276

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -162,6 +162,10 @@ func NewServer(
 
 // GetAccount returns the metadata of an account
 func (api *Server) GetAccount(ctx context.Context, in *iotexapi.GetAccountRequest) (*iotexapi.GetAccountResponse, error) {
+	if in.Address == address.RewardingPoolAddr || in.Address == address.StakingBucketPoolAddr {
+		return api.getProtocolAccount(ctx, in.Address)
+	}
+
 	state, tipHeight, err := accountutil.AccountStateWithHeight(api.sf, in.Address)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -1546,4 +1550,65 @@ func (api *Server) getProductivityByEpoch(
 		}
 	}
 	return num, produce, nil
+}
+
+func (api *Server) getProtocolAccount(ctx context.Context, addr string) (ret *iotexapi.GetAccountResponse, err error) {
+	var req *iotexapi.ReadStateRequest
+	var balance string
+	var out *iotexapi.ReadStateResponse
+	switch addr {
+	case address.RewardingPoolAddr:
+		req = &iotexapi.ReadStateRequest{
+			ProtocolID: []byte("rewarding"),
+			MethodName: []byte("TotalBalance"),
+		}
+		out, err = api.ReadState(ctx, req)
+		if err != nil {
+			return
+		}
+		val, ok := big.NewInt(0).SetString(string(out.GetData()), 10)
+		if !ok {
+			err = errors.New("balance convert error")
+			return
+		}
+		balance = val.String()
+	case address.StakingBucketPoolAddr:
+		methodName, err := proto.Marshal(&iotexapi.ReadStakingDataMethod{
+			Method: iotexapi.ReadStakingDataMethod_TOTAL_STAKING_AMOUNT,
+		})
+		if err != nil {
+			return nil, err
+		}
+		arg, err := proto.Marshal(&iotexapi.ReadStakingDataRequest{
+			Request: &iotexapi.ReadStakingDataRequest_TotalStakingAmount_{
+				TotalStakingAmount: &iotexapi.ReadStakingDataRequest_TotalStakingAmount{},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		req = &iotexapi.ReadStateRequest{
+			ProtocolID: []byte("staking"),
+			MethodName: methodName,
+			Arguments:  [][]byte{arg},
+		}
+		out, err = api.ReadState(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		acc := iotextypes.AccountMeta{}
+		if err := proto.Unmarshal(out.GetData(), &acc); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal account meta")
+		}
+		balance = acc.GetBalance()
+	}
+
+	ret = &iotexapi.GetAccountResponse{
+		AccountMeta: &iotextypes.AccountMeta{
+			Address: addr,
+			Balance: balance,
+		},
+		BlockIdentifier: out.GetBlockIdentifier(),
+	}
+	return
 }


### PR DESCRIPTION
work on #2276 

request:
```
grpcurl -v -plaintext -d '{"address": "io000000000000000000000000stakingprotocol"}' 127.0.0.1:14014 iotexapi.APIService.GetAccount

grpcurl -v -plaintext -d '{"address": "io0000000000000000000000rewardingprotocol"}' 127.0.0.1:14014 iotexapi.APIService.GetAccount
```
response:
```
{
  "accountMeta": {
    "address": "io0000000000000000000000rewardingprotocol",
    "balance": "0",
  },
  "blockIdentifier": {
    "hash": "6ba52c53ed61a04148147efe3b4a1270867342e160710fed7eedebcf3438e19d",
    "height": 3
  }
}

{
  "accountMeta": {
    "address": "io000000000000000000000000stakingprotocol",
    "balance": "0",
  },
  "blockIdentifier": {
    "hash": "6ba52c53ed61a04148147efe3b4a1270867342e160710fed7eedebcf3438e19d",
    "height": 3
  }
}
```