### PR TITLE
Revert "[evm] add contract address into receipt (#2978)"

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -98,7 +98,6 @@ type (
 		CurrentEpochProductivity    bool
 		FixSnapshotOrder            bool
 		AllowCorrectDefaultChainID  bool
-		ContractAddressInReceipt    bool
 		CorrectGetHashFn            bool
 	}
 
@@ -224,7 +223,6 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			CurrentEpochProductivity:    g.IsGreenland(height),
 			FixSnapshotOrder:            g.IsKamchatka(height),
 			AllowCorrectDefaultChainID:  g.IsToBeEnabled(height),
-			ContractAddressInReceipt:    g.IsToBeEnabled(height),
 			CorrectGetHashFn:            g.IsToBeEnabled(height),
 		},
 	)

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -205,9 +205,6 @@ func ExecuteContract(
 	if err != nil {
 		return nil, nil, err
 	}
-	if featureCtx.ContractAddressInReceipt && len(contractAddress) == 0 {
-		contractAddress = execution.Contract()
-	}
 	receipt := &action.Receipt{
 		GasConsumed:     ps.gas - remainingGas,
 		BlockHeight:     blkCtx.BlockHeight,

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -993,7 +993,7 @@ func TestConstantinople(t *testing.T) {
 			{
 				7,
 				crt2Hash,
-				"5254d2cbd18b6bf4311ef568613803c2df51488d1f26727f5b7f230e2e0368c0",
+				"53632287a97e4e118302f2d9b54b3f97f62d3533286c4d4eb955627b3602d3b0",
 				crt2Topic,
 			},
 		}
@@ -1009,7 +1009,7 @@ func TestConstantinople(t *testing.T) {
 			require.Equal(uint64(1), r.Status)
 			require.Equal(v.h, r.ActionHash)
 			require.Equal(v.height, r.BlockHeight)
-			if v.height == 1 || v.height >= cfg.Genesis.ToBeEnabledBlockHeight {
+			if v.height == 1 {
 				require.Equal("io1va03q4lcr608dr3nltwm64sfcz05czjuycsqgn", r.ContractAddress)
 			} else {
 				require.Empty(r.ContractAddress)
@@ -1133,7 +1133,6 @@ func TestConstantinople(t *testing.T) {
 	cfg.Genesis.AleutianBlockHeight = 2
 	cfg.Genesis.BeringBlockHeight = 8
 	cfg.Genesis.GreenlandBlockHeight = 9
-	cfg.Genesis.ToBeEnabledBlockHeight = 7
 	cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
 
 	t.Run("test Constantinople contract", func(t *testing.T) {


### PR DESCRIPTION
`receipt.ContractAddress` is intentionally designed to only record the newly created contract address, and equal to null for regular contract calls
see https://github.com/ethereum/go-ethereum/blob/7dec26db2abcb062e676fd4972abc1d282ac3ced/core/state_processor.go#L126-L129