### PR TITLE
need signer flag in ioctl xrc20 allowance cmd

### DIFF
--- a/ioctl/cmd/action/xrc20allowance.go
+++ b/ioctl/cmd/action/xrc20allowance.go
@@ -41,6 +41,10 @@ var xrc20AllowanceCmd = &cobra.Command{
 	},
 }
 
+func init() {
+	RegisterWriteCommand(xrc20AllowanceCmd)
+}
+
 func allowance(arg string) error {
 	caller, err := Signer()
 	if err != nil {


### PR DESCRIPTION
xrc20 allowance cmd requires signer flag(L49), but currently we miss it 