### PR TITLE
[evm] check null pointer before dump calldata

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -371,8 +371,15 @@ func executeInEVM(evmParams *Params, stateDB *StateDBAdapter, g genesis.Blockcha
 	if evmErr != nil {
 		errCode = evmErrToErrStatusCode(evmErr, g, blockHeight)
 		if errCode == uint64(iotextypes.ReceiptStatus_ErrUnknown) {
+			var addr string
+			if evmParams.contract != nil {
+				ioAddr, _ := address.FromBytes((*evmParams.contract)[:])
+				addr = ioAddr.String()
+			} else {
+				addr = "contract creation"
+			}
 			log.L().Warn("evm internal error", zap.Error(evmErr),
-				log.Hex("contract", (*evmParams.contract)[:]),
+				zap.String("address", addr),
 				log.Hex("calldata", evmParams.data))
 		}
 	}
@@ -439,7 +446,6 @@ func evmErrToErrStatusCode(evmErr error, g genesis.Blockchain, height uint64) (e
 			case "no compatible interpreter":
 				errStatusCode = uint64(iotextypes.ReceiptStatus_ErrNoCompatibleInterpreter)
 			default:
-				log.L().Error("evm internal error", zap.Error(evmErr))
 				errStatusCode = uint64(iotextypes.ReceiptStatus_ErrUnknown)
 			}
 		}


### PR DESCRIPTION
this might be the reason for api node restart