### PR TITLE
avoid multiple mint in one round

### DIFF
--- a/consensus/scheme/rolldpos/endorsementmanager.go
+++ b/consensus/scheme/rolldpos/endorsementmanager.go
@@ -31,7 +31,7 @@ var (
 	statusKey             = []byte("status")
 )
 
-//EndorsedByMajorityFunc defines a function to give an information of consensus status
+// EndorsedByMajorityFunc defines a function to give an information of consensus status
 type EndorsedByMajorityFunc func(blockHash []byte, topics []ConsensusVoteTopic) bool
 
 type endorserEndorsementCollection struct {
@@ -109,6 +109,7 @@ func (ee *endorserEndorsementCollection) Endorsement(
 }
 
 type blockEndorsementCollection struct {
+	isMinted  bool
 	blk       *block.Block
 	endorsers map[string]*endorserEndorsementCollection
 }
@@ -138,6 +139,7 @@ func (bc *blockEndorsementCollection) fromProto(blockPro *endorsementpb.BlockEnd
 		}
 		bc.endorsers[endorsement.Endorser] = ee
 	}
+	// TODO: bc.isMinted = blockPro.IsMinted
 	return nil
 }
 
@@ -154,6 +156,7 @@ func (bc *blockEndorsementCollection) toProto() (*endorsementpb.BlockEndorsement
 		}
 		bcProto.BlockMap = append(bcProto.BlockMap, ioEndorsement)
 	}
+	// TODO: bcProto.IsMinted = bc.isMinted
 	return bcProto, nil
 }
 
@@ -164,6 +167,10 @@ func (bc *blockEndorsementCollection) SetBlock(blk *block.Block) error {
 
 func (bc *blockEndorsementCollection) Block() *block.Block {
 	return bc.blk
+}
+
+func (bc *blockEndorsementCollection) minted() {
+	bc.isMinted = true
 }
 
 func (bc *blockEndorsementCollection) AddEndorsement(
@@ -311,6 +318,15 @@ func (m *endorsementManager) CollectionByBlockHash(blkHash []byte) *blockEndorse
 	return collections
 }
 
+func (m *endorsementManager) IsMintedByBlockHash(blkHash []byte) bool {
+	encodedBlockHash := encodeToString(blkHash)
+	collection, exists := m.collections[encodedBlockHash]
+	if !exists {
+		return false
+	}
+	return collection.isMinted
+}
+
 func (m *endorsementManager) Size() int {
 	return len(m.collections)
 }
@@ -332,6 +348,7 @@ func (m *endorsementManager) RegisterBlock(blk *block.Block) error {
 		return c.SetBlock(blk)
 	}
 	m.collections[encodedBlockHash] = newBlockEndorsementCollection(blk)
+	m.collections[encodedBlockHash].minted()
 
 	if m.eManagerDB != nil {
 		return m.PutEndorsementManagerToDB()
@@ -360,7 +377,7 @@ func (m *endorsementManager) AddVoteEndorsement(
 	if m.eManagerDB != nil && m.isMajorityFunc != nil {
 		afterVote = m.isMajorityFunc(vote.BlockHash(), []ConsensusVoteTopic{vote.Topic()})
 		if !beforeVote && afterVote {
-			//put into DB only it changes the status of consensus
+			// put into DB only it changes the status of consensus
 			return m.PutEndorsementManagerToDB()
 		}
 	}

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -82,9 +82,6 @@ type rollDPoSCtx struct {
 	eManagerDB        db.KVStore
 	toleratedOvertime time.Duration
 
-	// the last minted block height
-	// TODO: update lastMinted after sync
-	lastMinted  uint64
 	encodedAddr string
 	priKey      crypto.PrivateKey
 	round       *roundCtx
@@ -152,7 +149,6 @@ func newRollDPoSCtx(
 		roundCalc:         roundCalc,
 		eManagerDB:        eManagerDB,
 		toleratedOvertime: toleratedOvertime,
-		lastMinted:        chain.TipHeight(),
 	}, nil
 }
 
@@ -328,7 +324,7 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	if ctx.round.Proposer() != ctx.encodedAddr {
 		return nil, nil
 	}
-	if ctx.round.IsLocked() {
+	if ctx.round.IsLocked() && !ctx.round.isMinted() {
 		return ctx.endorseBlockProposal(newBlockProposal(
 			ctx.round.Block(ctx.round.HashOfBlockInLock()),
 			ctx.round.ProofOfLock(),
@@ -587,10 +583,6 @@ func (ctx *rollDPoSCtx) Active() bool {
 // /////////////////////////////////////////
 
 func (ctx *rollDPoSCtx) mintNewBlock() (*EndorsedConsensusMessage, error) {
-	if ctx.round.Height() != ctx.lastMinted+1 {
-		// TODO: calibrate something
-		return nil, errors.Errorf("already minted in this round")
-	}
 	blk, err := ctx.chain.MintNewBlock(ctx.round.StartTime())
 	if err != nil {
 		return nil, err
@@ -603,8 +595,7 @@ func (ctx *rollDPoSCtx) mintNewBlock() (*EndorsedConsensusMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctx.lastMinted = blk.Height()
-	return msg, nil
+	return msg, err
 }
 
 func (ctx *rollDPoSCtx) isDelegate() bool {

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -43,6 +43,7 @@ type roundCtx struct {
 	blockInLock []byte
 	proofOfLock []*endorsement.Endorsement
 	status      status
+	lastMinted  *block.Block
 	eManager    *endorsementManager
 }
 
@@ -119,6 +120,18 @@ func (ctx *roundCtx) IsLocked() bool {
 
 func (ctx *roundCtx) IsUnlocked() bool {
 	return ctx.status == unlocked
+}
+
+func (ctx *roundCtx) SetLastMinted(blk *block.Block) error {
+	ctx.lastMinted = blk
+	return ctx.eManager.SetLastMinted(blk)
+}
+
+func (ctx *roundCtx) IsMinted() bool {
+	if ctx.lastMinted == nil {
+		return false
+	}
+	return ctx.height == ctx.lastMinted.Height()
 }
 
 func (ctx *roundCtx) ReadyToCommit(addr string) *EndorsedConsensusMessage {

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -255,7 +255,3 @@ func (ctx *roundCtx) block(blkHash []byte) *block.Block {
 	}
 	return c.Block()
 }
-
-func (ctx *roundCtx) isMinted() bool {
-	return ctx.eManager.IsMintedByBlockHash(ctx.blockInLock)
-}

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -255,3 +255,7 @@ func (ctx *roundCtx) block(blkHash []byte) *block.Block {
 	}
 	return c.Block()
 }
+
+func (ctx *roundCtx) isMinted() bool {
+	return ctx.eManager.IsMintedByBlockHash(ctx.blockInLock)
+}

--- a/consensus/scheme/standalone.go
+++ b/consensus/scheme/standalone.go
@@ -13,11 +13,12 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/routine"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 // Standalone is the consensus scheme that periodically create blocks
@@ -74,7 +75,7 @@ func (s *Standalone) Stop(ctx context.Context) error {
 
 // HandleConsensusMsg handles incoming consensus message
 func (s *Standalone) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
-	log.L().Warn("Noop scheme does not handle incoming block propose requests.")
+	log.L().Warn("Standalone scheme does not handle incoming block propose requests.")
 	return nil
 }
 


### PR DESCRIPTION
1. How about avoid multiple endrose in one round
2. I tought may should think about round.IsLocked() state, I'm not clear on this state.
3. Maybe should calibrate something if already minted in this round.
4. TODO: update lastEndorse after sync