### PR TITLE
Fixed #2725 - Remove ctrl.Finish() from test files

### DIFF
--- a/action/protocol/account/protocol_test.go
+++ b/action/protocol/account/protocol_test.go
@@ -31,7 +31,6 @@ func TestLoadOrCreateAccountState(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 	cb := batch.NewCachedBatch()
 	sm.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -76,7 +75,6 @@ func TestLoadOrCreateAccountState(t *testing.T) {
 func TestProtocol_Initialize(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 	cb := batch.NewCachedBatch()
 	sm.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -47,7 +47,6 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
 	// set-up protocol and genesis states

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -30,7 +30,6 @@ import (
 func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	testTriePath, err := testutil.PathOfTempFile("trie")
 	require.NoError(err)
 
@@ -98,7 +97,6 @@ func TestLoadStoreCommit(t *testing.T) {
 
 	testLoadStoreCommit := func(cfg config.Config, t *testing.T, enableAsync bool) {
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		sm, err := initMockStateManager(ctrl)
 		require.NoError(err)
 		cntr1, err := newContract(hash.BytesToHash160(c1[:]), &state.Account{}, sm, enableAsync)
@@ -249,7 +247,6 @@ func TestLoadStoreCommit(t *testing.T) {
 func TestSnapshot(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	testfunc := func(enableAsync bool) {
 		sm, err := initMockStateManager(ctrl)
 		require.NoError(err)

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -28,7 +28,6 @@ import (
 
 func TestExecuteContractFailure(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 	sm.EXPECT().State(gomock.Any(), gomock.Any()).Return(uint64(0), state.ErrStateNotExist).AnyTimes()
@@ -70,7 +69,6 @@ func TestConstantinople(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 
 	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -88,7 +88,6 @@ func initMockStateManager(ctrl *gomock.Controller) (*mock_chainmanager.MockState
 func TestAddBalance(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
@@ -106,7 +105,6 @@ func TestAddBalance(t *testing.T) {
 func TestRefundAPIs(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
@@ -120,7 +118,6 @@ func TestRefundAPIs(t *testing.T) {
 func TestEmptyAndCode(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
@@ -137,7 +134,6 @@ func TestEmptyAndCode(t *testing.T) {
 func TestForEachStorage(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
@@ -173,7 +169,6 @@ func TestForEachStorage(t *testing.T) {
 func TestNonce(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
@@ -188,7 +183,6 @@ func TestSnapshotRevertAndCommit(t *testing.T) {
 	testSnapshotAndRevert := func(cfg config.Config, t *testing.T) {
 		require := require.New(t)
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		sm, err := initMockStateManager(ctrl)
 		require.NoError(err)
@@ -392,7 +386,6 @@ func TestGetCommittedState(t *testing.T) {
 	t.Run("committed state with in mem DB", func(t *testing.T) {
 		require := require.New(t)
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 
 		sm, err := initMockStateManager(ctrl)
 		require.NoError(err)
@@ -419,7 +412,6 @@ func TestGetCommittedState(t *testing.T) {
 
 func TestGetBalanceOnError(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 	errs := []error{
@@ -438,7 +430,6 @@ func TestGetBalanceOnError(t *testing.T) {
 func TestPreimage(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -218,7 +218,6 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 func TestCreateGenesisStates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, r, err := initConstruct(ctrl)
 	require.NoError(err)
 	require.NoError(p.CreateGenesisStates(ctx, sm))
@@ -242,7 +241,6 @@ func TestCreateGenesisStates(t *testing.T) {
 func TestCreatePostSystemActions(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, r, err := initConstruct(ctrl)
 	require.NoError(err)
 	_, err = shiftCandidates(sm)
@@ -267,7 +265,6 @@ func TestCreatePostSystemActions(t *testing.T) {
 func TestCreatePreStates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, _, err := initConstruct(ctrl)
 	require.NoError(err)
 
@@ -360,7 +357,6 @@ func TestCreatePreStates(t *testing.T) {
 func TestHandle(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	p, ctx, sm, _, err := initConstruct(ctrl)
 	require.NoError(err)
@@ -571,7 +567,6 @@ func TestHandle(t *testing.T) {
 func TestNextCandidates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, _, err := initConstruct(ctrl)
 	require.NoError(err)
 	probationListMap := map[string]uint32{
@@ -621,7 +616,6 @@ func TestNextCandidates(t *testing.T) {
 func TestDelegatesAndNextDelegates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, _, err := initConstruct(ctrl)
 	require.NoError(err)
 

--- a/action/protocol/poll/lifelong_protocol_test.go
+++ b/action/protocol/poll/lifelong_protocol_test.go
@@ -77,7 +77,6 @@ func initLifeLongDelegateProtocol(ctrl *gomock.Controller) (Protocol, context.Co
 func TestCreateGenesisStates_WithLifeLong(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	p, ctx, sm, err := initLifeLongDelegateProtocol(ctrl)
 	require.NoError(err)
@@ -88,7 +87,6 @@ func TestCreateGenesisStates_WithLifeLong(t *testing.T) {
 func TestProtocol_Handle_WithLifeLong(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	p, ctx, sm, err := initLifeLongDelegateProtocol(ctrl)
 	require.NoError(err)

--- a/action/protocol/poll/protocol_test.go
+++ b/action/protocol/poll/protocol_test.go
@@ -24,7 +24,6 @@ import (
 func TestNewProtocol(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	committee := mock_committee.NewMockCommittee(ctrl)
 	cfg := config.Default
 	cfg.Consensus.Scheme = config.RollDPoSScheme
@@ -53,7 +52,6 @@ func TestNewProtocol(t *testing.T) {
 func TestFindProtocol(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, _, _, _, _ := initConstruct(ctrl)
 	//if not registered
 	re := protocol.NewRegistry()
@@ -67,7 +65,6 @@ func TestFindProtocol(t *testing.T) {
 func TestMustGetProtocol(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, _, _, _, _ := initConstruct(ctrl)
 	//if not registered
 	re := protocol.NewRegistry()

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -144,7 +144,6 @@ func initConstructStakingCommittee(ctrl *gomock.Controller) (Protocol, context.C
 func TestCreateGenesisStates_StakingCommittee(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sm, r, err := initConstructStakingCommittee(ctrl)
 	require.NoError(err)
 	require.NoError(p.CreateGenesisStates(ctx, sm))
@@ -170,7 +169,6 @@ func TestCreateGenesisStates_StakingCommittee(t *testing.T) {
 func TestCreatePostSystemActions_StakingCommittee(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	p, ctx, sr, r, err := initConstructStakingCommittee(ctrl)
 	require.NoError(err)
 	psac, ok := p.(protocol.PostSystemActionsCreator)
@@ -193,7 +191,6 @@ func TestCreatePostSystemActions_StakingCommittee(t *testing.T) {
 func TestHandle_StakingCommittee(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	p, ctx, sm, _, err := initConstructStakingCommittee(ctrl)
 	require.NoError(err)

--- a/action/protocol/registry_test.go
+++ b/action/protocol/registry_test.go
@@ -24,7 +24,6 @@ func TestRegister(t *testing.T) {
 
 func TestFind(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	require := require.New(t)
 	reg := NewRegistry()
@@ -43,7 +42,6 @@ func TestFind(t *testing.T) {
 
 func TestAll(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	reg := NewRegistry()
 	p := NewMockProtocol(ctrl)

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -37,7 +37,6 @@ import (
 
 func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.StateManager, *Protocol), withExempt bool) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	registry := protocol.NewRegistry()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
@@ -241,7 +240,6 @@ func testProtocol(t *testing.T, test func(*testing.T, context.Context, protocol.
 
 func TestProtocol_Handle(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	cfg := config.Default
 	registry := protocol.NewRegistry()
@@ -469,7 +467,6 @@ func TestStateCheckLegacy(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	p := NewProtocol(
 		genesis.Default.FoundationBonusP2StartEpoch,
@@ -544,7 +541,6 @@ func TestStateCheckLegacy(t *testing.T) {
 func TestMigrateValue(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	p := NewProtocol(
 		genesis.Default.FoundationBonusP2StartEpoch,

--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -299,7 +299,6 @@ func TestProtocol_ClaimReward(t *testing.T) {
 
 func TestProtocol_NoRewardAddr(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	registry := protocol.NewRegistry()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)

--- a/action/protocol/rolldpos/epoch_test.go
+++ b/action/protocol/rolldpos/epoch_test.go
@@ -71,7 +71,6 @@ func TestProtocol_ReadState(t *testing.T) {
 	arg2 := []byte("20")
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 	sm.EXPECT().Height().Return(uint64(1), nil).AnyTimes()
 

--- a/action/protocol/staking/bucket_index_test.go
+++ b/action/protocol/staking/bucket_index_test.go
@@ -44,7 +44,6 @@ func TestGetPutBucketIndex(t *testing.T) {
 	testGetPut := func(t *testing.T) {
 		require := require.New(t)
 		ctrl := gomock.NewController(t)
-		defer ctrl.Finish()
 		sm := testdb.NewMockStateManager(ctrl)
 
 		tests := []struct {

--- a/action/protocol/staking/bucket_pool_test.go
+++ b/action/protocol/staking/bucket_pool_test.go
@@ -62,7 +62,6 @@ func TestBucketPool(t *testing.T) {
 	r.Equal(-1, bytes.Compare(bucketPoolAddrKey, bucketKey(0)))
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
 	pool, err := NewBucketPool(sm, false)

--- a/action/protocol/staking/candidate_statereader_test.go
+++ b/action/protocol/staking/candidate_statereader_test.go
@@ -19,7 +19,6 @@ func Test_CandidateStateReader(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	csr, err := GetStakingStateReader(sm)
 	require.NoError(err)

--- a/action/protocol/staking/candidate_test.go
+++ b/action/protocol/staking/candidate_test.go
@@ -180,7 +180,6 @@ func TestGetPutCandidate(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
 	// put candidates and get

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -60,7 +60,6 @@ func TestProtocol_HandleCreateStake(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	_, err := sm.PutState(
 		&totalBucketCount{count: 0},
@@ -238,7 +237,6 @@ func TestProtocol_HandleCreateStake(t *testing.T) {
 func TestProtocol_HandleCandidateRegister(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm, p, _, _ := initAll(t, ctrl)
 	tests := []struct {
 		initBalance     int64
@@ -597,7 +595,6 @@ func TestProtocol_HandleCandidateRegister(t *testing.T) {
 func TestProtocol_HandleCandidateUpdate(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	tests := []struct {
 		initBalance     int64
 		caller          address.Address
@@ -912,7 +909,6 @@ func TestProtocol_HandleCandidateUpdate(t *testing.T) {
 func TestProtocol_HandleUnstake(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	sm, p, candidate, candidate2 := initAll(t, ctrl)
 	initCreateStake(t, sm, identityset.Address(2), 100, big.NewInt(unit.Qev), 10000, 1, 1, time.Now(), 10000, p, candidate2, "100000000000000000000", false)
@@ -1194,7 +1190,6 @@ func TestProtocol_HandleUnstake(t *testing.T) {
 func TestProtocol_HandleWithdrawStake(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	tests := []struct {
 		// create stake fields
 		amount      string
@@ -1357,7 +1352,6 @@ func TestProtocol_HandleWithdrawStake(t *testing.T) {
 func TestProtocol_HandleChangeCandidate(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		// creat stake fields
@@ -1659,7 +1653,6 @@ func TestProtocol_HandleChangeCandidate(t *testing.T) {
 func TestProtocol_HandleTransferStake(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		// creat stake fields
@@ -1859,7 +1852,6 @@ func TestProtocol_HandleTransferStake(t *testing.T) {
 func TestProtocol_HandleConsignmentTransfer(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	tests := []struct {
 		bucketOwner string
@@ -2092,7 +2084,6 @@ func TestProtocol_HandleConsignmentTransfer(t *testing.T) {
 func TestProtocol_HandleRestake(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	callerAddr := identityset.Address(2)
 
 	tests := []struct {
@@ -2357,7 +2348,6 @@ func TestProtocol_HandleRestake(t *testing.T) {
 func TestProtocol_HandleDepositToStake(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	tests := []struct {
 		// creat stake fields
 		caller       address.Address

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -38,7 +38,6 @@ func TestProtocol(t *testing.T) {
 	r.Equal(byte(3), _candIndex)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	_, err := sm.PutState(
 		&totalBucketCount{count: 0},
@@ -186,7 +185,6 @@ func TestProtocol(t *testing.T) {
 func TestCreatePreStates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	p, err := NewProtocol(nil, genesis.Default.Staking, nil, genesis.Default.GreenlandBlockHeight)
 	require.NoError(err)
@@ -231,7 +229,6 @@ func TestCreatePreStates(t *testing.T) {
 func Test_CreatePreStatesWithRegisterProtocol(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
 	testPath, err := testutil.PathOfTempFile("test-bucket")
@@ -274,7 +271,6 @@ func Test_CreatePreStatesWithRegisterProtocol(t *testing.T) {
 func Test_CreateGenesisStates(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 
 	selfStake, _ := big.NewInt(0).SetString("1200000000000000000000000", 10)

--- a/action/protocol/staking/vote_bucket_test.go
+++ b/action/protocol/staking/vote_bucket_test.go
@@ -31,7 +31,6 @@ func TestGetPutStaking(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	sm.PutState(
 		&totalBucketCount{count: 0},

--- a/action/protocol/staking/vote_reviser_test.go
+++ b/action/protocol/staking/vote_reviser_test.go
@@ -21,7 +21,6 @@ func TestVoteReviser(t *testing.T) {
 	r := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sm := testdb.NewMockStateManager(ctrl)
 	_, err := sm.PutState(
 		&totalBucketCount{count: 0},

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -58,7 +58,6 @@ var (
 
 func TestActPool_NewActPool(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	cfg := config.Default
 
@@ -91,7 +90,6 @@ func TestActPool_NewActPool(t *testing.T) {
 func TestValidate(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	cfg := config.Default
 	cfg.Genesis.InitBalanceMap[addr1] = "100"
 	re := protocol.NewRegistry()
@@ -124,7 +122,6 @@ func TestValidate(t *testing.T) {
 func TestActPool_AddActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	sf.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(func(account interface{}, opts ...protocol.StateOption) (uint64, error) {
@@ -290,7 +287,6 @@ func TestActPool_AddActs(t *testing.T) {
 
 func TestActPool_PickActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	createActPool := func(cfg config.ActPool) (*actPool, []action.SealedEnvelope, []action.SealedEnvelope, []action.SealedEnvelope) {
@@ -371,7 +367,6 @@ func TestActPool_PickActs(t *testing.T) {
 
 func TestActPool_removeConfirmedActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -421,7 +416,6 @@ func TestActPool_removeConfirmedActs(t *testing.T) {
 
 func TestActPool_Reset(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 
@@ -775,7 +769,6 @@ func TestActPool_Reset(t *testing.T) {
 
 func TestActPool_removeInvalidActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -819,7 +812,6 @@ func TestActPool_removeInvalidActs(t *testing.T) {
 
 func TestActPool_GetPendingNonce(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -860,7 +852,6 @@ func TestActPool_GetPendingNonce(t *testing.T) {
 
 func TestActPool_GetUnconfirmedActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -902,7 +893,6 @@ func TestActPool_GetUnconfirmedActs(t *testing.T) {
 
 func TestActPool_GetActionByHash(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
@@ -936,7 +926,6 @@ func TestActPool_GetActionByHash(t *testing.T) {
 
 func TestActPool_GetCapacity(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -951,7 +940,6 @@ func TestActPool_GetCapacity(t *testing.T) {
 
 func TestActPool_GetSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 	// Create actpool
@@ -1002,7 +990,6 @@ func TestActPool_GetSize(t *testing.T) {
 
 func TestActPool_AddActionNotEnoughGasPrice(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	sf := mock_chainmanager.NewMockStateReader(ctrl)
 
 	apConfig := config.Default.ActPool

--- a/actpool/actqueue_test.go
+++ b/actpool/actqueue_test.go
@@ -120,7 +120,6 @@ func TestActQueueUpdateNonce(t *testing.T) {
 
 func TestActQueuePendingActs(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	require := require.New(t)
 	cfg := config.Default
 	sf := mock_chainmanager.NewMockStateReader(ctrl)

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1116,7 +1116,6 @@ func TestServer_GetChainMeta(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	var pol poll.Protocol
 	for _, test := range getChainMetaTests {
@@ -1180,7 +1179,6 @@ func TestServer_SendAction(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	chain := mock_blockchain.NewMockBlockchain(ctrl)
 	ap := mock_actpool.NewMockActPool(ctrl)
@@ -1606,7 +1604,6 @@ func TestServer_ReadCandidatesByEpoch(t *testing.T) {
 	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1678,7 +1675,6 @@ func TestServer_ReadBlockProducersByEpoch(t *testing.T) {
 	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1750,7 +1746,6 @@ func TestServer_ReadActiveBlockProducersByEpoch(t *testing.T) {
 	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	committee := mock_committee.NewMockCommittee(ctrl)
 	candidates := []*state.Candidate{
 		{
@@ -1865,7 +1860,6 @@ func TestServer_GetEpochMeta(t *testing.T) {
 	cfg := newConfig(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	svr, bfIndexFile, err := createServer(cfg, false)
 	require.NoError(err)

--- a/api/blocklistener_test.go
+++ b/api/blocklistener_test.go
@@ -26,7 +26,6 @@ var (
 
 func TestBlockListener(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	errChan := make(chan error, 10)
 

--- a/api/listener_test.go
+++ b/api/listener_test.go
@@ -20,7 +20,6 @@ import (
 // test for chainListener
 func TestChainListener(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	responder := mock_apiresponder.NewMockResponder(ctrl)
 	listener := NewChainListener()

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -1593,7 +1593,6 @@ func TestBlockchain_AddSubscriber(t *testing.T) {
 	bc := blockchain.NewBlockchain(cfg, nil, factory.NewMinter(sf, ap), blockchain.InMemDaoOption(sf))
 	// mock
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mb := mock_blockcreationsubscriber.NewMockBlockCreationSubscriber(ctrl)
 	req.NoError(bc.AddSubscriber(mb))
 	req.EqualError(bc.AddSubscriber(nil), "subscriber could not be nil")
@@ -1613,7 +1612,6 @@ func TestBlockchain_RemoveSubscriber(t *testing.T) {
 	bc := blockchain.NewBlockchain(cfg, nil, factory.NewMinter(sf, ap), blockchain.InMemDaoOption(sf))
 	// mock
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mb := mock_blockcreationsubscriber.NewMockBlockCreationSubscriber(ctrl)
 	req.Error(bc.RemoveSubscriber(mb))
 	req.NoError(bc.AddSubscriber(mb))

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -65,7 +65,6 @@ func TestNewBlockSyncer(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mBc := mock_blockchain.NewMockBlockchain(ctrl)
 	// TipHeight return ERROR
@@ -96,7 +95,6 @@ func TestBlockSyncerStart(t *testing.T) {
 	assert := assert.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	ctx := context.Background()
 	mBs := mock_blocksync.NewMockBlockSync(ctrl)
@@ -108,7 +106,6 @@ func TestBlockSyncerStop(t *testing.T) {
 	assert := assert.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	ctx := context.Background()
 	mBs := mock_blocksync.NewMockBlockSync(ctrl)
@@ -121,7 +118,6 @@ func TestBlockSyncerProcessSyncRequest(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mBc := mock_blockchain.NewMockBlockchain(ctrl)
 	mBc.EXPECT().ChainID().AnyTimes().Return(config.Default.Chain.ID)
@@ -150,7 +146,6 @@ func TestBlockSyncerProcessSyncRequest(t *testing.T) {
 func TestBlockSyncerProcessSyncRequestError(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	cfg, err := newTestConfig()
 	require.NoError(err)
@@ -206,7 +201,6 @@ func TestBlockSyncerProcessBlockTipHeight(t *testing.T) {
 
 	defer func() {
 		require.NoError(chain.Stop(ctx))
-		ctrl.Finish()
 	}()
 
 	h := chain.TipHeight()
@@ -293,7 +287,6 @@ func TestBlockSyncerProcessBlockOutOfOrder(t *testing.T) {
 	defer func() {
 		require.NoError(chain1.Stop(ctx))
 		require.NoError(chain2.Stop(ctx))
-		ctrl.Finish()
 	}()
 
 	// commit top
@@ -388,7 +381,6 @@ func TestBlockSyncerProcessBlock(t *testing.T) {
 	defer func() {
 		require.NoError(chain1.Stop(ctx))
 		require.NoError(chain2.Stop(ctx))
-		ctrl.Finish()
 	}()
 
 	ctx, err = chain1.Context(ctx)
@@ -457,7 +449,6 @@ func TestBlockSyncerSync(t *testing.T) {
 	defer func() {
 		require.NoError(bs.Stop(ctx))
 		require.NoError(chain.Stop(ctx))
-		ctrl.Finish()
 	}()
 
 	ctx, err = chain.Context(ctx)
@@ -535,7 +526,6 @@ func TestBlockSyncerPeerBlockList(t *testing.T) {
 
 	defer func() {
 		require.NoError(chain.Stop(ctx))
-		ctrl.Finish()
 	}()
 
 	ctx, err = chain.Context(ctx)

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/facebookgo/clock"
 	"github.com/golang/mock/gomock"
-	fsm "github.com/iotexproject/go-fsm"
+	"github.com/iotexproject/go-fsm"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -25,7 +25,6 @@ func TestBackdoorEvt(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockCtx := NewMockContext(ctrl)
 	mockCtx.EXPECT().IsFutureEvent(gomock.Any()).Return(false).AnyTimes()
 	mockCtx.EXPECT().IsStaleEvent(gomock.Any()).Return(false).AnyTimes()
@@ -65,7 +64,6 @@ func TestStateTransitionFunctions(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	mockClock := clock.NewMock()
 	mockCtx := NewMockContext(ctrl)
 	mockCtx.EXPECT().Logger().Return(log.Logger("consensus")).AnyTimes()

--- a/consensus/consensusfsm/fsm_test.go
+++ b/consensus/consensusfsm/fsm_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/facebookgo/clock"
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/go-fsm"
+	fsm "github.com/iotexproject/go-fsm"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -54,7 +54,6 @@ func TestNewRollDPoS(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	cfg := config.Default
 	rp := rolldpos.NewProtocol(
@@ -182,7 +181,6 @@ func makeBlock(t *testing.T, accountIndex, numOfEndosements int, makeInvalidEndo
 
 func TestValidateBlockFooter(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	candidates := make([]string, 5)
 	for i := 0; i < len(candidates); i++ {
 		candidates[i] = identityset.Address(i).String()
@@ -257,7 +255,6 @@ func TestRollDPoS_Metrics(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	candidates := make([]string, 5)
 	for i := 0; i < len(candidates); i++ {

--- a/db/kvstorewithbuffer_test.go
+++ b/db/kvstorewithbuffer_test.go
@@ -15,7 +15,6 @@ import (
 
 func TestFlusher(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	t.Run("create failed with nil kvStore", func(t *testing.T) {
 		f, err := NewKVStoreFlusher(nil, nil)
 		require.Nil(t, f)

--- a/ioctl/newcmd/account/accountcreate_test.go
+++ b/ioctl/newcmd/account/accountcreate_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestNewAccountCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString",
 		config.English).AnyTimes()

--- a/ioctl/newcmd/account/accountdelete_test.go
+++ b/ioctl/newcmd/account/accountdelete_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestNewAccountDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString",
 		config.English).AnyTimes()

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestNewAliasExport(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslation",
 		config.English).Times(4)

--- a/ioctl/newcmd/alias/aliasimport_test.go
+++ b/ioctl/newcmd/alias/aliasimport_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestNewAliasImportCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	cfg := config.Config{
 		Aliases: map[string]string{
 			"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",

--- a/ioctl/newcmd/alias/aliaslist_test.go
+++ b/ioctl/newcmd/alias/aliaslist_test.go
@@ -1,13 +1,12 @@
 package alias
 
 import (
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 // test for alias list command

--- a/ioctl/newcmd/alias/aliaslist_test.go
+++ b/ioctl/newcmd/alias/aliaslist_test.go
@@ -1,18 +1,18 @@
 package alias
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 // test for alias list command
 func TestNewAliasListCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("", config.English).Times(2)
 	cfg := config.Config{

--- a/ioctl/newcmd/alias/aliasremove_test.go
+++ b/ioctl/newcmd/alias/aliasremove_test.go
@@ -15,7 +15,6 @@ import (
 func TestNewAliasRemoveCmd(t *testing.T) {
 	// mock a client
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("%s is removed", config.English).Times(6)
 

--- a/ioctl/newcmd/alias/aliasset_test.go
+++ b/ioctl/newcmd/alias/aliasset_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestNewAliasSetCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	cfg := config.Config{
 		Aliases: map[string]string{
 			"a": "io19sdfxkwegeaenvxk2kjqf98al52gm56wa2eqks",

--- a/ioctl/newcmd/bc/bcblock_test.go
+++ b/ioctl/newcmd/bc/bcblock_test.go
@@ -25,7 +25,6 @@ import (
 // test for bc info command
 func TestNewBCBlockCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	cfg := config.Config{}

--- a/ioctl/newcmd/bc/bcinfo_test.go
+++ b/ioctl/newcmd/bc/bcinfo_test.go
@@ -24,7 +24,6 @@ import (
 // test for bc info command
 func TestNewBCInfoCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("", config.English).Times(3)

--- a/ioctl/newcmd/node/nodedelegate_test.go
+++ b/ioctl/newcmd/node/nodedelegate_test.go
@@ -18,7 +18,6 @@ import (
 func TestNewNodeDelegateCmd(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return(

--- a/ioctl/newcmd/node/nodereward_test.go
+++ b/ioctl/newcmd/node/nodereward_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestNewNodeRewardCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()

--- a/ioctl/newcmd/update/update_test.go
+++ b/ioctl/newcmd/update/update_test.go
@@ -20,7 +20,6 @@ import (
 
 func TestNewUpdateCmd(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationResult",
 		config.English).AnyTimes()

--- a/ioctl/newcmd/version/version_test.go
+++ b/ioctl/newcmd/version/version_test.go
@@ -23,7 +23,6 @@ import (
 
 func TestVersionCommand(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("", config.English).Times(2)
 	cfg := config.Config{}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -249,7 +249,6 @@ func testCandidates(sf Factory, t *testing.T) {
 	require.NotNil(t, selp)
 
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	committee := mock_committee.NewMockCommittee(ctrl)
 	committee.EXPECT().ResultByHeight(uint64(123456)).Return(result, nil).AnyTimes()
@@ -1013,7 +1012,6 @@ func testNewBlockBuilder(factory Factory, t *testing.T) {
 	require.NoError(err)
 	accMap[identityset.Address(29).String()] = []action.SealedEnvelope{selp2}
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	ap := mock_actpool.NewMockActPool(ctrl)
 	ap.EXPECT().PendingActionMap().Return(accMap).Times(1)
 	gasLimit := uint64(1000000)


### PR DESCRIPTION
Fix #2725 
1. Removed ctrl.Finish() from most tests files. 
2. In few files it was not removed as it was not being used anywhere in tests and removing will have to remove controller also.
Please see attached screenshot of remaining removals of ctrl.Finish()

<img width="648" alt="remaining" src="https://user-images.githubusercontent.com/8629099/125404091-dbca3980-e3d3-11eb-8e5e-229504d5f1b4.png">
