### PR TITLE
optimize staking index DB storage

### DIFF
--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -4,141 +4,266 @@ import (
 	"context"
 	"testing"
 
-	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/testutil"
 )
-
-func TestCandidatesBucketsIndexer_StartStop(t *testing.T) {
-	require := require.New(t)
-
-	ctx := context.Background()
-	store := db.NewMemKVStore()
-	cbi, err := NewStakingCandidatesBucketsIndexer(store)
-	require.NoError(err)
-
-	require.NoError(cbi.Start(ctx))
-	require.NoError(cbi.Stop(ctx))
-}
 
 func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 	require := require.New(t)
 
-	ctx := context.Background()
-	store := db.NewMemKVStore()
+	testPath, err := testutil.PathOfTempFile("test-candidate")
+	require.NoError(err)
+	defer func() {
+		testutil.CleanupPath(t, testPath)
+	}()
+
+	cfg := db.DefaultConfig
+	cfg.DbPath = testPath
+	store := db.NewBoltDB(cfg)
 	cbi, err := NewStakingCandidatesBucketsIndexer(store)
 	require.NoError(err)
-
+	ctx := context.Background()
 	require.NoError(cbi.Start(ctx))
+	defer func() {
+		require.NoError(cbi.Stop(ctx))
+	}()
 
-	candidates := &iotextypes.CandidateListV2{}
-	candidates.Candidates = append(candidates.Candidates, &iotextypes.CandidateV2{
-		Name:               "abc",
-		SelfStakeBucketIdx: 123,
-	})
-
-	require.NoError(cbi.PutCandidates(0, nil))
+	cand := []*iotextypes.CandidateV2{
+		{
+			OwnerAddress:       "owner1",
+			Name:               "abc",
+			SelfStakeBucketIdx: 123,
+		},
+	}
+	cand2 := &iotextypes.CandidateListV2{
+		Candidates: cand,
+	}
+	cand3 := &iotextypes.CandidateListV2{
+		Candidates: append(cand, &iotextypes.CandidateV2{
+			OwnerAddress:       "owner2",
+			Name:               "xyz",
+			SelfStakeBucketIdx: 456,
+		}),
+	}
 
 	tests := []struct {
 		height     uint64
 		candidates *iotextypes.CandidateListV2
 	}{
+		{0, nil},
 		{1, &iotextypes.CandidateListV2{}},
-		{2, candidates},
+		{2, cand2},
+		{3, cand3},
+		{4, cand3}, // same as block 3
+		{5, cand3}, // same as block 3
+		{6, cand2}, // same as block 2
+	}
+	tests2 := []struct {
+		offset, limit uint32
+	}{
+		{0, 1},
+		{0, 2},
+		{1, 5},
+		{1234, 5},
 	}
 
+	var r iotextypes.CandidateListV2
 	for _, v := range tests {
 		require.NoError(cbi.PutCandidates(v.height, v.candidates))
-	}
 
