### PR TITLE
api.GetActionByBlock to return all actions in block if count = -1

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1123,9 +1123,6 @@ func (api *Server) getUnconfirmedActionsByAddress(address string, start uint64, 
 
 // getActionsByBlock returns all actions in a block
 func (api *Server) getActionsByBlock(blkHash string, start uint64, count uint64) (*iotexapi.GetActionsResponse, error) {
-	if count == 0 {
-		return nil, status.Error(codes.InvalidArgument, "count must be greater than zero")
-	}
 	if count > api.cfg.API.RangeQueryLimit {
 		return nil, status.Error(codes.InvalidArgument, "range exceeds the limit")
 	}
@@ -1138,17 +1135,13 @@ func (api *Server) getActionsByBlock(blkHash string, start uint64, count uint64)
 	if err != nil {
 		return nil, status.Error(codes.NotFound, err.Error())
 	}
-	if len(blk.Actions) == 0 {
-		return &iotexapi.GetActionsResponse{}, nil
-	}
 	if start >= uint64(len(blk.Actions)) {
 		return nil, status.Error(codes.InvalidArgument, "start exceeds the limit")
 	}
 
-	res := api.actionsInBlock(blk, start, count)
 	return &iotexapi.GetActionsResponse{
 		Total:      uint64(len(blk.Actions)),
-		ActionInfo: res,
+		ActionInfo: api.actionsInBlock(blk, start, count),
 	}, nil
 }
 
@@ -1390,13 +1383,26 @@ func (api *Server) getAction(actHash hash.Hash256, checkPending bool) (*iotexapi
 }
 
 func (api *Server) actionsInBlock(blk *block.Block, start, count uint64) []*iotexapi.ActionInfo {
+	var res []*iotexapi.ActionInfo
+	if len(blk.Actions) == 0 || start >= uint64(len(blk.Actions)) {
+		return res
+	}
+
 	h := blk.HashBlock()
 	blkHash := hex.EncodeToString(h[:])
 	blkHeight := blk.Height()
 	ts := blk.Header.BlockHeaderCoreProto().Timestamp
 
-	var res []*iotexapi.ActionInfo
-	for i := start; i < uint64(len(blk.Actions)) && i < start+count; i++ {
+	lastAction := start + count
+	if count != 0 {
+		if lastAction >= uint64(len(blk.Actions)) {
+			lastAction = uint64(len(blk.Actions))
+		}
+	} else {
+		// count = 0 means to get all actions
+		lastAction = uint64(len(blk.Actions))
+	}
+	for i := start; i < lastAction; i++ {
 		selp := blk.Actions[i]
 		actHash := selp.Hash()
 		sender, _ := address.FromBytes(selp.SrcPubkey().Hash())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -9,6 +9,7 @@ package api
 import (
 	"context"
 	"encoding/hex"
+	"math"
 	"math/big"
 	"strconv"
 	"testing"
@@ -255,9 +256,15 @@ var (
 			3,
 		},
 		{
+			3,
+			0,
+			0,
+			0,
+		},
+		{
 			1,
 			0,
-			0,
+			math.MaxUint64,
 			2,
 		},
 	}
@@ -933,6 +940,10 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 			},
 		}
 		res, err := svr.GetActions(context.Background(), request)
+		if test.count == 0 {
+			require.Error(err)
+			continue
+		}
 		require.NoError(err)
 		require.Equal(test.numActions, len(res.ActionInfo))
 		for _, v := range res.ActionInfo {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -90,7 +90,7 @@ var (
 		big.NewInt(1), testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64), []byte{1})
 	executionHash3 = testExecution3.Hash()
 
-	blkHash      = map[uint64]hash.Hash256{}
+	blkHash      = map[uint64]string{}
 	implicitLogs = map[hash.Hash256]*block.TransactionLog{}
 )
 
@@ -928,12 +928,10 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 	require.NoError(err)
 
 	for _, test := range getActionsByBlockTests {
-		h := blkHash[test.blkHeight]
-		hStr := hex.EncodeToString(h[:])
 		request := &iotexapi.GetActionsRequest{
 			Lookup: &iotexapi.GetActionsRequest_ByBlk{
 				ByBlk: &iotexapi.GetActionsByBlockRequest{
-					BlkHash: hStr,
+					BlkHash: blkHash[test.blkHeight],
 					Start:   test.start,
 					Count:   test.count,
 				},
@@ -948,7 +946,7 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 		require.Equal(test.numActions, len(res.ActionInfo))
 		for _, v := range res.ActionInfo {
 			require.Equal(test.blkHeight, v.BlkHeight)
-			require.Equal(hStr, v.BlkHash)
+			require.Equal(blkHash[test.blkHeight], v.BlkHash)
 		}
 	}
 }
@@ -1891,8 +1889,7 @@ func TestServer_GetEvmTransfersByBlockHeight(t *testing.T) {
 				require.Equal(l.Proto(), log)
 			}
 			require.Equal(test.height, res.BlockIdentifier.Height)
-			h := blkHash[test.height]
-			require.Equal(hex.EncodeToString(h[:]), res.BlockIdentifier.Hash)
+			require.Equal(blkHash[test.height], res.BlockIdentifier.Hash)
 		}
 	}
 }
