### PR TITLE
add 'ioctl account info' command

### DIFF
--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -79,6 +79,7 @@ func init() {
 	AccountCmd.AddCommand(accountExportCmd)
 	AccountCmd.AddCommand(accountExportPublicCmd)
 	AccountCmd.AddCommand(accountImportCmd)
+	AccountCmd.AddCommand(accountInfoCmd)
 	AccountCmd.AddCommand(accountListCmd)
 	AccountCmd.AddCommand(accountNonceCmd)
 	AccountCmd.AddCommand(accountSignCmd)

--- a/ioctl/cmd/account/accountinfo.go
+++ b/ioctl/cmd/account/accountinfo.go
@@ -1,0 +1,100 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package account
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/spf13/cobra"
+
+	ioAddress "github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+// Multi-language support
+var (
+	infoCmdUses = map[config.Language]string{
+		config.English: "info [ALIAS|ADDRESS]",
+		config.Chinese: "info [别名|地址]",
+	}
+	infoCmdShorts = map[config.Language]string{
+		config.English: "Display an account's information",
+		config.Chinese: "显示账号信息",
+	}
+)
+
+// accountInfoCmd represents the account info command
+var accountInfoCmd = &cobra.Command{
+	Use:   config.TranslateInLang(infoCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(infoCmdShorts, config.UILanguage),
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		arg := ""
+		if len(args) == 1 {
+			arg = args[0]
+		}
+		err := info(arg)
+		return output.PrintError(err)
+	},
+}
+
+type infoMessage struct {
+	Address          string `json:"address"`
+	Balance          string `json:"balance"`
+	Nonce            int    `json:"nonce"`
+	PendingNonce     int    `json:"pendingNonce"`
+	NumActions       int    `json:"numActions"`
+	IsContract       bool   `json:"isContract"`
+	ContractByteCode string `json:"contractByteCode"`
+}
+
+// info gets information of an IoTeX blockchain address
+func info(arg string) error {
+	addr := arg
+	if arg != ioAddress.StakingBucketPoolAddr && arg != ioAddress.RewardingPoolAddr {
+		var err error
+		addr, err = util.GetAddress(arg)
+		if err != nil {
+			return output.NewError(output.AddressError, "", err)
+		}
+	}
+	accountMeta, err := GetAccountMeta(addr)
+	if err != nil {
+		return output.NewError(0, "", err) // TODO: undefined error
+	}
+	balance, ok := big.NewInt(0).SetString(accountMeta.Balance, 10)
+	if !ok {
+		return output.NewError(output.ConvertError, "", err)
+	}
+
+	message := infoMessage{
+		Address:          addr,
+		Balance:          util.RauToString(balance, util.IotxDecimalNum),
+		Nonce:            int(accountMeta.Nonce),
+		PendingNonce:     int(accountMeta.PendingNonce),
+		NumActions:       int(accountMeta.NumActions),
+		IsContract:       accountMeta.IsContract,
+		ContractByteCode: hex.EncodeToString(accountMeta.ContractByteCode),
+	}
+
+	fmt.Println((message.String()))
+	return nil
+}
+
+func (m *infoMessage) String() string {
+	if output.Format == "" {
+		s, _ := json.MarshalIndent(m, "", "  ")
+		return fmt.Sprintf("%s:\n%s", m.Address, string(s))
+	}
+	return output.FormatString(output.Result, m)
+}

--- a/ioctl/cmd/account/accountinfo.go
+++ b/ioctl/cmd/account/accountinfo.go
@@ -11,11 +11,13 @@ import (
 	"fmt"
 	"math/big"
 
-	ioAddress "github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/spf13/cobra"
+
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/spf13/cobra"
+
 )
 
 // Multi-language support
@@ -55,7 +57,7 @@ type infoMessage struct {
 // info gets information of an IoTeX blockchain address
 func info(arg string) error {
 	addr := arg
-	if arg != ioAddress.StakingBucketPoolAddr && arg != ioAddress.RewardingPoolAddr {
+	if arg != address.StakingBucketPoolAddr && arg != address.RewardingPoolAddr {
 		var err error
 		addr, err = util.GetAddress(arg)
 		if err != nil {

--- a/ioctl/cmd/account/accountinfo.go
+++ b/ioctl/cmd/account/accountinfo.go
@@ -8,16 +8,14 @@ package account
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"math/big"
-
-	"github.com/spf13/cobra"
 
 	ioAddress "github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/spf13/cobra"
 )
 
 // Multi-language support
@@ -39,11 +37,7 @@ var accountInfoCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cmd.SilenceUsage = true
-		arg := ""
-		if len(args) == 1 {
-			arg = args[0]
-		}
-		err := info(arg)
+		err := info(args[0])
 		return output.PrintError(err)
 	},
 }
@@ -70,7 +64,7 @@ func info(arg string) error {
 	}
 	accountMeta, err := GetAccountMeta(addr)
 	if err != nil {
-		return output.NewError(0, "", err) // TODO: undefined error
+		return output.NewError(output.APIError, "", err)
 	}
 	balance, ok := big.NewInt(0).SetString(accountMeta.Balance, 10)
 	if !ok {
@@ -93,8 +87,7 @@ func info(arg string) error {
 
 func (m *infoMessage) String() string {
 	if output.Format == "" {
-		s, _ := json.MarshalIndent(m, "", "  ")
-		return fmt.Sprintf("%s:\n%s", m.Address, string(s))
+		return fmt.Sprintf("%s:\n%s", m.Address, output.JSONString(m))
 	}
 	return output.FormatString(output.Result, m)
 }


### PR DESCRIPTION
fixed #2608 
By typing `ioctl account info (ALIAS|ADDRESS)` in the ioctl CLI, the information of the account will be displayed. 
e.g.

> io1vqzcl56vlfspyaadyxhqy07jrmalx73vdaklzn:
{
  "address": "io1vqzcl56vlfspyaadyxhqy07jrmalx73vdaklzn",
  "balance": "0",
  "nonce": 1,
  "pendingNonce": 2,
  "numActions": 10258,
  "isContract": true,
  "contractByteCode": "60806040526004361061018a5763ffffffff7c0100000000000000000000000000000000000000000000000000000000600035041663030ba25d811461018f57806307c35fc0146101b55780631b0690ed146101f257806324953eaa14610207578063286dd3f5146102705780632f54bf6e146102915780633f4ba83a146102b2578063423ce1ae146102c75780635c975abb146102eb5780635fec5c641461030057806363809953146103155780636c0a5ebd1461032a5780636e7b3017146103e557806376f70003146103fc5780637b24a5fd146104115780637b9417c81461043f5780637d56493714610460578063817b1cd2146104915780638456cb59146104a65780638da5cb5b146104bb57806394a9c0f9146104ec5780639b19251a14610562578063c698d49514610583578063c8fd6ed014610598578063ccfafd5c146105bc578063d09daa9914610638..."
}