### PR TITLE
[evm] apply clearSnapshots fix back to Kamchatka height

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -94,7 +94,6 @@ type (
 		UpdateBlockMeta             bool
 		CurrentEpochProductivity    bool
 		FixSnapshotOrder            bool
-		ClearSnapshots              bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -218,7 +217,6 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			UpdateBlockMeta:             g.IsGreenland(height),
 			CurrentEpochProductivity:    g.IsGreenland(height),
 			FixSnapshotOrder:            g.IsKamchatka(height),
-			ClearSnapshots:              g.IsLordHowe(height),
 		},
 	)
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -289,9 +289,6 @@ func prepareStateDB(ctx context.Context, sm protocol.StateManager) *StateDBAdapt
 	if featureCtx.FixSnapshotOrder {
 		opts = append(opts, FixSnapshotOrderOption())
 	}
-	if featureCtx.ClearSnapshots {
-		opts = append(opts, ClearSnapshotsOption())
-	}
 	return NewStateDBAdapter(
 		sm,
 		blkCtx.BlockHeight,

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -180,9 +180,6 @@ func TestConstantinople(t *testing.T) {
 		if g.IsKamchatka(e.height) {
 			opt = append(opt, FixSnapshotOrderOption())
 		}
-		if g.IsLordHowe(e.height) {
-			opt = append(opt, ClearSnapshotsOption())
-		}
 		stateDB := NewStateDBAdapter(sm, e.height, hash.ZeroHash256, opt...)
 
 		ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -67,7 +67,6 @@ type (
 		sortCachedContracts bool
 		usePendingNonce     bool
 		fixSnapshotOrder    bool
-		clearSnapshots      bool
 	}
 )
 
@@ -110,14 +109,6 @@ func UsePendingNonceOption() StateDBAdapterOption {
 func FixSnapshotOrderOption() StateDBAdapterOption {
 	return func(adapter *StateDBAdapter) error {
 		adapter.fixSnapshotOrder = true
-		return nil
-	}
-}
-
-// ClearSnapshotsOption set clearSnapshots as true
-func ClearSnapshotsOption() StateDBAdapterOption {
-	return func(adapter *StateDBAdapter) error {
-		adapter.clearSnapshots = true
 		return nil
 	}
 }
@@ -475,21 +466,11 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	stateDB.suicided = ds
 	if stateDB.fixSnapshotOrder {
 		delete(stateDB.suicideSnapshot, snapshot)
-		if stateDB.clearSnapshots {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.suicideSnapshot[i]; ok {
-					delete(stateDB.suicideSnapshot, i)
-				} else {
-					break
-				}
-			}
-		} else {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.suicideSnapshot[snapshot]; ok {
-					delete(stateDB.suicideSnapshot, i)
-				} else {
-					break
-				}
+		for i := snapshot + 1; ; i++ {
+			if _, ok := stateDB.suicideSnapshot[i]; ok {
+				delete(stateDB.suicideSnapshot, i)
+			} else {
+				break
 			}
 		}
 	}
@@ -505,21 +486,11 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	}
 	if stateDB.fixSnapshotOrder {
 		delete(stateDB.contractSnapshot, snapshot)
-		if stateDB.clearSnapshots {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.contractSnapshot[i]; ok {
-					delete(stateDB.contractSnapshot, i)
-				} else {
-					break
-				}
-			}
-		} else {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.contractSnapshot[snapshot]; ok {
-					delete(stateDB.contractSnapshot, i)
-				} else {
-					break
-				}
+		for i := snapshot + 1; ; i++ {
+			if _, ok := stateDB.contractSnapshot[i]; ok {
+				delete(stateDB.contractSnapshot, i)
+			} else {
+				break
 			}
 		}
 	}
@@ -528,21 +499,11 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	stateDB.preimages = stateDB.preimageSnapshot[snapshot]
 	if stateDB.fixSnapshotOrder {
 		delete(stateDB.preimageSnapshot, snapshot)
-		if stateDB.clearSnapshots {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.preimageSnapshot[i]; ok {
-					delete(stateDB.preimageSnapshot, i)
-				} else {
-					break
-				}
-			}
-		} else {
-			for i := snapshot + 1; ; i++ {
-				if _, ok := stateDB.preimageSnapshot[snapshot]; ok {
-					delete(stateDB.preimageSnapshot, i)
-				} else {
-					break
-				}
+		for i := snapshot + 1; ; i++ {
+			if _, ok := stateDB.preimageSnapshot[i]; ok {
+				delete(stateDB.preimageSnapshot, i)
+			} else {
+				break
 			}
 		}
 	}


### PR DESCRIPTION
the clearSnapshot fix is not properly implemented, so we fixed it again at LordHowe height https://github.com/iotexproject/iotex-core/commit/9dba94df2e4233d85ea4d5998f7316138933ff13

this PR is to apply the correct fix at Kamchatka height (as if we would have implemented it correctly at first time)

it is verified both Mainnet and Testnet can correctly sync with this change