### PR TITLE
Fixed #2739 : block.calculateTxRoot() to return (hash.Hash256, error)

### DIFF
--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -88,7 +88,12 @@ func (b *Block) Deserialize(buf []byte) error {
 	b.Receipts = nil
 
 	// verify merkle root can match after deserialize
-	if err := b.VerifyTxRoot(b.CalculateTxRoot()); err != nil {
+	txHash, err := b.CalculateTxRoot()
+	if err != nil {
+		log.L().Debug("error in getting hash ", zap.Error(err))
+		return err
+	}
+	if err := b.VerifyTxRoot(txHash); err != nil {
 		return err
 	}
 	return nil

--- a/blockchain/block/block_test.go
+++ b/blockchain/block/block_test.go
@@ -62,7 +62,8 @@ func TestMerkle(t *testing.T) {
 		producerPubKey,
 		actions,
 	)
-	hash := block.CalculateTxRoot()
+	hash, err := block.CalculateTxRoot()
+	require.NoError(err)
 	require.Equal("eb5cb75ae199d96de7c1cd726d5e1a3dff15022ed7bdc914a3d8b346f1ef89c9", hex.EncodeToString(hash[:]))
 
 	hashes := block.ActionHashs()
@@ -115,7 +116,10 @@ func TestConvertFromBlockPb(t *testing.T) {
 		},
 	}))
 
-	blk.Header.txRoot = blk.CalculateTxRoot()
+	txHash, err := blk.CalculateTxRoot()
+	require.NoError(t, err)
+
+	blk.Header.txRoot = txHash
 	blk.Header.receiptRoot = hash.Hash256b(([]byte)("test"))
 
 	raw, err := blk.Serialize()