-	tests2 := []struct {
-		height        uint64
-		offset, limit uint32
-		r1            int
-		r2            uint64
-	}{
-		{0, 0, 0, 0, 0},
-		{2, 0, 1, 1, 2},
-		{2, 0, 100, 1, 2},
-		{2, 1234, 0, 0, 2},
-		{2, 1111111, 1, 0, 2},
-		{21111111, 1111111, 1333333, 0, 2},
-	}
-	for _, v2 := range tests2 {
-		a, b, err := cbi.GetCandidates(v2.height, v2.offset, v2.limit)
-		require.NoError(err)
-
-		var r iotextypes.CandidateListV2
-		require.NoError(proto.Unmarshal(a, &r))
-		require.Equal(len(r.Candidates), v2.r1)
-		require.Equal(b, v2.r2)
-
-		if len(r.Candidates) > 0 {
-			require.Equal(r.Candidates[0].Name, tests[1].candidates.Candidates[0].Name)
-			require.Equal(r.Candidates[0].SelfStakeBucketIdx, tests[1].candidates.Candidates[0].SelfStakeBucketIdx)
+		for _, v2 := range tests2 {
+			a, b, err := cbi.GetCandidates(v.height, v2.offset, v2.limit)
+			require.NoError(err)
+			require.Equal(b, v.height)
+			require.NoError(proto.Unmarshal(a, &r))
+			if tests[v.height].candidates == nil {
+				continue
+			}
+			expectLen := uint32(len(tests[v.height].candidates.Candidates))
+			if expectLen == 0 || v2.offset >= expectLen {
+				require.Zero(len(r.Candidates))
+				continue
+			}
+			end := v2.offset + v2.limit
+			if end > expectLen {
+				end = expectLen
+			}
+			// check the returned list
+			expect := tests[v.height].candidates.Candidates[v2.offset:end]
+			for i, v := range expect {
+				actual := r.Candidates[i]
+				require.Equal(v.OwnerAddress, actual.OwnerAddress)
+				require.Equal(v.Name, actual.Name)
+				require.Equal(v.SelfStakeBucketIdx, actual.SelfStakeBucketIdx)
+			}
 		}
 	}
+
+	// test height > latest height
+	require.EqualValues(6, cbi.latestCandidatesHeight)
+	a, b, err := cbi.GetCandidates(7, 0, 1)
+	require.NoError(err)
+	require.EqualValues(6, b)
+	require.NoError(proto.Unmarshal(a, &r))
+	require.Equal(1, len(r.Candidates))
+	expect := tests[6].candidates.Candidates[0]
+	actual := r.Candidates[0]
+	require.Equal(expect.OwnerAddress, actual.OwnerAddress)
+	require.Equal(expect.Name, actual.Name)
+	require.Equal(expect.SelfStakeBucketIdx, actual.SelfStakeBucketIdx)
+
+	// test with a key larger than any existing key
+	height := uint64(8810200527999860736)
+	candMax := &iotextypes.CandidateListV2{
+		Candidates: append(cand, &iotextypes.CandidateV2{
+			OwnerAddress:       "ownermax",
+			Name:               "alphabeta",
+			SelfStakeBucketIdx: 789,
+		}),
+	}
+	require.NoError(cbi.PutCandidates(height, candMax))
+	lcHash := cbi.latestCandidatesHash
+	a, _, err = cbi.GetCandidates(height, 0, 4)
+	require.NoError(err)
+	c, err := getFromIndexer(store, StakingCandidatesNamespace, height+1)
+	require.NoError(err)
+	require.Equal(a, c)
 	require.NoError(cbi.Stop(ctx))
+
+	// reopen db to read latest height and hash
+	require.NoError(cbi.Start(ctx))
+	require.Equal(height, cbi.latestCandidatesHeight)
+	require.Equal(lcHash, cbi.latestCandidatesHash)
 }
 
 func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 	require := require.New(t)
 
-	ctx := context.Background()
-	store := db.NewMemKVStore()
+	testPath, err := testutil.PathOfTempFile("test-bucket")
+	require.NoError(err)
+	defer func() {
+		testutil.CleanupPath(t, testPath)
+	}()
+
+	cfg := db.DefaultConfig
+	cfg.DbPath = testPath
+	store := db.NewBoltDB(cfg)
 	cbi, err := NewStakingCandidatesBucketsIndexer(store)
 	require.NoError(err)
-
+	ctx := context.Background()
 	require.NoError(cbi.Start(ctx))
+	defer func() {
+		require.NoError(cbi.Stop(ctx))
+	}()
 
-	voteBuckets := &iotextypes.VoteBucketList{}
-	voteBuckets.Buckets = append(voteBuckets.Buckets, &iotextypes.VoteBucket{
-		Index:     uint64(1234),
-		AutoStake: true,
-	})
-
-	require.NoError(cbi.PutBuckets(0, nil))
+	bucket := []*iotextypes.VoteBucket{
+		{
+			Index:     uint64(1234),
+			AutoStake: true,
+			Owner:     "abc",
+		},
+	}
+	vote2 := &iotextypes.VoteBucketList{
+		Buckets: bucket,
+	}
+	vote4 := &iotextypes.VoteBucketList{
+		Buckets: append(bucket, &iotextypes.VoteBucket{
+			Index:     uint64(5678),
+			AutoStake: false,
+			Owner:     "xyz",
+		}),
+	}
 
 	tests := []struct {
 		height  uint64
 		buckets *iotextypes.VoteBucketList
 	}{
+		{0, nil},
 		{1, &iotextypes.VoteBucketList{}},
-		{2, voteBuckets},
+		{2, vote2},
+		{3, vote2}, // same as block 2
+		{4, vote4},
+		{5, vote4}, // same as block 4
+		{6, vote2}, // same as block 2
+	}
+	tests2 := []struct {
+		offset, limit uint32
+	}{
+		{0, 1},
+		{0, 2},
+		{1, 5},
+		{1234, 5},
 	}
 
