### PR TITLE
[api]Tracing sampling support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -155,6 +155,7 @@ func NewServer(
 		tracer.WithServiceName(cfg.API.Tracer.ServiceName),
 		tracer.WithEndpoint(cfg.API.Tracer.EndPoint),
 		tracer.WithInstanceID(cfg.API.Tracer.InstanceID),
+		tracer.WithSamplingRatio(cfg.API.Tracer.SamplingRatio),
 	)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot config tracer provider")

--- a/pkg/tracer/tracer.go
+++ b/pkg/tracer/tracer.go
@@ -65,7 +65,7 @@ func WithInstanceID(instanceID string) Option {
 	}
 }
 
-// WithSamplingRatio defines the sampling rate
+// WithSamplingRatio defines the sampling ratio
 func WithSamplingRatio(samplingRatio string) Option {
 	return func(ops *optionParams) error {
 		ops.samplingRatio = samplingRatio

--- a/pkg/tracer/tracer_test.go
+++ b/pkg/tracer/tracer_test.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,4 +12,16 @@ func TestTracer(t *testing.T) {
 	prv, err := NewProvider()
 	require.NoError(err)
 	require.Nil(prv)
+
+	_, err = NewProvider(
+		WithEndpoint("http://aa"),
+		WithSamplingRatio("4a32"),
+	)
+	require.ErrorIs(err, strconv.ErrSyntax)
+
+	_, err = NewProvider(
+		WithEndpoint("http://aa"),
+		WithSamplingRatio(".5"),
+	)
+	require.NoError(err)
 }


### PR DESCRIPTION
half of traces will be sampled
```
api:
  tracer:
    endpoint: http://localhost:14268/api/traces
    samplingRatio: .5
```