### PR TITLE
[action] improve envelope handling

### DIFF
--- a/action/actctx.go
+++ b/action/actctx.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/iotexproject/go-pkgs/crypto"
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 )
 
@@ -18,10 +17,9 @@ import (
 type AbstractAction struct {
 	version   uint32
 	nonce     uint64
-	srcPubkey crypto.PublicKey
 	gasLimit  uint64
 	gasPrice  *big.Int
-	hash      hash.Hash256
+	srcPubkey crypto.PublicKey
 }
 
 // Version returns the version
@@ -29,9 +27,6 @@ func (act *AbstractAction) Version() uint32 { return act.version }
 
 // Nonce returns the nonce
 func (act *AbstractAction) Nonce() uint64 { return act.nonce }
-
-// SrcPubkey returns the source public key
-func (act *AbstractAction) SrcPubkey() crypto.PublicKey { return act.srcPubkey }
 
 // GasLimit returns the gas limit
 func (act *AbstractAction) GasLimit() uint64 { return act.gasLimit }
@@ -44,9 +39,6 @@ func (act *AbstractAction) GasPrice() *big.Int {
 	}
 	return p.Set(act.gasPrice)
 }
-
-// Hash returns the hash value of referred SealedActionEnvelope hash.
-func (act *AbstractAction) Hash() hash.Hash256 { return act.hash }
 
 // BasicActionSize returns the basic size of action
 func (act *AbstractAction) BasicActionSize() uint32 {
@@ -67,16 +59,11 @@ func (act *AbstractAction) SetEnvelopeContext(selp SealedEnvelope) {
 	if act == nil {
 		return
 	}
-	ab := &Builder{}
-	*act = ab.SetVersion(selp.Version()).
-		SetNonce(selp.Nonce()).
-		SetSourcePublicKey(selp.SrcPubkey()).
-		SetGasLimit(selp.GasLimit()).
-		SetGasPrice(selp.GasPrice()).
-		Build()
-
-	// the reason to set hash here, after set act context, is because some actions use envelope information in their proto define. for example transfer use des addr as Receipt.
-	act.hash = selp.Hash()
+	act.version = selp.Version()
+	act.nonce = selp.Nonce()
+	act.gasLimit = selp.GasLimit()
+	act.gasPrice = selp.GasPrice()
+	act.srcPubkey = selp.SrcPubkey()
 }
 
 // SanityCheck validates the variables in the action

--- a/action/action.go
+++ b/action/action.go
@@ -29,11 +29,9 @@ type Action interface {
 }
 
 type actionPayload interface {
-	Serialize() []byte
+	Action
 	Cost() (*big.Int, error)
 	IntrinsicGas() (uint64, error)
-	SetEnvelopeContext(SealedEnvelope)
-	SanityCheck() error
 }
 
 type hasDestination interface {

--- a/action/action.go
+++ b/action/action.go
@@ -29,9 +29,10 @@ type Action interface {
 }
 
 type actionPayload interface {
-	Action
 	Cost() (*big.Int, error)
 	IntrinsicGas() (uint64, error)
+	SetEnvelopeContext(SealedEnvelope)
+	SanityCheck() error
 }
 
 type hasDestination interface {

--- a/action/builder_test.go
+++ b/action/builder_test.go
@@ -28,7 +28,6 @@ func TestActionBuilder(t *testing.T) {
 
 	assert.Equal(t, uint32(version.ProtocolVersion), act.Version())
 	assert.Equal(t, uint64(2), act.Nonce())
-	assert.Equal(t, srcPubKey, act.SrcPubkey())
 	assert.Equal(t, uint64(10003), act.GasLimit())
 	assert.Equal(t, big.NewInt(10004), act.GasPrice())
 }

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -120,7 +120,6 @@ func (elp *Envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
 	if elp == nil {
 		return errors.New("nil action to load proto")
 	}
-	*elp = Envelope{}
 	elp.version = pbAct.GetVersion()
 	elp.nonce = pbAct.GetNonce()
 	elp.gasLimit = pbAct.GetGasLimit()

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -120,6 +120,7 @@ func (elp *Envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
 	if elp == nil {
 		return errors.New("nil action to load proto")
 	}
+	*elp = Envelope{}
 	elp.version = pbAct.GetVersion()
 	elp.nonce = pbAct.GetNonce()
 	elp.gasLimit = pbAct.GetGasLimit()

--- a/action/execution.go
+++ b/action/execution.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
@@ -59,11 +58,6 @@ func NewExecution(
 		amount:   amount,
 		data:     data,
 	}, nil
-}
-
-// ExecutorPublicKey returns the executor's public key
-func (ex *Execution) ExecutorPublicKey() crypto.PublicKey {
-	return ex.SrcPubkey()
 }
 
 // Contract returns a contract address

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
@@ -28,7 +28,6 @@ import (
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
 	"github.com/iotexproject/iotex-core/testutil/testdb"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 func TestProtocol_ValidateTransfer(t *testing.T) {
@@ -154,7 +153,6 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 		if tLog != nil {
 			require.NotNil(tLog)
 			pbLog := tLog.Proto()
-			require.Equal(tsf.Hash(), hash.BytesToHash256(pbLog.ActionHash))
 			require.EqualValues(v.contractLog, pbLog.NumTransactions)
 			// TODO: verify gas transaction log
 			if len(pbLog.Transactions) > 1 {

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -189,7 +189,7 @@ func ExecuteContract(
 		blkCtx.BlockHeight,
 		hu.IsPre(config.Aleutian, blkCtx.BlockHeight),
 		hu.IsPost(config.Greenland, blkCtx.BlockHeight),
-		execution.Hash(),
+		actionCtx.ActionHash,
 		opts...,
 	)
 	ps, err := newParams(ctx, execution, stateDB, getBlockHash)
@@ -203,7 +203,7 @@ func ExecuteContract(
 	receipt := &action.Receipt{
 		GasConsumed:     ps.gas - remainingGas,
 		BlockHeight:     blkCtx.BlockHeight,
-		ActionHash:      execution.Hash(),
+		ActionHash:      actionCtx.ActionHash,
 		ContractAddress: contractAddress,
 	}
 

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -148,7 +148,7 @@ func TestConstantinople(t *testing.T) {
 		require.NoError(err)
 
 		hu := config.NewHeightUpgrade(&bcCtx.Genesis)
-		stateDB := NewStateDBAdapter(sm, e.height, hu.IsPre(config.Aleutian, e.height), hu.IsPost(config.Greenland, e.height), ex.Hash())
+		stateDB := NewStateDBAdapter(sm, e.height, hu.IsPre(config.Aleutian, e.height), hu.IsPost(config.Greenland, e.height), hash.ZeroHash256)
 		ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
 			Producer:    identityset.Address(27),
 			GasLimit:    testutil.TestGasLimit,

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -298,7 +298,7 @@ func runExecutions(
 		if err := ap.Add(context.Background(), selp); err != nil {
 			return nil, err
 		}
-		hashes = append(hashes, exec.Hash())
+		hashes = append(hashes, selp.Hash())
 	}
 	blk, err := bc.MintNewBlock(testutil.TimestampNow())
 	if err != nil {
@@ -609,7 +609,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(bc.CommitBlock(blk))
 		require.Equal(1, len(blk.Receipts))
 
-		eHash := execution.Hash()
+		eHash := selp.Hash()
 		r, _ := dao.GetReceiptByActionHash(eHash, blk.Height())
 		require.NotNil(r)
 		require.Equal(eHash, r.ActionHash)
@@ -672,7 +672,7 @@ func TestProtocol_Handle(t *testing.T) {
 			v := stateDB.GetState(evmContractAddrHash, emptyEVMHash)
 			require.Equal(byte(15), v[31])
 		*/
-		eHash = execution.Hash()
+		eHash = selp.Hash()
 		r, err = dao.GetReceiptByActionHash(eHash, blk.Height())
 		require.NoError(err)
 		require.Equal(eHash, r.ActionHash)
@@ -697,7 +697,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(bc.CommitBlock(blk))
 		require.Equal(1, len(blk.Receipts))
 
-		eHash = execution.Hash()
+		eHash = selp.Hash()
 		r, err = dao.GetReceiptByActionHash(eHash, blk.Height())
 		require.NoError(err)
 		require.Equal(eHash, r.ActionHash)

--- a/action/protocol/poll/consortium.go
+++ b/action/protocol/poll/consortium.go
@@ -25,6 +25,7 @@ import (
 var (
 	consortiumCommitteeContractCreator = address.ZeroAddress
 	consortiumCommitteeContractNonce   = uint64(0)
+	// this is a special execution that is not signed, set hash = hex-string of "consortiumCommitteeContractHash"
 	consortiumCommitteeContractHash, _ = hash.HexStringToHash256("00636f6e736f727469756d436f6d6d6974746565436f6e747261637448617368")
 )
 

--- a/action/protocol/poll/consortium.go
+++ b/action/protocol/poll/consortium.go
@@ -25,6 +25,7 @@ import (
 var (
 	consortiumCommitteeContractCreator = address.ZeroAddress
 	consortiumCommitteeContractNonce   = uint64(0)
+	consortiumCommitteeContractHash, _ = hash.HexStringToHash256("00636f6e736f727469756d436f6d6d6974746565436f6e747261637448617368")
 )
 
 type contractReader interface {
@@ -113,7 +114,7 @@ func (cc *consortiumCommittee) CreateGenesisStates(ctx context.Context, sm proto
 		return err
 	}
 	actionCtx.Nonce = consortiumCommitteeContractNonce
-	actionCtx.ActionHash = execution.Hash()
+	actionCtx.ActionHash = consortiumCommitteeContractHash
 	actionCtx.GasPrice = execution.GasPrice()
 	actionCtx.IntrinsicGas, err = execution.IntrinsicGas()
 	if err != nil {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -34,8 +34,11 @@ import (
 	"github.com/iotexproject/iotex-core/state"
 )
 
-var nativeStakingContractCreator = address.ZeroAddress
-var nativeStakingContractNonce = uint64(0)
+var (
+	nativeStakingContractCreator = address.ZeroAddress
+	nativeStakingContractNonce   = uint64(0)
+	nativeStakingContractHash, _ = hash.HexStringToHash256("000000000000006e61746976655374616b696e67436f6e747261637448617368")
+)
 
 type stakingCommittee struct {
 	electionCommittee    committee.Committee
@@ -124,7 +127,7 @@ func (sc *stakingCommittee) CreateGenesisStates(ctx context.Context, sm protocol
 		return err
 	}
 	actionCtx.Nonce = nativeStakingContractNonce
-	actionCtx.ActionHash = execution.Hash()
+	actionCtx.ActionHash = nativeStakingContractHash
 	actionCtx.GasPrice = execution.GasPrice()
 	actionCtx.IntrinsicGas, err = execution.IntrinsicGas()
 	if err != nil {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -37,6 +37,7 @@ import (
 var (
 	nativeStakingContractCreator = address.ZeroAddress
 	nativeStakingContractNonce   = uint64(0)
+	// this is a special execution that is not signed, set hash = hex-string of "nativeStakingContractHash"
 	nativeStakingContractHash, _ = hash.HexStringToHash256("000000000000006e61746976655374616b696e67436f6e747261637448617368")
 )
 

--- a/action/putpollresult.go
+++ b/action/putpollresult.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 
@@ -73,9 +72,6 @@ func (r *PutPollResult) Height() uint64 { return r.height }
 
 // Candidates returns the list of candidates.
 func (r *PutPollResult) Candidates() state.CandidateList { return r.candidates }
-
-// ProducerPublicKey return producer public key.
-func (r *PutPollResult) ProducerPublicKey() crypto.PublicKey { return r.SrcPubkey() }
 
 // Serialize returns the byte representation of put poll result action.
 func (r *PutPollResult) Serialize() []byte {

--- a/action/sealedenvelope.go
+++ b/action/sealedenvelope.go
@@ -47,22 +47,22 @@ func (sealed *SealedEnvelope) LoadProto(pbAct *iotextypes.Action) error {
 	if pbAct == nil {
 		return errors.New("empty action proto to load")
 	}
-	srcPub, err := crypto.BytesToPublicKey(pbAct.GetSenderPubKey())
-	if err != nil {
-		return err
-	}
 	if sealed == nil {
 		return errors.New("nil action to load proto")
 	}
-	*sealed = SealedEnvelope{}
 
-	sealed.srcPubkey = srcPub
-	sealed.signature = make([]byte, len(pbAct.GetSignature()))
-	copy(sealed.signature, pbAct.GetSignature())
 	if err := sealed.Envelope.LoadProto(pbAct.GetCore()); err != nil {
 		return err
 	}
 
+	// populate pubkey and signature
+	srcPub, err := crypto.BytesToPublicKey(pbAct.GetSenderPubKey())
+	if err != nil {
+		return err
+	}
+	sealed.srcPubkey = srcPub
+	sealed.signature = make([]byte, len(pbAct.GetSignature()))
+	copy(sealed.signature, pbAct.GetSignature())
 	sealed.payload.SetEnvelopeContext(*sealed)
 	return nil
 }

--- a/action/sealedenvelope.go
+++ b/action/sealedenvelope.go
@@ -51,6 +51,7 @@ func (sealed *SealedEnvelope) LoadProto(pbAct *iotextypes.Action) error {
 		return errors.New("nil action to load proto")
 	}
 
+	*sealed = SealedEnvelope{}
 	if err := sealed.Envelope.LoadProto(pbAct.GetCore()); err != nil {
 		return err
 	}

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
@@ -65,9 +64,6 @@ func (tsf *Transfer) Amount() *big.Int { return tsf.amount }
 
 // Payload returns the payload bytes
 func (tsf *Transfer) Payload() []byte { return tsf.payload }
-
-// SenderPublicKey returns the sender public key. It's the wrapper of Action.SrcPubkey
-func (tsf *Transfer) SenderPublicKey() crypto.PublicKey { return tsf.SrcPubkey() }
 
 // Recipient returns the recipient address. It's the wrapper of Action.DstAddr
 func (tsf *Transfer) Recipient() string { return tsf.recipient }

--- a/action/transfer_test.go
+++ b/action/transfer_test.go
@@ -7,6 +7,7 @@
 package action
 
 import (
+	"encoding/hex"
 	"math/big"
 	"strings"
 	"testing"
@@ -22,20 +23,24 @@ func TestTransferSignVerify(t *testing.T) {
 	recipientAddr := identityset.Address(28)
 	senderKey := identityset.PrivateKey(27)
 
-	tsf, err := NewTransfer(0, big.NewInt(10), recipientAddr.String(), []byte{}, uint64(100000), big.NewInt(10))
+	tsf, err := NewTransfer(1, big.NewInt(10), recipientAddr.String(), []byte{}, uint64(100000), big.NewInt(10))
 	require.NoError(err)
-
-	tsf.Proto()
+	require.Nil(tsf.srcPubkey)
 
 	bd := &EnvelopeBuilder{}
-	elp := bd.SetGasLimit(uint64(100000)).
-		SetGasPrice(big.NewInt(10)).
+	elp := bd.SetNonce(tsf.nonce).
+		SetGasLimit(tsf.gasLimit).
+		SetGasPrice(tsf.gasPrice).
 		SetAction(tsf).Build()
 
-	elp.Serialize()
+	require.Equal("0801100118a08d0622023130522f0a0231301229696f3172633264326465377274757563616c7371763464396e673068323937743633773777766c7068", hex.EncodeToString(elp.Serialize()))
 
 	w := AssembleSealedEnvelope(elp, senderKey.PublicKey(), []byte("lol"))
 	require.Error(Verify(w))
+	tsf2, ok := w.Envelope.payload.(*Transfer)
+	require.True(ok)
+	require.Equal(tsf, tsf2)
+	require.NotNil(tsf.srcPubkey)
 
 	// sign the transfer
 	selp, err := Sign(elp, senderKey)
@@ -72,7 +77,7 @@ func TestTransfer(t *testing.T) {
 	require.Equal(uint64(100000), tsf.GasLimit())
 	require.Equal("10", tsf.GasPrice().Text(10))
 	require.Equal(uint64(0), tsf.Nonce())
-	require.Equal(senderKey.PublicKey().HexString(), tsf.SenderPublicKey().HexString())
+	require.Equal(senderKey.PublicKey().HexString(), w.SrcPubkey().HexString())
 	require.Equal(recipientAddr.String(), tsf.Recipient())
 	require.Equal(recipientAddr.String(), tsf.Destination())
 	require.Equal(uint32(87), tsf.TotalSize())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1158,7 +1158,7 @@ func TestServer_SendAction(t *testing.T) {
 				return createServer(cfg, true)
 			},
 			&iotextypes.Action{},
-			"invalid public key",
+			"empty action proto to load",
 		},
 		{
 			func() (*Server, string, error) {


### PR DESCRIPTION
1. removed AbstractAction.hash. Hash of an action should be at the
level of Envelope and sealed envelope
2. removed unnecessary methods