### PR TITLE
Code reconstruction: wrap gRPC connection in ioctl into a function

### DIFF
--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -163,22 +163,11 @@ func LocalAccountToPrivateKey(signer, password string) (crypto.PrivateKey, error
 
 // GetAccountMeta gets account metadata
 func GetAccountMeta(addr string) (*iotextypes.AccountMeta, error) {
-	// conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
-	// if err != nil {
-	// 	return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	// }
-	// defer conn.Close()
-	// cli := iotexapi.NewAPIServiceClient(conn)
-	// ctx := context.Background()
-	request := iotexapi.GetAccountRequest{Address: addr}
-	// jwtMD, err := util.JwtAuth()
-	// if err == nil {
-	// 	ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
-	// }
 	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
 		return nil, err
 	}
+	request := iotexapi.GetAccountRequest{Address: addr}
 	response, err := cli.GetAccount(ctx, &request)
 
 	if err != nil {

--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"bytes"
-	"context"
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
@@ -19,7 +18,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	ecrypto "github.com/ethereum/go-ethereum/crypto"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
@@ -165,18 +163,21 @@ func LocalAccountToPrivateKey(signer, password string) (crypto.PrivateKey, error
 
 // GetAccountMeta gets account metadata
 func GetAccountMeta(addr string) (*iotextypes.AccountMeta, error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
-	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
+	// conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	// if err != nil {
+	// 	return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+	// }
+	// defer conn.Close()
+	// cli := iotexapi.NewAPIServiceClient(conn)
+	// ctx := context.Background()
 	request := iotexapi.GetAccountRequest{Address: addr}
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+	// jwtMD, err := util.JwtAuth()
+	// if err == nil {
+	// 	ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+	// }
+	cli, ctx, err := util.GetAPIClientAndContext()
+	if err != nil {
+		return nil, err
 	}
 	response, err := cli.GetAccount(ctx, &request)
 

--- a/ioctl/cmd/account/accountactions.go
+++ b/ioctl/cmd/account/accountactions.go
@@ -7,13 +7,11 @@
 package account
 
 import (
-	"context"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/rodaine/table"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
@@ -74,17 +72,9 @@ func accountActions(args []string) error {
 		return output.NewError(output.AddressError, "failed to get address", err)
 	}
 
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+		return err
 	}
 
 	requestGetAccount := iotexapi.GetAccountRequest{

--- a/ioctl/cmd/action/actionhash.go
+++ b/ioctl/cmd/action/actionhash.go
@@ -7,7 +7,6 @@
 package action
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"log"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -91,17 +89,9 @@ func (m *actionMessage) String() string {
 // getActionByHash gets action of IoTeX Blockchain by hash
 func getActionByHash(args []string) error {
 	hash := args[0]
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+		return err
 	}
 
 	// search action on blockchain

--- a/ioctl/cmd/bc/bcblock.go
+++ b/ioctl/cmd/bc/bcblock.go
@@ -7,12 +7,10 @@
 package bc
 
 import (
-	"context"
 	"encoding/hex"
 	"fmt"
 	"strconv"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
 
@@ -191,19 +189,11 @@ func getBlock(args []string) error {
 
 // getActionInfoByBlock gets action info by block hash with start index and action count
 func getActionInfoWithinBlock(height uint64) ([]blocksInfo, error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return nil, err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	request := iotexapi.GetRawBlocksRequest{StartHeight: height, Count: 1, WithReceipts: true}
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
-	}
 
 	response, err := cli.GetRawBlocks(ctx, &request)
 	if err != nil {
@@ -226,12 +216,10 @@ func getActionInfoWithinBlock(height uint64) ([]blocksInfo, error) {
 
 // getBlockMetaByHeight gets block metadata by height
 func getBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return nil, err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	request := &iotexapi.GetBlockMetasRequest{
 		Lookup: &iotexapi.GetBlockMetasRequest_ByIndex{
 			ByIndex: &iotexapi.GetBlockMetasByIndexRequest{
@@ -239,12 +227,6 @@ func getBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
 				Count: 1,
 			},
 		},
-	}
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
 
 	response, err := cli.GetBlockMetas(ctx, request)
@@ -263,22 +245,14 @@ func getBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
 
 // getBlockMetaByHash gets block metadata by hash
 func getBlockMetaByHash(hash string) (*iotextypes.BlockMeta, error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return nil, err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	request := &iotexapi.GetBlockMetasRequest{
 		Lookup: &iotexapi.GetBlockMetasRequest_ByHash{
 			ByHash: &iotexapi.GetBlockMetaByHashRequest{BlkHash: hash},
 		},
-	}
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
 
 	response, err := cli.GetBlockMetas(ctx, request)

--- a/ioctl/cmd/bc/bcbucket.go
+++ b/ioctl/cmd/bc/bcbucket.go
@@ -7,7 +7,6 @@
 package bc
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -16,7 +15,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
@@ -161,12 +159,10 @@ func getBucket(arg string) error {
 }
 
 func getBucketByIndex(index uint64) (*iotextypes.VoteBucket, error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return nil, err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	method := &iotexapi.ReadStakingDataMethod{
 		Method: iotexapi.ReadStakingDataMethod_BUCKETS_BY_INDEXES,
 	}
@@ -190,12 +186,6 @@ func getBucketByIndex(index uint64) (*iotextypes.VoteBucket, error) {
 		ProtocolID: []byte("staking"),
 		MethodName: methodData,
 		Arguments:  [][]byte{requestData},
-	}
-
-	ctx := context.Background()
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
 
 	response, err := cli.ReadState(ctx, request)
@@ -235,12 +225,10 @@ func getBucketsActiveCount() error {
 }
 
 func getBucketsCount() (count *iotextypes.BucketsCount, err error) {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return nil, err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	method := &iotexapi.ReadStakingDataMethod{
 		Method: iotexapi.ReadStakingDataMethod_BUCKETS_COUNT,
 	}
@@ -262,12 +250,6 @@ func getBucketsCount() (count *iotextypes.BucketsCount, err error) {
 		ProtocolID: []byte("staking"),
 		MethodName: methodData,
 		Arguments:  [][]byte{requestData},
-	}
-
-	ctx := context.Background()
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
 
 	response, err := cli.ReadState(ctx, request)

--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/codes"
@@ -176,18 +175,9 @@ func delegates() error {
 }
 
 func delegatesV2(pb *vote.ProbationList, epochMeta *iotexapi.GetEpochMetaResponse, message *delegatesMessage) error {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	}
-	defer conn.Close()
-
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+		return err
 	}
 
 	request := &iotexapi.ReadStateRequest{

--- a/ioctl/cmd/node/nodereward.go
+++ b/ioctl/cmd/node/nodereward.go
@@ -7,11 +7,9 @@
 package node
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
 
@@ -97,18 +95,11 @@ func (m *rewardMessage) String() string {
 }
 
 func rewardPool() error {
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
 
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
-	}
 	// AvailableBalance == Rewards in the pool that has not been issued to anyone
 	request := &iotexapi.ReadStateRequest{
 		ProtocolID: []byte("rewarding"),
@@ -160,17 +151,9 @@ func reward(arg string) error {
 	if err != nil {
 		return output.NewError(output.AddressError, "failed to get address", err)
 	}
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
-	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+		return err
 	}
 
 	request := &iotexapi.ReadStateRequest{

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -7,10 +7,8 @@
 package version
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc/status"
 
@@ -80,19 +78,11 @@ func version() error {
 	fmt.Println(message.String())
 
 	message = versionMessage{Object: config.ReadConfig.Endpoint}
-	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	cli, ctx, err := util.GetAPIClientAndContext()
 	if err != nil {
-		return output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+		return err
 	}
-	defer conn.Close()
-	cli := iotexapi.NewAPIServiceClient(conn)
 	request := &iotexapi.GetServerMetaRequest{}
-	ctx := context.Background()
-
-	jwtMD, err := util.JwtAuth()
-	if err == nil {
-		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
-	}
 
 	response, err := cli.GetServerMeta(ctx, request)
 	if err != nil {

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -76,6 +76,7 @@ func ConnectToEndpoint(secure bool) (*grpc.ClientConn, error) {
 	return grpc.Dial(endpoint, grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{})))
 }
 
+// GetAPIClientAndContext establishes a gPRC connection, and return APIServiceClient and context built on the connection
 func GetAPIClientAndContext() (iotexapi.APIServiceClient, context.Context, error) {
 	if gPRCConnInstance == nil {
 		conn, err := ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -52,8 +52,6 @@ const (
 
 var (
 	gPRCConnInstance *grpc.ClientConn
-	cli              iotexapi.APIServiceClient
-	ctx              context.Context
 )
 
 // ExecuteCmd executes cmd with args, and return system output, e.g., help info, and error
@@ -92,13 +90,12 @@ func GetAPIClientAndContext() (iotexapi.APIServiceClient, context.Context, error
 			conn.Close()
 			gPRCConnInstance = nil
 		})
-
-		cli = iotexapi.NewAPIServiceClient(gPRCConnInstance)
-		ctx = context.Background()
-		jwtMD, err := JwtAuth()
-		if err == nil {
-			ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
-		}
+	}
+	cli := iotexapi.NewAPIServiceClient(gPRCConnInstance)
+	ctx := context.Background()
+	jwtMD, err := JwtAuth()
+	if err == nil {
+		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
 	}
 	return cli, ctx, nil
 }


### PR DESCRIPTION
Try to fix #2607
Pack gRPC connection and JWT auth code snippet into function `GetAPIClientAndContext()` in ioctl/util/util.go. Three global variables (gPRCConnInstance, cli, ctx) are used for sharing same gRPC connection. The connection will be timeout and closed in 5 minutes.
This pull request is a draft. Only the code snippet in ioctl/cmd/account/account.go is replaced with new function.