### PR TITLE
[Archive Mode] 4. replace iteration with of multiple states with keysoption

### DIFF
--- a/action/protocol/managers.go
+++ b/action/protocol/managers.go
@@ -2,9 +2,9 @@ package protocol
 
 import (
 	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-core/db"
-	"github.com/iotexproject/iotex-core/state"
 	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/state"
 )
 
 // NamespaceOption creates an option for given namesapce
@@ -24,23 +24,19 @@ func KeyOption(key []byte) StateOption {
 	}
 }
 
+// KeysOption sets the key for call
+func KeysOption(f func() ([][]byte, error)) StateOption {
+	return func(cfg *StateConfig) (err error) {
+		cfg.Keys, err = f()
+		return err
+	}
+}
+
 // LegacyKeyOption sets the key for call with legacy key
 func LegacyKeyOption(key hash.Hash160) StateOption {
 	return func(cfg *StateConfig) error {
 		cfg.Key = make([]byte, len(key[:]))
 		copy(cfg.Key, key[:])
-		return nil
-	}
-}
-
-// FilterOption sets the filter
-func FilterOption(cond db.Condition, minKey, maxKey []byte) StateOption {
-	return func(cfg *StateConfig) error {
-		cfg.Cond = cond
-		cfg.MinKey = make([]byte, len(minKey))
-		copy(cfg.MinKey, minKey)
-		cfg.MaxKey = make([]byte, len(maxKey))
-		copy(cfg.MaxKey, maxKey)
 		return nil
 	}
 }
@@ -61,9 +57,7 @@ type (
 	StateConfig struct {
 		Namespace string // namespace used by state's storage
 		Key       []byte
-		MinKey    []byte
-		MaxKey    []byte
-		Cond      db.Condition
+		Keys      [][]byte
 	}
 
 	// StateOption sets parameter for access state

--- a/db/trie/mptrie/layertwoleafiterator.go
+++ b/db/trie/mptrie/layertwoleafiterator.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2018 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package mptrie
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/db/trie"
+)
+
+// NewLayerTwoLeafIterator returns a new leaf iterator
+func NewLayerTwoLeafIterator(tr trie.TwoLayerTrie, layerOneKey []byte, l int) (trie.Iterator, error) {
+	tlt, ok := tr.(*twoLayerTrie)
+	if !ok {
+		return nil, errors.New("trie is not supported type")
+	}
+	lt, err := tlt.layerTwoTrie(layerOneKey, l)
+	if err != nil {
+		return nil, err
+	}
+	return NewLeafIterator(lt.tr)
+}

--- a/state/iterator.go
+++ b/state/iterator.go
@@ -13,6 +13,9 @@ import (
 // ErrOutOfBoundary defines an error when the index in the iterator is out of boundary
 var ErrOutOfBoundary = errors.New("index is out of boundary")
 
+// ErrNilValue is an error when value is nil
+var ErrNilValue = errors.New("value is nil")
+
 // Iterator defines an interator to read a set of states
 type Iterator interface {
 	// Size returns the size of the iterator
@@ -41,5 +44,8 @@ func (it *iterator) Next(s interface{}) error {
 		return ErrOutOfBoundary
 	}
 	it.index = i + 1
+	if it.states[i] == nil {
+		return ErrNilValue
+	}
 	return Deserialize(s, it.states[i])
 }


### PR DESCRIPTION
Fix the way of reading states. The reason is that the key storing in db may not be the key on creation and the change is irreversible.

If "keys" is not set, iterate all values. If set, read values by keys.