+	var r iotextypes.VoteBucketList
 	for _, v := range tests {
 		require.NoError(cbi.PutBuckets(v.height, v.buckets))
-	}
 
-	tests2 := []struct {
-		height        uint64
-		offset, limit uint32
-		r1            int
-		r2            uint64
-	}{
-		{0, 0, 0, 0, 0},
-		{2, 0, 1, 1, 2},
-		{2, 0, 100, 1, 2},
-		{2, 1234, 0, 0, 2},
-		{2, 1111111, 1, 0, 2},
-		{21111111, 1111111, 1333333, 0, 2},
-	}
-	for _, v2 := range tests2 {
-		a, b, err := cbi.GetBuckets(v2.height, v2.offset, v2.limit)
-		require.NoError(err)
-
-		var r iotextypes.VoteBucketList
-		require.NoError(proto.Unmarshal(a, &r))
-		require.Equal(len(r.Buckets), v2.r1)
-		require.Equal(b, v2.r2)
-
-		if len(r.Buckets) > 0 {
-			require.Equal(r.Buckets[0].Index, tests[1].buckets.Buckets[0].Index)
-			require.Equal(r.Buckets[0].AutoStake, tests[1].buckets.Buckets[0].AutoStake)
-			require.Equal(r.Buckets[0].Owner, tests[1].buckets.Buckets[0].Owner)
+		for _, v2 := range tests2 {
+			a, b, err := cbi.GetBuckets(v.height, v2.offset, v2.limit)
+			require.NoError(err)
+			require.Equal(b, v.height)
+			require.NoError(proto.Unmarshal(a, &r))
+			if tests[v.height].buckets == nil {
+				continue
+			}
+			expectLen := uint32(len(tests[v.height].buckets.Buckets))
+			if expectLen == 0 || v2.offset >= expectLen {
+				require.Zero(len(r.Buckets))
+				continue
+			}
+			end := v2.offset + v2.limit
+			if end > expectLen {
+				end = expectLen
+			}
+			// check the returned list
+			expect := tests[v.height].buckets.Buckets[v2.offset:end]
+			for i, v := range expect {
+				actual := r.Buckets[i]
+				require.Equal(v.Index, actual.Index)
+				require.Equal(v.AutoStake, actual.AutoStake)
+				require.Equal(v.Owner, actual.Owner)
+			}
 		}
 	}
+
+	// test height > latest height
+	require.EqualValues(6, cbi.latestBucketsHeight)
+	a, b, err := cbi.GetBuckets(7, 0, 1)
+	require.NoError(err)
+	require.EqualValues(6, b)
+	require.NoError(proto.Unmarshal(a, &r))
+	require.Equal(1, len(r.Buckets))
+	expect := tests[6].buckets.Buckets[0]
+	actual := r.Buckets[0]
+	require.Equal(expect.Index, actual.Index)
+	require.Equal(expect.AutoStake, actual.AutoStake)
+	require.Equal(expect.Owner, actual.Owner)
+
+	// test with a key larger than any existing key
+	height := uint64(8810200527999860736)
+	voteMax := &iotextypes.VoteBucketList{
+		Buckets: append(bucket, &iotextypes.VoteBucket{
+			Index:     uint64(1357),
+			AutoStake: false,
+			Owner:     "ownermax",
+		}),
+	}
+	require.NoError(cbi.PutBuckets(height, voteMax))
+	lbHash := cbi.latestBucketsHash
+	a, _, err = cbi.GetBuckets(height, 0, 4)
+	require.NoError(err)
+	c, err := getFromIndexer(store, StakingBucketsNamespace, height+1)
+	require.NoError(err)
+	require.Equal(a, c)
 	require.NoError(cbi.Stop(ctx))
+
+	// reopen db to read latest height and hash
+	require.NoError(cbi.Start(ctx))
+	require.Equal(height, cbi.latestBucketsHeight)
+	require.Equal(lbHash, cbi.latestBucketsHash)
 }

