### PR TITLE
Add CachedStateDBOption to wrap kvstore with LRU cache in stateDB for speed up 

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -543,7 +543,7 @@ func TestProtocol_Handle(t *testing.T) {
 		rp := rolldpos.NewProtocol(cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs)
 		require.NoError(rp.Register(registry))
 		// create state factory
-		sf, err := factory.NewStateDB(cfg, factory.DefaultStateDBOption(), factory.RegistryStateDBOption(registry))
+		sf, err := factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
 		require.NoError(err)
 		ap, err := actpool.NewActPool(sf, cfg.ActPool)
 		require.NoError(err)

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -321,7 +321,6 @@ func runExecutions(
 func (sct *SmartContractTest) prepareBlockchain(
 	ctx context.Context,
 	cfg config.Config,
-	cachedStateDBOption bool,
 	r *require.Assertions,
 ) (blockchain.Blockchain, factory.Factory, blockdao.BlockDAO, actpool.ActPool) {
 	defer func() {
@@ -348,8 +347,12 @@ func (sct *SmartContractTest) prepareBlockchain(
 	r.NoError(rp.Register(registry))
 	// create state factory
 	var sf factory.Factory
-	if cachedStateDBOption {
-		sf, err = factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
+	if cfg.Chain.EnableTrielessStateDB {
+		if cfg.Chain.EnableStateDBCaching {
+			sf, err = factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
+		} else {
+			sf, err = factory.NewStateDB(cfg, factory.DefaultStateDBOption(), factory.RegistryStateDBOption(registry))
+		}
 	} else {
 		sf, err = factory.NewFactory(cfg, factory.InMemTrieOption(), factory.RegistryOption(registry))
 	}
@@ -433,7 +436,9 @@ func (sct *SmartContractTest) deployContracts(
 func (sct *SmartContractTest) run(r *require.Assertions) {
 	// prepare blockchain
 	ctx := context.Background()
-	bc, sf, dao, ap := sct.prepareBlockchain(ctx, config.Default, false, r)
+	cfg := config.Default
+	cfg.Chain.EnableTrielessStateDB = false
+	bc, sf, dao, ap := sct.prepareBlockchain(ctx, cfg, r)
 	defer func() {
 		r.NoError(bc.Stop(ctx))
 	}()
@@ -848,7 +853,7 @@ func TestMaxTime(t *testing.T) {
 	})
 }
 
-func benchmarkHotContract(b *testing.B, async bool, cachedStateDBOption bool) {
+func benchmarkHotContractWithFactory(b *testing.B, async bool) {
 	sct := SmartContractTest{
 		InitBalances: []ExpectedBalance{
 			{
@@ -871,12 +876,90 @@ func benchmarkHotContract(b *testing.B, async bool, cachedStateDBOption bool) {
 	ctx := context.Background()
 	cfg := config.Default
 	cfg.Genesis.NumSubEpochs = uint64(b.N)
+	cfg.Chain.EnableTrielessStateDB = false
 	if async {
 		cfg.Genesis.GreenlandBlockHeight = 0
 	} else {
 		cfg.Genesis.GreenlandBlockHeight = 10000000000
 	}
-	bc, sf, dao, ap := sct.prepareBlockchain(ctx, cfg, cachedStateDBOption, r)
+	bc, sf, dao, ap := sct.prepareBlockchain(ctx, cfg, r)
+	defer func() {
+		r.NoError(bc.Stop(ctx))
+	}()
+	contractAddresses := sct.deployContracts(bc, sf, dao, ap, r)
+	r.Equal(1, len(contractAddresses))
+	contractAddr := contractAddresses[0]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		receipts, err := runExecutions(
+			bc, sf, dao, ap, []*ExecutionConfig{
+				{
+					RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+					RawByteCode:   "1249c58b",
+					RawAmount:     "0",
+					RawGasLimit:   5000000,
+					RawGasPrice:   "0",
+					Failed:        false,
+					Comment:       "mint token",
+				},
+			},
+			[]string{contractAddr},
+		)
+		r.NoError(err)
+		r.Equal(1, len(receipts))
+		r.Equal(uint64(1), receipts[0].Status)
+		ecfgs := []*ExecutionConfig{}
+		contractAddrs := []string{}
+		for j := 0; j < 100; j++ {
+			ecfgs = append(ecfgs, &ExecutionConfig{
+				RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+				RawByteCode:   fmt.Sprintf("a9059cbb000000000000000000000000123456789012345678900987%016x0000000000000000000000000000000000000000000000000000000000000039", 100*i+j),
+				RawAmount:     "0",
+				RawGasLimit:   5000000,
+				RawGasPrice:   "0",
+				Failed:        false,
+				Comment:       "send token",
+			})
+			contractAddrs = append(contractAddrs, contractAddr)
+		}
+		receipts, err = runExecutions(bc, sf, dao, ap, ecfgs, contractAddrs)
+		r.NoError(err)
+		for _, receipt := range receipts {
+			r.Equal(uint64(1), receipt.Status)
+		}
+	}
+	b.StopTimer()
+}
+
+func benchmarkHotContractWithStateDB(b *testing.B, cachedStateDBOption bool) {
+	sct := SmartContractTest{
+		InitBalances: []ExpectedBalance{
+			{
+				Account:    "io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms",
+				RawBalance: "1000000000000000000000000000",
+			},
+		},
+		Deployments: []ExecutionConfig{
+			{
+				ContractIndex: 0,
+				RawPrivateKey: "cfa6ef757dee2e50351620dca002d32b9c090cfda55fb81f37f1d26b273743f1",
+				RawByteCode:   "608060405234801561001057600080fd5b506040516040806108018339810180604052810190808051906020019092919080519060200190929190505050816004819055508060058190555050506107a58061005c6000396000f300608060405260043610610078576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680631249c58b1461007d57806327e235e31461009457806353277879146100eb5780636941b84414610142578063810ad50514610199578063a9059cbb14610223575b600080fd5b34801561008957600080fd5b50610092610270565b005b3480156100a057600080fd5b506100d5600480360381019080803573ffffffffffffffffffffffffffffffffffffffff169060200190929190505050610475565b6040518082815260200191505060405180910390f35b3480156100f757600080fd5b5061012c600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919050505061048d565b6040518082815260200191505060405180910390f35b34801561014e57600080fd5b50610183600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104a5565b6040518082815260200191505060405180910390f35b3480156101a557600080fd5b506101da600480360381019080803573ffffffffffffffffffffffffffffffffffffffff1690602001909291905050506104bd565b604051808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020018281526020019250505060405180910390f35b34801561022f57600080fd5b5061026e600480360381019080803573ffffffffffffffffffffffffffffffffffffffff16906020019092919080359060200190929190505050610501565b005b436004546000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054011115151561032a576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260108152602001807f746f6f20736f6f6e20746f206d696e740000000000000000000000000000000081525060200191505060405180910390fd5b436000803373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002081905550600554600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008282540192505081905550600260003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600081548092919060010191905055503373ffffffffffffffffffffffffffffffffffffffff16600073ffffffffffffffffffffffffffffffffffffffff167fec61728879a33aa50b55e1f4789dcfc1c680f30a24d7b8694a9f874e242a97b46005546040518082815260200191505060405180910390a3565b60016020528060005260406000206000915090505481565b60026020528060005260406000206000915090505481565b60006020528060005260406000206000915090505481565b60036020528060005260406000206000915090508060000160009054906101000a900473ffffffffffffffffffffffffffffffffffffffff16908060010154905082565b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156105b8576040517f08c379a00000000000000000000000000000000000000000000000000000000081526004018080602001828103825260148152602001807f696e73756666696369656e742062616c616e636500000000000000000000000081525060200191505060405180910390fd5b80600160003373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254039250508190555080600160008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555060408051908101604052803373ffffffffffffffffffffffffffffffffffffffff16815260200182815250600360008473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002060008201518160000160006101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff160217905550602082015181600101559050508173ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff167fec61728879a33aa50b55e1f4789dcfc1c680f30a24d7b8694a9f874e242a97b4836040518082815260200191505060405180910390a350505600a165627a7a7230582047e5e1380e66d6b109548617ae59ff7baf70ee2d4a6734559b8fc5cabca0870b0029000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000186a0",
+				RawAmount:     "0",
+				RawGasLimit:   5000000,
+				RawGasPrice:   "0",
+			},
+		},
+	}
+	r := require.New(b)
+	ctx := context.Background()
+	cfg := config.Default
+	cfg.Genesis.NumSubEpochs = uint64(b.N)
+	if cachedStateDBOption {
+		cfg.Chain.EnableStateDBCaching = true
+	} else {
+		cfg.Chain.EnableStateDBCaching = false
+	}
+	bc, sf, dao, ap := sct.prepareBlockchain(ctx, cfg, r)
 	defer func() {
 		r.NoError(bc.Stop(ctx))
 	}()
@@ -927,15 +1010,15 @@ func benchmarkHotContract(b *testing.B, async bool, cachedStateDBOption bool) {
 
 func BenchmarkHotContract(b *testing.B) {
 	b.Run("async mode", func(b *testing.B) {
-		benchmarkHotContract(b, true, false)
+		benchmarkHotContractWithFactory(b, true)
 	})
 	b.Run("sync mode", func(b *testing.B) {
-		benchmarkHotContract(b, false, false)
+		benchmarkHotContractWithFactory(b, false)
 	})
-	b.Run("async mode & cachedStateDB", func(b *testing.B) {
-		benchmarkHotContract(b, true, true)
+	b.Run("cachedStateDB", func(b *testing.B) {
+		benchmarkHotContractWithStateDB(b, true)
 	})
-	b.Run("sync mode & cachedStateDB", func(b *testing.B) {
-		benchmarkHotContract(b, false, true)
+	b.Run("defaultStateDB", func(b *testing.B) {
+		benchmarkHotContractWithStateDB(b, false)
 	})
 }

--- a/blockchain/filedao/filedao_v2.go
+++ b/blockchain/filedao/filedao_v2.go
@@ -236,7 +236,7 @@ func (fd *fileDAOv2) PutBlock(_ context.Context, blk *block.Block) error {
 	if err := fd.kvStore.WriteBatch(fd.batch); err != nil {
 		return errors.Wrapf(err, "failed to put block at height %d", blk.Height())
 	}
-
+	fd.batch.Clear()
 	// update file tip
 	tip = &FileTip{Height: blk.Height(), Hash: blk.HashBlock()}
 	fd.storeTip(tip)
@@ -291,6 +291,7 @@ func (fd *fileDAOv2) DeleteTipBlock() error {
 	if err := fd.kvStore.WriteBatch(fd.batch); err != nil {
 		return err
 	}
+	fd.batch.Clear()
 	fd.storeTip(tip)
 	return nil
 }

--- a/blockindex/indexer.go
+++ b/blockindex/indexer.go
@@ -172,7 +172,11 @@ func (x *blockIndexer) DeleteTipBlock(blk *block.Block) error {
 	if err := x.tac.Revert(uint64(len(blk.Actions))); err != nil {
 		return err
 	}
-	return x.kvStore.WriteBatch(x.batch)
+	if err := x.kvStore.WriteBatch(x.batch); err != nil {
+		return err
+	}
+	x.batch.Clear()
+	return nil
 }
 
 // Height return the blockchain height
@@ -352,7 +356,11 @@ func (x *blockIndexer) commit() error {
 	if err := x.tac.Finalize(); err != nil {
 		return err
 	}
-	return x.kvStore.WriteBatch(x.batch)
+	if err := x.kvStore.WriteBatch(x.batch); err != nil {
+		return err
+	}
+	x.batch.Clear()
+	return nil
 }
 
 // getIndexerForAddr returns the counting indexer for an address

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -119,7 +119,11 @@ func New(
 		}
 	} else {
 		if cfg.Chain.EnableTrielessStateDB {
-			sf, err = factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
+			if cfg.Chain.EnableStateDBCaching {
+				sf, err = factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
+			} else {
+				sf, err = factory.NewStateDB(cfg, factory.DefaultStateDBOption(), factory.RegistryStateDBOption(registry))
+			}
 		} else {
 			sf, err = factory.NewFactory(cfg, factory.DefaultTrieOption(), factory.RegistryOption(registry))
 		}

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -119,7 +119,7 @@ func New(
 		}
 	} else {
 		if cfg.Chain.EnableTrielessStateDB {
-			sf, err = factory.NewStateDB(cfg, factory.DefaultStateDBOption(), factory.RegistryStateDBOption(registry))
+			sf, err = factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
 		} else {
 			sf, err = factory.NewFactory(cfg, factory.DefaultTrieOption(), factory.RegistryOption(registry))
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -124,8 +124,9 @@ var (
 			EnableStakingIndexer:          false,
 			CompressBlock:                 false,
 			AllowedBlockGasResidue:        10000,
-			StateMaxCacheSize:             1000,
+			MaxCacheSize:                  0,
 			PollInitialCandidatesInterval: 10 * time.Second,
+			StateDBCacheSize:              1000,
 			WorkingSetCacheSize:           20,
 			EnableArchiveMode:             false,
 		},
@@ -261,10 +262,12 @@ type (
 		CompressBlock bool `yaml:"compressBlock"`
 		// AllowedBlockGasResidue is the amount of gas remained when block producer could stop processing more actions
 		AllowedBlockGasResidue uint64 `yaml:"allowedBlockGasResidue"`
-		// StateMaxCacheSize is the max number of states that will be put into an LRU cache. 0 means disabled
-		StateMaxCacheSize int `yaml:"stateMaxCacheSize"`
+		// StateMaxCacheSize is the max number of blocks that will be put into an LRU cache. 0 means disabled
+		MaxCacheSize int `yaml:"maxCacheSize"`
 		// PollInitialCandidatesInterval is the config for committee init db
 		PollInitialCandidatesInterval time.Duration `yaml:"pollInitialCandidatesInterval"`
+		// StateDBCacheSize is the max size of statedb LRU cache
+		StateDBCacheSize int `yaml:"stateDBCacheSize"`
 		// WorkingSetCacheSize is the max size of workingset cache in state factory
 		WorkingSetCacheSize uint64 `yaml:"workingSetCacheSize"`
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -262,7 +262,7 @@ type (
 		CompressBlock bool `yaml:"compressBlock"`
 		// AllowedBlockGasResidue is the amount of gas remained when block producer could stop processing more actions
 		AllowedBlockGasResidue uint64 `yaml:"allowedBlockGasResidue"`
-		// StateMaxCacheSize is the max number of blocks that will be put into an LRU cache. 0 means disabled
+		// MaxCacheSize is the max number of blocks that will be put into an LRU cache. 0 means disabled
 		MaxCacheSize int `yaml:"maxCacheSize"`
 		// PollInitialCandidatesInterval is the config for committee init db
 		PollInitialCandidatesInterval time.Duration `yaml:"pollInitialCandidatesInterval"`

--- a/config/config.go
+++ b/config/config.go
@@ -124,7 +124,7 @@ var (
 			EnableStakingIndexer:          false,
 			CompressBlock:                 false,
 			AllowedBlockGasResidue:        10000,
-			MaxCacheSize:                  0,
+			StateMaxCacheSize:             1000,
 			PollInitialCandidatesInterval: 10 * time.Second,
 			WorkingSetCacheSize:           20,
 			EnableArchiveMode:             false,
@@ -261,8 +261,8 @@ type (
 		CompressBlock bool `yaml:"compressBlock"`
 		// AllowedBlockGasResidue is the amount of gas remained when block producer could stop processing more actions
 		AllowedBlockGasResidue uint64 `yaml:"allowedBlockGasResidue"`
-		// MaxCacheSize is the max number of blocks that will be put into an LRU cache. 0 means disabled
-		MaxCacheSize int `yaml:"maxCacheSize"`
+		// StateMaxCacheSize is the max number of states that will be put into an LRU cache. 0 means disabled
+		StateMaxCacheSize int `yaml:"stateMaxCacheSize"`
 		// PollInitialCandidatesInterval is the config for committee init db
 		PollInitialCandidatesInterval time.Duration `yaml:"pollInitialCandidatesInterval"`
 		// WorkingSetCacheSize is the max size of workingset cache in state factory

--- a/config/config.go
+++ b/config/config.go
@@ -118,6 +118,7 @@ var (
 				GravityChainAPIs: []string{},
 			},
 			EnableTrielessStateDB:         true,
+			EnableStateDBCaching:          true,
 			EnableAsyncIndexWrite:         true,
 			EnableSystemLogIndexer:        false,
 			EnableStakingProtocol:         true,
@@ -248,6 +249,8 @@ type (
 		Committee            committee.Config `yaml:"committee"`
 
 		EnableTrielessStateDB bool `yaml:"enableTrielessStateDB"`
+		// EnableStateDBCaching enables cachedStateDBOption
+		EnableStateDBCaching bool `yaml:"enableStateDBCaching"`
 		// EnableArchiveMode is only meaningful when EnableTrielessStateDB is false
 		EnableArchiveMode bool `yaml:"enableArchiveMode"`
 		// EnableAsyncIndexWrite enables writing the block actions' and receipts' index asynchronously

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -180,6 +180,7 @@ func TestDBBatch(t *testing.T) {
 		require.NoError(err)
 		require.Equal(testV2[0], value)
 		require.NoError(kvStore.WriteBatch(batch))
+		batch.Clear()
 
 		value, err = kvStore.Get(bucket1, testK1[0])
 		require.NoError(err)
@@ -195,6 +196,7 @@ func TestDBBatch(t *testing.T) {
 
 		batch.Put(bucket1, testK1[0], testV1[1], "")
 		require.NoError(kvStore.WriteBatch(batch))
+		batch.Clear()
 
 		require.Equal(0, batch.Size())
 
@@ -207,9 +209,11 @@ func TestDBBatch(t *testing.T) {
 		require.Equal(testV1[1], value)
 
 		require.NoError(kvStore.WriteBatch(batch))
+		batch.Clear()
 
 		batch.Put(bucket1, testK1[2], testV1[2], "")
 		require.NoError(kvStore.WriteBatch(batch))
+		batch.Clear()
 
 		value, err = kvStore.Get(bucket1, testK1[2])
 		require.NoError(err)
@@ -223,6 +227,7 @@ func TestDBBatch(t *testing.T) {
 		batch.Put(bucket1, testK1[2], testV1[2], "")
 		batch.Delete(bucket2, testK2[1], "")
 		require.NoError(kvStore.WriteBatch(batch))
+		batch.Clear()
 
 		value, err = kvStore.Get(bucket1, testK1[2])
 		require.NoError(err)

--- a/db/kvstorewithcache.go
+++ b/db/kvstorewithcache.go
@@ -136,8 +136,8 @@ func (kvc *kvStoreWithCache) deleteStateCachesIfExists(namespace string, key []b
 
 // look up stateCachces
 func (kvc *kvStoreWithCache) getStateCaches(namespace string, key []byte) ([]byte, error) {
-	kvc.mutex.Lock()
-	defer kvc.mutex.Unlock()
+	kvc.mutex.RLock()
+	defer kvc.mutex.RUnlock()
 	if sc, ok := kvc.stateCaches[namespace]; ok {
 		if data, ok := sc.Get(string(key)); ok {
 			if byteData, ok := data.([]byte); ok {

--- a/db/kvstorewithcache.go
+++ b/db/kvstorewithcache.go
@@ -1,0 +1,125 @@
+package db
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/go-pkgs/cache"
+	"github.com/iotexproject/iotex-core/db/batch"
+)
+
+// kvStoreWithCache is an implementation of KVStore, wrapping kvstore with LRU caches of latest states
+type kvStoreWithCache struct {
+	store       KVStore
+	stateCaches map[string]*cache.ThreadSafeLruCache // map having lru cache to store current states for speed up
+	cacheSize   int
+}
+
+// NewKvStoreWithCache wraps kvstore with stateCaches
+func NewKvStoreWithCache(kvstore KVStore, cacheSize int) KVStore {
+	return &kvStoreWithCache{
+		store:       kvstore,
+		stateCaches: make(map[string]*cache.ThreadSafeLruCache),
+		cacheSize:   cacheSize,
+	}
+}
+
+// Start starts the kvStoreWithCache
+func (kvc *kvStoreWithCache) Start(ctx context.Context) error {
+	return kvc.store.Start(ctx)
+}
+
+// Stop stops the kvStoreWithCache
+func (kvc *kvStoreWithCache) Stop(ctx context.Context) error {
+	for _, sc := range kvc.stateCaches {
+		sc.Clear()
+	}
+	return kvc.store.Stop(ctx)
+}
+
+// Put inserts a <key, value> record into stateCaches and kvstore
+func (kvc *kvStoreWithCache) Put(namespace string, key, value []byte) (err error) {
+	kvc.putStateCaches(namespace, key, value)
+	return kvc.store.Put(namespace, key, value)
+}
+
+// Get retrieves a <key, value> record from stateCaches, and if not exists, retrieves from kvstore
+func (kvc *kvStoreWithCache) Get(namespace string, key []byte) ([]byte, error) {
+	cachedData, err := kvc.getStateCaches(namespace, key)
+	if err != nil {
+		return nil, err
+	}
+	if cachedData != nil {
+		return cachedData, nil
+	}
+	return kvc.store.Get(namespace, key)
+}
+
+// Filter returns <k, v> pair in a bucket that meet the condition
+func (kvc *kvStoreWithCache) Filter(namespace string, cond Condition, minKey, maxKey []byte) ([][]byte, [][]byte, error) {
+	return kvc.store.Filter(namespace, cond, minKey, maxKey)
+}
+
+// Delete deletes a record from statecaches if exists, and from kvstore
+func (kvc *kvStoreWithCache) Delete(namespace string, key []byte) (err error) {
+	kvc.deleteStateCaches(namespace, key)
+	return kvc.store.Delete(namespace, key)
+}
+
+// WriteBatch commits a batch into stateCaches and kvstore
+func (kvc *kvStoreWithCache) WriteBatch(kvsb batch.KVStoreBatch) (err error) {
+	for i := 0; i < kvsb.Size(); i++ {
+		write, e := kvsb.Entry(i)
+		if e != nil {
+			return e
+		}
+		ns := write.Namespace()
+		if write.WriteType() == batch.Put {
+			kvc.putStateCaches(ns, write.Key(), write.Value())
+		} else if write.WriteType() == batch.Delete {
+			kvc.deleteStateCaches(ns, write.Key())
+		}
+	}
+	return kvc.store.WriteBatch(kvsb)
+}
+
+// ======================================
+// private functions
+// ======================================
+
+func (kvc *kvStoreWithCache) putStateCaches(namespace string, key, value []byte) {
+	// store on stateCaches
+	if sc, ok := kvc.stateCaches[namespace]; ok {
+		sc.Add(string(key), value)
+	} else {
+		sc := cache.NewThreadSafeLruCache(kvc.cacheSize)
+		sc.Add(string(key), value)
+		kvc.stateCaches[namespace] = sc
+	}
+	return
+}
+
+func (kvc *kvStoreWithCache) deleteStateCaches(namespace string, key []byte) {
+	// remove on stateCaches
+	if sc, ok := kvc.stateCaches[namespace]; ok {
+		sc.Remove(string(key))
+	} else {
+		sc := cache.NewThreadSafeLruCache(kvc.cacheSize)
+		kvc.stateCaches[namespace] = sc
+	}
+	return
+}
+
+func (kvc *kvStoreWithCache) getStateCaches(namespace string, key []byte) ([]byte, error) {
+	// look up stateCachces
+	if sc, ok := kvc.stateCaches[namespace]; ok {
+		if data, ok := sc.Get(string(key)); ok {
+			if byteData, ok := data.([]byte); ok {
+				return byteData, nil
+			}
+			return nil, errors.New("failed to convert interface{} to bytes from stateCaches")
+		}
+	}
+	return nil, nil
+}

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -174,7 +174,7 @@ func TestLocalCommit(t *testing.T) {
 	require.NoError(copyDB(testDBPath, testDBPath2))
 	require.NoError(copyDB(indexDBPath, indexDBPath2))
 	registry := protocol.NewRegistry()
-	sf2, err := factory.NewStateDB(cfg, factory.DefaultStateDBOption(), factory.RegistryStateDBOption(registry))
+	sf2, err := factory.NewStateDB(cfg, factory.CachedStateDBOption(), factory.RegistryStateDBOption(registry))
 	require.NoError(err)
 	ap2, err := actpool.NewActPool(sf2, cfg.ActPool)
 	require.NoError(err)

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"time"
 
-	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/go-pkgs/cache"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 
@@ -98,7 +98,7 @@ type (
 		twoLayerTrie             trie.TwoLayerTrie // global state trie, this is a read only trie
 		dao                      db.KVStore        // the underlying DB for account/contract storage
 		timerFactory             *prometheustimer.TimerFactory
-		workingsets              *lru.Cache // lru cache for workingsets
+		workingsets              *cache.ThreadSafeLruCache // lru cache for workingsets
 		protocolView             protocol.View
 		skipBlockValidationOnPut bool
 	}
@@ -182,6 +182,7 @@ func NewFactory(cfg config.Config, opts ...Option) (Factory, error) {
 		registry:           protocol.NewRegistry(),
 		saveHistory:        cfg.Chain.EnableArchiveMode,
 		protocolView:       protocol.View{},
+		workingsets:        cache.NewThreadSafeLruCache(int(cfg.Chain.WorkingSetCacheSize)),
 	}
 
 	for _, opt := range opts {
@@ -200,9 +201,6 @@ func NewFactory(cfg config.Config, opts ...Option) (Factory, error) {
 		log.L().Error("Failed to generate prometheus timer factory.", zap.Error(err))
 	}
 	sf.timerFactory = timerFactory
-	if sf.workingsets, err = lru.New(int(cfg.Chain.WorkingSetCacheSize)); err != nil {
-		return nil, errors.Wrap(err, "failed to generate lru cache for workingsets")
-	}
 
 	return sf, nil
 }
@@ -260,7 +258,7 @@ func (sf *factory) Stop(ctx context.Context) error {
 	if err := sf.dao.Stop(ctx); err != nil {
 		return err
 	}
-	sf.workingsets.Purge()
+	sf.workingsets.Clear()
 	return sf.lifecycle.OnStop(ctx)
 }
 

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -98,7 +98,8 @@ type (
 		twoLayerTrie             trie.TwoLayerTrie // global state trie, this is a read only trie
 		dao                      db.KVStore        // the underlying DB for account/contract storage
 		timerFactory             *prometheustimer.TimerFactory
-		workingsets              *cache.ThreadSafeLruCache // lru cache for workingsets
+		workingsets              *cache.ThreadSafeLruCache            // lru cache for workingsets
+		stateCaches              map[string]*cache.ThreadSafeLruCache // map having lru cache to store current states for speed up
 		protocolView             protocol.View
 		skipBlockValidationOnPut bool
 	}
@@ -183,6 +184,7 @@ func NewFactory(cfg config.Config, opts ...Option) (Factory, error) {
 		saveHistory:        cfg.Chain.EnableArchiveMode,
 		protocolView:       protocol.View{},
 		workingsets:        cache.NewThreadSafeLruCache(int(cfg.Chain.WorkingSetCacheSize)),
+		stateCaches:        make(map[string]*cache.ThreadSafeLruCache),
 	}
 
 	for _, opt := range opts {
@@ -259,6 +261,9 @@ func (sf *factory) Stop(ctx context.Context) error {
 		return err
 	}
 	sf.workingsets.Clear()
+	for _, sc := range sf.stateCaches {
+		sc.Clear()
+	}
 	return sf.lifecycle.OnStop(ctx)
 }
 
@@ -293,6 +298,15 @@ func (sf *factory) newWorkingSet(ctx context.Context, height uint64) (*workingSe
 		finalized: false,
 		dock:      protocol.NewDock(),
 		getStateFunc: func(ns string, key []byte, s interface{}) error {
+			// look up stateCachces first
+			if sc, ok := sf.stateCaches[ns]; ok {
+				if data, ok := sc.Get(string(key)); ok {
+					if byteData, ok := data.([]byte); ok {
+						return state.Deserialize(s, byteData)
+					} 
+					return errors.New("failed to convert interface{} to bytes from stateCaches")
+				}
+			}
 			return readState(tlt, ns, key, s)
 		},
 		putStateFunc: func(ns string, key []byte, s interface{}) error {
@@ -301,12 +315,27 @@ func (sf *factory) newWorkingSet(ctx context.Context, height uint64) (*workingSe
 				return errors.Wrapf(err, "failed to convert account %v to bytes", s)
 			}
 			flusher.KVStoreWithBuffer().MustPut(ns, key, ss)
+			// store on stateCaches
+			if sc, ok := sf.stateCaches[ns]; ok {
+				sc.Add(string(key), ss)
+			} else {
+				sc := cache.NewThreadSafeLruCache(sf.cfg.Chain.StateMaxCacheSize)
+				sc.Add(string(key), ss)
+				sf.stateCaches[ns] = sc
+			}
 			nsHash := hash.Hash160b([]byte(ns))
 
 			return tlt.Upsert(nsHash[:], toLegacyKey(key), ss)
 		},
 		delStateFunc: func(ns string, key []byte) error {
 			flusher.KVStoreWithBuffer().MustDelete(ns, key)
+			// remove on stateCaches
+			if sc, ok := sf.stateCaches[ns]; ok {
+				sc.Remove(string(key))
+			} else {
+				sc := cache.NewThreadSafeLruCache(sf.cfg.Chain.StateMaxCacheSize)
+				sf.stateCaches[ns] = sc
+			}
 			nsHash := hash.Hash160b([]byte(ns))
 
 			err := tlt.Delete(nsHash[:], toLegacyKey(key))
@@ -371,6 +400,9 @@ func (sf *factory) newWorkingSet(ctx context.Context, height uint64) (*workingSe
 			return s
 		},
 		revertFunc: func(snapshot int) error {
+			for _, sc := range sf.stateCaches {
+				sc.Clear()
+			}
 			if err := flusher.KVStoreWithBuffer().Revert(snapshot); err != nil {
 				return err
 			}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -105,7 +105,7 @@ func TestSDBSnapshot(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "5"
 	cfg.Genesis.InitBalanceMap[identityset.Address(29).String()] = "7"
 	registry := protocol.NewRegistry()
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), RegistryStateDBOption(registry))
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), RegistryStateDBOption(registry))
 	require.NoError(err)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(acc.Register(registry))
@@ -359,7 +359,7 @@ func TestHistoryState(t *testing.T) {
 	// using stateDB and enable history
 	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	sf, err = NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sf, err = NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 
@@ -374,7 +374,7 @@ func TestHistoryState(t *testing.T) {
 	// using stateDB and disable history
 	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	sf, err = NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sf, err = NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
 }
@@ -394,7 +394,7 @@ func TestFactoryStates(t *testing.T) {
 	// using stateDB
 	cfg.Chain.TrieDBPath, err = testutil.PathOfTempFile(triePath)
 	r.NoError(err)
-	sf, err = NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sf, err = NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	r.NoError(err)
 	testFactoryStates(sf, t)
 }
@@ -405,7 +405,7 @@ func TestSDBState(t *testing.T) {
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	require.NoError(t, err)
 	testState(sdb, t)
 }
@@ -690,7 +690,7 @@ func TestSDBNonce(t *testing.T) {
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	require.NoError(t, err)
 
 	testNonce(sdb, t)
@@ -807,7 +807,7 @@ func TestSDBLoadStoreHeight(t *testing.T) {
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
-	db, err := NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	db, err := NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	require.NoError(t, err)
 
 	testLoadStoreHeight(db, t)
@@ -901,7 +901,7 @@ func TestSTXRunActions(t *testing.T) {
 	cfg.Chain.TrieDBPath = testStateDBPath
 	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100"
 	cfg.Genesis.InitBalanceMap[identityset.Address(29).String()] = "200"
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), SkipBlockValidationStateDBOption())
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	require.NoError(err)
 
 	registry := protocol.NewRegistry()
@@ -1013,7 +1013,7 @@ func TestSTXPickAndRunActions(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100"
 	cfg.Genesis.InitBalanceMap[identityset.Address(29).String()] = "200"
 	registry := protocol.NewRegistry()
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), RegistryStateDBOption(registry))
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), RegistryStateDBOption(registry))
 	require.NoError(err)
 
 	acc := account.NewProtocol(rewarding.DepositGas)
@@ -1123,7 +1123,7 @@ func TestSTXSimulateExecution(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100"
 	cfg.Genesis.InitBalanceMap[identityset.Address(29).String()] = "200"
 	registry := protocol.NewRegistry()
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption(), RegistryStateDBOption(registry))
+	sdb, err := NewStateDB(cfg, CachedStateDBOption(), RegistryStateDBOption(registry))
 	require.NoError(err)
 
 	acc := account.NewProtocol(rewarding.DepositGas)
@@ -1320,7 +1320,7 @@ func BenchmarkSDBRunAction(b *testing.B) {
 	}
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = tp
-	sdb, err := NewStateDB(cfg, DefaultStateDBOption())
+	sdb, err := NewStateDB(cfg, CachedStateDBOption())
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
-	//"fmt"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -261,9 +261,7 @@ func (sdb *stateDB) newWorkingSet(ctx context.Context, height uint64) (*workingS
 			return sdb.protocolView.Write(name, v)
 		},
 		snapshotFunc: flusher.KVStoreWithBuffer().Snapshot,
-		revertFunc: func(sid int) error {
-			return flusher.KVStoreWithBuffer().Revert(sid)
-		},
+		revertFunc:   flusher.KVStoreWithBuffer().Revert,
 		dbFunc: func() db.KVStore {
 			return flusher.KVStoreWithBuffer()
 		},


### PR DESCRIPTION
works on #2457 
Define kvStoreWithCache(LRU) in stateDB to store latest states to speed up (statedb caching).
We can decide StateMaxCacheSize by experiments. 
