### PR TITLE
use nonce = 0 for very first tx

### DIFF
--- a/action/protocol/generic_validator.go
+++ b/action/protocol/generic_validator.go
@@ -51,8 +51,7 @@ func (v *GenericValidator) Validate(ctx context.Context, selp action.SealedEnvel
 		return errors.Wrapf(err, "invalid state of account %s", caller.String())
 	}
 
-	pendingNonce := confirmedState.Nonce + 1
-	if selp.Nonce() > 0 && pendingNonce > selp.Nonce() {
+	if confirmedState.PendingNonce() > selp.Nonce() {
 		return action.ErrNonceTooLow
 	}
 	return selp.Action().SanityCheck()

--- a/action/protocol/generic_validator_test.go
+++ b/action/protocol/generic_validator_test.go
@@ -75,6 +75,7 @@ func TestActionProtoAndGenericValidator(t *testing.T) {
 		bd := &action.EnvelopeBuilder{}
 		elp := bd.SetGasPrice(big.NewInt(10)).
 			SetGasLimit(uint64(100000)).
+			SetNonce(3).
 			SetAction(v).Build()
 		selp, err := action.Sign(elp, identityset.PrivateKey(28))
 		require.NoError(err)

--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -249,7 +249,7 @@ func (ap *actPool) GetPendingNonce(addr string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	return confirmedState.Nonce + 1, err
+	return confirmedState.PendingNonce(), err
 }
 
 // GetUnconfirmedActs returns unconfirmed actions in pool given an account address

--- a/state/account.go
+++ b/state/account.go
@@ -35,8 +35,8 @@ type Account struct {
 	VotingWeight *big.Int
 }
 
-// ToProto converts to protobuf's Account
-func (st *Account) ToProto() *accountpb.Account {
+// toProto converts to protobuf's Account
+func (st *Account) toProto() *accountpb.Account {
 	acPb := &accountpb.Account{}
 	acPb.Nonce = st.Nonce
 	if st.Balance != nil {
@@ -55,11 +55,11 @@ func (st *Account) ToProto() *accountpb.Account {
 
 // Serialize serializes account state into bytes
 func (st Account) Serialize() ([]byte, error) {
-	return proto.Marshal(st.ToProto())
+	return proto.Marshal(st.toProto())
 }
 
-// FromProto converts from protobuf's Account
-func (st *Account) FromProto(acPb *accountpb.Account) {
+// fromProto converts from protobuf's Account
+func (st *Account) fromProto(acPb *accountpb.Account) {
 	st.Nonce = acPb.Nonce
 	st.Balance = big.NewInt(0)
 	if acPb.Balance != "" {
@@ -84,7 +84,7 @@ func (st *Account) Deserialize(buf []byte) error {
 	if err := proto.Unmarshal(buf, acPb); err != nil {
 		return err
 	}
-	st.FromProto(acPb)
+	st.fromProto(acPb)
 	return nil
 }
 
@@ -102,6 +102,15 @@ func (st *Account) SubBalance(amount *big.Int) error {
 	}
 	st.Balance.Sub(st.Balance, amount)
 	return nil
+}
+
+// PendingNonce returns the pending nonce of account
+func (st *Account) PendingNonce() uint64 {
+	if st.Nonce == 0 {
+		// to be compatible with Ethereum, where a new account's first tx use nonce = 0
+		return st.Nonce
+	}
+	return st.Nonce + 1
 }
 
 // IsContract returns true for contract account

--- a/state/account_test.go
+++ b/state/account_test.go
@@ -11,8 +11,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/golang/mock/gomock"
-
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/stretchr/testify/require"
 )
@@ -50,8 +48,6 @@ func TestProto(t *testing.T) {
 
 func TestBalance(t *testing.T) {
 	require := require.New(t)
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	state := &Account{Balance: big.NewInt(20)}
 	// Add 10 to the balance
@@ -60,6 +56,15 @@ func TestBalance(t *testing.T) {
 	require.Equal(0, state.Balance.Cmp(big.NewInt(30)))
 	// Sub 40 to the balance
 	require.Equal(ErrNotEnoughBalance, state.SubBalance(big.NewInt(40)))
+}
+
+func TestPendingNonce(t *testing.T) {
+	require := require.New(t)
+
+	state := &Account{Balance: big.NewInt(20)}
+	require.Zero(state.PendingNonce())
+	state.Nonce = 7
+	require.EqualValues(8, state.PendingNonce())
 }
 
 func TestClone(t *testing.T) {


### PR DESCRIPTION
There's a request to use nonce = 0 for a new account's first tx, see https://github.com/gnosis/safe-singleton-factory/issues/10

1. this should NOT be a hard-fork b/c all our existing tx start from nonce = 1, now allowing start from 0 would not break it
2. this is code change on a quick check, may not cover all cases. If we decide to do this, need more scrutiny and comprehensive testing