### PR TITLE
[staking] fix change candidate bug

### DIFF
--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -313,6 +313,14 @@ func (p *Protocol) handleChangeCandidate(ctx context.Context, act *action.Change
 		}
 	}
 
+	if p.hu.IsPost(config.Hawaii, blkCtx.BlockHeight) && address.Equal(prevCandidate.Owner, candidate.Owner) {
+		// change to same candidate, do nothing
+		return log, &handleError{
+			err:           errors.New("change to same candidate"),
+			failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,
+		}
+	}
+
 	// update bucket index
 	if err := delCandBucketIndex(csm, bucket.Candidate, act.BucketIndex()); err != nil {
 		return log, errors.Wrapf(err, "failed to delete candidate bucket index for candidate %s", bucket.Candidate.String())
@@ -381,6 +389,14 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 		}
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), act.VoterAddress().Bytes(), bucket.Candidate.Bytes())
+
+	if p.hu.IsPost(config.Hawaii, blkCtx.BlockHeight) && address.Equal(newOwner, bucket.Owner) {
+		// change to same owner, do nothing
+		return log, &handleError{
+			err:           errors.New("transfer to same owner"),
+			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
+		}
+	}
 
 	// update bucket index
 	if err := delVoterBucketIndex(csm, bucket.Owner, act.BucketIndex()); err != nil {

--- a/action/protocol/staking/vote_reviser.go
+++ b/action/protocol/staking/vote_reviser.go
@@ -41,6 +41,11 @@ func (vr *VoteReviser) Revise(csm CandidateStateManager, height uint64) error {
 	return vr.flush(height, csm)
 }
 
+func (vr *VoteReviser) result(height uint64) (CandidateList, bool) {
+	cands, ok := vr.cache[height]
+	return cands, ok
+}
+
 func (vr *VoteReviser) storeToCache(height uint64, cands CandidateList) {
 	vr.cache[height] = cands
 }

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -254,7 +254,12 @@ func New(
 	)
 	// staking protocol need to be put in registry before poll protocol when enabling
 	if cfg.Chain.EnableStakingProtocol {
-		stakingProtocol, err = staking.NewProtocol(rewarding.DepositGas, cfg.Genesis.Staking, candBucketsIndexer, cfg.Genesis.GreenlandBlockHeight)
+		stakingProtocol, err = staking.NewProtocol(
+			rewarding.DepositGas,
+			cfg.Genesis.Staking, candBucketsIndexer,
+			cfg.Genesis.GreenlandBlockHeight,
+			cfg.Genesis.HawaiiBlockHeight,
+		)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When the new candidate is same as old one, staking handler are dealing
with 2 copies of the same candidate: vote of the first being deducted,
and vote of the second being added -- yet the second change overwrites
the first, b/c these 2 are the same candidate. This caused the total
vote to be incorrectly increased.