--- a/blockchain/block/blockstore.go
+++ b/blockchain/block/blockstore.go
@@ -7,6 +7,8 @@
 package block
 
 import (
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
@@ -46,7 +48,12 @@ func (in *Store) FromProto(pb *iotextypes.BlockStore) error {
 		return err
 	}
 	// verify merkle root can match after deserialize
-	if err := in.Block.VerifyTxRoot(in.Block.CalculateTxRoot()); err != nil {
+	txHash, err := in.Block.CalculateTxRoot()
+	if err != nil {
+		log.L().Debug("error in getting hash", zap.Error(err))
+		return err
+	}
+	if err := in.Block.VerifyTxRoot(txHash); err != nil {
 		return err
 	}
 

--- a/blockchain/block/body.go
+++ b/blockchain/block/body.go
@@ -62,7 +62,7 @@ func (b *Body) Deserialize(buf []byte) error {
 }
 
 // CalculateTxRoot returns the Merkle root of all txs and actions in this block.
-func (b *Body) CalculateTxRoot() hash.Hash256 {
+func (b *Body) CalculateTxRoot() (hash.Hash256, error) {
 	return calculateTxRoot(b.Actions)
 }
 

--- a/blockchain/block/body_test.go
+++ b/blockchain/block/body_test.go
@@ -66,12 +66,14 @@ func TestLoadProto(t *testing.T) {
 func TestCalculateTxRoot(t *testing.T) {
 	require := require.New(t)
 	body := Body{}
-	h := body.CalculateTxRoot()
+	h, err := body.CalculateTxRoot()
+	require.NoError(err)
 	require.Equal(h, hash.ZeroHash256)
 
-	body, err := makeBody()
+	body, err = makeBody()
 	require.NoError(err)
-	h = body.CalculateTxRoot()
+	h, err = body.CalculateTxRoot()
+	require.NoError(err)
 	require.NotEqual(h, hash.ZeroHash256)
 }
 

--- a/blockchain/block/runnable.go
+++ b/blockchain/block/runnable.go
@@ -8,6 +8,8 @@ package block
 
 import (
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
 )
@@ -43,6 +45,11 @@ func (b *RunnableActionsBuilder) AddActions(acts ...action.SealedEnvelope) *Runn
 
 // Build signs and then builds a block.
 func (b *RunnableActionsBuilder) Build() RunnableActions {
-	b.ra.txHash = calculateTxRoot(b.ra.actions)
+	var err error
+	b.ra.txHash, err = calculateTxRoot(b.ra.actions)
+	if err != nil {
+		log.L().Debug("error in getting hash ", zap.Error(err))
+		return RunnableActions{}
+	}
 	return b.ra
 }

--- a/blockchain/block/testing.go
+++ b/blockchain/block/testing.go
@@ -72,7 +72,11 @@ func (b *TestingBuilder) SetReceipts(receipts []*action.Receipt) *TestingBuilder
 
 // SignAndBuild signs and then builds a block.
 func (b *TestingBuilder) SignAndBuild(signerPrvKey crypto.PrivateKey) (Block, error) {
-	b.blk.Header.txRoot = b.blk.CalculateTxRoot()
+	var err error
+	b.blk.Header.txRoot, err = b.blk.CalculateTxRoot()
+	if err != nil {
+		return Block{}, errors.New("Failed to get hash")
+	}
 	b.blk.Header.pubkey = signerPrvKey.PublicKey()
 	h := b.blk.Header.HashHeaderCore()
 	sig, err := signerPrvKey.Sign(h[:])
@@ -108,6 +112,10 @@ func NewBlockDeprecated(
 		},
 	}
 
-	block.Header.txRoot = block.CalculateTxRoot()
+	var err error
+	block.Header.txRoot, err = block.CalculateTxRoot()
+	if err != nil {
+		return &Block{}
+	}
 	return block
 }

--- a/blockchain/block/utils.go
+++ b/blockchain/block/utils.go
@@ -19,20 +19,20 @@ import (
 	"github.com/iotexproject/iotex-core/crypto"
 )
 
-func calculateTxRoot(acts []action.SealedEnvelope) hash.Hash256 {
+func calculateTxRoot(acts []action.SealedEnvelope) (hash.Hash256, error) {
 	h := make([]hash.Hash256, 0, len(acts))
 	for _, act := range acts {
 		actHash, err := act.Hash()
 		if err != nil {
 			log.L().Debug("Error in getting hash", zap.Error(err))
-			return hash.ZeroHash256
+			return hash.ZeroHash256, err
 		}
 		h = append(h, actHash)
 	}
 	if len(h) == 0 {
-		return hash.ZeroHash256
+		return hash.ZeroHash256, errors.Errorf("hash length is zero")
 	}
-	return crypto.NewMerkleTree(h).HashTree()
+	return crypto.NewMerkleTree(h).HashTree(), nil
 }
 
 // calculateTransferAmount returns the calculated transfer amount
@@ -59,7 +59,11 @@ func VerifyBlock(blk *Block) error {
 	}
 
 	hashExpect := blk.TxRoot()
-	hashActual := blk.CalculateTxRoot()
+	hashActual, err := blk.CalculateTxRoot()
+	if err != nil {
+		log.L().Debug("error in getting hash", zap.Error(err))
+		return err
+	}
 	if !bytes.Equal(hashExpect[:], hashActual[:]) {
 		return errors.Errorf(
 			"wrong tx hash %x, expecting %x",

--- a/blockchain/block/utils_test.go
+++ b/blockchain/block/utils_test.go
@@ -39,7 +39,8 @@ func TestBody_CalculateTxRoot(t *testing.T) {
 		sevlps = append(sevlps, sevlp)
 	}
 
-	c := calculateTxRoot(sevlps)
+	c, err := calculateTxRoot(sevlps)
+	require.NoError(t, err)
 
 	c2 := []byte{158, 73, 244, 188, 155, 10, 251, 87, 98, 163, 234, 194, 38, 174,
 		215, 255, 8, 148, 44, 204, 10, 56, 102, 180, 99, 188, 79, 146, 66, 219, 41, 30}

--- a/consensus/scheme/rolldpos/subchain_test.go
+++ b/consensus/scheme/rolldpos/subchain_test.go
@@ -65,7 +65,8 @@ func TestPutBlockToParentChain(t *testing.T) {
 		},
 	}
 	require.NoError(t, blk.ConvertFromBlockPb(blkpb))
-	txRoot := blk.CalculateTxRoot()
+	txRoot, err := blk.CalculateTxRoot()
+	require.NoError(t, err)
 	blkpb.Header.Core.TxRoot = txRoot[:]
 	blk = block.Block{}
 	require.NoError(t, blk.ConvertFromBlockPb(blkpb))


### PR DESCRIPTION
Fixed #2739 

1. Update function block.calculateTxRoot() to return (hash.Hash256, error)
2. Update calling of this function and few internal functions