### PR TITLE
disable flag parsing in deprecated cmd

### DIFF
--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -28,9 +28,9 @@ var (
 
 // actionDeployCmd represents the action deploy command
 var actionDeployCmd = &cobra.Command{
-	Use:   config.TranslateInLang(deployCmdUses, config.UILanguage),
-	Short: config.TranslateInLang(deployCmdShorts, config.UILanguage),
-	Args:  cobra.MaximumNArgs(1),
+	Use:                config.TranslateInLang(deployCmdUses, config.UILanguage),
+	Short:              config.TranslateInLang(deployCmdShorts, config.UILanguage),
+	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		var err error

--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -30,6 +30,7 @@ var (
 var actionDeployCmd = &cobra.Command{
 	Use:                config.TranslateInLang(deployCmdUses, config.UILanguage),
 	Short:              config.TranslateInLang(deployCmdShorts, config.UILanguage),
+	Hidden:             true,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/ioctl/cmd/action/actiondeploy.go
+++ b/ioctl/cmd/action/actiondeploy.go
@@ -27,6 +27,8 @@ var (
 )
 
 // actionDeployCmd represents the action deploy command
+// Deprecated: notify users to use the new ioctl contract command
+// TODO: this command will be deprecated soon
 var actionDeployCmd = &cobra.Command{
 	Use:                config.TranslateInLang(deployCmdUses, config.UILanguage),
 	Short:              config.TranslateInLang(deployCmdShorts, config.UILanguage),

--- a/ioctl/cmd/action/actioninvoke.go
+++ b/ioctl/cmd/action/actioninvoke.go
@@ -28,9 +28,9 @@ var (
 
 // actionInvokeCmd represents the action invoke command
 var actionInvokeCmd = &cobra.Command{
-	Use:   config.TranslateInLang(invokeCmdUses, config.UILanguage),
-	Short: config.TranslateInLang(invokeCmdShorts, config.UILanguage),
-	Args:  cobra.RangeArgs(1, 2),
+	Use:                config.TranslateInLang(invokeCmdUses, config.UILanguage),
+	Short:              config.TranslateInLang(invokeCmdShorts, config.UILanguage),
+	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
 		var err error

--- a/ioctl/cmd/action/actioninvoke.go
+++ b/ioctl/cmd/action/actioninvoke.go
@@ -30,6 +30,7 @@ var (
 var actionInvokeCmd = &cobra.Command{
 	Use:                config.TranslateInLang(invokeCmdUses, config.UILanguage),
 	Short:              config.TranslateInLang(invokeCmdShorts, config.UILanguage),
+	Hidden:             true,
 	DisableFlagParsing: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true

--- a/ioctl/cmd/action/actioninvoke.go
+++ b/ioctl/cmd/action/actioninvoke.go
@@ -27,6 +27,8 @@ var (
 )
 
 // actionInvokeCmd represents the action invoke command
+// Deprecated: notify users to use the new ioctl contract command
+// TODO: this command will be deprecated soon
 var actionInvokeCmd = &cobra.Command{
 	Use:                config.TranslateInLang(invokeCmdUses, config.UILanguage),
 	Short:              config.TranslateInLang(invokeCmdShorts, config.UILanguage),


### PR DESCRIPTION
disable flag parsing in deprecated cmd
Now `ioctl action deploy/invoke contract <flag> <arguments>` will not show useless information, they will return new cmd examples.