### PR TITLE
[action] add Key() as unique key for DB storage

### DIFF
--- a/action/sealedenvelope.go
+++ b/action/sealedenvelope.go
@@ -18,7 +18,12 @@ type SealedEnvelope struct {
 	signature []byte
 }
 
-// Hash returns the hash value of SealedEnvelope.
+// Key is a unique identifer of the tx, used as key for DB storage
+func (sealed *SealedEnvelope) Key() hash.Hash256 {
+	return hash.Hash256b(byteutil.Must(proto.Marshal(sealed.Proto())))
+}
+
+// Hash returns the hash value of SealedEnvelope, used by API query
 func (sealed *SealedEnvelope) Hash() hash.Hash256 {
 	return hash.Hash256b(byteutil.Must(proto.Marshal(sealed.Proto())))
 }

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"


### PR DESCRIPTION
1. Add Key() which is always hash(Marshall(proto)), consistent for all tx

2. Hash() == Key() for native tx, will be != Key() for upcoming RLP tx

3. Use Key() as key for DB storage, to maintain consistency

4. API query pass in Hash(), indexer will internally do a Hash() --> Key() lookup