### PR TITLE
[api] fix nonce bug in getTransactionCount

### DIFF
--- a/api/web3server.go
+++ b/api/web3server.go
@@ -97,6 +97,10 @@ var (
 	errNotImplemented = errors.New("method not implemented")
 	errInvalidFiterID = errors.New("filter not found")
 	errInvalidBlock   = errors.New("invalid block")
+
+	pendingBlockNumber  = "pending"
+	latestBlockNumber   = "latest"
+	earliestBlockNumber = "earliest"
 )
 
 func init() {
@@ -371,6 +375,13 @@ func (svr *Web3Server) getTransactionCount(in interface{}) (interface{}, error) 
 	blkNum, err := getStringFromArray(in, 1)
 	if err != nil {
 		return nil, err
+	}
+	if blkNum == pendingBlockNumber {
+		accountMeta, _, err := svr.coreService.Account(ioAddr)
+		if err != nil {
+			return nil, err
+		}
+		return uint64ToHex(accountMeta.PendingNonce), nil
 	}
 	num, err := svr.parseBlockNumber(blkNum)
 	if err != nil {

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -206,6 +206,10 @@ func TestGetTransactionCount(t *testing.T) {
 	testData := []interface{}{"0xDa7e12Ef57c236a06117c5e0d04a228e7181CF36", "0x1"}
 	ret, _ := svr.web3Server.getTransactionCount(testData)
 	require.Equal(ret, uint64ToHex(1))
+
+	testData2 := []interface{}{"0xDa7e12Ef57c236a06117c5e0d04a228e7181CF36", "pending"}
+	ret, _ = svr.web3Server.getTransactionCount(testData2)
+	require.Equal(ret, uint64ToHex(2))
 }
 
 func TestCall(t *testing.T) {

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -309,9 +309,9 @@ func (svr *Web3Server) getTransactionCreateFromActionInfo(actInfo *iotexapi.Acti
 
 func (svr *Web3Server) parseBlockNumber(str string) (uint64, error) {
 	switch str {
-	case "earliest":
+	case earliestBlockNumber:
 		return 1, nil
-	case "", "pending", "latest":
+	case "", pendingBlockNumber, latestBlockNumber:
 		return svr.coreService.bc.TipHeight(), nil
 	default:
 		return hexStringToNumber(str)


### PR DESCRIPTION
https://github.com/ethereum/go-ethereum/blob/master/internal/ethapi/api.go#L1552

When blk number is "pending", the pending nonce of the addr in the actpool should be returned.
Otherwise, the number of confirmed nonce should be returned.


