### PR TITLE
increase http connections timeout

### DIFF
--- a/pkg/util/httputil/httputil.go
+++ b/pkg/util/httputil/httputil.go
@@ -10,8 +10,8 @@ import (
 
 const (
 	_connectionCount = 400
-	_readTimeout     = 5 * time.Second
-	_writeTimeout    = 5 * time.Second
+	_readTimeout     = 35 * time.Second
+	_writeTimeout    = 35 * time.Second
 	_idleTimeout     = 120 * time.Second
 )
 


### PR DESCRIPTION
for getting better prof connection: https://golang.org/src/net/http/pprof/pprof.go

```
// Profile responds with the pprof-formatted cpu profile.
// Profiling lasts for duration specified in seconds GET parameter, or for 30 seconds if not specified.
// The package initialization registers it as /debug/pprof/profile.
```