### PR TITLE
[actpool] fix iterator issue and make code more efficient in cleanTimeout

### DIFF
--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -139,10 +139,11 @@ func (q *actQueue) FilterNonce(threshold uint64) []action.SealedEnvelope {
 }
 
 func (q *actQueue) cleanTimeout() []action.SealedEnvelope {
-	removedFromQueue := make([]action.SealedEnvelope, 0)
-	i := 0
-	timeNow := q.clock.Now()
-	for i < len(q.index) {
+	var (
+		removedFromQueue = make([]action.SealedEnvelope, 0)
+		timeNow          = q.clock.Now()
+	)
+	for i := 0; i < len(q.index); {
 		if timeNow.After(q.index[i].deadline) {
 			removedFromQueue = append(removedFromQueue, q.items[q.index[i].nonce])
 			delete(q.items, q.index[i].nonce)

--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -140,14 +140,19 @@ func (q *actQueue) FilterNonce(threshold uint64) []action.SealedEnvelope {
 
 func (q *actQueue) cleanTimeout() []action.SealedEnvelope {
 	removedFromQueue := make([]action.SealedEnvelope, 0)
-	for i := 0; i < len(q.index); i++ {
-		if q.clock.Now().After(q.index[i].deadline) {
-			// remove
+	i := 0
+	timeNow := q.clock.Now()
+	for i < len(q.index) {
+		if timeNow.After(q.index[i].deadline) {
 			removedFromQueue = append(removedFromQueue, q.items[q.index[i].nonce])
 			delete(q.items, q.index[i].nonce)
-			q.index = append(q.index[:i], q.index[i+1:]...)
+			q.index[i] = q.index[len(q.index)-1]
+			q.index = q.index[:len(q.index)-1]
+			continue
 		}
+		i++
 	}
+	heap.Init(&q.index)
 	return removedFromQueue
 }
 


### PR DESCRIPTION
### Issue 
- After deleting `i`th element in the array, the old `i+1`th element become `i`th element in the new array. So `i++` should be skipped. 
- Old deleting method would make heap invalid in certain scenarios. For instance, If `7` is removed from heap `[1, 5, 2, 6, 7, 3]`, the new heap `[1, 5, 2, 6, 3]` is invalid.
### Optimization
 - func `clock.Now()` is time-consuming. Remove it out of the loop
 - `append(q.index[:i], q.index[i+1:]...)` is O(n). Deleting the element can be achieved by swap it with the last element in the array. And reinitate the heap `heap.Init(&q.index)` in the end.