### PR TITLE
[api] fix web3 empty return

### DIFF
--- a/api/web3server.go
+++ b/api/web3server.go
@@ -623,7 +623,7 @@ func (svr *Web3Server) getTransactionReceipt(in interface{}) (interface{}, error
 		return nil, err
 	}
 	tx, err := svr.getTransactionFromActionInfo(actInfo)
-	if err != nil || tx == nil {
+	if err != nil {
 		return nil, err
 	}
 

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -642,3 +642,47 @@ func TestGetNetworkID(t *testing.T) {
 	res, _ := svr.web3Server.getNetworkID()
 	require.Equal("1", res)
 }
+
+func TestIsResultValid(t *testing.T) {
+	require := require.New(t)
+	testData := []struct {
+		data    web3Resp
+		isValid bool
+	}{
+		{
+			data: web3Resp{
+				ID:      1,
+				Jsonrpc: "2.0",
+				Result:  []string{},
+			},
+			isValid: true,
+		},
+		{
+			data: web3Resp{
+				ID:      1,
+				Jsonrpc: "2.0",
+			},
+			isValid: false,
+		},
+		{
+			data: web3Resp{
+				ID:      1,
+				Jsonrpc: "2.0",
+				Result:  nil,
+			},
+			isValid: false,
+		},
+		{
+			data: web3Resp{
+				ID:      1,
+				Jsonrpc: "2.0",
+				Error:   &web3Err{},
+			},
+			isValid: true,
+		},
+	}
+
+	for _, v := range testData {
+		require.Equal(v.isValid, isResultValid(v.data))
+	}
+}

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -158,7 +158,7 @@ func (svr *Web3Server) getBlockWithTransactions(blkMeta *iotextypes.BlockMeta, i
 		for _, info := range actionInfos {
 			if isDetailed {
 				tx, err := svr.getTransactionFromActionInfo(info)
-				if err != nil || tx == nil {
+				if err != nil {
 					log.L().Error("failed to get info from action", zap.Error(err), zap.String("info", fmt.Sprintf("%+v", info)))
 					continue
 				}
@@ -284,7 +284,7 @@ func (svr *Web3Server) getTransactionFromActionInfo(actInfo *iotexapi.ActionInfo
 
 func (svr *Web3Server) getTransactionCreateFromActionInfo(actInfo *iotexapi.ActionInfo) (transactionObject, error) {
 	tx, err := svr.getTransactionFromActionInfo(actInfo)
-	if err != nil || tx == nil {
+	if err != nil {
 		return transactionObject{}, err
 	}
 

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -158,7 +158,7 @@ func (svr *Web3Server) getBlockWithTransactions(blkMeta *iotextypes.BlockMeta, i
 		for _, info := range actionInfos {
 			if isDetailed {
 				tx, err := svr.getTransactionFromActionInfo(info)
-				if err != nil {
+				if err != nil || tx == nil {
 					log.L().Error("failed to get info from action", zap.Error(err), zap.String("info", fmt.Sprintf("%+v", info)))
 					continue
 				}
@@ -404,6 +404,18 @@ func (svr *Web3Server) getLogsWithFilter(from uint64, to uint64, addrs []string,
 		})
 	}
 	return ret, nil
+}
+
+func isResultValid(in web3Resp) bool {
+	objInByte, err := json.Marshal(in)
+	if err != nil || !gjson.Valid(string(objInByte)) {
+		return false
+	}
+	parsedReqs := gjson.Parse(string(objInByte))
+	if !parsedReqs.Get("error").Exists() && !parsedReqs.Get("result").Exists() {
+		return false
+	}
+	return true
 }
 
 func byteToHex(b []byte) string {

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -284,7 +284,7 @@ func (svr *Web3Server) getTransactionFromActionInfo(actInfo *iotexapi.ActionInfo
 
 func (svr *Web3Server) getTransactionCreateFromActionInfo(actInfo *iotexapi.ActionInfo) (transactionObject, error) {
 	tx, err := svr.getTransactionFromActionInfo(actInfo)
-	if err != nil {
+	if err != nil || tx == nil {
 		return transactionObject{}, err
 	}
 
@@ -381,7 +381,7 @@ func (svr *Web3Server) getLogsWithFilter(from uint64, to uint64, addrs []string,
 	}
 
 	// parse log results
-	var ret []logsObject
+	ret := make([]logsObject, 0)
 	for _, l := range logs {
 		var topics []string
 		for _, val := range l.Topics {


### PR DESCRIPTION
fix the bug that the server returns `null` instead of `[]` when calling web3 api `eth_getLogs`, 