@@ -1928,7 +1925,8 @@ func addTestingBlocks(bc blockchain.Blockchain, ap actpool.ActPool) error {
 		return err
 	}
 	ap.Reset()
-	blkHash[1] = blk.HashBlock()
+	h := blk.HashBlock()
+	blkHash[1] = hex.EncodeToString(h[:])
 
 	// Add block 2
 	// Charlie transfer--> A, B, D, P
@@ -1976,7 +1974,8 @@ func addTestingBlocks(bc blockchain.Blockchain, ap actpool.ActPool) error {
 		return err
 	}
 	ap.Reset()
-	blkHash[2] = blk.HashBlock()
+	h = blk.HashBlock()
+	blkHash[2] = hex.EncodeToString(h[:])
 
 	// Add block 3
 	// Empty actions
@@ -1987,7 +1986,8 @@ func addTestingBlocks(bc blockchain.Blockchain, ap actpool.ActPool) error {
 		return err
 	}
 	ap.Reset()
-	blkHash[3] = blk.HashBlock()
+	h = blk.HashBlock()
+	blkHash[3] = hex.EncodeToString(h[:])
 
 	// Add block 4
 	// Charlie transfer--> C
@@ -2041,7 +2041,8 @@ func addTestingBlocks(bc blockchain.Blockchain, ap actpool.ActPool) error {
 	if blk, err = bc.MintNewBlock(blk1Time.Add(time.Second * 3)); err != nil {
 		return err
 	}
-	blkHash[4] = blk.HashBlock()
+	h = blk.HashBlock()
+	blkHash[4] = hex.EncodeToString(h[:])
 	return bc.CommitBlock(blk)
 }
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -250,15 +250,15 @@ var (
 		},
 		{
 			4,
-			0,
+			2,
 			5,
-			5,
+			3,
 		},
 		{
 			1,
 			0,
 			0,
-			0,
+			2,
 		},
 	}
 
@@ -921,26 +921,24 @@ func TestServer_GetActionsByBlock(t *testing.T) {
 	require.NoError(err)
 
 	for _, test := range getActionsByBlockTests {
-		header, err := svr.bc.BlockHeaderByHeight(test.blkHeight)
-		require.NoError(err)
-		blkHash := header.HashBlock()
+		h := blkHash[test.blkHeight]
+		hStr := hex.EncodeToString(h[:])
 		request := &iotexapi.GetActionsRequest{
 			Lookup: &iotexapi.GetActionsRequest_ByBlk{
 				ByBlk: &iotexapi.GetActionsByBlockRequest{
-					BlkHash: hex.EncodeToString(blkHash[:]),
+					BlkHash: hStr,
 					Start:   test.start,
 					Count:   test.count,
 				},
 			},
 		}
 		res, err := svr.GetActions(context.Background(), request)
-		if test.count == 0 {
-			require.Error(err)
-			continue
-		}
 		require.NoError(err)
 		require.Equal(test.numActions, len(res.ActionInfo))
-		require.Equal(test.blkHeight, res.ActionInfo[0].BlkHeight)
+		for _, v := range res.ActionInfo {
+			require.Equal(test.blkHeight, v.BlkHeight)
+			require.Equal(hStr, v.BlkHash)
+		}
 	}
 }
 


### PR DESCRIPTION
SWFT/IoTeX chat group raised the question to get all actions in a block, it needs 2 RPC calls:

1. call GetBlockMeta, to get numActions = # of actions in the block
2. call GetActionsByBlock, with start = 0, count = numActions to get all actions

with this PR, just need 1 RPC call: call GetActionsByBlock, with start = 0, count = 0 will return all actions in the block