### PR TITLE
fixed: ioctl  node delegate crashes if ROLLDPOS not register (#2390)

### DIFF
--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -131,7 +131,7 @@ func delegates() error {
 		if epochData == nil {
 			return output.NewError(0, "ROLLDPOS is not registered", nil)
 		}
-		epochNum = chainMeta.GetEpoch().Num
+		epochNum = epochData.Num
 	}
 	response, err := bc.GetEpochMeta(epochNum)
 	if err != nil {

--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -70,7 +70,6 @@ var nodeDelegateCmd = &cobra.Command{
 		cmd.SilenceUsage = true
 		err := delegates()
 		return output.PrintError(err)
-
 	},
 }
 
@@ -128,7 +127,11 @@ func delegates() error {
 		if err != nil {
 			return output.NewError(0, "failed to get chain meta", err)
 		}
-		epochNum = chainMeta.Epoch.Num
+		epochData := chainMeta.GetEpoch()
+		if epochData == nil {
+			return output.NewError(0, "ROLLDPOS is not registered", nil)
+		}
+		epochNum = chainMeta.GetEpoch().Num
 	}
 	response, err := bc.GetEpochMeta(epochNum)
 	if err != nil {

--- a/ioctl/cmd/node/nodeprobationlist.go
+++ b/ioctl/cmd/node/nodeprobationlist.go
@@ -73,6 +73,7 @@ func probationlist() error {
 		if epochData == nil {
 			return output.NewError(0, "ROLLDPOS is not registered", nil)
 		}
+		epochNum = epochData.Num
 	}
 	response, err := bc.GetEpochMeta(epochNum)
 	if err != nil {

--- a/ioctl/cmd/node/nodeprobationlist.go
+++ b/ioctl/cmd/node/nodeprobationlist.go
@@ -69,7 +69,10 @@ func probationlist() error {
 		if err != nil {
 			return output.NewError(0, "failed to get chain meta", err)
 		}
-		epochNum = chainMeta.Epoch.Num
+		epochData := chainMeta.GetEpoch()
+		if epochData == nil {
+			return output.NewError(0, "ROLLDPOS is not registered", nil)
+		}
 	}
 	response, err := bc.GetEpochMeta(epochNum)
 	if err != nil {


### PR DESCRIPTION
In [standalone](https://github.com/iotexproject/iotex-core/blob/master/config/standalone-config.yaml) mode or no consensus configurations mode, `ioctl node delegate` or `ioctl node probationlist` will crash cause no consensus registered.