### PR TITLE
Check LogsBloomFilter before look up receipts in getLogs API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1469,6 +1469,13 @@ func (api *Server) getLogsInBlock(filter *LogFilter, start, count uint64) ([]*io
 		end = api.bc.TipHeight()
 	}
 	for i := start; i <= end; i++ {
+		header, err := api.dao.HeaderByHeight(i)
+		if err != nil {
+			return logs, status.Error(codes.InvalidArgument, err.Error())
+		}
+		if !filter.ExistInBloomFilter(header.LogsBloomfilter()) {
+			continue
+		}
 		receipts, err := api.dao.GetReceipts(i)
 		if err != nil {
 			return logs, status.Error(codes.InvalidArgument, err.Error())


### PR DESCRIPTION
As we are doing in https://github.com/iotexproject/iotex-core/blob/master/api/logfilter.go#L45 here, in getLogs API, look up LogsBloomFilter first, and then if it exists, look up the logs in the receipts. 