### PR TITLE
Fix test TestProtocol_ClaimReward

### DIFF
--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -226,6 +226,11 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		claimActionCtx.Caller = identityset.Address(0)
 		claimCtx := protocol.WithActionCtx(ctx, claimActionCtx)
 
+		// Record the init balance of account
+		primAcc, err := accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
+		require.NoError(t, err)
+		initBalance := primAcc.Balance
+
 		_, err = p.Claim(claimCtx, sm, big.NewInt(5))
 		require.NoError(t, err)
 
@@ -235,9 +240,10 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		unclaimedBalance, _, err := p.UnclaimedBalance(ctx, sm, claimActionCtx.Caller)
 		require.NoError(t, err)
 		assert.Equal(t, big.NewInt(5), unclaimedBalance)
-		primAcc, err := accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
+		primAcc, err = accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
 		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1000005), primAcc.Balance)
+		initBalance = initBalance.Add(initBalance, big.NewInt(5))
+		assert.Equal(t, initBalance, primAcc.Balance)
 
 		// Claim negative amount of token will fail
 		_, err = p.Claim(claimCtx, sm, big.NewInt(-5))
@@ -255,7 +261,7 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		assert.Equal(t, big.NewInt(5), unclaimedBalance)
 		primAcc, err = accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
 		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1000005), primAcc.Balance)
+		assert.Equal(t, initBalance, primAcc.Balance)
 
 		// Claim another 5 token
 		rlog, err := p.Claim(claimCtx, sm, big.NewInt(5))
@@ -274,7 +280,8 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		assert.Equal(t, big.NewInt(0), unclaimedBalance)
 		primAcc, err = accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
 		require.NoError(t, err)
-		assert.Equal(t, big.NewInt(1000010), primAcc.Balance)
+		initBalance = initBalance.Add(initBalance, big.NewInt(5))
+		assert.Equal(t, initBalance, primAcc.Balance)
 
 		// Claim the 3-rd 5 token will fail be cause no balance for the address
 		_, err = p.Claim(claimCtx, sm, big.NewInt(5))

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -242,7 +242,7 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		assert.Equal(t, big.NewInt(5), unclaimedBalance)
 		primAcc, err = accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
 		require.NoError(t, err)
-		initBalance = initBalance.Add(initBalance, big.NewInt(5))
+		initBalance = new(big.Int).Add(initBalance, big.NewInt(5))
 		assert.Equal(t, initBalance, primAcc.Balance)
 
 		// Claim negative amount of token will fail
@@ -280,7 +280,7 @@ func TestProtocol_ClaimReward(t *testing.T) {
 		assert.Equal(t, big.NewInt(0), unclaimedBalance)
 		primAcc, err = accountutil.LoadAccount(sm, hash.BytesToHash160(claimActionCtx.Caller.Bytes()))
 		require.NoError(t, err)
-		initBalance = initBalance.Add(initBalance, big.NewInt(5))
+		initBalance = new(big.Int).Add(initBalance, big.NewInt(5))
 		assert.Equal(t, initBalance, primAcc.Balance)
 
 		// Claim the 3-rd 5 token will fail be cause no balance for the address


### PR DESCRIPTION
fix #2521 

## Issue description:
Run `go test -run TestProtocol_ClaimReward` will fail, but run `go test` will pass.

## Reason:
When run `go test`, func TestProtocol_Handle runs before func TestProtocol_ClaimReward. The initial balance of account was changed to 1000000 on Line 302 in `protocol_test.go` 
```
cfg.Genesis.Rewarding.InitBalanceStr = "1000000"
```
However, if func TestProtocol_Handle runs alone, its initial balance is 100000000000000000000000000

## Solution:
Use a variable `initBalance` to record the initial balance of account when entering func TestProtocol_Handle