### PR TITLE
[BlockDAO] add FileDAO interface to manage chain db file

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -350,7 +350,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 	indexer, err := blockindex.NewIndexer(db.NewMemKVStore(), cfg.Genesis.Hash())
 	r.NoError(err)
 	// create BlockDAO
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf, indexer}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer}, cfg.DB)
 	r.NotNil(dao)
 	bc := blockchain.NewBlockchain(
 		cfg,
@@ -553,7 +553,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 		// create BlockDAO
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		dao := blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), []blockdao.BlockIndexer{sf, indexer}, cfg.Chain.CompressBlock, cfg.DB)
+		dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer}, cfg.DB)
 		require.NotNil(dao)
 		bc := blockchain.NewBlockchain(
 			cfg,

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -2100,7 +2100,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 		return nil, nil, nil, nil, nil, nil, errors.New("failed to create indexer")
 	}
 	// create BlockDAO
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf, indexer}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer}, cfg.DB)
 	if dao == nil {
 		return nil, nil, nil, nil, nil, nil, errors.New("failed to create blockdao")
 	}

--- a/blockchain/block/block_test.go
+++ b/blockchain/block/block_test.go
@@ -114,12 +114,7 @@ func TestConvertFromBlockPb(t *testing.T) {
 	var newblk Block
 	err = newblk.Deserialize(raw)
 	require.NoError(t, err)
-
-	require.Equal(t, uint64(123456789), newblk.Header.height)
-	require.Equal(t, uint64(101), newblk.Actions[0].Nonce())
-	require.Equal(t, uint64(102), newblk.Actions[1].Nonce())
-	require.Equal(t, blk.Header.txRoot, blk.TxRoot())
-	require.Equal(t, blk.Header.receiptRoot, blk.ReceiptRoot())
+	require.Equal(t, blk, newblk)
 }
 
 func TestBlockCompressionSize(t *testing.T) {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -465,18 +465,14 @@ func (bc *blockchain) tipInfo() (*protocol.TipInfo, error) {
 			Timestamp: time.Unix(bc.config.Genesis.Timestamp, 0),
 		}, nil
 	}
-	tipHash, err := bc.dao.GetBlockHash(tipHeight)
-	if err != nil {
-		return nil, err
-	}
-	header, err := bc.dao.Header(tipHash)
+	header, err := bc.dao.HeaderByHeight(tipHeight)
 	if err != nil {
 		return nil, err
 	}
 
 	return &protocol.TipInfo{
 		Height:    tipHeight,
-		Hash:      tipHash,
+		Hash:      header.HashBlock(),
 		Timestamp: header.Timestamp(),
 	}, nil
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -26,7 +26,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/prometheustimer"
@@ -154,12 +153,7 @@ func BoltDBDaoOption(indexers ...blockdao.BlockIndexer) Option {
 			return nil
 		}
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath // TODO: remove this after moving TrieDBPath from cfg.Chain to cfg.DB
-		bc.dao = blockdao.NewBlockDAO(
-			db.NewBoltDB(cfg.DB),
-			indexers,
-			cfg.Chain.CompressBlock,
-			cfg.DB,
-		)
+		bc.dao = blockdao.NewBlockDAO(indexers, cfg.Chain.CompressBlock, cfg.DB)
 		return nil
 	}
 }
@@ -170,12 +164,7 @@ func InMemDaoOption(indexers ...blockdao.BlockIndexer) Option {
 		if bc.dao != nil {
 			return nil
 		}
-		bc.dao = blockdao.NewBlockDAO(
-			db.NewMemKVStore(),
-			indexers,
-			cfg.Chain.CompressBlock,
-			cfg.DB,
-		)
+		bc.dao = blockdao.NewBlockDAOInMemForTest(indexers, cfg.DB)
 		return nil
 	}
 }

--- a/blockchain/blockdao/blockdao.go
+++ b/blockchain/blockdao/blockdao.go
@@ -8,21 +8,14 @@ package blockdao
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"path"
-	"strconv"
-	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/go-pkgs/cache"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
@@ -32,32 +25,20 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
-	"github.com/iotexproject/iotex-core/db/batch"
-	"github.com/iotexproject/iotex-core/pkg/cache"
-	"github.com/iotexproject/iotex-core/pkg/compress"
-	"github.com/iotexproject/iotex-core/pkg/enc"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/prometheustimer"
-	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 const (
-	blockNS                  = "blk"
 	blockHashHeightMappingNS = "h2h"
-	blockHeaderNS            = "bhr"
-	blockBodyNS              = "bbd"
-	blockFooterNS            = "bfr"
-	receiptsNS               = "rpt"
 	systemLogNS              = "syl"
 )
 
 var (
-	topHeightKey       = []byte("th")
-	topHashKey         = []byte("ts")
-	hashPrefix         = []byte("ha.")
-	heightPrefix       = []byte("he.")
-	heightToFileBucket = []byte("h2f")
+	topHeightKey = []byte("th")
+	topHashKey   = []byte("ts")
+	hashPrefix   = []byte("ha.")
 )
 
 // vars
@@ -69,35 +50,24 @@ var (
 		},
 		[]string{"result"},
 	)
-	patternLen      = len("00000000.db")
-	suffixLen       = len(".db")
-	ErrAlreadyExist = errors.New("block already exist")
-	ErrNotSupported = errors.New("feature not supported")
+	patternLen        = len("00000000.db")
+	suffixLen         = len(".db")
+	ErrAlreadyExist   = errors.New("block already exist")
+	ErrDataCorruption = errors.New("data is corrupted")
 )
 
 type (
 	// BlockDAO represents the block data access object
 	BlockDAO interface {
-		Start(ctx context.Context) error
-		Stop(ctx context.Context) error
-		GetBlockHash(uint64) (hash.Hash256, error)
-		GetBlockHeight(hash.Hash256) (uint64, error)
-		GetBlock(hash.Hash256) (*block.Block, error)
-		GetBlockByHeight(uint64) (*block.Block, error)
-		Height() (uint64, error)
+		FileDAO
 		Header(hash.Hash256) (*block.Header, error)
 		Body(hash.Hash256) (*block.Body, error)
 		Footer(hash.Hash256) (*block.Footer, error)
 		GetActionByActionHash(hash.Hash256, uint64) (action.SealedEnvelope, error)
 		GetReceiptByActionHash(hash.Hash256, uint64) (*action.Receipt, error)
-		GetReceipts(uint64) ([]*action.Receipt, error)
-		PutBlock(context.Context, *block.Block) error
 		DeleteBlockToTarget(uint64) error
-		KVStore() db.KVStore
 		HeaderByHeight(uint64) (*block.Header, error)
 		FooterByHeight(uint64) (*block.Footer, error)
-		ContainsTransactionLog() bool
-		TransactionLogs(uint64) (*iotextypes.TransactionLogs, error)
 	}
 
 	// BlockIndexer defines an interface to accept block to build index
@@ -110,31 +80,30 @@ type (
 	}
 
 	blockDAO struct {
-		compressBlock bool
-		kvStore       db.KVStore
-		indexers      []BlockIndexer
-		htf           db.RangeIndex
-		kvStores      sync.Map //store like map[index]db.KVStore,index from 1...N
-		topIndex      atomic.Value
-		timerFactory  *prometheustimer.TimerFactory
-		lifecycle     lifecycle.Lifecycle
-		headerCache   *cache.ThreadSafeLruCache
-		bodyCache     *cache.ThreadSafeLruCache
-		footerCache   *cache.ThreadSafeLruCache
-		cfg           config.DB
-		mutex         sync.RWMutex // for create new db file
-		tipHeight     uint64
+		blockStore   FileDAO
+		indexers     []BlockIndexer
+		timerFactory *prometheustimer.TimerFactory
+		lifecycle    lifecycle.Lifecycle
+		headerCache  *cache.ThreadSafeLruCache
+		bodyCache    *cache.ThreadSafeLruCache
+		footerCache  *cache.ThreadSafeLruCache
+		tipHeight    uint64
 	}
 )
 
 // NewBlockDAO instantiates a block DAO
 func NewBlockDAO(kvStore db.KVStore, indexers []BlockIndexer, compressBlock bool, cfg config.DB) BlockDAO {
-	blockDAO := &blockDAO{
-		compressBlock: compressBlock,
-		kvStore:       kvStore,
-		cfg:           cfg,
-		indexers:      indexers,
+	blkStore, err := NewFileDAO(kvStore, compressBlock, cfg)
+	if err != nil {
+		return nil
 	}
+
+	blockDAO := &blockDAO{
+		blockStore: blkStore,
+		indexers:   indexers,
+	}
+
+	blockDAO.lifecycle.Add(blkStore)
 	for _, indexer := range indexers {
 		blockDAO.lifecycle.Add(indexer)
 	}
@@ -153,8 +122,6 @@ func NewBlockDAO(kvStore db.KVStore, indexers []BlockIndexer, compressBlock bool
 		return nil
 	}
 	blockDAO.timerFactory = timerFactory
-	blockDAO.lifecycle.Add(kvStore)
-
 	return blockDAO
 }
 
@@ -164,59 +131,13 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to start child services")
 	}
-	// set init height value and transaction log flag
-	if _, err = dao.kvStore.Get(blockNS, topHeightKey); err != nil &&
-		errors.Cause(err) == db.ErrNotExist {
-		zero8bytes := make([]byte, 8)
-		if err := dao.kvStore.Put(blockNS, topHeightKey, zero8bytes); err != nil {
-			return errors.Wrap(err, "failed to write initial value for top height")
-		}
-		if err := dao.kvStore.Put(systemLogNS, zero8bytes, []byte(systemLogNS)); err != nil {
-			return errors.Wrap(err, "failed to write initial value for transaction log")
-		}
-	}
-	tipHeight, err := dao.getTipHeight()
+
+	tipHeight, err := dao.blockStore.Height()
 	if err != nil {
 		return err
 	}
 	atomic.StoreUint64(&dao.tipHeight, tipHeight)
-	if err := dao.initStores(); err != nil {
-		return err
-	}
 	return dao.checkIndexers(ctx)
-}
-
-func (dao *blockDAO) initStores() error {
-	cfg := dao.cfg
-	model, dir := getFileNameAndDir(cfg.DbPath)
-	files, err := ioutil.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-	var maxN uint64
-	for _, file := range files {
-		name := file.Name()
-		lens := len(name)
-		if lens < patternLen || !strings.Contains(name, model) {
-			continue
-		}
-		num := name[lens-patternLen : lens-suffixLen]
-		n, err := strconv.Atoi(num)
-		if err != nil {
-			continue
-		}
-		if _, _, err := dao.openDB(uint64(n)); err != nil {
-			return err
-		}
-		if uint64(n) > maxN {
-			maxN = uint64(n)
-		}
-	}
-	if maxN == 0 {
-		maxN = 1
-	}
-	dao.topIndex.Store(maxN)
-	return nil
 }
 
 func (dao *blockDAO) fillWithBlockInfoAsTip(ctx context.Context, height uint64) (context.Context, error) {
@@ -231,17 +152,13 @@ func (dao *blockDAO) fillWithBlockInfoAsTip(ctx context.Context, height uint64) 
 			Timestamp: time.Unix(bcCtx.Genesis.Timestamp, 0),
 		}
 	} else {
-		tipHash, err := dao.GetBlockHash(height)
-		if err != nil {
-			return nil, err
-		}
-		header, err := dao.Header(tipHash)
+		header, err := dao.HeaderByHeight(height)
 		if err != nil {
 			return nil, err
 		}
 		bcCtx.Tip = protocol.TipInfo{
 			Height:    height,
-			Hash:      tipHash,
+			Hash:      header.HashHeader(),
 			Timestamp: header.Timestamp(),
 		}
 	}
