### PR TITLE
Change https://www.iotex.io/research-paper -> https://iotex.io/research/

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 Welcome to the official Go implementation of IoTeX protocol! IoTeX is building the next generation of the decentralized 
 network for IoT powered by scalability- and privacy-centric blockchains. Please refer to IoTeX
-[whitepaper](https://www.iotex.io/research-paper) for details.
+[whitepaper](https://iotex.io/research/) for details.
 
 ## Get started
 


### PR DESCRIPTION
The link of whitepaper link no longer exists. Home site is changed. Use the new url