### PR TITLE
[actpool] use heap.Remove() instead of heap.Init() in actqueue.go

### DIFF
--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -40,7 +40,7 @@ func (h noncePriorityQueue) Swap(i, j int) {
 
 func (h *noncePriorityQueue) Push(x interface{}) {
 	if in, ok := x.(*nonceWithTTL); ok {
-		in.idx = h.Len()
+		in.idx = len(*h)
 		*h = append(*h, in)
 	}
 }

--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -151,23 +151,23 @@ func (q *actQueue) cleanTimeout() []action.SealedEnvelope {
 		return []action.SealedEnvelope{}
 	}
 	var (
-		removedNonceList = make([]*nonceWithTTL, 0)
+		removedFromQueue = make([]action.SealedEnvelope, 0)
 		timeNow          = q.clock.Now()
+		size             = len(q.index)
 	)
-	for _, nonce := range q.index {
-		if timeNow.After(nonce.deadline) {
-			removedNonceList = append(removedNonceList, nonce)
+	for i := 0; i < size; {
+		if timeNow.After(q.index[i].deadline) {
+			removedFromQueue = append(removedFromQueue, q.items[q.index[i].nonce])
+			delete(q.items, q.index[i].nonce)
+			q.index[i] = q.index[size-1]
+			size--
+			continue
 		}
+		i++
 	}
-	if len(removedNonceList) == 0 {
-		return []action.SealedEnvelope{}
-	}
-	removedFromQueue := make([]action.SealedEnvelope, 0, len(removedNonceList))
-	for _, removedNonce := range removedNonceList {
-		removedFromQueue = append(removedFromQueue, q.items[removedNonce.nonce])
-		delete(q.items, removedNonce.nonce)
-		heap.Remove(&q.index, removedNonce.idx)
-	}
+	q.index = q.index[:size]
+	// using heap.Init is better here, more detail to see BenchmarkHeapInitAndRemove
+	heap.Init(&q.index)
 	return removedFromQueue
 }
 

--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -146,6 +146,7 @@ func (q *actQueue) cleanTimeout() []action.SealedEnvelope {
 	}
 	var (
 		removedFromQueue = make([]action.SealedEnvelope, 0)
+		removedIndex     = 0
 		timeNow          = q.clock.Now()
 		size             = len(q.index)
 	)
@@ -154,13 +155,18 @@ func (q *actQueue) cleanTimeout() []action.SealedEnvelope {
 			removedFromQueue = append(removedFromQueue, q.items[q.index[i].nonce])
 			delete(q.items, q.index[i].nonce)
 			q.index[i] = q.index[size-1]
+			removedIndex = i
 			size--
 			continue
 		}
 		i++
 	}
 	q.index = q.index[:size]
-	heap.Init(&q.index)
+	if len(removedFromQueue) == 1 {
+		heap.Fix(&q.index, removedIndex)
+	} else {
+		heap.Init(&q.index)
+	}
 	return removedFromQueue
 }
 

--- a/actpool/actqueue_test.go
+++ b/actpool/actqueue_test.go
@@ -264,10 +264,12 @@ func TestActQueueCleanTimeout(t *testing.T) {
 	require.Equal(2, len(ret))
 }
 
-// BenchmarkHeapFixWithInit compare the heap re-establish performance between
-// using the heap.Init and the heap.Fix after remove only one element.
-// more detail: https://github.com/iotexproject/iotex-core/issues/2995
-func BenchmarkHeapRemove(b *testing.B) {
+// BenchmarkHeapInitAndRemove compare the heap re-establish performance between
+// using the heap.Init and the heap.Remove after remove some elements.
+// The bench result show that the performance of heap.Init is better than heap.Remove
+// in the most cases.
+// More detail to see the discusses in https://github.com/iotexproject/iotex-core/pull/3013
+func BenchmarkHeapInitAndRemove(b *testing.B) {
 	const batch = 20
 	testIndex := noncePriorityQueue{}
 	index := noncePriorityQueue{}


### PR DESCRIPTION
close #2995 

~~`heap.Remove` is not fit in this case, I use `heap.Fix` instead of it.~~

following is my bench result
```
BenchmarkHeapFixWithInit/heap.Init-8         	 5078799	       233.5 ns/op
BenchmarkHeapFixWithInit/heap.Fix-8          	16654287	        72.61 ns/op
```