### PR TITLE
[evm] add contract address into receipt

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -95,6 +95,7 @@ type (
 		CurrentEpochProductivity    bool
 		FixSnapshotOrder            bool
 		AllowCorrectDefaultChainID  bool
+		ContractAddressInReceipt    bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -219,6 +220,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			CurrentEpochProductivity:    g.IsGreenland(height),
 			FixSnapshotOrder:            g.IsKamchatka(height),
 			AllowCorrectDefaultChainID:  g.IsToBeEnabled(height),
+			ContractAddressInReceipt:    g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -195,6 +195,9 @@ func ExecuteContract(
 	if err != nil {
 		return nil, nil, err
 	}
+	if featureCtx.ContractAddressInReceipt && len(contractAddress) == 0 {
+		contractAddress = execution.Contract()
+	}
 	receipt := &action.Receipt{
 		GasConsumed:     ps.gas - remainingGas,
 		BlockHeight:     blkCtx.BlockHeight,


### PR DESCRIPTION
found during debugging EVM, when doing a normal contract call (not deployment), our receipt did not save the contract's address but left it empty instead. This is somehow neglected in the current codebase