### PR TITLE
[docker] fix err when installing logrotate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.17-alpine as build
 
 WORKDIR apps/iotex-core
 
-RUN apk add --no-cache make gcc musl-dev linux-headers git logrotate ca-certificates
+RUN apk add --no-cache make gcc musl-dev linux-headers git ca-certificates
 
 COPY go.mod .
 COPY go.sum .
@@ -25,6 +25,7 @@ COPY --from=build /go/apps/iotex-core/bin/ioctl /usr/local/bin/ioctl
 CMD [ "iotex-server"]
 
 # logrotate log file daily
+RUN apk add logrotate
 COPY logrotate.conf /etc/logrotate.d/iotex
 RUN mkdir -p /var/lib/
 RUN touch /var/lib/logrotate.status


### PR DESCRIPTION
Docker image building will fail if `logrotate` is added with `--no-cache`  option 