### PR TITLE
[statedb] clear snapshots after running each transaction

### DIFF
--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -17,51 +17,18 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 
-	"github.com/iotexproject/iotex-core/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/config"
-	"github.com/iotexproject/iotex-core/db/batch"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/test/identityset"
-	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
-	testTriePath, err := testutil.PathOfTempFile("trie")
+	sm, err := initMockStateManager(ctrl)
 	require.NoError(err)
-
-	cfg := config.Default
-	cfg.Chain.TrieDBPath = testTriePath
-	sm := mock_chainmanager.NewMockStateManager(ctrl)
-	cb := batch.NewCachedBatch()
-	sm.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(account interface{}, opts ...protocol.StateOption) (uint64, error) {
-			cfg, err := protocol.CreateStateConfig(opts...)
-			if err != nil {
-				return 0, err
-			}
-			val, err := cb.Get("state", cfg.Key)
-			if err != nil {
-				return 0, state.ErrStateNotExist
-			}
-			return 0, state.Deserialize(account, val)
-		}).AnyTimes()
-	sm.EXPECT().PutState(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(account interface{}, opts ...protocol.StateOption) (uint64, error) {
-			cfg, err := protocol.CreateStateConfig(opts...)
-			if err != nil {
-				return 0, err
-			}
-			ss, err := state.Serialize(account)
-			if err != nil {
-				return 0, err
-			}
-			cb.Put("state", cfg.Key, ss, "failed to put state")
-			return 0, nil
-		}).AnyTimes()
 
 	addr := identityset.Address(28)
 	_, err = accountutil.LoadOrCreateAccount(sm, addr.String())

--- a/db/batch/batch.go
+++ b/db/batch/batch.go
@@ -67,5 +67,7 @@ type (
 		Snapshot() int
 		// Revert sets the cached batch to the state at the given snapshot
 		Revert(int) error
+		// ClearSnapshots clears all saved snapshots
+		ClearSnapshots()
 	}
 )

