### PR TITLE
[ioctl/newcmd] build account sign command line into new ioctl

### DIFF
--- a/ioctl/newcmd/account/account.go
+++ b/ioctl/newcmd/account/account.go
@@ -81,6 +81,7 @@ func NewAccountCmd(client ioctl.Client) *cobra.Command {
 	ac.AddCommand(NewAccountCreate(client))
 	ac.AddCommand(NewAccountDelete(client))
 	ac.AddCommand(NewAccountNonce(client))
+	ac.AddCommand(NewAccountSign(client))
 
 	flagEndpointUsage, _ := client.SelectTranslation(flagEndpoint)
 	flagInsecureUsage, _ := client.SelectTranslation(flagInsecure)

--- a/ioctl/newcmd/account/account.go
+++ b/ioctl/newcmd/account/account.go
@@ -93,8 +93,8 @@ func NewAccountCmd(client ioctl.Client) *cobra.Command {
 }
 
 // Sign sign message with signer
-func Sign(signer, password, message string) (string, error) {
-	pri, err := PrivateKeyFromSigner(signer, password)
+func Sign(client ioctl.Client, signer, password, message string) (string, error) {
+	pri, err := PrivateKeyFromSigner(client, signer, password)
 	if err != nil {
 		return "", err
 	}
@@ -118,7 +118,7 @@ func Sign(signer, password, message string) (string, error) {
 }
 
 // keyStoreAccountToPrivateKey generates our PrivateKey interface from Keystore account
-func keyStoreAccountToPrivateKey(signer, password string) (crypto.PrivateKey, error) {
+func keyStoreAccountToPrivateKey(client ioctl.Client, signer, password string) (crypto.PrivateKey, error) {
 	addrString, err := util.Address(signer)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func keyStoreAccountToPrivateKey(signer, password string) (crypto.PrivateKey, er
 		}
 	} else {
 		// find the account in keystore
-		ks := keystore.NewKeyStore(config.ReadConfig.Wallet,
+		ks := client.NewKeyStore(config.ReadConfig.Wallet,
 			keystore.StandardScryptN, keystore.StandardScryptP)
 		for _, account := range ks.Accounts() {
 			if bytes.Equal(addr.Bytes(), account.Address.Bytes()) {
@@ -150,19 +150,19 @@ func keyStoreAccountToPrivateKey(signer, password string) (crypto.PrivateKey, er
 }
 
 // PrivateKeyFromSigner returns private key from signer
-func PrivateKeyFromSigner(signer, password string) (crypto.PrivateKey, error) {
+func PrivateKeyFromSigner(client ioctl.Client, signer, password string) (crypto.PrivateKey, error) {
 	var (
 		prvKey crypto.PrivateKey
 		err    error
 	)
 
-	if !IsSignerExist(signer) && !util.AliasIsHdwalletKey(signer) {
+	if !IsSignerExist(client, signer) && !util.AliasIsHdwalletKey(signer) {
 		return nil, fmt.Errorf("invalid address #%s", signer)
 	}
 
 	if password == "" {
 		output.PrintQuery(fmt.Sprintf("Enter password for #%s:\n", signer))
-		password, err = util.ReadSecretFromStdin()
+		password, err = client.ReadSecret()
 		if err != nil {
 			return nil, output.NewError(output.InputError, "failed to get password", err)
 		}
@@ -179,7 +179,7 @@ func PrivateKeyFromSigner(signer, password string) (crypto.PrivateKey, error) {
 		}
 		return prvKey, nil
 	}
-	return keyStoreAccountToPrivateKey(signer, password)
+	return keyStoreAccountToPrivateKey(client, signer, password)
 }
 
 // GetAccountMeta gets account metadata
@@ -212,7 +212,7 @@ func GetAccountMeta(addr string, client ioctl.Client) (*iotextypes.AccountMeta, 
 }
 
 // IsSignerExist checks whether signer account is existed
-func IsSignerExist(signer string) bool {
+func IsSignerExist(client ioctl.Client, signer string) bool {
 	addr, err := address.FromString(signer)
 	if err != nil {
 		return false
@@ -225,7 +225,7 @@ func IsSignerExist(signer string) bool {
 	}
 
 	// find the account in keystore
-	ks := keystore.NewKeyStore(config.ReadConfig.Wallet,
+	ks := client.NewKeyStore(config.ReadConfig.Wallet,
 		keystore.StandardScryptN, keystore.StandardScryptP)
 	for _, ksAccount := range ks.Accounts() {
 		if address.Equal(addr, ksAccount.Address) {

--- a/ioctl/newcmd/account/accountsign.go
+++ b/ioctl/newcmd/account/accountsign.go
@@ -59,7 +59,7 @@ func NewAccountSign(client ioctl.Client) *cobra.Command {
 					return output.NewError(output.AddressError, "failed to get address", err)
 				}
 			}
-			signedMessage, err := Sign(addr, "", msg)
+			signedMessage, err := Sign(client, addr, "", msg)
 			if err != nil {
 				return output.NewError(output.KeystoreError, "failed to sign message", err)
 			}

--- a/ioctl/newcmd/account/accountsign.go
+++ b/ioctl/newcmd/account/accountsign.go
@@ -7,11 +7,12 @@
 package account
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/spf13/cobra"
 )
 
 var signer string

--- a/ioctl/newcmd/account/accountsign.go
+++ b/ioctl/newcmd/account/accountsign.go
@@ -1,0 +1,65 @@
+package account
+
+import (
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/spf13/cobra"
+)
+
+var signer string
+
+// Multi-language support
+var (
+	signCmdShorts = map[config.Language]string{
+		config.English: "Sign message with private key from wallet",
+		config.Chinese: "用钱包中的私钥对信息签名",
+	}
+	signCmdUses = map[config.Language]string{
+		config.English: "sign MESSAGE [-s SIGNER]",
+		config.Chinese: "sign 信息 [-s 签署人]",
+	}
+	flagSignerUsages = map[config.Language]string{
+		config.English: "choose a signing account",
+		config.Chinese: "选择一个签名账户",
+	}
+)
+
+// NewAccountSign represents the account sign command
+func NewAccountSign(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(signCmdUses)
+	short, _ := client.SelectTranslation(signCmdShorts)
+	usage, _ := client.SelectTranslation(flagSignerUsages)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			msg := args[0]
+
+			var (
+				addr string
+				err  error
+			)
+			if util.AliasIsHdwalletKey(signer) {
+				addr = signer
+			} else {
+				addr, err = util.Address(signer)
+				if err != nil {
+					return output.NewError(output.AddressError, "failed to get address", err)
+				}
+			}
+			signedMessage, err := Sign(addr, "", msg)
+			if err != nil {
+				return output.NewError(output.KeystoreError, "failed to sign message", err)
+			}
+			output.PrintResult(signedMessage)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&signer, "signer", "s", "", usage)
+	return cmd
+}

--- a/ioctl/newcmd/account/accountsign.go
+++ b/ioctl/newcmd/account/accountsign.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
 package account
 
 import (

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -1,0 +1,24 @@
+package account
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAccountSign(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
+
+	// test for not invalid account address
+	cmd := NewAccountSign(client)
+	cmd.Flag("signer").Value.Set("io1rc2d2de7rtuucalsqv4d9ng0h297t63w7wvlph")
+	_, err := util.ExecuteCmd(cmd)
+	require.Equal("failed to sign message: invalid address #io1rc2d2de7rtuucalsqv4d9ng0h297t63w7wvlph", err.Error())
+}

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -1,3 +1,9 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
 package account
 
 import (

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -10,10 +10,11 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewAccountSign(t *testing.T) {


### PR DESCRIPTION
close #3001 
Add `accountsign.go` and `accountsign_test.go` in `./ioctl/newcmd/account`.