### PR TITLE
fix a bf indexer rebuilding bug by adding receipts in blockdao 

### DIFF
--- a/blockchain/blockdao/blockdao.go
+++ b/blockchain/blockdao/blockdao.go
@@ -148,6 +148,12 @@ func (dao *blockDAO) checkIndexers(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
+			if blk.Receipts == nil {
+				blk.Receipts, err = dao.GetReceipts(i)
+				if err != nil {
+					return err
+				}
+			}
 			producer, err := address.FromBytes(blk.PublicKey().Hash())
 			if err != nil {
 				return err


### PR DESCRIPTION
when we rebuild bloomfilter indexer, in case of filedao_legacy, ```dao.GetBlockByHeight()``` does not include receipts. 
In order to fix a bug of rebuilding bf indexer, added ```dao.getReceipts() ```