--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -32,6 +32,14 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 		require.NoError(cbi.Stop(ctx))
 	}()
 
+	// nothing in db, return empty list
+	a, height, err := cbi.GetCandidates(1, 0, 1)
+	require.NoError(err)
+	require.EqualValues(0, height)
+	var r iotextypes.CandidateListV2
+	require.NoError(proto.Unmarshal(a, &r))
+	require.Zero(len(r.Candidates))
+
 	cand := []*iotextypes.CandidateV2{
 		{
 			OwnerAddress:       "owner1",
@@ -71,7 +79,6 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 		{1234, 5},
 	}
 
-	var r iotextypes.CandidateListV2
 	for _, v := range tests {
 		require.NoError(cbi.PutCandidates(v.height, v.candidates))
 
@@ -105,9 +112,9 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 
 	// test height > latest height
 	require.EqualValues(6, cbi.latestCandidatesHeight)
-	a, b, err := cbi.GetCandidates(7, 0, 1)
+	a, height, err = cbi.GetCandidates(7, 0, 1)
 	require.NoError(err)
-	require.EqualValues(6, b)
+	require.EqualValues(6, height)
 	require.NoError(proto.Unmarshal(a, &r))
 	require.Equal(1, len(r.Candidates))
 	expect := tests[6].candidates.Candidates[0]
@@ -117,7 +124,7 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 	require.Equal(expect.SelfStakeBucketIdx, actual.SelfStakeBucketIdx)
 
 	// test with a key larger than any existing key
-	height := uint64(8810200527999860736)
+	height = 8810200527999860736
 	candMax := &iotextypes.CandidateListV2{
 		Candidates: append(cand, &iotextypes.CandidateV2{
 			OwnerAddress:       "ownermax",
@@ -160,6 +167,14 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 		require.NoError(cbi.Stop(ctx))
 	}()
 
+	// nothing in db, return empty list
+	a, height, err := cbi.GetBuckets(1, 0, 1)
+	require.NoError(err)
+	require.EqualValues(0, height)
+	var r iotextypes.VoteBucketList
+	require.NoError(proto.Unmarshal(a, &r))
+	require.Zero(len(r.Buckets))
+
 	bucket := []*iotextypes.VoteBucket{
 		{
 			Index:     uint64(1234),
@@ -199,7 +214,6 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 		{1234, 5},
 	}
 
-	var r iotextypes.VoteBucketList
 	for _, v := range tests {
 		require.NoError(cbi.PutBuckets(v.height, v.buckets))
 
@@ -245,7 +259,7 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 	require.Equal(expect.Owner, actual.Owner)
 
 	// test with a key larger than any existing key
-	height := uint64(8810200527999860736)
+	height = 8810200527999860736
 	voteMax := &iotextypes.VoteBucketList{
 		Buckets: append(bucket, &iotextypes.VoteBucket{
 			Index:     uint64(1357),

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/testutil"
 	"github.com/iotexproject/iotex-core/testutil/testdb"
 )
 
@@ -233,7 +234,15 @@ func Test_CreatePreStatesWithRegisterProtocol(t *testing.T) {
 	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
-	store := db.NewMemKVStore()
+	testPath, err := testutil.PathOfTempFile("test-bucket")
+	require.NoError(err)
+	defer func() {
+		testutil.CleanupPath(t, testPath)
+	}()
+
+	cfg := db.DefaultConfig
+	cfg.DbPath = testPath
+	store := db.NewBoltDB(cfg)
 	cbi, err := NewStakingCandidatesBucketsIndexer(store)
 	require.NoError(err)
 

--- a/db/kvstore.go
+++ b/db/kvstore.go
@@ -49,8 +49,8 @@ type (
 		KVStore
 		// Insert inserts a value into the index
 		Insert([]byte, uint64, []byte) error
-		// Seek returns value by the key
-		Seek([]byte, uint64) ([]byte, error)
+		// SeekNext returns value by the key (if key not exist, use next key)
+		SeekNext([]byte, uint64) ([]byte, error)
 		// Remove removes an existing key
 		Remove([]byte, uint64) error
 		// Purge deletes an existing key and all keys before it
@@ -59,5 +59,7 @@ type (
 		GetBucketByPrefix([]byte) ([][]byte, error)
 		// GetKeyByPrefix retrieves all keys those with const prefix
 		GetKeyByPrefix(namespace, prefix []byte) ([][]byte, error)
+		// SeekPrev returns value by the key (if key not exist, use previous key)
+		SeekPrev([]byte, uint64) ([]byte, error)
 	}
 )

--- a/db/mock_kvstore.go
+++ b/db/mock_kvstore.go
@@ -506,19 +506,19 @@ func (mr *MockKVStoreForRangeIndexMockRecorder) Insert(arg0, arg1, arg2 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockKVStoreForRangeIndex)(nil).Insert), arg0, arg1, arg2)
 }
 
-// Seek mocks base method
-func (m *MockKVStoreForRangeIndex) Seek(arg0 []byte, arg1 uint64) ([]byte, error) {
+// SeekNext mocks base method
+func (m *MockKVStoreForRangeIndex) SeekNext(arg0 []byte, arg1 uint64) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Seek", arg0, arg1)
+	ret := m.ctrl.Call(m, "SeekNext", arg0, arg1)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Seek indicates an expected call of Seek
-func (mr *MockKVStoreForRangeIndexMockRecorder) Seek(arg0, arg1 interface{}) *gomock.Call {
+// SeekNext indicates an expected call of SeekNext
+func (mr *MockKVStoreForRangeIndexMockRecorder) SeekNext(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Seek", reflect.TypeOf((*MockKVStoreForRangeIndex)(nil).Seek), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekNext", reflect.TypeOf((*MockKVStoreForRangeIndex)(nil).SeekNext), arg0, arg1)
 }
 
 // Remove mocks base method
@@ -577,4 +577,19 @@ func (m *MockKVStoreForRangeIndex) GetKeyByPrefix(namespace, prefix []byte) ([][
 func (mr *MockKVStoreForRangeIndexMockRecorder) GetKeyByPrefix(namespace, prefix interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKeyByPrefix", reflect.TypeOf((*MockKVStoreForRangeIndex)(nil).GetKeyByPrefix), namespace, prefix)
+}
+
+// SeekPrev mocks base method
+func (m *MockKVStoreForRangeIndex) SeekPrev(arg0 []byte, arg1 uint64) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SeekPrev", arg0, arg1)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SeekPrev indicates an expected call of SeekPrev
+func (mr *MockKVStoreForRangeIndexMockRecorder) SeekPrev(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SeekPrev", reflect.TypeOf((*MockKVStoreForRangeIndex)(nil).SeekPrev), arg0, arg1)
 }

--- a/db/range_index.go
+++ b/db/range_index.go
@@ -94,7 +94,7 @@ func (r *rangeIndex) Insert(key uint64, value []byte) error {
 
 // Get returns value by the key
 func (r *rangeIndex) Get(key uint64) ([]byte, error) {
-	return r.kvStore.Seek(r.bucket, key)
+	return r.kvStore.SeekNext(r.bucket, key)
 }
 
 // Delete deletes an existing key

--- a/test/mock/mock_blocksync/mock_blocksync.go
+++ b/test/mock/mock_blocksync/mock_blocksync.go
@@ -91,17 +91,17 @@ func (mr *MockBlockSyncMockRecorder) ProcessSyncRequest(arg0, arg1, arg2, arg3 i
 }
 
 // ProcessBlock mocks base method
-func (m *MockBlockSync) ProcessBlock(arg0 context.Context, arg1 *block.Block) error {
+func (m *MockBlockSync) ProcessBlock(arg0 context.Context, arg1 string, arg2 *block.Block) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessBlock", arg0, arg1)
+	ret := m.ctrl.Call(m, "ProcessBlock", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ProcessBlock indicates an expected call of ProcessBlock
-func (mr *MockBlockSyncMockRecorder) ProcessBlock(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBlockSyncMockRecorder) ProcessBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlock", reflect.TypeOf((*MockBlockSync)(nil).ProcessBlock), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessBlock", reflect.TypeOf((*MockBlockSync)(nil).ProcessBlock), arg0, arg1, arg2)
 }
 
 // SyncStatus mocks base method

--- a/test/mock/mock_dispatcher/mock_dispatcher.go
+++ b/test/mock/mock_dispatcher/mock_dispatcher.go
@@ -10,7 +10,7 @@ import (
 	dispatcher "github.com/iotexproject/iotex-core/dispatcher"
 	iotexrpc "github.com/iotexproject/iotex-proto/golang/iotexrpc"
 	iotextypes "github.com/iotexproject/iotex-proto/golang/iotextypes"
-	go_libp2p_peerstore "github.com/libp2p/go-libp2p-peerstore"
+	peerstore "github.com/libp2p/go-libp2p-peerstore"
 	proto "google.golang.org/protobuf/proto"
 	reflect "reflect"
 )
@@ -65,21 +65,21 @@ func (mr *MockSubscriberMockRecorder) HandleAction(arg0, arg1 interface{}) *gomo
 }
 
 // HandleBlock mocks base method
-func (m *MockSubscriber) HandleBlock(arg0 context.Context, arg1 *iotextypes.Block) error {
+func (m *MockSubscriber) HandleBlock(arg0 context.Context, arg1 string, arg2 *iotextypes.Block) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleBlock", arg0, arg1)
+	ret := m.ctrl.Call(m, "HandleBlock", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // HandleBlock indicates an expected call of HandleBlock
-func (mr *MockSubscriberMockRecorder) HandleBlock(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSubscriberMockRecorder) HandleBlock(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlock", reflect.TypeOf((*MockSubscriber)(nil).HandleBlock), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBlock", reflect.TypeOf((*MockSubscriber)(nil).HandleBlock), arg0, arg1, arg2)
 }
 
 // HandleSyncRequest mocks base method
-func (m *MockSubscriber) HandleSyncRequest(arg0 context.Context, arg1 go_libp2p_peerstore.PeerInfo, arg2 *iotexrpc.BlockSync) error {
+func (m *MockSubscriber) HandleSyncRequest(arg0 context.Context, arg1 peerstore.PeerInfo, arg2 *iotexrpc.BlockSync) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HandleSyncRequest", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -170,19 +170,19 @@ func (mr *MockDispatcherMockRecorder) AddSubscriber(arg0, arg1 interface{}) *gom
 }
 
 // HandleBroadcast mocks base method
-func (m *MockDispatcher) HandleBroadcast(arg0 context.Context, arg1 uint32, arg2 proto.Message) {
+func (m *MockDispatcher) HandleBroadcast(arg0 context.Context, arg1 uint32, arg2 string, arg3 proto.Message) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "HandleBroadcast", arg0, arg1, arg2)
+	m.ctrl.Call(m, "HandleBroadcast", arg0, arg1, arg2, arg3)
 }
 
 // HandleBroadcast indicates an expected call of HandleBroadcast
-func (mr *MockDispatcherMockRecorder) HandleBroadcast(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockDispatcherMockRecorder) HandleBroadcast(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBroadcast", reflect.TypeOf((*MockDispatcher)(nil).HandleBroadcast), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleBroadcast", reflect.TypeOf((*MockDispatcher)(nil).HandleBroadcast), arg0, arg1, arg2, arg3)
 }
 
 // HandleTell mocks base method
-func (m *MockDispatcher) HandleTell(arg0 context.Context, arg1 uint32, arg2 go_libp2p_peerstore.PeerInfo, arg3 proto.Message) {
+func (m *MockDispatcher) HandleTell(arg0 context.Context, arg1 uint32, arg2 peerstore.PeerInfo, arg3 proto.Message) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "HandleTell", arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
current db may store a lot of duplicates, for example:

height: 5 --> cand{1, 2, 3}
height: 6 --> cand{1, 2, 3} // same as height 5
height: 7 --> cand{1, 2, 3} // same as height 5
height: 8 --> cand{1, 2, 3, 4}

with this change, duplicates are removed, so the db becomes:

height: 5 --> cand{1, 2, 3}
height: 8 --> cand{1, 2, 3, 4}

query for height 6/7 will fallback to height 5