### PR TITLE
[api] fix type err in GetNetworkID()

### DIFF
--- a/api/web3server.go
+++ b/api/web3server.go
@@ -519,7 +519,7 @@ func (svr *Web3Server) getNodeInfo() (interface{}, error) {
 }
 
 func (svr *Web3Server) getNetworkID() (interface{}, error) {
-	return svr.coreService.EVMNetworkID(), nil
+	return strconv.Itoa(int(svr.coreService.EVMNetworkID())), nil
 }
 
 func (svr *Web3Server) getPeerCount() (interface{}, error) {

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -609,3 +609,15 @@ func TestGetStorageAt(t *testing.T) {
 		require.Error(err)
 	}
 }
+
+func TestGetNetworkID(t *testing.T) {
+	require := require.New(t)
+	cfg := newConfig(t)
+	config.SetEVMNetworkID(1)
+	svr, bfIndexFile, _ := createServerV2(cfg, false)
+	defer func() {
+		testutil.CleanupPath(t, bfIndexFile)
+	}()
+	res, _ := svr.web3Server.getNetworkID()
+	require.Equal("1", res)
+}


### PR DESCRIPTION
GetNetworkID() should return value in string type 