@@ -263,7 +180,7 @@ func (dao *blockDAO) checkIndexers(ctx context.Context) error {
 			return errors.New("indexer tip height cannot by higher than dao tip height")
 		}
 		for i := tipHeight + 1; i <= dao.tipHeight; i++ {
-			blk, err := dao.getBlockByHeight(i)
+			blk, err := dao.GetBlockByHeight(i)
 			if err != nil {
 				return err
 			}
@@ -306,67 +223,120 @@ func (dao *blockDAO) checkIndexers(ctx context.Context) error {
 func (dao *blockDAO) Stop(ctx context.Context) error { return dao.lifecycle.OnStop(ctx) }
 
 func (dao *blockDAO) GetBlockHash(height uint64) (hash.Hash256, error) {
-	return dao.getBlockHash(height)
+	timer := dao.timerFactory.NewTimer("get_block_hash")
+	defer timer.End()
+	return dao.blockStore.GetBlockHash(height)
 }
 
 func (dao *blockDAO) GetBlockHeight(hash hash.Hash256) (uint64, error) {
-	return dao.getBlockHeight(hash)
+	timer := dao.timerFactory.NewTimer("get_block_height")
+	defer timer.End()
+	return dao.blockStore.GetBlockHeight(hash)
 }
 
 func (dao *blockDAO) GetBlock(hash hash.Hash256) (*block.Block, error) {
-	return dao.getBlock(hash)
+	timer := dao.timerFactory.NewTimer("get_block")
+	defer timer.End()
+	return dao.blockStore.GetBlock(hash)
 }
 
 func (dao *blockDAO) GetBlockByHeight(height uint64) (*block.Block, error) {
-	return dao.getBlockByHeight(height)
-}
-
-func (dao *blockDAO) getBlockByHeight(height uint64) (*block.Block, error) {
-	hash, err := dao.getBlockHash(height)
-	if err != nil {
-		return nil, err
-	}
-	return dao.getBlock(hash)
+	timer := dao.timerFactory.NewTimer("get_block_byheight")
+	defer timer.End()
+	return dao.blockStore.GetBlockByHeight(height)
 }
 
 func (dao *blockDAO) HeaderByHeight(height uint64) (*block.Header, error) {
-	hash, err := dao.getBlockHash(height)
+	if v, ok := lruCacheGet(dao.headerCache, height); ok {
+		cacheMtc.WithLabelValues("hit_header").Inc()
+		return v.(*block.Header), nil
+	}
+	cacheMtc.WithLabelValues("miss_header").Inc()
+
+	blk, err := dao.blockStore.GetBlockByHeight(height)
 	if err != nil {
 		return nil, err
 	}
-	return dao.header(hash)
+
+	header := blk.Header
+	lruCachePut(dao.headerCache, height, &header)
+	return &header, nil
 }
 
 func (dao *blockDAO) FooterByHeight(height uint64) (*block.Footer, error) {
-	hash, err := dao.getBlockHash(height)
+	if v, ok := lruCacheGet(dao.footerCache, height); ok {
+		cacheMtc.WithLabelValues("hit_footer").Inc()
+		return v.(*block.Footer), nil
+	}
+	cacheMtc.WithLabelValues("miss_footer").Inc()
+
+	blk, err := dao.blockStore.GetBlockByHeight(height)
 	if err != nil {
 		return nil, err
 	}
-	return dao.footer(hash)
+
+	footer := blk.Footer
+	lruCachePut(dao.footerCache, height, &footer)
+	return &footer, nil
 }
 
 func (dao *blockDAO) Height() (uint64, error) {
-	return atomic.LoadUint64(&dao.tipHeight), nil
+	return dao.blockStore.Height()
 }
 
 func (dao *blockDAO) Header(h hash.Hash256) (*block.Header, error) {
-	return dao.header(h)
+	if header, ok := lruCacheGet(dao.headerCache, h); ok {
+		cacheMtc.WithLabelValues("hit_header").Inc()
+		return header.(*block.Header), nil
+	}
+	cacheMtc.WithLabelValues("miss_header").Inc()
+
+	blk, err := dao.GetBlock(h)
+	if err != nil {
+		return nil, err
+	}
+
+	header := blk.Header
+	lruCachePut(dao.headerCache, h, &header)
+	return &header, nil
 }
 
 func (dao *blockDAO) Body(h hash.Hash256) (*block.Body, error) {
-	return dao.body(h)
+	if v, ok := lruCacheGet(dao.bodyCache, h); ok {
+		cacheMtc.WithLabelValues("hit_body").Inc()
+		return v.(*block.Body), nil
+	}
+	cacheMtc.WithLabelValues("miss_body").Inc()
+
+	blk, err := dao.GetBlock(h)
+	if err != nil {
+		return nil, err
+	}
+
+	body := blk.Body
+	lruCachePut(dao.bodyCache, h, &body)
+	return &body, nil
 }
 
 func (dao *blockDAO) Footer(h hash.Hash256) (*block.Footer, error) {
-	return dao.footer(h)
+	if v, ok := lruCacheGet(dao.footerCache, h); ok {
+		cacheMtc.WithLabelValues("hit_footer").Inc()
+		return v.(*block.Footer), nil
+	}
+	cacheMtc.WithLabelValues("miss_footer").Inc()
+
+	blk, err := dao.GetBlock(h)
+	if err != nil {
+		return nil, err
+	}
+
+	footer := blk.Footer
+	lruCachePut(dao.footerCache, h, &footer)
+	return &footer, nil
 }
 
 func (dao *blockDAO) GetActionByActionHash(h hash.Hash256, height uint64) (action.SealedEnvelope, error) {
-	bh, err := dao.getBlockHash(height)
-	if err != nil {
-		return action.SealedEnvelope{}, err
-	}
-	blk, err := dao.body(bh)
+	blk, err := dao.blockStore.GetBlockByHeight(height)
 	if err != nil {
 		return action.SealedEnvelope{}, err
 	}
@@ -379,7 +349,7 @@ func (dao *blockDAO) GetActionByActionHash(h hash.Hash256, height uint64) (actio
 }
 
 func (dao *blockDAO) GetReceiptByActionHash(h hash.Hash256, height uint64) (*action.Receipt, error) {
-	receipts, err := dao.getReceipts(height)
+	receipts, err := dao.blockStore.GetReceipts(height)
 	if err != nil {
 		return nil, err
 	}
@@ -391,38 +361,39 @@ func (dao *blockDAO) GetReceiptByActionHash(h hash.Hash256, height uint64) (*act
 	return nil, errors.Errorf("receipt of action %x isn't found", h)
 }
 
-func (dao *blockDAO) GetReceipts(blkHeight uint64) ([]*action.Receipt, error) {
-	return dao.getReceipts(blkHeight)
+func (dao *blockDAO) GetReceipts(height uint64) ([]*action.Receipt, error) {
+	timer := dao.timerFactory.NewTimer("get_receipt")
+	defer timer.End()
+	return dao.blockStore.GetReceipts(height)
+}
+
+func (dao *blockDAO) ContainsTransactionLog() bool {
+	return dao.blockStore.ContainsTransactionLog()
+}
+
+func (dao *blockDAO) TransactionLogs(height uint64) (*iotextypes.TransactionLogs, error) {
+	timer := dao.timerFactory.NewTimer("get_transactionlog")
+	defer timer.End()
+	return dao.blockStore.TransactionLogs(height)
 }
 
 func (dao *blockDAO) PutBlock(ctx context.Context, blk *block.Block) error {
-	// early exit if block already exists
-	blkHeight := blk.Height()
-	blkHash, err := dao.getBlockHash(blkHeight)
-	if err == nil && blkHash != hash.ZeroHash256 {
-		log.L().Debug("Block already exists.", zap.Uint64("height", blkHeight))
-		return ErrAlreadyExist
-	}
-	// early exit if it's a db io error
-	if err != nil && errors.Cause(err) != db.ErrNotExist && errors.Cause(err) != db.ErrBucketNotExist {
-		return err
-	}
+	timer := dao.timerFactory.NewTimer("put_block")
+	defer timer.End()
 
-	err = func() error {
-		var err error
-		ctx, err = dao.fillWithBlockInfoAsTip(ctx, dao.tipHeight)
-		if err != nil {
-			return err
-		}
-		if err := dao.putBlock(blk); err != nil {
-			return err
-		}
-		atomic.StoreUint64(&dao.tipHeight, blkHeight)
-		return nil
-	}()
+	var err error
+	ctx, err = dao.fillWithBlockInfoAsTip(ctx, dao.tipHeight)
 	if err != nil {
 		return err
 	}
+	if err := dao.blockStore.PutBlock(ctx, blk); err != nil {
+		return err
+	}
+	atomic.StoreUint64(&dao.tipHeight, blk.Height())
+	header := blk.Header
+	lruCachePut(dao.headerCache, blk.Height(), &header)
+	lruCachePut(dao.headerCache, header.HashHeader(), &header)
+
 	// index the block if there's indexer
 	for _, indexer := range dao.indexers {
 		if err := indexer.PutBlock(ctx, blk); err != nil {
@@ -432,18 +403,19 @@ func (dao *blockDAO) PutBlock(ctx context.Context, blk *block.Block) error {
 	return nil
 }
 
+func (dao *blockDAO) DeleteTipBlock() error {
+	timer := dao.timerFactory.NewTimer("del_block")
+	defer timer.End()
+	return dao.blockStore.DeleteTipBlock()
+}
+
 func (dao *blockDAO) DeleteBlockToTarget(targetHeight uint64) error {
-	tipHeight, err := dao.getTipHeight()
+	tipHeight, err := dao.blockStore.Height()
 	if err != nil {
 		return err
 	}
 	for tipHeight > targetHeight {
-		// Obtain tip block hash
-		h, err := dao.getTipHash()
-		if err != nil {
-			return errors.Wrap(err, "failed to get tip block hash")
-		}
-		blk, err := dao.getBlock(h)
+		blk, err := dao.blockStore.GetBlockByHeight(tipHeight)
 		if err != nil {
 			return errors.Wrap(err, "failed to get tip block")
 		}
@@ -454,581 +426,43 @@ func (dao *blockDAO) DeleteBlockToTarget(targetHeight uint64) error {
 			}
 		}
 
-		if err := dao.deleteTipBlock(); err != nil {
+		if err := dao.blockStore.DeleteTipBlock(); err != nil {
 			return err
 		}
+		// purge from cache
+		h := blk.HashBlock()
+		lruCacheDel(dao.headerCache, tipHeight)
+		lruCacheDel(dao.headerCache, h)
+		lruCacheDel(dao.bodyCache, tipHeight)
+		lruCacheDel(dao.bodyCache, h)
+		lruCacheDel(dao.footerCache, tipHeight)
+		lruCacheDel(dao.footerCache, h)
+
 		tipHeight--
 		atomic.StoreUint64(&dao.tipHeight, tipHeight)
 	}
 	return nil
 }
 
-func (dao *blockDAO) ContainsTransactionLog() bool {
-	sys, err := dao.kvStore.Get(systemLogNS, make([]byte, 8))
-	return err == nil && string(sys) == systemLogNS
+func lruCacheGet(c *cache.ThreadSafeLruCache, key interface{}) (interface{}, bool) {
+	if c != nil {
+		return c.Get(key)
+	}
+	return nil, false
 }
 
-func (dao *blockDAO) TransactionLogs(height uint64) (*iotextypes.TransactionLogs, error) {
-	if !dao.ContainsTransactionLog() {
-		return nil, ErrNotSupported
+func lruCachePut(c *cache.ThreadSafeLruCache, k, v interface{}) {
+	if c != nil {
+		c.Add(k, v)
 	}
-
-	logsBytes, err := dao.kvStore.Get(systemLogNS, heightKey(height))
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to get transaction log")
-	}
-	return block.DeserializeSystemLogPb(logsBytes)
 }
 
-func (dao *blockDAO) indexFile(height uint64, index []byte) error {
-	dao.mutex.Lock()
-	defer dao.mutex.Unlock()
-
-	if dao.htf == nil {
-		htf, err := db.NewRangeIndex(dao.kvStore, heightToFileBucket, make([]byte, 8))
-		if err != nil {
-			return err
-		}
-		dao.htf = htf
+func lruCacheDel(c *cache.ThreadSafeLruCache, k interface{}) {
+	if c != nil {
+		c.Remove(k)
 	}
-	return dao.htf.Insert(height, index)
-}
-
-// getFileIndex return the db filename
-func (dao *blockDAO) getFileIndex(height uint64) ([]byte, error) {
-	dao.mutex.RLock()
-	defer dao.mutex.RUnlock()
-
-	if dao.htf == nil {
-		htf, err := db.NewRangeIndex(dao.kvStore, heightToFileBucket, make([]byte, 8))
-		if err != nil {
-			return nil, err
-		}
-		dao.htf = htf
-	}
-	return dao.htf.Get(height)
-}
-
-func (dao *blockDAO) KVStore() db.KVStore {
-	return dao.kvStore
-}
-
-// getBlockHash returns the block hash by height
-func (dao *blockDAO) getBlockHash(height uint64) (hash.Hash256, error) {
-	h := hash.ZeroHash256
-	if height == 0 {
-		return h, nil
-	}
-	key := heightKey(height)
-	value, err := dao.kvStore.Get(blockHashHeightMappingNS, key)
-	if err != nil {
-		return h, errors.Wrap(err, "failed to get block hash")
-	}
-	if len(h) != len(value) {
-		return h, errors.Wrapf(err, "blockhash is broken with length = %d", len(value))
-	}
-	copy(h[:], value)
-	return h, nil
-}
-
-// getBlockHeight returns the block height by hash
-func (dao *blockDAO) getBlockHeight(hash hash.Hash256) (uint64, error) {
-	key := hashKey(hash)
-	value, err := dao.kvStore.Get(blockHashHeightMappingNS, key)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to get block height")
-	}
-	if len(value) == 0 {
-		return 0, errors.Wrapf(db.ErrNotExist, "height missing for block with hash = %x", hash)
-	}
-	return enc.MachineEndian.Uint64(value), nil
-}
-
-// getBlock returns a block
-func (dao *blockDAO) getBlock(hash hash.Hash256) (*block.Block, error) {
-	header, err := dao.header(hash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block header %x", hash)
-	}
-	body, err := dao.body(hash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block body %x", hash)
-	}
-	footer, err := dao.footer(hash)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block footer %x", hash)
-	}
-	return &block.Block{
-		Header: *header,
-		Body:   *body,
-		Footer: *footer,
-	}, nil
-}
-
-func (dao *blockDAO) header(h hash.Hash256) (*block.Header, error) {
-	if dao.headerCache != nil {
-		header, ok := dao.headerCache.Get(h)
-		if ok {
-			cacheMtc.WithLabelValues("hit_header").Inc()
-			return header.(*block.Header), nil
-		}
-		cacheMtc.WithLabelValues("miss_header").Inc()
-	}
-	value, err := dao.getBlockValue(blockHeaderNS, h)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block header %x", h)
-	}
-	if dao.compressBlock {
-		timer := dao.timerFactory.NewTimer("decompress_header")
-		value, err = compress.Decompress(value)
-		timer.End()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error when decompressing a block header %x", h)
-		}
-	}
-	if len(value) == 0 {
-		return nil, errors.Wrapf(db.ErrNotExist, "block header %x is missing", h)
-	}
-	header := &block.Header{}
-	if err := header.Deserialize(value); err != nil {
-		return nil, errors.Wrapf(err, "failed to deserialize block header %x", h)
-	}
-	if dao.headerCache != nil {
-		dao.headerCache.Add(h, header)
-	}
-	return header, nil
-}
-
-func (dao *blockDAO) body(h hash.Hash256) (*block.Body, error) {
-	if dao.bodyCache != nil {
-		body, ok := dao.bodyCache.Get(h)
-		if ok {
-			cacheMtc.WithLabelValues("hit_body").Inc()
-			return body.(*block.Body), nil
-		}
-		cacheMtc.WithLabelValues("miss_body").Inc()
-	}
-	value, err := dao.getBlockValue(blockBodyNS, h)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block body %x", h)
-	}
-	if dao.compressBlock {
-		timer := dao.timerFactory.NewTimer("decompress_body")
-		value, err = compress.Decompress(value)
-		timer.End()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error when decompressing a block body %x", h)
-		}
-	}
-	if len(value) == 0 {
-		return nil, errors.Wrapf(db.ErrNotExist, "block body %x is missing", h)
-	}
-	body := &block.Body{}
-	if err := body.Deserialize(value); err != nil {
-		return nil, errors.Wrapf(err, "failed to deserialize block body %x", h)
-	}
-	if dao.bodyCache != nil {
-		dao.bodyCache.Add(h, body)
-	}
-	return body, nil
-}
-
-func (dao *blockDAO) footer(h hash.Hash256) (*block.Footer, error) {
-	if dao.footerCache != nil {
-		footer, ok := dao.footerCache.Get(h)
-		if ok {
-			cacheMtc.WithLabelValues("hit_footer").Inc()
-			return footer.(*block.Footer), nil
-		}
-		cacheMtc.WithLabelValues("miss_footer").Inc()
-	}
-	value, err := dao.getBlockValue(blockFooterNS, h)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get block footer %x", h)
-	}
-	if dao.compressBlock {
-		timer := dao.timerFactory.NewTimer("decompress_footer")
-		value, err = compress.Decompress(value)
-		timer.End()
-		if err != nil {
-			return nil, errors.Wrapf(err, "error when decompressing a block footer %x", h)
-		}
-	}
-	if len(value) == 0 {
-		return nil, errors.Wrapf(db.ErrNotExist, "block footer %x is missing", h)
-	}
-	footer := &block.Footer{}
-	if err := footer.Deserialize(value); err != nil {
-		return nil, errors.Wrapf(err, "failed to deserialize block footer %x", h)
-	}
-	if dao.footerCache != nil {
-		dao.footerCache.Add(h, footer)
-	}
-	return footer, nil
-}
-
-// getTipHeight returns the blockchain height
-func (dao *blockDAO) getTipHeight() (uint64, error) {
-	value, err := dao.kvStore.Get(blockNS, topHeightKey)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to get top height")
-	}
-	if len(value) == 0 {
-		return 0, errors.Wrap(db.ErrNotExist, "blockchain height missing")
-	}
-	return enc.MachineEndian.Uint64(value), nil
-}
-
-// getTipHash returns the blockchain tip hash
-func (dao *blockDAO) getTipHash() (hash.Hash256, error) {
-	value, err := dao.kvStore.Get(blockNS, topHashKey)
-	if err != nil {
-		return hash.ZeroHash256, errors.Wrap(err, "failed to get tip hash")
-	}
-	return hash.BytesToHash256(value), nil
-}
-
-func (dao *blockDAO) getReceipts(blkHeight uint64) ([]*action.Receipt, error) {
-	kvStore, _, err := dao.getDBFromHeight(blkHeight)
-	if err != nil {
-		return nil, err
-	}
-	value, err := kvStore.Get(receiptsNS, byteutil.Uint64ToBytes(blkHeight))
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to get receipts of block %d", blkHeight)
-	}
-	if len(value) == 0 {
-		return nil, errors.Wrap(db.ErrNotExist, "block receipts missing")
-	}
-	receiptsPb := &iotextypes.Receipts{}
-	if err := proto.Unmarshal(value, receiptsPb); err != nil {
-		return nil, errors.Wrap(err, "failed to unmarshal block receipts")
-	}
-	var blockReceipts []*action.Receipt
-	for _, receiptPb := range receiptsPb.Receipts {
-		receipt := &action.Receipt{}
-		receipt.ConvertFromReceiptPb(receiptPb)
-		blockReceipts = append(blockReceipts, receipt)
-	}
-	return blockReceipts, nil
-}
-
-// putBlock puts a block
-func (dao *blockDAO) putBlock(blk *block.Block) error {
-	blkHeight := blk.Height()
-	h, err := dao.getBlockHash(blkHeight)
-	if h != hash.ZeroHash256 && err == nil {
-		return errors.Errorf("block %d already exist", blkHeight)
-	}
-
-	serHeader, err := blk.Header.Serialize()
-	if err != nil {
-		return errors.Wrap(err, "failed to serialize block header")
-	}
-	serBody, err := blk.Body.Serialize()
-	if err != nil {
-		return errors.Wrap(err, "failed to serialize block body")
-	}
-	serFooter, err := blk.Footer.Serialize()
-	if err != nil {
-		return errors.Wrap(err, "failed to serialize block footer")
-	}
-	if dao.compressBlock {
-		timer := dao.timerFactory.NewTimer("compress_header")
-		serHeader, err = compress.Compress(serHeader)
-		timer.End()
-		if err != nil {
-			return errors.Wrapf(err, "error when compressing a block header")
-		}
-		timer = dao.timerFactory.NewTimer("compress_body")
-		serBody, err = compress.Compress(serBody)
-		timer.End()
-		if err != nil {
-			return errors.Wrapf(err, "error when compressing a block body")
-		}
-		timer = dao.timerFactory.NewTimer("compress_footer")
-		serFooter, err = compress.Compress(serFooter)
-		timer.End()
-		if err != nil {
-			return errors.Wrapf(err, "error when compressing a block footer")
-		}
-	}
-	batchForBlock := batch.NewBatch()
-	hash := blk.HashBlock()
-	heightKey := heightKey(blkHeight)
-	batchForBlock.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
-	batchForBlock.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
-	batchForBlock.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
-	if dao.ContainsTransactionLog() {
-		if sysLog := blk.TransactionLog(); sysLog != nil {
-			batchForBlock.Put(systemLogNS, heightKey, sysLog.Serialize(), "failed to put transaction log")
-		}
-	}
-	kv, _, err := dao.getTopDB(blkHeight)
-	if err != nil {
-		return err
-	}
-	// write receipts
-	if blk.Receipts != nil {
-		receipts := iotextypes.Receipts{}
-		for _, r := range blk.Receipts {
-			receipts.Receipts = append(receipts.Receipts, r.ConvertToReceiptPb())
-		}
-		if receiptsBytes, err := proto.Marshal(&receipts); err == nil {
-			batchForBlock.Put(receiptsNS, byteutil.Uint64ToBytes(blkHeight), receiptsBytes, "failed to put receipts")
-		} else {
-			log.L().Error("failed to serialize receipits for block", zap.Uint64("height", blkHeight))
-		}
-	}
-	if err := kv.WriteBatch(batchForBlock); err != nil {
-		return err
-	}
-
-	b := batch.NewBatch()
-	heightValue := byteutil.Uint64ToBytes(blkHeight)
-	hashKey := hashKey(hash)
-	b.Put(blockHashHeightMappingNS, hashKey, heightValue, "failed to put hash -> height mapping")
-	b.Put(blockHashHeightMappingNS, heightKey, hash[:], "failed to put height -> hash mapping")
-	tipHeight, err := dao.kvStore.Get(blockNS, topHeightKey)
-	if err != nil {
-		return errors.Wrap(err, "failed to get top height")
-	}
-	if blkHeight > enc.MachineEndian.Uint64(tipHeight) {
-		b.Put(blockNS, topHeightKey, heightValue, "failed to put top height")
-		b.Put(blockNS, topHashKey, hash[:], "failed to put top hash")
-	}
-	return dao.kvStore.WriteBatch(b)
-}
-
-// deleteTipBlock deletes the tip block
-func (dao *blockDAO) deleteTipBlock() error {
-	// First obtain tip height from db
-	height, err := dao.getTipHeight()
-	if err != nil {
-		return errors.Wrap(err, "failed to get tip height")
-	}
-	if height == 0 {
-		// should not delete genesis block
-		return errors.New("cannot delete genesis block")
-	}
-	// Obtain tip block hash
-	hash, err := dao.getTipHash()
-	if err != nil {
-		return errors.Wrap(err, "failed to get tip block hash")
-	}
-
-	b := batch.NewBatch()
-	batchForBlock := batch.NewBatch()
-	whichDB, _, err := dao.getDBFromHeight(height)
-	if err != nil {
-		return err
-	}
-	// Delete hash -> block mapping
-	batchForBlock.Delete(blockHeaderNS, hash[:], "failed to delete block header")
-	if dao.headerCache != nil {
-		dao.headerCache.Remove(hash)
-	}
-	batchForBlock.Delete(blockBodyNS, hash[:], "failed to delete block body")
-	if dao.bodyCache != nil {
-		dao.bodyCache.Remove(hash)
-	}
-	batchForBlock.Delete(blockFooterNS, hash[:], "failed to delete block footer")
-	if dao.footerCache != nil {
-		dao.footerCache.Remove(hash)
-	}
-	// delete receipt
-	batchForBlock.Delete(receiptsNS, byteutil.Uint64ToBytes(height), "failed to delete receipt")
-	// Delete hash -> height mapping
-	hashKey := hashKey(hash)
-	b.Delete(blockHashHeightMappingNS, hashKey, "failed to delete hash -> height mapping")
-
-	// Delete height -> hash mapping
-	heightKey := heightKey(height)
-	b.Delete(blockHashHeightMappingNS, heightKey, "failed to delete height -> hash mapping")
-
-	// Update tip height
-	b.Put(blockNS, topHeightKey, byteutil.Uint64ToBytes(height-1), "failed to put top height")
-
-	// Update tip hash
-	hash2, err := dao.getBlockHash(height - 1)
-	if err != nil {
-		return errors.Wrap(err, "failed to get tip block hash")
-	}
-	b.Put(blockNS, topHashKey, hash2[:], "failed to put top hash")
-
-	if err := dao.kvStore.WriteBatch(b); err != nil {
-		return err
-	}
-	return whichDB.WriteBatch(batchForBlock)
-}
-
-// getDBFromHash returns db of this block stored
-func (dao *blockDAO) getDBFromHash(h hash.Hash256) (db.KVStore, uint64, error) {
-	height, err := dao.getBlockHeight(h)
-	if err != nil {
-		return nil, 0, err
-	}
-	return dao.getDBFromHeight(height)
-}
-
-func (dao *blockDAO) getTopDB(blkHeight uint64) (kvStore db.KVStore, index uint64, err error) {
-	if dao.cfg.SplitDBSizeMB == 0 || blkHeight <= dao.cfg.SplitDBHeight {
-		return dao.kvStore, 0, nil
-	}
-	topIndex := dao.topIndex.Load().(uint64)
-	file, dir := getFileNameAndDir(dao.cfg.DbPath)
-	if err != nil {
-		return
-	}
-	longFileName := dir + "/" + file + fmt.Sprintf("-%08d", topIndex) + ".db"
-	dat, err := os.Stat(longFileName)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			// something wrong getting FileInfo
-			return
-		}
-		// index the height --> file index mapping
-		if err = dao.indexFile(blkHeight, byteutil.Uint64ToBytesBigEndian(topIndex)); err != nil {
-			return
-		}
-		// db file does not exist, create it
-		return dao.openDB(topIndex)
-	}
-	// other errors except file does not exist
-	if err != nil {
-		return
-	}
-	// file exists,but need create new db
-	if uint64(dat.Size()) > dao.cfg.SplitDBSize() {
-		kvStore, index, err = dao.openDB(topIndex + 1)
-		dao.topIndex.Store(index)
-		// index the height --> file index mapping
-		err = dao.indexFile(blkHeight, byteutil.Uint64ToBytesBigEndian(index))
-		return
-	}
-	// db exist,need load from kvStores
-	kv, ok := dao.kvStores.Load(topIndex)
-	if ok {
-		kvStore, ok = kv.(db.KVStore)
-		if !ok {
-			err = errors.New("db convert error")
-		}
-		index = topIndex
-		return
-	}
-	// file exists,but not opened
-	return dao.openDB(topIndex)
-}
-
-func (dao *blockDAO) getDBFromHeight(blkHeight uint64) (kvStore db.KVStore, index uint64, err error) {
-	if dao.cfg.SplitDBSizeMB == 0 {
-		return dao.kvStore, 0, nil
-	}
-	if blkHeight <= dao.cfg.SplitDBHeight {
-		return dao.kvStore, 0, nil
-	}
-	// get file index
-	value, err := dao.getFileIndex(blkHeight)
-	if err != nil {
-		return
-	}
-	return dao.getDBFromIndex(byteutil.BytesToUint64BigEndian(value))
-}
-
-func (dao *blockDAO) getDBFromIndex(idx uint64) (kvStore db.KVStore, index uint64, err error) {
-	if idx == 0 {
-		return dao.kvStore, 0, nil
-	}
-	kv, ok := dao.kvStores.Load(idx)
-	if ok {
-		kvStore, ok = kv.(db.KVStore)
-		if !ok {
-			err = errors.New("db convert error")
-		}
-		index = idx
-		return
-	}
-	// if user rm some db files manully,then call this method will create new file
-	return dao.openDB(idx)
-}
-
-// getBlockValue get block's data from db,if this db failed,it will try the previous one
-func (dao *blockDAO) getBlockValue(blockNS string, h hash.Hash256) ([]byte, error) {
-	whichDB, index, err := dao.getDBFromHash(h)
-	if err != nil {
-		return nil, err
-	}
-	value, err := whichDB.Get(blockNS, h[:])
-	if errors.Cause(err) == db.ErrNotExist {
-		idx := index - 1
-		if index == 0 {
-			idx = 0
-		}
-		db, _, err := dao.getDBFromIndex(idx)
-		if err != nil {
-			return nil, err
-		}
-		value, err = db.Get(blockNS, h[:])
-		if err != nil {
-			return nil, err
-		}
-	}
-	return value, err
-}
-
-// openDB open file if exists, or create new file
-func (dao *blockDAO) openDB(idx uint64) (kvStore db.KVStore, index uint64, err error) {
-	if idx == 0 {
-		return dao.kvStore, 0, nil
-	}
-	cfg := dao.cfg
-	model, _ := getFileNameAndDir(cfg.DbPath)
-	name := model + fmt.Sprintf("-%08d", idx) + ".db"
-
-	dao.mutex.Lock()
-	defer dao.mutex.Unlock()
-	// open or create this db file
-	cfg.DbPath = path.Dir(cfg.DbPath) + "/" + name
-	var newFile bool
-	_, err = os.Stat(cfg.DbPath)
-	if err != nil {
-		if !os.IsNotExist(err) {
-			// something wrong getting FileInfo
-			return
-		}
-		newFile = true
-	}
-
-	kvStore = db.NewBoltDB(cfg)
-	dao.kvStores.Store(idx, kvStore)
-	err = kvStore.Start(context.Background())
-	if err != nil {
-		return
-	}
-
-	if newFile {
-		if err = kvStore.Put(systemLogNS, make([]byte, 8), []byte(systemLogNS)); err != nil {
-			return
-		}
-	}
-	dao.lifecycle.Add(kvStore)
-	index = idx
-	return
-}
-
-func getFileNameAndDir(p string) (fileName, dir string) {
-	var withSuffix, suffix string
-	withSuffix = path.Base(p)
-	suffix = path.Ext(withSuffix)
-	fileName = strings.TrimSuffix(withSuffix, suffix)
-	dir = path.Dir(p)
-	return
 }
 
 func hashKey(h hash.Hash256) []byte {
 	return append(hashPrefix, h[:]...)
-}
-
-func heightKey(height uint64) []byte {
-	return append(heightPrefix, byteutil.Uint64ToBytes(height)...)
 }

--- a/blockchain/blockdao/filedao.go
+++ b/blockchain/blockdao/filedao.go
@@ -1,0 +1,119 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package blockdao
+
+import (
+	"context"
+
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
+)
+
+var (
+	// ErrNotSupported indicates not supported
+	ErrNotSupported = errors.New("feature not supported")
+)
+
+type (
+	// FileDAO represents the data access object for managing block db file
+	FileDAO interface {
+		Start(ctx context.Context) error
+		Stop(ctx context.Context) error
+		Height() (uint64, error)
+		GetBlockHash(uint64) (hash.Hash256, error)
+		GetBlockHeight(hash.Hash256) (uint64, error)
+		GetBlock(hash.Hash256) (*block.Block, error)
+		GetBlockByHeight(uint64) (*block.Block, error)
+		GetReceipts(uint64) ([]*action.Receipt, error)
+		ContainsTransactionLog() bool
+		TransactionLogs(uint64) (*iotextypes.TransactionLogs, error)
+		PutBlock(context.Context, *block.Block) error
+		DeleteTipBlock() error
+	}
+
+	// fileDAO implements FileDAO
+	fileDAO struct {
+		legacyFd FileDAO
+	}
+)
+
+// NewFileDAO creates an instance of FileDAO
+func NewFileDAO(kvStore db.KVStore, compressBlock bool, cfg config.DB) (FileDAO, error) {
+	legacyFd, err := newFileDAOLegacy(kvStore, compressBlock, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: create map of new files
+	return &fileDAO{
+		legacyFd: legacyFd,
+	}, nil
+}
+
+func (fd *fileDAO) Start(ctx context.Context) error {
+	return fd.legacyFd.Start(ctx)
+}
+
+func (fd *fileDAO) Stop(ctx context.Context) error {
+	return fd.legacyFd.Stop(ctx)
+}
+
+func (fd *fileDAO) Height() (uint64, error) {
+	return fd.legacyFd.Height()
+}
+
+func (fd *fileDAO) GetBlockHash(height uint64) (hash.Hash256, error) {
+	return fd.legacyFd.GetBlockHash(height)
+}
+
+func (fd *fileDAO) GetBlockHeight(hash hash.Hash256) (uint64, error) {
+	return fd.legacyFd.GetBlockHeight(hash)
+}
+
+func (fd *fileDAO) GetBlock(hash hash.Hash256) (*block.Block, error) {
+	return fd.legacyFd.GetBlock(hash)
+}
+
+func (fd *fileDAO) GetBlockByHeight(height uint64) (*block.Block, error) {
+	return fd.legacyFd.GetBlockByHeight(height)
+}
+
+func (fd *fileDAO) GetReceipts(height uint64) ([]*action.Receipt, error) {
+	return fd.legacyFd.GetReceipts(height)
+}
+
+func (fd *fileDAO) ContainsTransactionLog() bool {
+	return fd.legacyFd.ContainsTransactionLog()
+}
+
+func (fd *fileDAO) TransactionLogs(height uint64) (*iotextypes.TransactionLogs, error) {
+	return fd.legacyFd.TransactionLogs(height)
+}
+
+func (fd *fileDAO) PutBlock(ctx context.Context, blk *block.Block) error {
+	// bail out if block already exists
+	h := blk.HashBlock()
+	if _, err := fd.GetBlockHeight(h); err == nil {
+		log.L().Info("Block already exists.", zap.Uint64("height", blk.Height()), log.Hex("hash", h[:]))
+		return ErrAlreadyExist
+	}
+	// TODO: check if need to split DB
+	return fd.legacyFd.PutBlock(ctx, blk)
+}
+
+func (fd *fileDAO) DeleteTipBlock() error {
+	return fd.legacyFd.DeleteTipBlock()
+}

--- a/blockchain/blockdao/filedao_legacy.go
+++ b/blockchain/blockdao/filedao_legacy.go
@@ -1,0 +1,636 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package blockdao
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/db/batch"
+	"github.com/iotexproject/iotex-core/pkg/compress"
+	"github.com/iotexproject/iotex-core/pkg/enc"
+	"github.com/iotexproject/iotex-core/pkg/lifecycle"
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+)
+
+const (
+	blockNS       = "blk"
+	blockHeaderNS = "bhr"
+	blockBodyNS   = "bbd"
+	blockFooterNS = "bfr"
+	receiptsNS    = "rpt"
+)
+
+var (
+	heightPrefix       = []byte("he.")
+	heightToFileBucket = []byte("h2f")
+)
+
+type (
+	// fileDAOLegacy handles chain db file before file split activation at Ithaca height
+	fileDAOLegacy struct {
+		compressBlock bool
+		lifecycle     lifecycle.Lifecycle
+		cfg           config.DB
+		mutex         sync.RWMutex // for create new db file
+		topIndex      atomic.Value
+		htf           db.RangeIndex
+		kvStore       db.KVStore
+		kvStores      sync.Map //store like map[index]db.KVStore,index from 1...N
+	}
+)
+
+func newFileDAOLegacy(kvStore db.KVStore, compressBlock bool, cfg config.DB) (FileDAO, error) {
+	if kvStore == nil {
+		return nil, errors.New("empty KVStore")
+	}
+	return &fileDAOLegacy{
+		compressBlock: compressBlock,
+		cfg:           cfg,
+		kvStore:       kvStore,
+	}, nil
+}
+
+func (fd *fileDAOLegacy) Start(ctx context.Context) error {
+	if err := fd.kvStore.Start(ctx); err != nil {
+		return err
+	}
+
+	// set init height value and transaction log flag
+	if _, err := fd.kvStore.Get(blockNS, topHeightKey); err != nil &&
+		errors.Cause(err) == db.ErrNotExist {
+		zero8bytes := make([]byte, 8)
+		if err := fd.kvStore.Put(blockNS, topHeightKey, zero8bytes); err != nil {
+			return errors.Wrap(err, "failed to write initial value for top height")
+		}
+		if err := fd.kvStore.Put(systemLogNS, zero8bytes, []byte(systemLogNS)); err != nil {
+			return errors.Wrap(err, "failed to write initial value for transaction log")
+		}
+	}
+
+	// loop thru all legacy files
+	model, dir := getFileNameAndDir(fd.cfg.DbPath)
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	var maxN uint64
+	for _, file := range files {
+		name := file.Name()
+		lens := len(name)
+		if lens < patternLen || !strings.Contains(name, model) {
+			continue
+		}
+		num := name[lens-patternLen : lens-suffixLen]
+		n, err := strconv.Atoi(num)
+		if err != nil {
+			continue
+		}
+		if _, _, err := fd.openDB(uint64(n)); err != nil {
+			return err
+		}
+		if uint64(n) > maxN {
+			maxN = uint64(n)
+		}
+	}
+	if maxN == 0 {
+		maxN = 1
+	}
+	fd.topIndex.Store(maxN)
+	return nil
+}
+
+func (fd *fileDAOLegacy) Stop(ctx context.Context) error {
+	if err := fd.lifecycle.OnStop(ctx); err != nil {
+		return err
+	}
+	return fd.kvStore.Stop(ctx)
+}
+
+func (fd *fileDAOLegacy) Height() (uint64, error) {
+	value, err := fd.kvStore.Get(blockNS, topHeightKey)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get top height")
+	}
+	if len(value) != 8 {
+		return 0, errors.Wrap(ErrDataCorruption, "blockchain height missing")
+	}
+	return enc.MachineEndian.Uint64(value), nil
+}
+
+func (fd *fileDAOLegacy) GetBlockHash(height uint64) (hash.Hash256, error) {
+	h := hash.ZeroHash256
+	if height == 0 {
+		return h, nil
+	}
+	value, err := fd.kvStore.Get(blockHashHeightMappingNS, heightKey(height))
+	if err != nil {
+		return h, errors.Wrap(err, "failed to get block hash")
+	}
+	if len(h) != len(value) {
+		return h, errors.Wrapf(err, "blockhash is broken with length = %d", len(value))
+	}
+	copy(h[:], value)
+	return h, nil
+}
+
+func (fd *fileDAOLegacy) GetBlockHeight(h hash.Hash256) (uint64, error) {
+	value, err := fd.kvStore.Get(blockHashHeightMappingNS, hashKey(h))
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to get block height")
+	}
+	if len(value) != 8 {
+		return 0, errors.Wrapf(ErrDataCorruption, "height missing for block with hash = %x", h)
+	}
+	return enc.MachineEndian.Uint64(value), nil
+}
+
+func (fd *fileDAOLegacy) GetBlock(h hash.Hash256) (*block.Block, error) {
+	header, err := fd.header(h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block header %x", h)
+	}
+	body, err := fd.body(h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block body %x", h)
+	}
+	footer, err := fd.footer(h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block footer %x", h)
+	}
+	return &block.Block{
+		Header: *header,
+		Body:   *body,
+		Footer: *footer,
+	}, nil
+}
+
+func (fd *fileDAOLegacy) GetBlockByHeight(height uint64) (*block.Block, error) {
+	hash, err := fd.GetBlockHash(height)
+	if err != nil {
+		return nil, err
+	}
+	return fd.GetBlock(hash)
+}
+
+func (fd *fileDAOLegacy) GetReceipts(height uint64) ([]*action.Receipt, error) {
+	kvStore, _, err := fd.getDBFromHeight(height)
+	if err != nil {
+		return nil, err
+	}
+	value, err := kvStore.Get(receiptsNS, byteutil.Uint64ToBytes(height))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get receipts of block %d", height)
+	}
+	if len(value) == 0 {
+		return nil, errors.Wrap(ErrDataCorruption, "block receipts missing")
+	}
+	receiptsPb := &iotextypes.Receipts{}
+	if err := proto.Unmarshal(value, receiptsPb); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal block receipts")
+	}
+
+	var blockReceipts []*action.Receipt
+	for _, receiptPb := range receiptsPb.Receipts {
+		receipt := &action.Receipt{}
+		receipt.ConvertFromReceiptPb(receiptPb)
+		blockReceipts = append(blockReceipts, receipt)
+	}
+	return blockReceipts, nil
+}
+
+func (fd *fileDAOLegacy) header(h hash.Hash256) (*block.Header, error) {
+	value, err := fd.getBlockValue(blockHeaderNS, h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block header %x", h)
+	}
+	if fd.compressBlock {
+		value, err = compress.Decompress(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error when decompressing a block header %x", h)
+		}
+	}
+	if len(value) == 0 {
+		return nil, errors.Wrapf(ErrDataCorruption, "block header %x is missing", h)
+	}
+
+	header := &block.Header{}
+	if err := header.Deserialize(value); err != nil {
+		return nil, errors.Wrapf(err, "failed to deserialize block header %x", h)
+	}
+	return header, nil
+}
+
+func (fd *fileDAOLegacy) body(h hash.Hash256) (*block.Body, error) {
+	value, err := fd.getBlockValue(blockBodyNS, h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block body %x", h)
+	}
+	if fd.compressBlock {
+		value, err = compress.Decompress(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error when decompressing a block body %x", h)
+		}
+	}
+
+	body := &block.Body{}
+	if len(value) == 0 {
+		// block body could be empty
+		return body, nil
+	}
+	if err := body.Deserialize(value); err != nil {
+		return nil, errors.Wrapf(err, "failed to deserialize block body %x", h)
+	}
+	return body, nil
+}
+
+func (fd *fileDAOLegacy) footer(h hash.Hash256) (*block.Footer, error) {
+	value, err := fd.getBlockValue(blockFooterNS, h)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get block footer %x", h)
+	}
+	if fd.compressBlock {
+		value, err = compress.Decompress(value)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error when decompressing a block footer %x", h)
+		}
+	}
+	if len(value) == 0 {
+		return nil, errors.Wrapf(ErrDataCorruption, "block footer %x is missing", h)
+	}
+
+	footer := &block.Footer{}
+	if err := footer.Deserialize(value); err != nil {
+		return nil, errors.Wrapf(err, "failed to deserialize block footer %x", h)
+	}
+	return footer, nil
+}
+
+func (fd *fileDAOLegacy) ContainsTransactionLog() bool {
+	sys, err := fd.kvStore.Get(systemLogNS, make([]byte, 8))
+	return err == nil && string(sys) == systemLogNS
+}
+
+func (fd *fileDAOLegacy) TransactionLogs(height uint64) (*iotextypes.TransactionLogs, error) {
+	if !fd.ContainsTransactionLog() {
+		return nil, ErrNotSupported
+	}
+
+	logsBytes, err := fd.kvStore.Get(systemLogNS, heightKey(height))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get transaction log")
+	}
+	return block.DeserializeSystemLogPb(logsBytes)
+}
+
+func (fd *fileDAOLegacy) PutBlock(ctx context.Context, blk *block.Block) error {
+	serHeader, err := blk.Header.Serialize()
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize block header")
+	}
+	serBody, err := blk.Body.Serialize()
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize block body")
+	}
+	serFooter, err := blk.Footer.Serialize()
+	if err != nil {
+		return errors.Wrap(err, "failed to serialize block footer")
+	}
+	if fd.compressBlock {
+		serHeader, err = compress.Compress(serHeader)
+		if err != nil {
+			return errors.Wrapf(err, "error when compressing a block header")
+		}
+		serBody, err = compress.Compress(serBody)
+		if err != nil {
+			return errors.Wrapf(err, "error when compressing a block body")
+		}
+		serFooter, err = compress.Compress(serFooter)
+		if err != nil {
+			return errors.Wrapf(err, "error when compressing a block footer")
+		}
+	}
+	batchForBlock := batch.NewBatch()
+	hash := blk.HashBlock()
+	batchForBlock.Put(blockHeaderNS, hash[:], serHeader, "failed to put block header")
+	batchForBlock.Put(blockBodyNS, hash[:], serBody, "failed to put block body")
+	batchForBlock.Put(blockFooterNS, hash[:], serFooter, "failed to put block footer")
+	blkHeight := blk.Height()
+	heightKey := heightKey(blkHeight)
+	if fd.ContainsTransactionLog() {
+		if sysLog := blk.TransactionLog(); sysLog != nil {
+			batchForBlock.Put(systemLogNS, heightKey, sysLog.Serialize(), "failed to put transaction log")
+		}
+	}
+	kv, _, err := fd.getTopDB(blkHeight)
+	if err != nil {
+		return err
+	}
+	// write receipts
+	if blk.Receipts != nil {
+		receipts := iotextypes.Receipts{}
+		for _, r := range blk.Receipts {
+			receipts.Receipts = append(receipts.Receipts, r.ConvertToReceiptPb())
+		}
+		if receiptsBytes, err := proto.Marshal(&receipts); err == nil {
+			batchForBlock.Put(receiptsNS, byteutil.Uint64ToBytes(blkHeight), receiptsBytes, "failed to put receipts")
+		} else {
+			log.L().Error("failed to serialize receipits for block", zap.Uint64("height", blkHeight))
+		}
+	}
+	if err := kv.WriteBatch(batchForBlock); err != nil {
+		return err
+	}
+
+	b := batch.NewBatch()
+	heightValue := byteutil.Uint64ToBytes(blkHeight)
+	hashKey := hashKey(hash)
+	b.Put(blockHashHeightMappingNS, hashKey, heightValue, "failed to put hash -> height mapping")
+	b.Put(blockHashHeightMappingNS, heightKey, hash[:], "failed to put height -> hash mapping")
+	tipHeight, err := fd.kvStore.Get(blockNS, topHeightKey)
+	if err != nil {
+		return errors.Wrap(err, "failed to get top height")
+	}
+	if blkHeight > enc.MachineEndian.Uint64(tipHeight) {
+		b.Put(blockNS, topHeightKey, heightValue, "failed to put top height")
+		b.Put(blockNS, topHashKey, hash[:], "failed to put top hash")
+	}
+	return fd.kvStore.WriteBatch(b)
+}
+
+func (fd *fileDAOLegacy) DeleteTipBlock() error {
+	// First obtain tip height from db
+	height, err := fd.Height()
+	if err != nil {
+		return errors.Wrap(err, "failed to get tip height")
+	}
+	if height == 0 {
+		// should not delete genesis block
+		return errors.New("cannot delete genesis block")
+	}
+	// Obtain tip block hash
+	hash, err := fd.getTipHash()
+	if err != nil {
+		return errors.Wrap(err, "failed to get tip block hash")
+	}
+
+	b := batch.NewBatch()
+	batchForBlock := batch.NewBatch()
+	whichDB, _, err := fd.getDBFromHeight(height)
+	if err != nil {
+		return err
+	}
+	// Delete hash -> block mapping
+	batchForBlock.Delete(blockHeaderNS, hash[:], "failed to delete block header")
+	batchForBlock.Delete(blockBodyNS, hash[:], "failed to delete block body")
+	batchForBlock.Delete(blockFooterNS, hash[:], "failed to delete block footer")
+	// delete receipt
+	batchForBlock.Delete(receiptsNS, byteutil.Uint64ToBytes(height), "failed to delete receipt")
+	// Delete hash -> height mapping
+	hashKey := hashKey(hash)
+	b.Delete(blockHashHeightMappingNS, hashKey, "failed to delete hash -> height mapping")
+	// Delete height -> hash mapping
+	heightKey := heightKey(height)
+	b.Delete(blockHashHeightMappingNS, heightKey, "failed to delete height -> hash mapping")
+
+	// Update tip height
+	b.Put(blockNS, topHeightKey, byteutil.Uint64ToBytes(height-1), "failed to put top height")
+	// Update tip hash
+	hash2, err := fd.GetBlockHash(height - 1)
+	if err != nil {
+		return errors.Wrap(err, "failed to get tip block hash")
+	}
+	b.Put(blockNS, topHashKey, hash2[:], "failed to put top hash")
+
+	if err := fd.kvStore.WriteBatch(b); err != nil {
+		return err
+	}
+	return whichDB.WriteBatch(batchForBlock)
+}
+
+// getTipHash returns the blockchain tip hash
+func (fd *fileDAOLegacy) getTipHash() (hash.Hash256, error) {
+	value, err := fd.kvStore.Get(blockNS, topHashKey)
+	if err != nil {
+		return hash.ZeroHash256, errors.Wrap(err, "failed to get tip hash")
+	}
+	return hash.BytesToHash256(value), nil
+}
+
+func (fd *fileDAOLegacy) indexFile(height uint64, index []byte) error {
+	fd.mutex.Lock()
+	defer fd.mutex.Unlock()
+
+	if fd.htf == nil {
+		htf, err := db.NewRangeIndex(fd.kvStore, heightToFileBucket, make([]byte, 8))
+		if err != nil {
+			return err
+		}
+		fd.htf = htf
+	}
+	return fd.htf.Insert(height, index)
+}
+
+// getFileIndex return the db filename
+func (fd *fileDAOLegacy) getFileIndex(height uint64) ([]byte, error) {
+	fd.mutex.RLock()
+	defer fd.mutex.RUnlock()
+
+	if fd.htf == nil {
+		htf, err := db.NewRangeIndex(fd.kvStore, heightToFileBucket, make([]byte, 8))
+		if err != nil {
+			return nil, err
+		}
+		fd.htf = htf
+	}
+	return fd.htf.Get(height)
+}
+
+func (fd *fileDAOLegacy) getTopDB(blkHeight uint64) (kvStore db.KVStore, index uint64, err error) {
+	if fd.cfg.SplitDBSizeMB == 0 || blkHeight <= fd.cfg.SplitDBHeight {
+		return fd.kvStore, 0, nil
+	}
+	topIndex := fd.topIndex.Load().(uint64)
+	file, dir := getFileNameAndDir(fd.cfg.DbPath)
+	if err != nil {
+		return
+	}
+	longFileName := dir + "/" + file + fmt.Sprintf("-%08d", topIndex) + ".db"
+	dat, err := os.Stat(longFileName)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// something wrong getting FileInfo
+			return
+		}
+		// index the height --> file index mapping
+		if err = fd.indexFile(blkHeight, byteutil.Uint64ToBytesBigEndian(topIndex)); err != nil {
+			return
+		}
+		// db file does not exist, create it
+		return fd.openDB(topIndex)
+	}
+	// other errors except file does not exist
+	if err != nil {
+		return
+	}
+	// file exists,but need create new db
+	if uint64(dat.Size()) > fd.cfg.SplitDBSize() {
+		kvStore, index, err = fd.openDB(topIndex + 1)
+		fd.topIndex.Store(index)
+		// index the height --> file index mapping
+		err = fd.indexFile(blkHeight, byteutil.Uint64ToBytesBigEndian(index))
+		return
+	}
+	// db exist,need load from kvStores
+	kv, ok := fd.kvStores.Load(topIndex)
+	if ok {
+		kvStore, ok = kv.(db.KVStore)
+		if !ok {
+			err = errors.New("db convert error")
+		}
+		index = topIndex
+		return
+	}
+	// file exists,but not opened
+	return fd.openDB(topIndex)
+}
+
+// getDBFromHash returns db of this block stored
+func (fd *fileDAOLegacy) getDBFromHash(h hash.Hash256) (db.KVStore, uint64, error) {
+	height, err := fd.GetBlockHeight(h)
+	if err != nil {
+		return nil, 0, err
+	}
+	return fd.getDBFromHeight(height)
+}
+
+func (fd *fileDAOLegacy) getDBFromHeight(blkHeight uint64) (kvStore db.KVStore, index uint64, err error) {
+	if fd.cfg.SplitDBSizeMB == 0 {
+		return fd.kvStore, 0, nil
+	}
+	if blkHeight <= fd.cfg.SplitDBHeight {
+		return fd.kvStore, 0, nil
+	}
+	// get file index
+	value, err := fd.getFileIndex(blkHeight)
+	if err != nil {
+		return
+	}
+	return fd.getDBFromIndex(byteutil.BytesToUint64BigEndian(value))
+}
+
+func (fd *fileDAOLegacy) getDBFromIndex(idx uint64) (kvStore db.KVStore, index uint64, err error) {
+	if idx == 0 {
+		return fd.kvStore, 0, nil
+	}
+	kv, ok := fd.kvStores.Load(idx)
+	if ok {
+		kvStore, ok = kv.(db.KVStore)
+		if !ok {
+			err = errors.New("db convert error")
+		}
+		index = idx
+		return
+	}
+	// if user rm some db files manully,then call this method will create new file
+	return fd.openDB(idx)
+}
+
+// getBlockValue get block's data from db,if this db failed,it will try the previous one
+func (fd *fileDAOLegacy) getBlockValue(blockNS string, h hash.Hash256) ([]byte, error) {
+	whichDB, index, err := fd.getDBFromHash(h)
+	if err != nil {
+		return nil, err
+	}
+	value, err := whichDB.Get(blockNS, h[:])
+	if errors.Cause(err) == db.ErrNotExist {
+		idx := index - 1
+		if index == 0 {
+			idx = 0
+		}
+		db, _, err := fd.getDBFromIndex(idx)
+		if err != nil {
+			return nil, err
+		}
+		value, err = db.Get(blockNS, h[:])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return value, err
+}
+
+// openDB open file if exists, or create new file
+func (fd *fileDAOLegacy) openDB(idx uint64) (kvStore db.KVStore, index uint64, err error) {
+	if idx == 0 {
+		return fd.kvStore, 0, nil
+	}
+	cfg := fd.cfg
+	model, _ := getFileNameAndDir(cfg.DbPath)
+	name := model + fmt.Sprintf("-%08d", idx) + ".db"
+
+	fd.mutex.Lock()
+	defer fd.mutex.Unlock()
+	// open or create this db file
+	cfg.DbPath = path.Dir(cfg.DbPath) + "/" + name
+	var newFile bool
+	_, err = os.Stat(cfg.DbPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			// something wrong getting FileInfo
+			return
+		}
+		newFile = true
+	}
+
+	kvStore = db.NewBoltDB(cfg)
+	fd.kvStores.Store(idx, kvStore)
+	err = kvStore.Start(context.Background())
+	if err != nil {
+		return
+	}
+
+	if newFile {
+		if err = kvStore.Put(systemLogNS, make([]byte, 8), []byte(systemLogNS)); err != nil {
+			return
+		}
+	}
+	fd.lifecycle.Add(kvStore)
+	index = idx
+	return
+}
+
+func getFileNameAndDir(p string) (fileName, dir string) {
+	var withSuffix, suffix string
+	withSuffix = path.Base(p)
+	suffix = path.Ext(withSuffix)
+	fileName = strings.TrimSuffix(withSuffix, suffix)
+	dir = path.Dir(p)
+	return
+}
+
+func heightKey(height uint64) []byte {
+	return append(heightPrefix, byteutil.Uint64ToBytes(height)...)
+}

