### PR TITLE
ioctl did should have global flags endpoint and insecure 2376

### DIFF
--- a/ioctl/cmd/did/did.go
+++ b/ioctl/cmd/did/did.go
@@ -22,6 +22,14 @@ var (
 		config.English: "did command",
 		config.Chinese: "did command",
 	}
+	flagEndpoint = map[config.Language]string{
+		config.English: "set endpoint for once",
+		config.Chinese: "一次设置端点",
+	}
+	flagInsecure = map[config.Language]string{
+		config.English: "insecure connection for once",
+		config.Chinese: "一次不安全连接",
+	}
 )
 
 // DIDCmd represents the DID command
@@ -37,4 +45,7 @@ func init() {
 	DIDCmd.AddCommand(didGetURICmd)
 	DIDCmd.AddCommand(didUpdateCmd)
 	DIDCmd.AddCommand(didDeregisterCmd)
+	DIDCmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
+		config.ReadConfig.Endpoint, config.TranslateInLang(flagEndpoint, config.UILanguage))
+	DIDCmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure, config.TranslateInLang(flagInsecure, config.UILanguage))
 }


### PR DESCRIPTION
work on #2376

ioctl did command add endpoint flag support,like this:

`ioctl did gethash io1m3wjevwhz2s58sasq0wj4luxrnqt047s687zw8 did:io:0x8601CAb8A22bA1DB04ce909E4Ec1deE5555Bf3B0 --endpoint api.testnet.iotex.one:80 --insecure`