### PR TITLE
[api] correct total block number in result

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1274,7 +1274,7 @@ func (api *Server) getBlockMetas(start uint64, count uint64) (*iotexapi.GetBlock
 		count--
 	}
 	return &iotexapi.GetBlockMetasResponse{
-		Total:    tipHeight,
+		Total:    uint64(len(res)),
 		BlkMetas: res,
 	}, nil
 }


### PR DESCRIPTION
`Total` denotes the size of array