--- a/blockchain/blockdao/filedao_legacy.go
+++ b/blockchain/blockdao/filedao_legacy.go
@@ -46,6 +46,8 @@ const (
 var (
 	heightPrefix       = []byte("he.")
 	heightToFileBucket = []byte("h2f")
+	patternLen         = len("00000000.db")
+	suffixLen          = len(".db")
 )
 
 type (

--- a/blockchain/blockdao/filedao_test.go
+++ b/blockchain/blockdao/filedao_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package blockdao
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+)
+
+func TestChecksumNamespaceAndKeys(t *testing.T) {
+	require := require.New(t)
+
+	a := []hash.Hash256{
+		// blockdao
+		hash.BytesToHash256([]byte(blockHashHeightMappingNS)),
+		hash.BytesToHash256([]byte(systemLogNS)),
+		hash.BytesToHash256(topHeightKey),
+		hash.BytesToHash256(topHashKey),
+		hash.BytesToHash256(hashPrefix),
+		// filedao_legacy
+		hash.BytesToHash256([]byte(blockNS)),
+		hash.BytesToHash256([]byte(blockHeaderNS)),
+		hash.BytesToHash256([]byte(blockBodyNS)),
+		hash.BytesToHash256([]byte(blockFooterNS)),
+		hash.BytesToHash256([]byte(receiptsNS)),
+		hash.BytesToHash256(heightPrefix),
+		hash.BytesToHash256(heightToFileBucket),
+	}
+
+	checksum := crypto.NewMerkleTree(a)
+	require.NotNil(checksum)
+	h := checksum.HashTree()
+	require.Equal("3ed359035cea947b14288bc0f581391c63d087e161d82b452e0353375cde2f0d", hex.EncodeToString(h[:]))
+}

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -529,7 +529,7 @@ func TestCreateBlockchain(t *testing.T) {
 	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(err)
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		dao,
@@ -573,7 +573,7 @@ func TestBlockchain_MintNewBlock(t *testing.T) {
 	require.NoError(t, err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(t, err)
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		dao,
@@ -645,7 +645,7 @@ func TestBlockchain_MintNewBlock_PopAccount(t *testing.T) {
 	require.NoError(t, err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(t, err)
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		dao,
@@ -741,7 +741,7 @@ func TestConstantinople(t *testing.T) {
 		require.NoError(err)
 		// create BlockDAO
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		dao := blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), []blockdao.BlockIndexer{sf, indexer}, cfg.Chain.CompressBlock, cfg.DB)
+		dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf, indexer}, cfg.Chain.CompressBlock, cfg.DB)
 		require.NotNil(dao)
 		bc := blockchain.NewBlockchain(
 			cfg,
@@ -978,7 +978,7 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
 		// create BlockDAO
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		dao := blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), indexers, cfg.Chain.CompressBlock, cfg.DB)
+		dao := blockdao.NewBlockDAO(indexers, cfg.Chain.CompressBlock, cfg.DB)
 		require.NotNil(dao)
 		bc := blockchain.NewBlockchain(
 			cfg,
@@ -1675,7 +1675,7 @@ func newChain(t *testing.T, stateTX bool) (blockchain.Blockchain, factory.Factor
 	cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
 	// create BlockDAO
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	dao := blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), indexers, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAO(indexers, cfg.Chain.CompressBlock, cfg.DB)
 	require.NotNil(dao)
 	bc := blockchain.NewBlockchain(
 		cfg,

--- a/blockindex/indexbuilder.go
+++ b/blockindex/indexbuilder.go
@@ -151,30 +151,6 @@ func (ib *IndexBuilder) init() error {
 	if startHeight >= tipHeight {
 		// successfully migrated to latest block
 		zap.L().Info("Finished migrating DB", zap.Uint64("height", startHeight))
-		return ib.purgeObsoleteIndex()
-	}
-	return nil
-}
-
-func (ib *IndexBuilder) purgeObsoleteIndex() error {
-	store := ib.dao.KVStore()
-	if err := store.Delete(blockAddressActionMappingNS, nil); err != nil {
-		return err
-	}
-	if err := store.Delete(blockAddressActionCountMappingNS, nil); err != nil {
-		return err
-	}
-	if err := store.Delete(blockActionBlockMappingNS, nil); err != nil {
-		return err
-	}
-	if err := store.Delete(blockActionReceiptMappingNS, nil); err != nil {
-		return err
-	}
-	if err := store.Delete(numActionsNS, nil); err != nil {
-		return err
-	}
-	if err := store.Delete(transferAmountNS, nil); err != nil {
-		return err
 	}
 	return nil
 }

--- a/blockindex/indexbuilder_test.go
+++ b/blockindex/indexbuilder_test.go
@@ -59,8 +59,7 @@ func TestIndexBuilder(t *testing.T) {
 		},
 	}
 
-	testIndexer := func(kvStore db.KVStore, indexer Indexer, t *testing.T) {
-		dao := blockdao.NewBlockDAO(kvStore, nil, false, config.Default.DB)
+	testIndexer := func(dao blockdao.BlockDAO, indexer Indexer, t *testing.T) {
 		ctx := protocol.WithBlockchainCtx(
 			context.Background(),
 			protocol.BlockchainCtx{
@@ -152,28 +151,44 @@ func TestIndexBuilder(t *testing.T) {
 		}
 	}
 
-	t.Run("In-memory KV indexer", func(t *testing.T) {
-		indexer, err := NewIndexer(db.NewMemKVStore(), hash.ZeroHash256)
-		require.NoError(err)
-		testIndexer(db.NewMemKVStore(), indexer, t)
-	})
 	path := "test-indexer"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
 	indexPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	cfg := config.Default.DB
-	t.Run("Bolt DB indexer", func(t *testing.T) {
+	testutil.CleanupPath(t, testPath)
+	testutil.CleanupPath(t, indexPath)
+	defer func() {
 		testutil.CleanupPath(t, testPath)
 		testutil.CleanupPath(t, indexPath)
-		defer func() {
-			testutil.CleanupPath(t, testPath)
-			testutil.CleanupPath(t, indexPath)
-		}()
-		cfg.DbPath = indexPath
-		indexer, err := NewIndexer(db.NewBoltDB(cfg), hash.ZeroHash256)
-		require.NoError(err)
-		cfg.DbPath = testPath
-		testIndexer(db.NewBoltDB(cfg), indexer, t)
-	})
+	}()
+	cfg := config.Default.DB
+	cfg.DbPath = testPath
+
+	for _, v := range []struct {
+		dao   blockdao.BlockDAO
+		inMem bool
+	}{
+		{
+			blockdao.NewBlockDAOInMemForTest(nil, cfg), true,
+		},
+		{
+			blockdao.NewBlockDAO(nil, false, cfg), false,
+		},
+	} {
+		t.Run("test indexbuilder", func(t *testing.T) {
+			var (
+				indexer Indexer
+				err     error
+			)
+			if v.inMem {
+				indexer, err = NewIndexer(db.NewMemKVStore(), hash.ZeroHash256)
+			} else {
+				cfg.DbPath = indexPath
+				indexer, err = NewIndexer(db.NewBoltDB(cfg), hash.ZeroHash256)
+			}
+			require.NoError(err)
+			testIndexer(v.dao, indexer, t)
+		})
+	}
 }

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockchain"
@@ -180,7 +179,7 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 	require.NotNil(ap)
 	require.NoError(err)
 	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	chain := bc.NewBlockchain(
 		cfg,
 		dao,
@@ -238,7 +237,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	require.NotNil(ap1)
 	require.NoError(err)
 	ap1.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	chain1 := bc.NewBlockchain(
 		cfg,
 		dao,
@@ -262,7 +261,7 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	require.NotNil(ap2)
 	require.NoError(err)
 	ap2.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf2, accountutil.AccountState))
-	dao2 := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf2}, cfg.Chain.CompressBlock, cfg.DB)
+	dao2 := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf2}, cfg.DB)
 	chain2 := bc.NewBlockchain(
 		cfg,
 		dao2,
@@ -329,7 +328,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	require.NotNil(ap1)
 	require.NoError(err)
 	ap1.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	chain1 := bc.NewBlockchain(
 		cfg,
 		dao,
@@ -352,7 +351,7 @@ func TestBlockSyncerProcessBlockSync(t *testing.T) {
 	require.NotNil(ap2)
 	require.NoError(err)
 	ap2.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf2, accountutil.AccountState))
-	dao2 := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf2}, cfg.Chain.CompressBlock, cfg.DB)
+	dao2 := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf2}, cfg.DB)
 	chain2 := bc.NewBlockchain(
 		cfg,
 		dao2,
@@ -412,7 +411,7 @@ func TestBlockSyncerSync(t *testing.T) {
 	require.NotNil(ap)
 	require.NoError(err)
 	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	chain := bc.NewBlockchain(
 		cfg,
 		dao,

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -183,15 +183,13 @@ func New(
 	}
 
 	// create BlockDAO
-	var kvStore db.KVStore
+	var dao blockdao.BlockDAO
 	if ops.isTesting {
-		kvStore = db.NewMemKVStore()
+		dao = blockdao.NewBlockDAOInMemForTest(indexers, cfg.DB)
 	} else {
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		kvStore = db.NewBoltDB(cfg.DB)
+		dao = blockdao.NewBlockDAO(indexers, cfg.Chain.CompressBlock, cfg.DB)
 	}
-	var dao blockdao.BlockDAO
-	dao = blockdao.NewBlockDAO(kvStore, indexers, cfg.Chain.CompressBlock, cfg.DB)
 
 	// Create ActPool
 	actOpts := make([]actpool.Option, 0)

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/testutil"
 )
@@ -84,7 +83,7 @@ func prepareBlockchain(ctx context.Context, executor string, r *require.Assertio
 	r.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	r.NoError(err)
-	dao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		dao,

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/p2p"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/server/itx"
@@ -549,7 +548,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 
 	// Recover to height 3 from empty state DB
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	dao = blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), nil, cfg.Chain.CompressBlock, cfg.DB)
+	dao = blockdao.NewBlockDAO(nil, cfg.Chain.CompressBlock, cfg.DB)
 	require.NoError(dao.Start(protocol.WithBlockchainCtx(ctx,
 		protocol.BlockchainCtx{
 			Genesis: cfg.Genesis,
@@ -572,7 +571,7 @@ func TestStartExistingBlockchain(t *testing.T) {
 	// Recover to height 2 from an existing state DB with Height 3
 	require.NoError(svr.Stop(ctx))
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	dao = blockdao.NewBlockDAO(db.NewBoltDB(cfg.DB), nil, cfg.Chain.CompressBlock, cfg.DB)
+	dao = blockdao.NewBlockDAO(nil, cfg.Chain.CompressBlock, cfg.DB)
 	require.NoError(dao.Start(protocol.WithBlockchainCtx(ctx,
 		protocol.BlockchainCtx{
 			Genesis: cfg.Genesis,

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -54,7 +53,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	require.NoError(t, err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(t, err)
-	blkMemDao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	blkMemDao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blkMemDao,
@@ -130,7 +129,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	require.NoError(t, err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(t, err)
-	blkMemDao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	blkMemDao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blkMemDao,
@@ -183,7 +182,7 @@ func TestEstimateGasForAction(t *testing.T) {
 	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(err)
-	blkMemDao := blockdao.NewBlockDAO(db.NewMemKVStore(), []blockdao.BlockIndexer{sf}, cfg.Chain.CompressBlock, cfg.DB)
+	blkMemDao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf}, cfg.DB)
 	bc := blockchain.NewBlockchain(cfg, blkMemDao, factory.NewMinter(sf, ap))
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)

--- a/misc/scripts/mockgen.sh
+++ b/misc/scripts/mockgen.sh
@@ -17,6 +17,7 @@ mockgen -destination=./test/mock/mock_blockchain/mock_blockchain.go  \
 mkdir -p ./test/mock/mock_blockdao
 mockgen -destination=./test/mock/mock_blockdao/mock_blockdao.go  \
         -source=./blockchain/blockdao/blockdao.go \
+        -aux_files=github.com/iotexproject/iotex-core/blockchain/blockdao=./blockchain/blockdao/filedao.go \
         -package=mock_blockdao \
         BlockDAO
 

--- a/test/mock/mock_blockdao/mock_blockdao.go
+++ b/test/mock/mock_blockdao/mock_blockdao.go
@@ -10,7 +10,6 @@ import (
 	hash "github.com/iotexproject/go-pkgs/hash"
 	action "github.com/iotexproject/iotex-core/action"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
-	db "github.com/iotexproject/iotex-core/db"
 	iotextypes "github.com/iotexproject/iotex-proto/golang/iotextypes"
 	reflect "reflect"
 )
@@ -64,6 +63,21 @@ func (m *MockBlockDAO) Stop(ctx context.Context) error {
 func (mr *MockBlockDAOMockRecorder) Stop(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockBlockDAO)(nil).Stop), ctx)
+}
+
+// Height mocks base method
+func (m *MockBlockDAO) Height() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Height")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Height indicates an expected call of Height
+func (mr *MockBlockDAOMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockBlockDAO)(nil).Height))
 }
 
 // GetBlockHash mocks base method
@@ -126,19 +140,76 @@ func (mr *MockBlockDAOMockRecorder) GetBlockByHeight(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByHeight", reflect.TypeOf((*MockBlockDAO)(nil).GetBlockByHeight), arg0)
 }
 
-// Height mocks base method
-func (m *MockBlockDAO) Height() (uint64, error) {
+// GetReceipts mocks base method
+func (m *MockBlockDAO) GetReceipts(arg0 uint64) ([]*action.Receipt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Height")
-	ret0, _ := ret[0].(uint64)
+	ret := m.ctrl.Call(m, "GetReceipts", arg0)
+	ret0, _ := ret[0].([]*action.Receipt)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Height indicates an expected call of Height
-func (mr *MockBlockDAOMockRecorder) Height() *gomock.Call {
+// GetReceipts indicates an expected call of GetReceipts
+func (mr *MockBlockDAOMockRecorder) GetReceipts(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockBlockDAO)(nil).Height))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceipts", reflect.TypeOf((*MockBlockDAO)(nil).GetReceipts), arg0)
+}
+
+// ContainsTransactionLog mocks base method
+func (m *MockBlockDAO) ContainsTransactionLog() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContainsTransactionLog")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// ContainsTransactionLog indicates an expected call of ContainsTransactionLog
+func (mr *MockBlockDAOMockRecorder) ContainsTransactionLog() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsTransactionLog", reflect.TypeOf((*MockBlockDAO)(nil).ContainsTransactionLog))
+}
+
+// TransactionLogs mocks base method
+func (m *MockBlockDAO) TransactionLogs(arg0 uint64) (*iotextypes.TransactionLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionLogs", arg0)
+	ret0, _ := ret[0].(*iotextypes.TransactionLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TransactionLogs indicates an expected call of TransactionLogs
+func (mr *MockBlockDAOMockRecorder) TransactionLogs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionLogs", reflect.TypeOf((*MockBlockDAO)(nil).TransactionLogs), arg0)
+}
+
+// PutBlock mocks base method
+func (m *MockBlockDAO) PutBlock(arg0 context.Context, arg1 *block.Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutBlock", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutBlock indicates an expected call of PutBlock
+func (mr *MockBlockDAOMockRecorder) PutBlock(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBlock", reflect.TypeOf((*MockBlockDAO)(nil).PutBlock), arg0, arg1)
+}
+
+// DeleteTipBlock mocks base method
+func (m *MockBlockDAO) DeleteTipBlock() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTipBlock")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteTipBlock indicates an expected call of DeleteTipBlock
+func (mr *MockBlockDAOMockRecorder) DeleteTipBlock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTipBlock", reflect.TypeOf((*MockBlockDAO)(nil).DeleteTipBlock))
 }
 
 // Header mocks base method
@@ -216,35 +287,6 @@ func (mr *MockBlockDAOMockRecorder) GetReceiptByActionHash(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceiptByActionHash", reflect.TypeOf((*MockBlockDAO)(nil).GetReceiptByActionHash), arg0, arg1)
 }
 
-// GetReceipts mocks base method
-func (m *MockBlockDAO) GetReceipts(arg0 uint64) ([]*action.Receipt, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReceipts", arg0)
-	ret0, _ := ret[0].([]*action.Receipt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReceipts indicates an expected call of GetReceipts
-func (mr *MockBlockDAOMockRecorder) GetReceipts(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReceipts", reflect.TypeOf((*MockBlockDAO)(nil).GetReceipts), arg0)
-}
-
-// PutBlock mocks base method
-func (m *MockBlockDAO) PutBlock(arg0 context.Context, arg1 *block.Block) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutBlock", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutBlock indicates an expected call of PutBlock
-func (mr *MockBlockDAOMockRecorder) PutBlock(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBlock", reflect.TypeOf((*MockBlockDAO)(nil).PutBlock), arg0, arg1)
-}
-
 // DeleteBlockToTarget mocks base method
 func (m *MockBlockDAO) DeleteBlockToTarget(arg0 uint64) error {
 	m.ctrl.T.Helper()
@@ -257,20 +299,6 @@ func (m *MockBlockDAO) DeleteBlockToTarget(arg0 uint64) error {
 func (mr *MockBlockDAOMockRecorder) DeleteBlockToTarget(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBlockToTarget", reflect.TypeOf((*MockBlockDAO)(nil).DeleteBlockToTarget), arg0)
-}
-
-// KVStore mocks base method
-func (m *MockBlockDAO) KVStore() db.KVStore {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "KVStore")
-	ret0, _ := ret[0].(db.KVStore)
-	return ret0
-}
-
-// KVStore indicates an expected call of KVStore
-func (mr *MockBlockDAOMockRecorder) KVStore() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "KVStore", reflect.TypeOf((*MockBlockDAO)(nil).KVStore))
 }
 
 // HeaderByHeight mocks base method
@@ -301,35 +329,6 @@ func (m *MockBlockDAO) FooterByHeight(arg0 uint64) (*block.Footer, error) {
 func (mr *MockBlockDAOMockRecorder) FooterByHeight(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FooterByHeight", reflect.TypeOf((*MockBlockDAO)(nil).FooterByHeight), arg0)
-}
-
-// ContainsTransactionLog mocks base method
-func (m *MockBlockDAO) ContainsTransactionLog() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ContainsTransactionLog")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// ContainsTransactionLog indicates an expected call of ContainsTransactionLog
-func (mr *MockBlockDAOMockRecorder) ContainsTransactionLog() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContainsTransactionLog", reflect.TypeOf((*MockBlockDAO)(nil).ContainsTransactionLog))
-}
-
-// TransactionLogs mocks base method
-func (m *MockBlockDAO) TransactionLogs(arg0 uint64) (*iotextypes.TransactionLogs, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransactionLogs", arg0)
-	ret0, _ := ret[0].(*iotextypes.TransactionLogs)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TransactionLogs indicates an expected call of TransactionLogs
-func (mr *MockBlockDAOMockRecorder) TransactionLogs(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionLogs", reflect.TypeOf((*MockBlockDAO)(nil).TransactionLogs), arg0)
 }
 
 // MockBlockIndexer is a mock of BlockIndexer interface

--- a/tools/iomigrater/cmds/check-height.go
+++ b/tools/iomigrater/cmds/check-height.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/tools/iomigrater/common"
 )
 
@@ -54,12 +53,7 @@ func checkDbFileHeight(filePath string) (uint64, error) {
 	}
 
 	cfg.DB.DbPath = filePath
-	blockDao := blockdao.NewBlockDAO(
-		db.NewBoltDB(cfg.DB),
-		nil,
-		cfg.Chain.CompressBlock,
-		cfg.DB,
-	)
+	blockDao := blockdao.NewBlockDAO(nil, cfg.Chain.CompressBlock, cfg.DB)
 
 	// Load height value.
 	ctx := context.Background()

--- a/tools/iomigrater/cmds/migrate-db.go
+++ b/tools/iomigrater/cmds/migrate-db.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/tools/iomigrater/common"
 )
 
@@ -114,20 +113,10 @@ func migrateDbFile() error {
 	}
 
 	cfg.DB.DbPath = oldFile
-	oldDAO := blockdao.NewBlockDAO(
-		db.NewBoltDB(cfg.DB),
-		nil,
-		cfg.Chain.CompressBlock,
-		cfg.DB,
-	)
+	oldDAO := blockdao.NewBlockDAO(nil, cfg.Chain.CompressBlock, cfg.DB)
 
 	cfg.DB.DbPath = newFile
-	newDAO := blockdao.NewBlockDAO(
-		db.NewBoltDB(cfg.DB),
-		nil,
-		cfg.Chain.CompressBlock,
-		cfg.DB,
-	)
+	newDAO := blockdao.NewBlockDAO(nil, cfg.Chain.CompressBlock, cfg.DB)
 
 	ctx := context.Background()
 	if err := oldDAO.Start(ctx); err != nil {


### PR DESCRIPTION
1. this PR only adds the FileDAO interface and move current block read/write code to filedao_legacy.go
2. next PR will handle the new file implementation
3. last PR will take care how to handle chain db file depending on sf.Height(), and starting chain only on statedb