### PR TITLE
[api] move protobuf input from `ReadContract()` and `estimateGas`

### DIFF
--- a/action/actctx.go
+++ b/action/actctx.go
@@ -32,16 +32,16 @@ func (act *AbstractAction) ChainID() uint32 { return act.chainID }
 func (act *AbstractAction) Nonce() uint64 { return act.nonce }
 
 // SetNonce sets gaslimit
-func (ex *Execution) SetNonce(val uint64) {
-	ex.nonce = val
+func (act *AbstractAction) SetNonce(val uint64) {
+	act.nonce = val
 }
 
 // GasLimit returns the gas limit
 func (act *AbstractAction) GasLimit() uint64 { return act.gasLimit }
 
 // SetGasLimit sets gaslimit
-func (ex *Execution) SetGasLimit(val uint64) {
-	ex.gasLimit = val
+func (act *AbstractAction) SetGasLimit(val uint64) {
+	act.gasLimit = val
 }
 
 // GasPrice returns the gas price
@@ -54,8 +54,8 @@ func (act *AbstractAction) GasPrice() *big.Int {
 }
 
 // SetGasPrice sets gaslimit
-func (ex *Execution) SetGasPrice(val *big.Int) {
-	ex.gasPrice = val
+func (act *AbstractAction) SetGasPrice(val *big.Int) {
+	act.gasPrice = val
 }
 
 // BasicActionSize returns the basic size of action

--- a/action/actctx.go
+++ b/action/actctx.go
@@ -31,8 +31,18 @@ func (act *AbstractAction) ChainID() uint32 { return act.chainID }
 // Nonce returns the nonce
 func (act *AbstractAction) Nonce() uint64 { return act.nonce }
 
+// SetNonce sets gaslimit
+func (ex *Execution) SetNonce(val uint64) {
+	ex.nonce = val
+}
+
 // GasLimit returns the gas limit
 func (act *AbstractAction) GasLimit() uint64 { return act.gasLimit }
+
+// SetGasLimit sets gaslimit
+func (ex *Execution) SetGasLimit(val uint64) {
+	ex.gasLimit = val
+}
 
 // GasPrice returns the gas price
 func (act *AbstractAction) GasPrice() *big.Int {
@@ -41,6 +51,11 @@ func (act *AbstractAction) GasPrice() *big.Int {
 		return p
 	}
 	return p.Set(act.gasPrice)
+}
+
+// SetGasPrice sets gaslimit
+func (ex *Execution) SetGasPrice(val *big.Int) {
+	ex.gasPrice = val
 }
 
 // BasicActionSize returns the basic size of action

--- a/action/action.go
+++ b/action/action.go
@@ -119,8 +119,8 @@ func ClassifyActions(actions []SealedEnvelope) ([]*Transfer, []*Execution) {
 }
 
 func CalculateIntrinsicGas(baseIntrinsicGas uint64, payloadGas uint64, payloadSize uint64) (uint64, error) {
-	if payloadGas == 0 {
-		panic("payload gas price cannot be zero")
+	if payloadGas == 0 && payloadSize == 0 {
+		return baseIntrinsicGas, nil
 	}
 	if (math.MaxUint64-baseIntrinsicGas)/payloadGas < payloadSize {
 		return 0, ErrInsufficientFunds

--- a/action/action.go
+++ b/action/action.go
@@ -118,7 +118,7 @@ func ClassifyActions(actions []SealedEnvelope) ([]*Transfer, []*Execution) {
 	return tsfs, exes
 }
 
-func calculateIntrinsicGas(baseIntrinsicGas uint64, payloadGas uint64, payloadSize uint64) (uint64, error) {
+func CalculateIntrinsicGas(baseIntrinsicGas uint64, payloadGas uint64, payloadSize uint64) (uint64, error) {
 	if payloadGas == 0 {
 		panic("payload gas price cannot be zero")
 	}

--- a/action/action.go
+++ b/action/action.go
@@ -118,6 +118,7 @@ func ClassifyActions(actions []SealedEnvelope) ([]*Transfer, []*Execution) {
 	return tsfs, exes
 }
 
+// CalculateIntrinsicGas returns the intrinsic gas of an action
 func CalculateIntrinsicGas(baseIntrinsicGas uint64, payloadGas uint64, payloadSize uint64) (uint64, error) {
 	if payloadGas == 0 && payloadSize == 0 {
 		return baseIntrinsicGas, nil

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -108,3 +108,30 @@ func TestActionFakeSeal(t *testing.T) {
 	selp := FakeSeal(selp1.Envelope, priKey.PublicKey())
 	require.Equal(selp.srcPubkey, priKey.PublicKey())
 }
+
+func TestAbstractActionSetter(t *testing.T) {
+	require := require.New(t)
+	t.Run("set nonce", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
+		require.NoError(err)
+		require.Equal(uint64(1), ex.nonce)
+		ex.SetNonce(2)
+		require.Equal(uint64(2), ex.nonce)
+	})
+
+	t.Run("set gaslimit", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
+		require.NoError(err)
+		require.Equal(uint64(0), ex.gasLimit)
+		ex.SetGasLimit(10000)
+		require.Equal(uint64(10000), ex.gasLimit)
+	})
+
+	t.Run("set gasPrice", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(10), []byte{})
+		require.NoError(err)
+		require.Equal(big.NewInt(10), ex.gasPrice)
+		ex.SetGasPrice(big.NewInt(0))
+		require.Equal(big.NewInt(0), ex.gasPrice)
+	})
+}

--- a/action/candidate_register.go
+++ b/action/candidate_register.go
@@ -200,7 +200,7 @@ func (cr *CandidateRegister) LoadProto(pbAct *iotextypes.CandidateRegister) erro
 // IntrinsicGas returns the intrinsic gas of a CandidateRegister
 func (cr *CandidateRegister) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(cr.Payload()))
-	return calculateIntrinsicGas(CandidateRegisterBaseIntrinsicGas, CandidateRegisterPayloadGas, payloadSize)
+	return CalculateIntrinsicGas(CandidateRegisterBaseIntrinsicGas, CandidateRegisterPayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a CandidateRegister

--- a/action/claimreward.go
+++ b/action/claimreward.go
@@ -65,7 +65,7 @@ func (c *ClaimFromRewardingFund) LoadProto(claim *iotextypes.ClaimFromRewardingF
 // IntrinsicGas returns the intrinsic gas of a claim action
 func (c *ClaimFromRewardingFund) IntrinsicGas() (uint64, error) {
 	dataLen := uint64(len(c.Data()))
-	return calculateIntrinsicGas(ClaimFromRewardingFundBaseGas, ClaimFromRewardingFundGasPerByte, dataLen)
+	return CalculateIntrinsicGas(ClaimFromRewardingFundBaseGas, ClaimFromRewardingFundGasPerByte, dataLen)
 }
 
 // Cost returns the total cost of a claim action

--- a/action/depositreward.go
+++ b/action/depositreward.go
@@ -65,7 +65,7 @@ func (d *DepositToRewardingFund) LoadProto(deposit *iotextypes.DepositToRewardin
 // IntrinsicGas returns the intrinsic gas of a deposit action
 func (d *DepositToRewardingFund) IntrinsicGas() (uint64, error) {
 	dataLen := uint64(len(d.Data()))
-	return calculateIntrinsicGas(DepositToRewardingFundBaseGas, DepositToRewardingFundGasPerByte, dataLen)
+	return CalculateIntrinsicGas(DepositToRewardingFundBaseGas, DepositToRewardingFundGasPerByte, dataLen)
 }
 
 // Cost returns the total cost of a deposit action

--- a/action/execution.go
+++ b/action/execution.go
@@ -88,21 +88,6 @@ func (ex *Execution) TotalSize() uint32 {
 	return size + uint32(len(ex.data))
 }
 
-// SetGasLimit sets gaslimit
-func (ex *Execution) SetGasLimit(val uint64) {
-	ex.gasLimit = val
-}
-
-// SetNonce sets gaslimit
-func (ex *Execution) SetNonce(val uint64) {
-	ex.nonce = val
-}
-
-// SetGasPrice sets gaslimit
-func (ex *Execution) SetGasPrice(val *big.Int) {
-	ex.gasPrice = val
-}
-
 // Serialize returns a raw byte stream of this Transfer
 func (ex *Execution) Serialize() []byte {
 	return byteutil.Must(proto.Marshal(ex.Proto()))

--- a/action/execution.go
+++ b/action/execution.go
@@ -88,6 +88,21 @@ func (ex *Execution) TotalSize() uint32 {
 	return size + uint32(len(ex.data))
 }
 
+// SetGasLimit sets gaslimit
+func (ex *Execution) SetGasLimit(val uint64) {
+	ex.gasLimit = val
+}
+
+// SetNonce sets gaslimit
+func (ex *Execution) SetNonce(val uint64) {
+	ex.nonce = val
+}
+
+// SetGasPrice sets gaslimit
+func (ex *Execution) SetGasPrice(val *big.Int) {
+	ex.gasPrice = val
+}
+
 // Serialize returns a raw byte stream of this Transfer
 func (ex *Execution) Serialize() []byte {
 	return byteutil.Must(proto.Marshal(ex.Proto()))
@@ -125,7 +140,7 @@ func (ex *Execution) LoadProto(pbAct *iotextypes.Execution) error {
 // IntrinsicGas returns the intrinsic gas of an execution
 func (ex *Execution) IntrinsicGas() (uint64, error) {
 	dataSize := uint64(len(ex.Data()))
-	return calculateIntrinsicGas(ExecutionBaseIntrinsicGas, ExecutionDataGas, dataSize)
+	return CalculateIntrinsicGas(ExecutionBaseIntrinsicGas, ExecutionDataGas, dataSize)
 }
 
 // Cost returns the cost of an execution

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -49,6 +49,10 @@ func TestExecutionSignVerify(t *testing.T) {
 
 	// verify signature
 	require.NoError(Verify(selp))
+}
+
+func TestExecutionSanityCheck(t *testing.T) {
+	require := require.New(t)
 	t.Run("Negative amount", func(t *testing.T) {
 		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
 		require.NoError(err)
@@ -72,5 +76,32 @@ func TestExecutionSignVerify(t *testing.T) {
 		ex, err := NewExecution(identityset.Address(29).String(), uint64(1), big.NewInt(100), uint64(0), big.NewInt(-1), []byte{})
 		require.NoError(err)
 		require.Equal(ErrNegativeValue, errors.Cause(ex.SanityCheck()))
+	})
+}
+
+func TestExecutionSetter(t *testing.T) {
+	require := require.New(t)
+	t.Run("set nonce", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
+		require.NoError(err)
+		require.Equal(uint64(1), ex.nonce)
+		ex.SetNonce(2)
+		require.Equal(uint64(2), ex.nonce)
+	})
+
+	t.Run("set gaslimit", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
+		require.NoError(err)
+		require.Equal(uint64(0), ex.gasLimit)
+		ex.SetGasLimit(10000)
+		require.Equal(uint64(10000), ex.gasLimit)
+	})
+
+	t.Run("set gasPrice", func(t *testing.T) {
+		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(10), []byte{})
+		require.NoError(err)
+		require.Equal(big.NewInt(10), ex.gasPrice)
+		ex.SetGasPrice(big.NewInt(0))
+		require.Equal(big.NewInt(0), ex.gasPrice)
 	})
 }

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -78,30 +78,3 @@ func TestExecutionSanityCheck(t *testing.T) {
 		require.Equal(ErrNegativeValue, errors.Cause(ex.SanityCheck()))
 	})
 }
-
-func TestExecutionSetter(t *testing.T) {
-	require := require.New(t)
-	t.Run("set nonce", func(t *testing.T) {
-		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
-		require.NoError(err)
-		require.Equal(uint64(1), ex.nonce)
-		ex.SetNonce(2)
-		require.Equal(uint64(2), ex.nonce)
-	})
-
-	t.Run("set gaslimit", func(t *testing.T) {
-		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(0), []byte{})
-		require.NoError(err)
-		require.Equal(uint64(0), ex.gasLimit)
-		ex.SetGasLimit(10000)
-		require.Equal(uint64(10000), ex.gasLimit)
-	})
-
-	t.Run("set gasPrice", func(t *testing.T) {
-		ex, err := NewExecution("2", uint64(1), big.NewInt(-100), uint64(0), big.NewInt(10), []byte{})
-		require.NoError(err)
-		require.Equal(big.NewInt(10), ex.gasPrice)
-		ex.SetGasPrice(big.NewInt(0))
-		require.Equal(big.NewInt(0), ex.gasPrice)
-	})
-}

--- a/action/stake_adddeposit.go
+++ b/action/stake_adddeposit.go
@@ -106,7 +106,7 @@ func (ds *DepositToStake) LoadProto(pbAct *iotextypes.StakeAddDeposit) error {
 // IntrinsicGas returns the intrinsic gas of a DepositToStake
 func (ds *DepositToStake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(ds.Payload()))
-	return calculateIntrinsicGas(DepositToStakeBaseIntrinsicGas, DepositToStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(DepositToStakeBaseIntrinsicGas, DepositToStakePayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a DepositToStake

--- a/action/stake_changecandidate.go
+++ b/action/stake_changecandidate.go
@@ -96,7 +96,7 @@ func (cc *ChangeCandidate) LoadProto(pbAct *iotextypes.StakeChangeCandidate) err
 // IntrinsicGas returns the intrinsic gas of a ChangeCandidate
 func (cc *ChangeCandidate) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(cc.Payload()))
-	return calculateIntrinsicGas(MoveStakeBaseIntrinsicGas, MoveStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(MoveStakeBaseIntrinsicGas, MoveStakePayloadGas, payloadSize)
 }
 
 // Cost returns the tstal cost of a ChangeCandidate

--- a/action/stake_create.go
+++ b/action/stake_create.go
@@ -133,7 +133,7 @@ func (cs *CreateStake) LoadProto(pbAct *iotextypes.StakeCreate) error {
 // IntrinsicGas returns the intrinsic gas of a CreateStake
 func (cs *CreateStake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(cs.Payload()))
-	return calculateIntrinsicGas(CreateStakeBaseIntrinsicGas, CreateStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(CreateStakeBaseIntrinsicGas, CreateStakePayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a CreateStake

--- a/action/stake_reclaim.go
+++ b/action/stake_reclaim.go
@@ -95,7 +95,7 @@ func NewUnstake(
 // IntrinsicGas returns the intrinsic gas of a Unstake
 func (su *Unstake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(su.Payload()))
-	return calculateIntrinsicGas(ReclaimStakeBaseIntrinsicGas, ReclaimStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(ReclaimStakeBaseIntrinsicGas, ReclaimStakePayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a Unstake
@@ -138,7 +138,7 @@ func NewWithdrawStake(
 // IntrinsicGas returns the intrinsic gas of a WithdrawStake
 func (sw *WithdrawStake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(sw.Payload()))
-	return calculateIntrinsicGas(ReclaimStakeBaseIntrinsicGas, ReclaimStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(ReclaimStakeBaseIntrinsicGas, ReclaimStakePayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a WithdrawStake

--- a/action/stake_restake.go
+++ b/action/stake_restake.go
@@ -104,7 +104,7 @@ func (rs *Restake) LoadProto(pbAct *iotextypes.StakeRestake) error {
 // IntrinsicGas returns the intrinsic gas of a Restake
 func (rs *Restake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(rs.Payload()))
-	return calculateIntrinsicGas(RestakeBaseIntrinsicGas, RestakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(RestakeBaseIntrinsicGas, RestakePayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a Restake

--- a/action/stake_transferownership.go
+++ b/action/stake_transferownership.go
@@ -97,7 +97,7 @@ func (ts *TransferStake) LoadProto(pbAct *iotextypes.StakeTransferOwnership) err
 // IntrinsicGas returns the intrinsic gas of a TransferStake
 func (ts *TransferStake) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(ts.Payload()))
-	return calculateIntrinsicGas(MoveStakeBaseIntrinsicGas, MoveStakePayloadGas, payloadSize)
+	return CalculateIntrinsicGas(MoveStakeBaseIntrinsicGas, MoveStakePayloadGas, payloadSize)
 }
 
 // Cost returns the tstal cost of a TransferStake

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -120,7 +120,7 @@ func (tsf *Transfer) LoadProto(pbAct *iotextypes.Transfer) error {
 // IntrinsicGas returns the intrinsic gas of a transfer
 func (tsf *Transfer) IntrinsicGas() (uint64, error) {
 	payloadSize := uint64(len(tsf.Payload()))
-	return calculateIntrinsicGas(TransferBaseIntrinsicGas, TransferPayloadGas, payloadSize)
+	return CalculateIntrinsicGas(TransferBaseIntrinsicGas, TransferPayloadGas, payloadSize)
 }
 
 // Cost returns the total cost of a transfer

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -332,12 +332,7 @@ func (core *coreService) ReceiptByAction(actHash hash.Hash256) (*action.Receipt,
 }
 
 // ReadContract reads the state in a contract address specified by the slot
-func (core *coreService) ReadContract(ctx context.Context, in *iotextypes.Execution, callerAddr address.Address, gasLimit uint64) (string, *iotextypes.Receipt, error) {
-	log.L().Debug("receive read smart contract request")
-	sc := &action.Execution{}
-	if err := sc.LoadProto(in); err != nil {
-		return "", nil, status.Error(codes.InvalidArgument, err.Error())
-	}
+func (core *coreService) ReadContract(ctx context.Context, callerAddr address.Address, sc *action.Execution) (string, *iotextypes.Receipt, error) {
 	key := hash.Hash160b(append([]byte(sc.Contract()), sc.Data()...))
 	// TODO: either moving readcache into the upper layer or change the storage format
 	if d, ok := core.readCache.Get(key); ok {
@@ -353,18 +348,12 @@ func (core *coreService) ReadContract(ctx context.Context, in *iotextypes.Execut
 	if ctx, err = core.bc.Context(ctx); err != nil {
 		return "", nil, err
 	}
-
-	if gasLimit == 0 || core.cfg.Genesis.BlockGasLimit < gasLimit {
-		gasLimit = core.cfg.Genesis.BlockGasLimit
+	sc.SetNonce(state.Nonce + 1)
+	if sc.GasLimit() == 0 || core.cfg.Genesis.BlockGasLimit < sc.GasLimit() {
+		sc.SetGasLimit(core.cfg.Genesis.BlockGasLimit)
 	}
-	sc, _ = action.NewExecution(
-		sc.Contract(),
-		state.Nonce+1,
-		sc.Amount(),
-		gasLimit,
-		big.NewInt(0), // ReadContract() is read-only, use 0 to prevent insufficient gas
-		sc.Data(),
-	)
+	sc.SetGasPrice(big.NewInt(0)) // ReadContract() is read-only, use 0 to prevent insufficient gas
+
 	retval, receipt, err := core.sf.SimulateExecution(ctx, callerAddr, sc, core.dao.GetBlockHash)
 	if err != nil {
 		return "", nil, status.Error(codes.Internal, err.Error())
@@ -1321,22 +1310,20 @@ func (core *coreService) getLogsInRange(filter *logfilter.LogFilter, start, end,
 }
 
 // CalculateGasConsumption estimate gas consumption for actions except execution
-func (core *coreService) CalculateGasConsumption(intrinsicGas, payloadGas, payloadSize uint64) uint64 {
-	return payloadGas*payloadSize + intrinsicGas
+func (core *coreService) CalculateGasConsumption(intrinsicGas, payloadGas, payloadSize uint64) (uint64, error) {
+	return action.CalculateIntrinsicGas(intrinsicGas, payloadGas, payloadSize)
 }
 
 // EstimateExecutionGasConsumption estimate gas consumption for execution action
-func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, exec *iotextypes.Execution, callerAddr address.Address) (uint64, error) {
-	sc := &action.Execution{}
-	if err := sc.LoadProto(exec); err != nil {
-		return 0, status.Error(codes.InvalidArgument, err.Error())
-	}
+func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address) (uint64, error) {
 	state, err := accountutil.AccountState(core.sf, callerAddr)
 	if err != nil {
 		return 0, status.Error(codes.InvalidArgument, err.Error())
 	}
-	nonce := state.Nonce + 1
-	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc, nonce, core.cfg.Genesis.BlockGasLimit)
+	sc.SetNonce(state.Nonce + 1)
+	sc.SetGasPrice(big.NewInt(0))
+	sc.SetGasLimit(core.cfg.Genesis.BlockGasLimit)
+	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc)
 	if err != nil {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
@@ -1347,7 +1334,8 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, ex
 		return 0, status.Error(codes.Internal, fmt.Sprintf("execution simulation failed: status = %d", receipt.Status))
 	}
 	estimatedGas := receipt.GasConsumed
-	enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc, nonce, estimatedGas)
+	sc.SetGasLimit(estimatedGas)
+	enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
 	if err != nil && err != action.ErrInsufficientFunds {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
@@ -1356,7 +1344,8 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, ex
 		estimatedGas = high
 		for low <= high {
 			mid := (low + high) / 2
-			enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc, nonce, mid)
+			sc.SetGasLimit(mid)
+			enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
 			if err != nil && err != action.ErrInsufficientFunds {
 				return 0, status.Error(codes.Internal, err.Error())
 			}
@@ -1376,19 +1365,9 @@ func (core *coreService) isGasLimitEnough(
 	ctx context.Context,
 	caller address.Address,
 	sc *action.Execution,
-	nonce uint64,
-	gasLimit uint64,
 ) (bool, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "Server.isGasLimitEnough")
 	defer span.End()
-	sc, _ = action.NewExecution(
-		sc.Contract(),
-		nonce,
-		sc.Amount(),
-		gasLimit,
-		big.NewInt(0),
-		sc.Data(),
-	)
 	ctx, err := core.bc.Context(ctx)
 	if err != nil {
 		return false, nil, err

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -333,6 +333,7 @@ func (core *coreService) ReceiptByAction(actHash hash.Hash256) (*action.Receipt,
 
 // ReadContract reads the state in a contract address specified by the slot
 func (core *coreService) ReadContract(ctx context.Context, callerAddr address.Address, sc *action.Execution) (string, *iotextypes.Receipt, error) {
+	log.L().Debug("receive read smart contract request")
 	key := hash.Hash160b(append([]byte(sc.Contract()), sc.Data()...))
 	// TODO: either moving readcache into the upper layer or change the storage format
 	if d, ok := core.readCache.Get(key); ok {

--- a/api/grpcserver.go
+++ b/api/grpcserver.go
@@ -314,7 +314,7 @@ func (svr *GRPCServer) EstimateActionGasConsumption(ctx context.Context, in *iot
 	case in.GetCandidateRegister() != nil:
 		intrinsicGas, payloadGas, payloadSize = action.CandidateRegisterBaseIntrinsicGas, action.CandidateRegisterPayloadGas, uint64(len(in.GetCandidateRegister().Payload))
 	case in.GetCandidateUpdate() != nil:
-		intrinsicGas, payloadGas, payloadSize = action.CandidateUpdateBaseIntrinsicGas, 100, 0 // payloadGas can't be 0 in CalculateGasConsumption()
+		intrinsicGas, payloadGas, payloadSize = action.CandidateUpdateBaseIntrinsicGas, 0, 0
 	default:
 		return nil, status.Error(codes.InvalidArgument, "invalid argument")
 	}

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -642,3 +642,15 @@ func setupTestServer(t *testing.T) (*ServerV2, func()) {
 			testutil.CleanupPath(t, bfIndexFile)
 		}
 }
+
+func TestEthAccounts(t *testing.T) {
+	require := require.New(t)
+	cfg := newConfig(t)
+	config.SetEVMNetworkID(1)
+	svr, bfIndexFile, _ := createServerV2(cfg, false)
+	defer func() {
+		testutil.CleanupPath(t, bfIndexFile)
+	}()
+	res, _ := svr.web3Server.ethAccounts()
+	require.Equal(0, len(res.([]string)))
+}


### PR DESCRIPTION
 - move *iotextypes.Execution from readContract() and estimateGas
 - add SetGasLimit(), SetNonce(), SetGasPrice() to update fields in execution instead of creating new execution
 - use action.CalculateIntrinsicGas() in coreService