### PR TITLE
AccountState updated to use address.Address()

### DIFF
--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -113,9 +113,11 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 			GasLimit:    testutil.TestGasLimit,
 		})
 
-		sender, err := accountutil.AccountState(sm, v.caller.String())
+		sender, err := accountutil.AccountState(sm, v.caller)
 		require.NoError(err)
-		recipient, err := accountutil.AccountState(sm, v.recipient)
+		addr, err := address.FromString(v.recipient)
+		require.NoError(err)
+		recipient, err := accountutil.AccountState(sm, addr)
 		require.NoError(err)
 		gasFee := new(big.Int).Mul(v.gasPrice, new(big.Int).SetUint64(gas))
 
@@ -124,7 +126,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 		if err != nil {
 			require.Nil(receipt)
 			// sender balance/nonce remains the same in case of error
-			newSender, err := accountutil.AccountState(sm, v.caller.String())
+			newSender, err := accountutil.AccountState(sm, v.caller)
 			require.NoError(err)
 			require.Equal(sender.Balance, newSender.Balance)
 			require.Equal(sender.Nonce, newSender.Nonce)
@@ -136,13 +138,15 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 		if receipt.Status == uint64(iotextypes.ReceiptStatus_Success) && !v.isContract {
 			gasFee.Add(gasFee, v.amount)
 			// verify recipient
-			newRecipient, err := accountutil.AccountState(sm, v.recipient)
+			addr, err := address.FromString(v.recipient)
+			require.NoError(err)
+			newRecipient, err := accountutil.AccountState(sm, addr)
 			require.NoError(err)
 			recipient.AddBalance(v.amount)
 			require.Equal(recipient.Balance, newRecipient.Balance)
 		}
 		// verify sender balance/nonce
-		newSender, err := accountutil.AccountState(sm, v.caller.String())
+		newSender, err := accountutil.AccountState(sm, v.caller)
 		require.NoError(err)
 		sender.SubBalance(gasFee)
 		require.Equal(sender.Balance, newSender.Balance)

--- a/action/protocol/account/util/util.go
+++ b/action/protocol/account/util/util.go
@@ -87,17 +87,13 @@ func Recorded(sr protocol.StateReader, addr address.Address) (bool, error) {
 }
 
 // AccountState returns the confirmed account state on the chain
-func AccountState(sr protocol.StateReader, encodedAddr string) (*state.Account, error) {
-	a, _, err := AccountStateWithHeight(sr, encodedAddr)
+func AccountState(sr protocol.StateReader, addr address.Address) (*state.Account, error) {
+	a, _, err := AccountStateWithHeight(sr, addr)
 	return a, err
 }
 
 // AccountStateWithHeight returns the confirmed account state on the chain with what height the state is read from.
-func AccountStateWithHeight(sr protocol.StateReader, encodedAddr string) (*state.Account, uint64, error) {
-	addr, err := address.FromString(encodedAddr)
-	if err != nil {
-		return nil, 0, errors.Wrap(err, "error when getting the pubkey hash")
-	}
+func AccountStateWithHeight(sr protocol.StateReader, addr address.Address) (*state.Account, uint64, error) {
 	pkHash := hash.BytesToHash160(addr.Bytes())
 	var account state.Account
 	h, err := sr.State(&account, protocol.LegacyKeyOption(pkHash))

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -224,7 +224,7 @@ func readExecution(
 	contractAddr string,
 ) ([]byte, *action.Receipt, error) {
 	log.S().Info(ecfg.Comment)
-	state, err := accountutil.AccountState(sf, ecfg.Executor().String())
+	state, err := accountutil.AccountState(sf, ecfg.Executor())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -265,8 +265,8 @@ func runExecutions(
 		log.S().Info(ecfg.Comment)
 		var nonce uint64
 		var ok bool
-		executor := ecfg.Executor().String()
-		if nonce, ok = nonces[executor]; !ok {
+		executor := ecfg.Executor()
+		if nonce, ok = nonces[executor.String()]; !ok {
 			state, err := accountutil.AccountState(sf, executor)
 			if err != nil {
 				return nil, err
@@ -274,7 +274,7 @@ func runExecutions(
 			nonce = state.Nonce
 		}
 		nonce = nonce + 1
-		nonces[executor] = nonce
+		nonces[executor.String()] = nonce
 		exec, err := action.NewExecution(
 			contractAddrs[i],
 			nonce,
@@ -511,7 +511,9 @@ func (sct *SmartContractTest) run(r *require.Assertions) {
 			if account == "" {
 				account = contractAddr
 			}
-			state, err := accountutil.AccountState(sf, account)
+			addr, err := address.FromString(account)
+			r.NoError(err)
+			state, err := accountutil.AccountState(sf, addr)
 			r.NoError(err)
 			r.Equal(
 				0,
@@ -631,7 +633,7 @@ func TestProtocol_Handle(t *testing.T) {
 		require.NoError(err)
 
 		// test IsContract
-		state, err := accountutil.AccountState(sf, contract.String())
+		state, err := accountutil.AccountState(sf, contract)
 		require.NoError(err)
 		require.True(state.IsContract())
 

--- a/action/protocol/generic_validator.go
+++ b/action/protocol/generic_validator.go
@@ -11,13 +11,15 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/state"
 )
 
 type (
 	// AccountState defines a function to return the account state of a given address
-	AccountState func(StateReader, string) (*state.Account, error)
+	AccountState func(StateReader, address.Address) (*state.Account, error)
 	// GenericValidator is the validator for generic action verification
 	GenericValidator struct {
 		accountState AccountState
@@ -44,7 +46,7 @@ func (v *GenericValidator) Validate(ctx context.Context, selp action.SealedEnvel
 		return errors.New("failed to get address")
 	}
 	// Reject action if nonce is too low
-	confirmedState, err := v.accountState(v.sr, caller.String())
+	confirmedState, err := v.accountState(v.sr, caller)
 	if err != nil {
 		return errors.Wrapf(err, "invalid state of account %s", caller.String())
 	}

--- a/action/protocol/generic_validator_test.go
+++ b/action/protocol/generic_validator_test.go
@@ -59,10 +59,10 @@ func TestActionProtoAndGenericValidator(t *testing.T) {
 
 	ctx = genesis.WithGenesisContext(ctx, config.Default.Genesis)
 
-	valid := NewGenericValidator(nil, func(sr StateReader, addr string) (*state.Account, error) {
+	valid := NewGenericValidator(nil, func(sr StateReader, addr address.Address) (*state.Account, error) {
 		pk := identityset.PrivateKey(27).PublicKey()
 		eAddr := pk.Address()
-		if strings.EqualFold(eAddr.String(), addr) {
+		if strings.EqualFold(eAddr.String(), addr.String()) {
 			return nil, errors.New("MockChainManager nonce error")
 		}
 		return &state.Account{Nonce: 2}, nil

--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -238,7 +238,11 @@ func (ap *actPool) GetPendingNonce(addr string) (uint64, error) {
 	if queue, ok := ap.accountActs[addr]; ok {
 		return queue.PendingNonce(), nil
 	}
-	confirmedState, err := accountutil.AccountState(ap.sf, addr)
+	addr1, err := address.FromString(addr)
+	if err != nil {
+		return 0, err
+	}
+	confirmedState, err := accountutil.AccountState(ap.sf, addr1)
 	if err != nil {
 		return 0, err
 	}
@@ -348,7 +352,11 @@ func (ap *actPool) validate(ctx context.Context, selp action.SealedEnvelope) err
 // private functions
 //======================================
 func (ap *actPool) enqueueAction(sender string, act action.SealedEnvelope, actHash hash.Hash256, actNonce uint64) error {
-	confirmedState, err := accountutil.AccountState(ap.sf, sender)
+	addr, err := address.FromString(sender)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get sender's address for action %x", actHash)
+	}
+	confirmedState, err := accountutil.AccountState(ap.sf, addr)
 	if err != nil {
 		actpoolMtc.WithLabelValues("failedToGetNonce").Inc()
 		return errors.Wrapf(err, "failed to get sender's nonce for action %x", actHash)
@@ -364,7 +372,7 @@ func (ap *actPool) enqueueAction(sender string, act action.SealedEnvelope, actHa
 		pendingNonce := confirmedNonce + 1
 		queue.SetPendingNonce(pendingNonce)
 		// Initialize balance for new account
-		state, err := accountutil.AccountState(ap.sf, sender)
+		state, err := accountutil.AccountState(ap.sf, addr)
 		if err != nil {
 			actpoolMtc.WithLabelValues("failedToGetBalance").Inc()
 			return errors.Wrapf(err, "failed to get sender's balance for action %x", actHash)
@@ -434,7 +442,12 @@ func (ap *actPool) enqueueAction(sender string, act action.SealedEnvelope, actHa
 // removeConfirmedActs removes processed (committed to block) actions from pool
 func (ap *actPool) removeConfirmedActs() {
 	for from, queue := range ap.accountActs {
-		confirmedState, err := accountutil.AccountState(ap.sf, from)
+		addr, err := address.FromString(from)
+		if err != nil {
+			log.L().Error("Error when getting address", zap.Error(err))
+			return
+		}
+		confirmedState, err := accountutil.AccountState(ap.sf, addr)
 		if err != nil {
 			log.L().Error("Error when removing confirmed actions", zap.Error(err))
 			return
@@ -507,7 +520,12 @@ func (ap *actPool) reset() {
 	ap.removeConfirmedActs()
 	for from, queue := range ap.accountActs {
 		// Reset pending balance for each account
-		state, err := accountutil.AccountState(ap.sf, from)
+		addr, err := address.FromString(from)
+		if err != nil {
+			log.L().Error("Error when getting  address.", zap.Error(err))
+			return
+		}
+		state, err := accountutil.AccountState(ap.sf, addr)
 		if err != nil {
 			log.L().Error("Error when resetting actpool state.", zap.Error(err))
 			return

--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -1022,7 +1024,11 @@ func (ap *actPool) getPendingNonce(addr string) (uint64, error) {
 	if queue, ok := ap.accountActs[addr]; ok {
 		return queue.PendingNonce(), nil
 	}
-	committedState, err := accountutil.AccountState(ap.sf, addr)
+	addr1, err := address.FromString(addr)
+	if err != nil {
+		return 0, err
+	}
+	committedState, err := accountutil.AccountState(ap.sf, addr1)
 	return committedState.Nonce + 1, err
 }
 
@@ -1031,7 +1037,11 @@ func (ap *actPool) getPendingBalance(addr string) (*big.Int, error) {
 	if queue, ok := ap.accountActs[addr]; ok {
 		return queue.PendingBalance(), nil
 	}
-	state, err := accountutil.AccountState(ap.sf, addr)
+	addr1, err := address.FromString(addr)
+	if err != nil {
+		return nil, err
+	}
+	state, err := accountutil.AccountState(ap.sf, addr1)
 	if err != nil {
 		return nil, err
 	}

--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -16,6 +16,8 @@ import (
 	"github.com/facebookgo/clock"
 	"github.com/pkg/errors"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -232,7 +234,12 @@ func (q *actQueue) PendingActs() []action.SealedEnvelope {
 		return []action.SealedEnvelope{}
 	}
 	acts := make([]action.SealedEnvelope, 0, len(q.items))
-	confirmedState, err := accountutil.AccountState(q.ap.sf, q.address)
+	addr, err := address.FromString(q.address)
+	if err != nil {
+		log.L().Error("Error when getting the address", zap.String("address", q.address), zap.Error(err))
+		return nil
+	}
+	confirmedState, err := accountutil.AccountState(q.ap.sf, addr)
 	if err != nil {
 		log.L().Error("Error when getting the nonce", zap.String("address", q.address), zap.Error(err))
 		return nil

--- a/blockchain/block/validator_test.go
+++ b/blockchain/block/validator_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/state"
@@ -31,10 +33,10 @@ func TestValidator(t *testing.T) {
 	v := NewValidator(nil)
 	require.NoError(v.Validate(ctx, blk))
 
-	valid := protocol.NewGenericValidator(nil, func(sr protocol.StateReader, addr string) (*state.Account, error) {
+	valid := protocol.NewGenericValidator(nil, func(sr protocol.StateReader, addr address.Address) (*state.Account, error) {
 		pk := identityset.PrivateKey(27).PublicKey()
 		eAddr := pk.Address()
-		if strings.EqualFold(eAddr.String(), addr) {
+		if strings.EqualFold(eAddr.String(), addr.String()) {
 			return nil, errors.New("MockChainManager nonce error")
 		}
 		return &state.Account{Nonce: 2}, nil

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -1261,12 +1261,16 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		fmt.Printf("Cannot add block 3 again: %v\n", err)
 
 		// invalid address returns error
-		act, err := accountutil.AccountState(sf, "")
+		addr, err := address.FromString("")
+		require.NoError(err)
+		act, err := accountutil.AccountState(sf, addr)
 		require.Equal("invalid bech32 string length 0", errors.Cause(err).Error())
 		require.Nil(act)
 
 		// valid but unused address should return empty account
-		act, err = accountutil.AccountState(sf, "io1066kus4vlyvk0ljql39fzwqw0k22h7j8wmef3n")
+		addr, err = address.FromString("io1066kus4vlyvk0ljql39fzwqw0k22h7j8wmef3n")
+		require.NoError(err)
+		act, err = accountutil.AccountState(sf, addr)
 		require.NoError(err)
 		require.Equal(uint64(0), act.Nonce)
 		require.Equal(big.NewInt(0), act.Balance)
@@ -1449,7 +1453,7 @@ func TestBlockchain_AccountState(t *testing.T) {
 	bc := blockchain.NewBlockchain(cfg, nil, factory.NewMinter(sf, ap), blockchain.InMemDaoOption(sf))
 	require.NoError(bc.Start(context.Background()))
 	require.NotNil(bc)
-	s, err := accountutil.AccountState(sf, identityset.Address(0).String())
+	s, err := accountutil.AccountState(sf, identityset.Address(0))
 	require.NoError(err)
 	require.Equal(uint64(0), s.Nonce)
 	require.Equal(big.NewInt(100), s.Balance)
@@ -1648,9 +1652,9 @@ func TestHistoryForAccount(t *testing.T) {
 func testHistoryForAccount(t *testing.T, statetx bool) {
 	require := require.New(t)
 	bc, sf, _, _, ap := newChain(t, statetx)
-	a := identityset.Address(28).String()
+	a := identityset.Address(28)
 	priKeyA := identityset.PrivateKey(28)
-	b := identityset.Address(29).String()
+	b := identityset.Address(29)
 
 	// check the original balance a and b before transfer
 	AccountA, err := accountutil.AccountState(sf, a)
@@ -1662,8 +1666,8 @@ func testHistoryForAccount(t *testing.T, statetx bool) {
 
 	// make a transfer from a to b
 	actionMap := make(map[string][]action.SealedEnvelope)
-	actionMap[a] = []action.SealedEnvelope{}
-	tsf, err := action.SignedTransfer(b, priKeyA, 1, big.NewInt(10), []byte{}, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))
+	actionMap[a.String()] = []action.SealedEnvelope{}
+	tsf, err := action.SignedTransfer(b.String(), priKeyA, 1, big.NewInt(10), []byte{}, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))
 	require.NoError(err)
 	require.NoError(ap.Add(context.Background(), tsf))
 	blk, err := bc.MintNewBlock(testutil.TimestampNow())
@@ -1707,7 +1711,9 @@ func testHistoryForContract(t *testing.T, statetx bool) {
 	// deploy and get contract address
 	contract := deployXrc20(bc, dao, ap, t)
 
-	account, err := accountutil.AccountState(sf, contract)
+	addr, err := address.FromString(contract)
+	require.NoError(err)
+	account, err := accountutil.AccountState(sf, addr)
 	require.NoError(err)
 	// check the original balance
 	balance := BalanceOfContract(contract, genesisAccount, kv, t, account.Root)
@@ -1716,7 +1722,7 @@ func testHistoryForContract(t *testing.T, statetx bool) {
 	require.Equal(expect, balance)
 	// make a transfer for contract
 	makeTransfer(contract, bc, ap, t)
-	account, err = accountutil.AccountState(sf, contract)
+	account, err = accountutil.AccountState(sf, addr)
 	require.NoError(err)
 	// check the balance after transfer
 	balance = BalanceOfContract(contract, genesisAccount, kv, t, account.Root)
@@ -1726,10 +1732,10 @@ func testHistoryForContract(t *testing.T, statetx bool) {
 
 	// check the the original balance again
 	if statetx {
-		_, err = accountutil.AccountState(factory.NewHistoryStateReader(sf, bc.TipHeight()-1), contract)
+		_, err = accountutil.AccountState(factory.NewHistoryStateReader(sf, bc.TipHeight()-1), addr)
 		require.True(errors.Cause(err) == factory.ErrNotSupported)
 	} else {
-		account, err = accountutil.AccountState(factory.NewHistoryStateReader(sf, bc.TipHeight()-1), contract)
+		account, err = accountutil.AccountState(factory.NewHistoryStateReader(sf, bc.TipHeight()-1), addr)
 		require.NoError(err)
 		balance = BalanceOfContract(contract, genesisAccount, kv, t, account.Root)
 		expect, ok = big.NewInt(0).SetString("2000000000000000000000000000", 10)

--- a/e2etest/bigint_test.go
+++ b/e2etest/bigint_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -42,13 +44,15 @@ func TestTransfer_Negative(t *testing.T) {
 	ctx := context.Background()
 	bc, sf, ap := prepareBlockchain(ctx, executor, r)
 	defer r.NoError(bc.Stop(ctx))
-	stateBeforeTransfer, err := accountutil.AccountState(sf, executor)
+	addr, err := address.FromString(executor)
+	r.NoError(err)
+	stateBeforeTransfer, err := accountutil.AccountState(sf, addr)
 	r.NoError(err)
 	blk, err := prepareTransfer(bc, sf, ap, r)
 	r.NoError(err)
 	r.Equal(2, len(blk.Actions))
 	r.Error(bc.ValidateBlock(blk))
-	state, err := accountutil.AccountState(sf, executor)
+	state, err := accountutil.AccountState(sf, addr)
 	r.NoError(err)
 	r.Equal(0, state.Balance.Cmp(stateBeforeTransfer.Balance))
 }
@@ -58,14 +62,16 @@ func TestAction_Negative(t *testing.T) {
 	ctx := context.Background()
 	bc, sf, ap := prepareBlockchain(ctx, executor, r)
 	defer r.NoError(bc.Stop(ctx))
-	stateBeforeTransfer, err := accountutil.AccountState(sf, executor)
+	addr, err := address.FromString(executor)
+	r.NoError(err)
+	stateBeforeTransfer, err := accountutil.AccountState(sf, addr)
 	r.NoError(err)
 	blk, err := prepareAction(bc, sf, ap, r)
 	r.NoError(err)
 	r.NotNil(blk)
 	r.Equal(2, len(blk.Actions))
 	r.Error(bc.ValidateBlock(blk))
-	state, err := accountutil.AccountState(sf, executor)
+	state, err := accountutil.AccountState(sf, addr)
 	r.NoError(err)
 	r.Equal(0, state.Balance.Cmp(stateBeforeTransfer.Balance))
 }

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -82,7 +82,7 @@ func TestLocalCommit(t *testing.T) {
 	require.NotNil(sf)
 	require.NotNil(ap)
 
-	i27State, err := accountutil.AccountState(sf, identityset.Address(27).String())
+	i27State, err := accountutil.AccountState(sf, identityset.Address(27))
 	require.NoError(err)
 	require.NoError(addTestingTsfBlocks(bc, ap))
 	require.NotNil(svr.ChainService(chainID).ActionPool())
@@ -113,48 +113,48 @@ func TestLocalCommit(t *testing.T) {
 	}()
 
 	// check balance
-	s, err := accountutil.AccountState(sf, identityset.Address(28).String())
+	s, err := accountutil.AccountState(sf, identityset.Address(28))
 	require.NoError(err)
 	change := s.Balance
 	t.Logf("Alfa balance = %d", change)
 	require.True(change.String() == "23")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(29).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(29))
 	require.NoError(err)
 	beta := s.Balance
 	t.Logf("Bravo balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "34")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(30).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(30))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Charlie balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "47")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(31).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(31))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Delta balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "69")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(32).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(32))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Echo balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "100")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(33).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(33))
 	require.NoError(err)
 	fox := s.Balance
 	t.Logf("Foxtrot balance = %d", fox)
 	change.Add(change, fox)
 	require.True(fox.String() == "5242883")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(27).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(27))
 	require.NoError(err)
 	test := s.Balance
 	t.Logf("test balance = %d", test)
@@ -218,7 +218,7 @@ func TestLocalCommit(t *testing.T) {
 
 	// transfer 1
 	// C --> A
-	s, _ = accountutil.AccountState(sf, identityset.Address(30).String())
+	s, _ = accountutil.AccountState(sf, identityset.Address(30))
 	tsf1, err := action.SignedTransfer(identityset.Address(28).String(), identityset.PrivateKey(30), s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
@@ -239,7 +239,7 @@ func TestLocalCommit(t *testing.T) {
 
 	// transfer 2
 	// F --> D
-	s, _ = accountutil.AccountState(sf, identityset.Address(33).String())
+	s, _ = accountutil.AccountState(sf, identityset.Address(33))
 	tsf2, err := action.SignedTransfer(identityset.Address(31).String(), identityset.PrivateKey(33), s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
@@ -260,7 +260,7 @@ func TestLocalCommit(t *testing.T) {
 
 	// transfer 3
 	// B --> B
-	s, _ = accountutil.AccountState(sf, identityset.Address(29).String())
+	s, _ = accountutil.AccountState(sf, identityset.Address(29))
 	tsf3, err := action.SignedTransfer(identityset.Address(29).String(), identityset.PrivateKey(29), s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
@@ -281,7 +281,7 @@ func TestLocalCommit(t *testing.T) {
 
 	// transfer 4
 	// test --> E
-	s, _ = accountutil.AccountState(sf, identityset.Address(27).String())
+	s, _ = accountutil.AccountState(sf, identityset.Address(27))
 	tsf4, err := action.SignedTransfer(identityset.Address(32).String(), identityset.PrivateKey(27), s.Nonce+1, big.NewInt(1), []byte{}, 100000, big.NewInt(0))
 	require.NoError(err)
 
@@ -312,48 +312,48 @@ func TestLocalCommit(t *testing.T) {
 	require.True(9 == bc.TipHeight())
 
 	// check balance
-	s, err = accountutil.AccountState(sf, identityset.Address(28).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(28))
 	require.NoError(err)
 	change = s.Balance
 	t.Logf("Alfa balance = %d", change)
 	require.True(change.String() == "24")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(29).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(29))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Bravo balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "34")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(30).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(30))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Charlie balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "46")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(31).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(31))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Delta balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "70")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(32).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(32))
 	require.NoError(err)
 	beta = s.Balance
 	t.Logf("Echo balance = %d", beta)
 	change.Add(change, beta)
 	require.True(beta.String() == "101")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(33).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(33))
 	require.NoError(err)
 	fox = s.Balance
 	t.Logf("Foxtrot balance = %d", fox)
 	change.Add(change, fox)
 	require.True(fox.String() == "5242882")
 
-	s, err = accountutil.AccountState(sf, identityset.Address(27).String())
+	s, err = accountutil.AccountState(sf, identityset.Address(27))
 	require.NoError(err)
 	test = s.Balance
 	t.Logf("test balance = %d", test)

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/blockchain"
@@ -408,7 +410,9 @@ func TestLocalTransfer(t *testing.T) {
 			require.Equal(tsfTest.nonce, selp.Proto().GetCore().GetNonce(), tsfTest.message)
 			require.Equal(senderPriKey.PublicKey().Bytes(), selp.Proto().SenderPubKey, tsfTest.message)
 
-			newSenderState, _ := accountutil.AccountState(sf, senderAddr)
+			senderAddr1, err := address.FromString(senderAddr)
+			require.NoError(err)
+			newSenderState, _ := accountutil.AccountState(sf, senderAddr1)
 			minusAmount := big.NewInt(0).Sub(tsfTest.senderBalance, tsfTest.amount)
 			gasUnitPayloadConsumed := big.NewInt(0).Mul(big.NewInt(int64(action.TransferPayloadGas)),
 				big.NewInt(int64(len(tsfTest.payload))))
@@ -418,7 +422,9 @@ func TestLocalTransfer(t *testing.T) {
 			expectedSenderBalance := big.NewInt(0).Sub(minusAmount, gasConsumed)
 			require.Equal(expectedSenderBalance.String(), newSenderState.Balance.String(), tsfTest.message)
 
-			newRecvState, err := accountutil.AccountState(sf, recvAddr)
+			recvAddr1, err := address.FromString(recvAddr)
+			require.NoError(err)
+			newRecvState, err := accountutil.AccountState(sf, recvAddr1)
 			require.NoError(err)
 			expectedRecvrBalance := big.NewInt(0)
 			if tsfTest.recvAcntState == AcntNotRegistered {
@@ -463,7 +469,9 @@ func TestLocalTransfer(t *testing.T) {
 			require.Error(err, tsfTest.message)
 
 			if tsfTest.senderAcntState == AcntCreate || tsfTest.senderAcntState == AcntExist {
-				newSenderState, _ := accountutil.AccountState(sf, senderAddr)
+				senderAddr1, err := address.FromString(senderAddr)
+				require.NoError(err)
+				newSenderState, _ := accountutil.AccountState(sf, senderAddr1)
 				require.Equal(tsfTest.senderBalance.String(), newSenderState.Balance.String())
 			}
 
@@ -526,7 +534,7 @@ func initStateKeyAddr(
 			return nil, "", errors.New("failed to get address")
 		}
 		retAddr = addr.String()
-		existState, err := accountutil.AccountState(sf, retAddr)
+		existState, err := accountutil.AccountState(sf, addr)
 		if err != nil {
 			return nil, "", err
 		}

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -261,14 +261,16 @@ func TestBlockEpochReward(t *testing.T) {
 		chains[i] = svrs[i].ChainService(configs[i].Chain.ID).Blockchain()
 		apis[i] = svrs[i].ChainService(configs[i].Chain.ID).APIServer()
 
+		rewardAddr := identityset.Address(i + numNodes)
 		rewardAddrStr := identityset.Address(i + numNodes).String()
 		exptUnclaimed[rewardAddrStr] = big.NewInt(0)
-		initState, err := accountutil.AccountState(sfs[i], rewardAddrStr)
+		initState, err := accountutil.AccountState(sfs[i], rewardAddr)
 		require.NoError(t, err)
 		initBalances[rewardAddrStr] = initState.Balance
 
+		operatorAddr := identityset.Address(i)
 		operatorAddrStr := identityset.Address(i).String()
-		initState, err = accountutil.AccountState(sfs[i], operatorAddrStr)
+		initState, err = accountutil.AccountState(sfs[i], operatorAddr)
 		require.NoError(t, err)
 		initBalances[operatorAddrStr] = initState.Balance
 
@@ -453,8 +455,9 @@ func TestBlockEpochReward(t *testing.T) {
 
 	for i := 0; i < numNodes; i++ {
 		//Check Reward address balance
+		rewardAddr := identityset.Address(i + numNodes)
 		rewardAddrStr := identityset.Address(i + numNodes).String()
-		endState, err := accountutil.AccountState(sfs[0], rewardAddrStr)
+		endState, err := accountutil.AccountState(sfs[0], rewardAddr)
 		require.NoError(t, err)
 		fmt.Println("Server ", i, " ", rewardAddrStr, " Closing Balance ", endState.Balance.String())
 		expectBalance := big.NewInt(0).Add(initBalances[rewardAddrStr], claimedAmount[rewardAddrStr])
@@ -462,8 +465,9 @@ func TestBlockEpochReward(t *testing.T) {
 		require.Equal(t, expectBalance.String(), endState.Balance.String())
 
 		//Make sure the non-reward addresses have not received money
+		operatorAddr := identityset.Address(i)
 		operatorAddrStr := identityset.Address(i).String()
-		operatorState, err := accountutil.AccountState(sfs[i], operatorAddrStr)
+		operatorState, err := accountutil.AccountState(sfs[i], operatorAddr)
 		require.NoError(t, err)
 		require.Equal(t, initBalances[operatorAddrStr], operatorState.Balance)
 	}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -402,12 +402,12 @@ func TestSDBState(t *testing.T) {
 
 func testState(sf Factory, t *testing.T) {
 	// Create a dummy iotex address
-	a := identityset.Address(28).String()
+	a := identityset.Address(28)
 	priKeyA := identityset.PrivateKey(28)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, sf.Register(acc))
 	ge := genesis.Default
-	ge.InitBalanceMap[a] = "100"
+	ge.InitBalanceMap[a.String()] = "100"
 	gasLimit := uint64(1000000)
 	ctx := protocol.WithBlockCtx(
 		context.Background(),
@@ -460,13 +460,13 @@ func testState(sf Factory, t *testing.T) {
 
 func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 	// Create a dummy iotex address
-	a := identityset.Address(28).String()
-	b := identityset.Address(31).String()
+	a := identityset.Address(28)
+	b := identityset.Address(31)
 	priKeyA := identityset.PrivateKey(28)
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, sf.Register(acc))
 	ge := genesis.Default
-	ge.InitBalanceMap[a] = "100"
+	ge.InitBalanceMap[a.String()] = "100"
 	gasLimit := uint64(1000000)
 	ctx := protocol.WithBlockCtx(
 		context.Background(),
@@ -488,7 +488,7 @@ func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 	require.NoError(t, err)
 	require.Equal(t, big.NewInt(100), accountA.Balance)
 	require.Equal(t, big.NewInt(0), accountB.Balance)
-	tsf, err := action.NewTransfer(1, big.NewInt(10), b, nil, uint64(20000), big.NewInt(0))
+	tsf, err := action.NewTransfer(1, big.NewInt(10), b.String(), nil, uint64(20000), big.NewInt(0))
 	require.NoError(t, err)
 	bd := &action.EnvelopeBuilder{}
 	elp := bd.SetAction(tsf).SetGasLimit(20000).Build()
@@ -725,7 +725,7 @@ func testNonce(sf Factory, t *testing.T) {
 	)
 	_, err = ws.runAction(ctx, selp)
 	require.NoError(t, err)
-	state, err := accountutil.AccountState(sf, a.String())
+	state, err := accountutil.AccountState(sf, a)
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), state.Nonce)
 
@@ -745,7 +745,7 @@ func testNonce(sf Factory, t *testing.T) {
 	require.NoError(t, err)
 
 	require.NoError(t, sf.PutBlock(ctx, &blk))
-	state, err = accountutil.AccountState(sf, a.String())
+	state, err = accountutil.AccountState(sf, a)
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), state.Nonce)
 }
@@ -1516,7 +1516,11 @@ func benchState(sf Factory, b *testing.B) {
 	for n := 1; n < b.N; n++ {
 		b.StartTimer()
 		idx := rand.Int() % len(accounts)
-		_, err := accountutil.AccountState(sf, accounts[idx])
+		addr, err := address.FromString(accounts[idx])
+		if err != nil {
+			b.Fatal(err)
+		}
+		_, err = accountutil.AccountState(sf, addr)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -15,6 +15,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/iotex-address/address"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
@@ -309,7 +311,11 @@ func (ws *workingSet) validateNonce(blk *block.Block) error {
 	}
 	// Verify each account's Nonce
 	for srcAddr, receivedNonces := range accountNonceMap {
-		confirmedState, err := accountutil.AccountState(ws, srcAddr)
+		addr, err := address.FromString(srcAddr)
+		if err != nil {
+			return errors.Wrapf(err, "failed to get the address.Address of address %s", srcAddr)
+		}
+		confirmedState, err := accountutil.AccountState(ws, addr)
 		if err != nil {
 			return errors.Wrapf(err, "failed to get the confirmed nonce of address %s", srcAddr)
 		}


### PR DESCRIPTION
Fixed issue #2775 in new PR. Closing original PR #2778 

1. Updated AccountState() to use address.Address
2. Updated all calling of this function
3. No other method is updated for address.Address(), if needed address is converted from string to address.Address()
4. All review comments on previous PRs are incorporated and imports are organised well.
5. All tests passed in local run