### PR TITLE
[api] use ttl.Cache for responder and read cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/iotexproject/go-fsm v1.0.0
 	github.com/iotexproject/go-p2p v0.3.3
-	github.com/iotexproject/go-pkgs v0.1.6
+	github.com/iotexproject/go-pkgs v0.1.8
 	github.com/iotexproject/iotex-address v0.2.5
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d

--- a/go.sum
+++ b/go.sum
@@ -432,8 +432,9 @@ github.com/iotexproject/go-p2p v0.3.3 h1:qDGwaHu1oYG93PIcJAnY5Hl2iK0GoeAQewB0Qtv
 github.com/iotexproject/go-p2p v0.3.3/go.mod h1:MjgwpexfBxhgq0cDoqHCxMQ1cLkv96p3xZJ02LLVGLA=
 github.com/iotexproject/go-pkgs v0.1.5-0.20210604060651-be5ee19f2575/go.mod h1:ttXhcwrtODyh7JozpJlCml09CjP0pcKqTe2B0MbTGc8=
 github.com/iotexproject/go-pkgs v0.1.5/go.mod h1:ttXhcwrtODyh7JozpJlCml09CjP0pcKqTe2B0MbTGc8=
-github.com/iotexproject/go-pkgs v0.1.6 h1:oIZdurWrUrotPaa6qb+z6ZS6SYqO1mKxPm/jMPJ5AoQ=
 github.com/iotexproject/go-pkgs v0.1.6/go.mod h1:E+Fl0XQZz56EzXFajFET2yFoRGsIbL6wQooVIkSim3o=
+github.com/iotexproject/go-pkgs v0.1.8 h1:NEknefON3SvcZxJRkdDXFY4+PH9W5E0adU31jvK+gwo=
+github.com/iotexproject/go-pkgs v0.1.8/go.mod h1:E+Fl0XQZz56EzXFajFET2yFoRGsIbL6wQooVIkSim3o=
 github.com/iotexproject/iotex-address v0.2.4/go.mod h1:K78yPSMB4K7gF/iQ7djT1amph0RBrP3rSkFfH7gNG70=
 github.com/iotexproject/iotex-address v0.2.5 h1:BMljqmEjC6uSnbdmi1HWdl9SLD8Erw6K9i0Fy6VU79k=
 github.com/iotexproject/iotex-address v0.2.5/go.mod h1:K78yPSMB4K7gF/iQ7djT1amph0RBrP3rSkFfH7gNG70=

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -19,13 +19,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iotexproject/go-pkgs/cache/ttl"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
-	"github.com/iotexproject/go-pkgs/cache"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -263,7 +263,7 @@ func main() {
 		}
 
 		expectedBalancesMap := util.GetAllBalanceMap(client, chainAddrs)
-		pendingActionMap := cache.NewThreadSafeLruCache(0)
+		pendingActionMap, _ := ttl.NewCache(ttl.EvictOnErrorOption())
 
 		log.L().Info("Start action injections.")
 
@@ -288,9 +288,9 @@ func main() {
 		})
 
 		totalPendingActions := 0
-		pendingActionMap.Range(func(selphash cache.Key, vi interface{}) bool {
+		pendingActionMap.Range(func(selphash, vi interface{}) error {
 			totalPendingActions++
-			return true
+			return nil
 		})
 
 		if err != nil {


### PR DESCRIPTION
as discussed earlier, Responder and read cache in API does not need LRU, instead just need thread-safe map

tested on fullnode, register/exit Responder can work correctly