--- a/db/batch/batch_impl.go
+++ b/db/batch/batch_impl.go
@@ -57,7 +57,7 @@ func (b *baseKVStoreBatch) Unlock() {
 // ClearAndUnlock clears the write queue and unlocks the batch
 func (b *baseKVStoreBatch) ClearAndUnlock() {
 	defer b.mutex.Unlock()
-	b.writeQueue = nil
+	b.writeQueue = b.writeQueue[:0]
 
 	b.fillLock.Lock()
 	defer b.fillLock.Unlock()
@@ -116,7 +116,7 @@ func (b *baseKVStoreBatch) SerializeQueue(serialize WriteInfoSerialize, filter W
 func (b *baseKVStoreBatch) Clear() {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
-	b.writeQueue = nil
+	b.writeQueue = b.writeQueue[:0]
 
 	b.fillLock.Lock()
 	defer b.fillLock.Unlock()
@@ -228,10 +228,8 @@ func (cb *cachedBatch) ClearAndUnlock() {
 	cb.kvStoreBatch.Clear()
 	// clear all saved snapshots
 	cb.tag = 0
-	cb.batchShots = nil
-	cb.cacheShots = nil
-	cb.batchShots = make([]int, 0)
-	cb.cacheShots = make([]KVStoreCache, 0)
+	cb.batchShots = cb.batchShots[:0]
+	cb.cacheShots = cb.cacheShots[:0]
 }
 
 // Put inserts a <key, value> record
@@ -260,10 +258,8 @@ func (cb *cachedBatch) Clear() {
 	cb.kvStoreBatch.Clear()
 	// clear all saved snapshots
 	cb.tag = 0
-	cb.batchShots = nil
-	cb.cacheShots = nil
-	cb.batchShots = make([]int, 0)
-	cb.cacheShots = make([]KVStoreCache, 0)
+	cb.batchShots = cb.batchShots[:0]
+	cb.cacheShots = cb.cacheShots[:0]
 }
 
 // Get retrieves a record
@@ -300,6 +296,15 @@ func (cb *cachedBatch) Revert(snapshot int) error {
 	cb.KVStoreCache = nil
 	cb.KVStoreCache = cb.cacheShots[snapshot]
 	return nil
+}
+
+func (cb *cachedBatch) ClearSnapshots() {
+	cb.lock.Lock()
+	defer cb.lock.Unlock()
+	// clear all saved snapshots
+	cb.tag = 0
+	cb.batchShots = cb.batchShots[:0]
+	cb.cacheShots = cb.cacheShots[:0]
 }
 
 func (cb *cachedBatch) CheckFillPercent(ns string) (float64, bool) {

--- a/db/kvstorewithbuffer.go
+++ b/db/kvstorewithbuffer.go
@@ -115,9 +115,7 @@ func (f *flusher) Flush() error {
 		return err
 	}
 
-	f.kvb.buffer.Lock()
-	f.kvb.buffer.ClearAndUnlock()
-
+	f.kvb.buffer.Clear()
 	return nil
 }
 

--- a/db/kvstorewithbuffer_test.go
+++ b/db/kvstorewithbuffer_test.go
@@ -61,8 +61,7 @@ func TestFlusher(t *testing.T) {
 		t.Run("flush successfully", func(t *testing.T) {
 			buffer.EXPECT().Translate(gomock.Any()).Return(buffer).Times(1)
 			store.EXPECT().WriteBatch(gomock.Any()).Return(nil).Times(1)
-			buffer.EXPECT().Lock().Times(1)
-			buffer.EXPECT().ClearAndUnlock().Times(1)
+			buffer.EXPECT().Clear().Times(1)
 			require.NoError(t, f.Flush())
 		})
 		t.Run("Get", func(t *testing.T) {

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -281,7 +281,8 @@ func (sf *factory) newWorkingSet(ctx context.Context, height uint64) (*workingSe
 	span.AddEvent("factory.newWorkingSet")
 	defer span.End()
 
-	flusher, err := db.NewKVStoreFlusher(sf.dao, batch.NewCachedBatch(), sf.flusherOptions(ctx, height)...)
+	cb := batch.NewCachedBatch()
+	flusher, err := db.NewKVStoreFlusher(sf.dao, cb, sf.flusherOptions(ctx, height)...)
 	if err != nil {
 		return nil, err
 	}
@@ -390,6 +391,9 @@ func (sf *factory) newWorkingSet(ctx context.Context, height uint64) (*workingSe
 		},
 		dbFunc: func() db.KVStore {
 			return flusher.KVStoreWithBuffer()
+		},
+		clearActFunc: func() {
+			cb.ClearSnapshots()
 		},
 	}, nil
 }

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -213,7 +213,8 @@ func (sdb *stateDB) Height() (uint64, error) {
 }
 
 func (sdb *stateDB) newWorkingSet(ctx context.Context, height uint64) (*workingSet, error) {
-	flusher, err := db.NewKVStoreFlusher(sdb.dao, batch.NewCachedBatch(), sdb.flusherOptions(ctx, height)...)
+	cb := batch.NewCachedBatch()
+	flusher, err := db.NewKVStoreFlusher(sdb.dao, cb, sdb.flusherOptions(ctx, height)...)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +284,9 @@ func (sdb *stateDB) newWorkingSet(ctx context.Context, height uint64) (*workingS
 		revertFunc:   flusher.KVStoreWithBuffer().Revert,
 		dbFunc: func() db.KVStore {
 			return flusher.KVStoreWithBuffer()
+		},
+		clearActFunc: func() {
+			cb.ClearSnapshots()
 		},
 	}, nil
 }

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -60,6 +60,7 @@ type (
 		putStateFunc  func(string, []byte, interface{}) error
 		revertFunc    func(int) error
 		snapshotFunc  func() int
+		clearActFunc  func()
 	}
 
 	workingSetCreator interface {
@@ -170,6 +171,7 @@ func (ws *workingSet) runAction(
 	}
 	for _, actionHandler := range reg.All() {
 		receipt, err := actionHandler.Handle(ctx, elp.Action(), ws)
+		ws.clearActFunc()
 		elpHash, err1 := elp.Hash()
 		if err1 != nil {
 			return nil, errors.Wrapf(err1, "Failed to get hash")

--- a/test/mock/mock_batch/mock_batch.go
+++ b/test/mock/mock_batch/mock_batch.go
@@ -274,6 +274,18 @@ func (mr *MockCachedBatchMockRecorder) ClearAndUnlock() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAndUnlock", reflect.TypeOf((*MockCachedBatch)(nil).ClearAndUnlock))
 }
 
+// ClearSnapshots mocks base method.
+func (m *MockCachedBatch) ClearSnapshots() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearSnapshots")
+}
+
+// ClearSnapshots indicates an expected call of ClearSnapshots.
+func (mr *MockCachedBatchMockRecorder) ClearSnapshots() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearSnapshots", reflect.TypeOf((*MockCachedBatch)(nil).ClearSnapshots))
+}
+
 // Delete mocks base method.
 func (m *MockCachedBatch) Delete(arg0 string, arg1 []byte, arg2 string, arg3 ...interface{}) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
when workingset is running all tx in the block, all snapshots made during one tx are meaningless for the next tx, so after running one tx, clear all snapshots to reduce memory consumption/growth of underlying `CachedBatch`