### PR TITLE
[action] support ledger action with eip2718

### DIFF
--- a/action/rlp_tx.go
+++ b/action/rlp_tx.go
@@ -23,12 +23,12 @@ type rlpTransaction interface {
 	Payload() []byte
 }
 
-type ActionType uint32
+type actionType uint32
 
 const (
-	unsupportedTxType ActionType = 0
-	legacyTxType      ActionType = 1
-	ledgerTxType      ActionType = 2
+	unsupportedTxType actionType = 0
+	legacyTxType      actionType = 1
+	ledgerTxType      actionType = 2
 
 	ledgerTxByte byte = 0x71 // TODO: to be dertermined
 )
@@ -123,7 +123,7 @@ func DecodeRawTx(rawData string, chainID uint32) (*types.Transaction, []byte, bo
 	return tx, sig, actType == legacyTxType, nil
 }
 
-func handleSpecialActionType(data []byte) (ActionType, []byte) {
+func handleSpecialActionType(data []byte) (actionType, []byte) {
 	if len(data) == 0 {
 		return legacyTxType, data
 	}

--- a/action/rlp_tx.go
+++ b/action/rlp_tx.go
@@ -3,13 +3,12 @@ package action
 import (
 	"encoding/hex"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/go-pkgs/util"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/sha3"
@@ -24,8 +23,19 @@ type rlpTransaction interface {
 	Payload() []byte
 }
 
+type ActionType uint32
+
+const (
+	unsupportedTxType ActionType = 0
+
+	legacyTxType ActionType = 1
+
+	ledgerTxType ActionType = 2
+	ledgerTxByte byte       = 0x71 // TODO: to be dertermined
+)
+
 func rlpRawHash(tx rlpTransaction, chainID uint32) (hash.Hash256, error) {
-	rawTx, err := generateRlpTx(tx)
+	rawTx, err := rlpToEthTx(tx)
 	if err != nil {
 		return hash.ZeroHash256, err
 	}
@@ -43,7 +53,7 @@ func rlpSignedHash(tx rlpTransaction, chainID uint32, sig []byte) (hash.Hash256,
 	return hash.BytesToHash256(h.Sum(nil)), nil
 }
 
-func generateRlpTx(act rlpTransaction) (*types.Transaction, error) {
+func rlpToEthTx(act rlpTransaction) (*types.Transaction, error) {
 	if act == nil {
 		return nil, errors.New("nil action to generate RLP tx")
 	}
@@ -70,7 +80,7 @@ func reconstructSignedRlpTxFromSig(tx rlpTransaction, chainID uint32, sig []byte
 		sc[64] -= 27
 	}
 
-	rawTx, err := generateRlpTx(tx)
+	rawTx, err := rlpToEthTx(tx)
 	if err != nil {
 		return nil, err
 	}
@@ -82,35 +92,49 @@ func reconstructSignedRlpTxFromSig(tx rlpTransaction, chainID uint32, sig []byte
 }
 
 // DecodeRawTx decodes raw data string into eth tx
-func DecodeRawTx(rawData string, chainID uint32) (tx *types.Transaction, sig []byte, pubkey crypto.PublicKey, err error) {
+func DecodeRawTx(rawData string, chainID uint32) (*types.Transaction, []byte, bool, error) {
 	//remove Hex prefix and decode string to byte
-	rawData = strings.Replace(rawData, "0x", "", -1)
-	rawData = strings.Replace(rawData, "0X", "", -1)
-	var dataInString []byte
-	dataInString, err = hex.DecodeString(rawData)
+	dataInBytes, err := hex.DecodeString(util.Remove0xPrefix(rawData))
 	if err != nil {
-		return
+		return nil, nil, false, err
 	}
 
-	// decode raw data into rlp tx
-	tx = &types.Transaction{}
-	err = rlp.DecodeBytes(dataInString, tx)
-	if err != nil {
-		return
+	// handle special action if transactionType(eip-2718) is set
+	actType, dataInBytes := handleSpecialActionType(dataInBytes)
+	if actType == unsupportedTxType {
+		return nil, nil, false, errors.New("unsupported action type")
 	}
 
-	// extract signature and recover pubkey
+	// decode raw data into eth tx
+	tx := &types.Transaction{}
+	if rlp.DecodeBytes(dataInBytes, tx) != nil {
+		return nil, nil, false, err
+	}
+
+	// extract signature
 	v, r, s := tx.RawSignatureValues()
 	recID := uint32(v.Int64()) - 2*chainID - 8
-	sig = make([]byte, 64, 65)
+	sig := make([]byte, 64, 65)
 	rSize := len(r.Bytes())
 	copy(sig[32-rSize:32], r.Bytes())
 	sSize := len(s.Bytes())
 	copy(sig[64-sSize:], s.Bytes())
 	sig = append(sig, byte(recID))
 
-	// recover public key
-	rawHash := types.NewEIP155Signer(big.NewInt(int64(chainID))).Hash(tx)
-	pubkey, err = crypto.RecoverPubkey(rawHash[:], sig)
-	return
+	return tx, sig, actType == legacyTxType, nil
+}
+
+func handleSpecialActionType(data []byte) (ActionType, []byte) {
+	if len(data) == 0 {
+		return legacyTxType, data
+	}
+	if data[0] > 0x7f {
+		return legacyTxType, data
+	}
+	switch data[0] {
+	case ledgerTxByte:
+		return ledgerTxType, data[1:]
+	default:
+		return unsupportedTxType, data
+	}
 }

--- a/action/rlp_tx.go
+++ b/action/rlp_tx.go
@@ -27,11 +27,10 @@ type ActionType uint32
 
 const (
 	unsupportedTxType ActionType = 0
+	legacyTxType      ActionType = 1
+	ledgerTxType      ActionType = 2
 
-	legacyTxType ActionType = 1
-
-	ledgerTxType ActionType = 2
-	ledgerTxByte byte       = 0x71 // TODO: to be dertermined
+	ledgerTxByte byte = 0x71 // TODO: to be dertermined
 )
 
 func rlpRawHash(tx rlpTransaction, chainID uint32) (hash.Hash256, error) {


### PR DESCRIPTION
fix #2976 
fix #2916 

TransactionType introduced in [eip-2718](https://eips.ethereum.org/EIPS/eip-2718) is used to mark special tx in web3.
Temporally, the byte `0x71` is used to indicate the special tx signed from ledger.