### PR TITLE
[api] return bytecode for contract account and gasLimit/gasUsed in Bl…

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -271,24 +271,30 @@ var (
 	}
 
 	getBlockMetasTests = []struct {
-		start   uint64
-		count   uint64
-		numBlks int
+		start, count      uint64
+		numBlks           int
+		gasLimit, gasUsed uint64
 	}{
 		{
 			1,
 			4,
 			4,
+			20000,
+			10000,
 		},
 		{
 			2,
 			5,
 			3,
+			120000,
+			60100,
 		},
 		{
 			1,
 			0,
 			0,
+			20000,
+			10000,
 		},
 	}
 
@@ -791,7 +797,8 @@ func TestServer_GetAccount(t *testing.T) {
 	require.EqualValues(1, accountMeta.PendingNonce)
 	require.EqualValues(0, accountMeta.NumActions)
 	require.True(accountMeta.IsContract)
-	require.Contains(contractCode, hex.EncodeToString(accountMeta.ContractCode))
+	require.True(len(accountMeta.ContractByteCode) > 0)
+	require.Contains(contractCode, hex.EncodeToString(accountMeta.ContractByteCode))
 
 	// success
 	for _, test := range getAccountTests {
@@ -1032,6 +1039,9 @@ func TestServer_GetBlockMetas(t *testing.T) {
 		}
 		require.NoError(err)
 		require.Equal(test.numBlks, len(res.BlkMetas))
+		meta := res.BlkMetas[0]
+		require.Equal(test.gasLimit, meta.GasLimit)
+		require.Equal(test.gasUsed, meta.GasUsed)
 		var prevBlkPb *iotextypes.BlockMeta
 		for _, blkPb := range res.BlkMetas {
 			if prevBlkPb != nil {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.4
 	github.com/iotexproject/iotex-antenna-go/v2 v2.4.2-0.20201211202736-96d536a425fe
 	github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54
-	github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb
+	github.com/iotexproject/iotex-proto v0.5.0
 	github.com/libp2p/go-libp2p v0.0.21 // indirect
 	github.com/libp2p/go-libp2p-peerstore v0.0.5
 	github.com/mattn/go-sqlite3 v1.11.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.4
 	github.com/iotexproject/iotex-antenna-go/v2 v2.4.2-0.20201211202736-96d536a425fe
 	github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54
-	github.com/iotexproject/iotex-proto v0.4.8
+	github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb
 	github.com/libp2p/go-libp2p v0.0.21 // indirect
 	github.com/libp2p/go-libp2p-peerstore v0.0.5
 	github.com/mattn/go-sqlite3 v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54 h1:n
 github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54/go.mod h1:rA7Vl9hDRRb3qYUuwH4ywMKsITjO5J1ThyLWoA+VQ2U=
 github.com/iotexproject/iotex-proto v0.4.0/go.mod h1:SttnbjoUJKHuKtDxCDJ5ewziAY4XrMPE2wo++Xod4b0=
 github.com/iotexproject/iotex-proto v0.4.4-0.20201029172022-a8466422b0f1/go.mod h1:VamfHxZ58AbpWJumRIE/u9tt/TouIlDkzk0dazVKKRY=
-github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb h1:ALiNRR3s1StvbFZNKS/kRbalt+Ri2RFbxujUOHJ2D6I=
-github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
+github.com/iotexproject/iotex-proto v0.5.0 h1:yPkyIFpPv8/AioHSevBr45i8pF8fHsETZ0oEFN8W6pE=
+github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54 h1:n
 github.com/iotexproject/iotex-election v0.3.5-0.20201031050050-c3ab4f339a54/go.mod h1:rA7Vl9hDRRb3qYUuwH4ywMKsITjO5J1ThyLWoA+VQ2U=
 github.com/iotexproject/iotex-proto v0.4.0/go.mod h1:SttnbjoUJKHuKtDxCDJ5ewziAY4XrMPE2wo++Xod4b0=
 github.com/iotexproject/iotex-proto v0.4.4-0.20201029172022-a8466422b0f1/go.mod h1:VamfHxZ58AbpWJumRIE/u9tt/TouIlDkzk0dazVKKRY=
-github.com/iotexproject/iotex-proto v0.4.8 h1:Wl9ssafjLahUX2j/Z9Lvi3AbmjMyHVYn85Psv8UB1Tc=
-github.com/iotexproject/iotex-proto v0.4.8/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
+github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb h1:ALiNRR3s1StvbFZNKS/kRbalt+Ri2RFbxujUOHJ2D6I=
+github.com/iotexproject/iotex-proto v0.4.9-0.20210416214326-28e18e4a85cb/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
 github.com/ipfs/go-cid v0.0.1 h1:GBjWPktLnNyX0JiQCNFpUuUSoMw5KMyqrsejHYlILBE=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-datastore v0.0.1/go.mod h1:d4KVXhMt913cLBEI/PXAy6ko+W7e9AhyAKBGh803qeE=


### PR DESCRIPTION
…ockMeta

Due to adding gasLimit and gasUsed to BlockMeta, the server is no longer able
to generate the response using only indexer's data, but have to use the entire
block. As a result, duplicate code using indexer are removed.