### PR TITLE
Format output of `ioctl node reward pool`

### DIFF
--- a/ioctl/cmd/node/nodereward.go
+++ b/ioctl/cmd/node/nodereward.go
@@ -76,7 +76,7 @@ type rewardPoolMessage struct {
 
 func (m *rewardPoolMessage) String() string {
 	if output.Format == "" {
-		message := fmt.Sprintf("TotalUnclaimed: %s IOTX   TotalAvailable: %s IOTX	TotalBalance: %s IOTX",
+		message := fmt.Sprintf("Total Unclaimed:\t %s IOTX\nTotal Available:\t %s IOTX\nTotal Balance:\t\t %s IOTX",
 			m.TotalUnclaimed, m.TotalAvailable, m.TotalBalance)
 		return message
 	}


### PR DESCRIPTION
```
➜  iotex-core git:(raullen) ✗ ioctl node reward pool
Total Unclaimed:	 26670626.912383428847851662 IOTX
Total Available:	 882465182.37090161749159405 IOTX
Total Balance:		 909135809.283285046339445712 IOTX
```