### PR TITLE
[ioctl/newcmd] replace ioutil  with io or os  for Go 1.16+

### DIFF
--- a/ioctl/newcmd/account/account.go
+++ b/ioctl/newcmd/account/account.go
@@ -12,7 +12,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -313,7 +312,7 @@ func newAccountByKey(alias string, privateKey string, walletDir string) (string,
 }
 
 func newAccountByKeyStore(alias, passwordOfKeyStore, keyStorePath string, walletDir string) (string, error) {
-	keyJSON, err := ioutil.ReadFile(keyStorePath)
+	keyJSON, err := os.ReadFile(keyStorePath)
 	if err != nil {
 		return "", output.NewError(output.ReadFileError,
 			fmt.Sprintf("keystore file \"%s\" read error", keyStorePath), nil)
@@ -388,7 +387,7 @@ func findSm2PemFile(addr address.Address) (string, error) {
 
 func listSm2Account() ([]string, error) {
 	sm2Accounts := make([]string, 0)
-	files, err := ioutil.ReadDir(config.ReadConfig.Wallet)
+	files, err := os.ReadDir(config.ReadConfig.Wallet)
 	if err != nil {
 		return nil, output.NewError(output.ReadFileError, "failed to read files in wallet", err)
 	}

--- a/ioctl/newcmd/alias/aliasimport.go
+++ b/ioctl/newcmd/alias/aliasimport.go
@@ -9,7 +9,7 @@ package alias
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 
@@ -93,7 +93,7 @@ func NewAliasImportCmd(c ioctl.Client) *cobra.Command {
 			if err != nil {
 				return output.NewError(output.SerializationError, "failed to marshal config", err)
 			}
-			if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+			if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 				return output.NewError(output.WriteFileError,
 					fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 			}

--- a/ioctl/newcmd/alias/aliasremove.go
+++ b/ioctl/newcmd/alias/aliasremove.go
@@ -2,14 +2,15 @@ package alias
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/validator"
-	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v2"
 )
 
 var (
@@ -63,7 +64,7 @@ func NewAliasRemove(c ioctl.Client) *cobra.Command {
 			if err != nil {
 				return output.NewError(output.SerializationError, marshalError, err)
 			}
-			if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+			if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 				return output.NewError(output.WriteFileError, fmt.Sprintf(writeError, config.DefaultConfigFile), err)
 			}
 			fmt.Println(fmt.Sprintf(result, alias))


### PR DESCRIPTION
io or os is preferred as for Go1.16+