### PR TITLE
Solve a bug in checkIndexers()

### DIFF
--- a/blockchain/blockdao/blockdao.go
+++ b/blockchain/blockdao/blockdao.go
@@ -161,12 +161,12 @@ func (dao *blockDAO) checkIndexers(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			ctx, err = dao.fillWithBlockInfoAsTip(ctx, i-1)
+			ctxNew, err := dao.fillWithBlockInfoAsTip(ctx, i-1)
 			if err != nil {
 				return err
 			}
 			if err := indexer.PutBlock(protocol.WithBlockCtx(
-				ctx,
+				ctxNew,
 				protocol.BlockCtx{
 					BlockHeight:    i,
 					BlockTimeStamp: blk.Timestamp(),

--- a/blockchain/blockdao/blockdao.go
+++ b/blockchain/blockdao/blockdao.go
@@ -161,12 +161,12 @@ func (dao *blockDAO) checkIndexers(ctx context.Context) error {
 			if err != nil {
 				return err
 			}
-			ctxNew, err := dao.fillWithBlockInfoAsTip(ctx, i-1)
+			ctxWithTip, err := dao.fillWithBlockInfoAsTip(ctx, i-1)
 			if err != nil {
 				return err
 			}
 			if err := indexer.PutBlock(protocol.WithBlockCtx(
-				ctxNew,
+				ctxWithTip,
 				protocol.BlockCtx{
 					BlockHeight:    i,
 					BlockTimeStamp: blk.Timestamp(),


### PR DESCRIPTION
fix #2698 
The issue is caused by reuse of context in [L164](https://github.com/iotexproject/iotex-core/blob/0796d378aaedf3b802fead0090a7f26669a0c37f/blockchain/blockdao/blockdao.go#L164). As block height increases, the context var becomes larger due to reuse.