### PR TITLE
enable split v2 DB file at every 1,000,000 blocks

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -192,6 +192,7 @@ var (
 			NumRetries:          3,
 			MaxCacheSize:        64,
 			BlockStoreBatchSize: 16,
+			V2BlocksToSplitDB:   1000000,
 			Compressor:          "Snappy",
 			CompressLegacy:      false,
 			SQLITE3: SQLITE3{


### PR DESCRIPTION
as discussed in mtg, roll out this feature in 1.2 release