### PR TITLE
Replace ioutil package with relevant methods

### DIFF
--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -12,7 +12,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"os"
 	"testing"
@@ -217,7 +217,7 @@ func NewSmartContractTest(t *testing.T, file string) {
 	require := require.New(t)
 	jsonFile, err := os.Open(file)
 	require.NoError(err)
-	sctBytes, err := ioutil.ReadAll(jsonFile)
+	sctBytes, err := io.ReadAll(jsonFile)
 	require.NoError(err)
 	sct := &SmartContractTest{}
 	require.NoError(json.Unmarshal(sctBytes, sct))

--- a/api/web3server.go
+++ b/api/web3server.go
@@ -5,7 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/big"
 	"net/http"
 	"strconv"
@@ -271,7 +271,7 @@ func (svr *Web3Server) handlePOSTReq(req *http.Request) interface{} {
 }
 
 func parseWeb3Reqs(req *http.Request) ([]gjson.Result, error) {
-	data, err := ioutil.ReadAll(req.Body)
+	data, err := io.ReadAll(req.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/blockchain/filedao/filedao_util.go
+++ b/blockchain/filedao/filedao_util.go
@@ -9,7 +9,6 @@ package filedao
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -91,7 +90,7 @@ func checkAuxFiles(filename, fileType string) (uint64, []string) {
 	}
 
 	dir := path.Dir(filename)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return 0, nil
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -8,7 +8,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -38,13 +37,13 @@ func makePathAndWriteFile(cfgStr, flagForPath string) (err error) {
 	switch flagForPath {
 	case overwritePath:
 		_overwritePath = filepath.Join(os.TempDir(), "config.yaml")
-		err = ioutil.WriteFile(_overwritePath, []byte(cfgStr), 0666)
+		err = os.WriteFile(_overwritePath, []byte(cfgStr), 0666)
 	case secretPath:
 		_secretPath = filepath.Join(os.TempDir(), "secret.yaml")
-		err = ioutil.WriteFile(_secretPath, []byte(cfgStr), 0666)
+		err = os.WriteFile(_secretPath, []byte(cfgStr), 0666)
 	case subChainPath:
 		_subChainPath = filepath.Join(os.TempDir(), "config.yaml")
-		err = ioutil.WriteFile(_subChainPath, []byte(cfgStr), 0666)
+		err = os.WriteFile(_subChainPath, []byte(cfgStr), 0666)
 	}
 	return err
 }

--- a/e2etest/util.go
+++ b/e2etest/util.go
@@ -9,8 +9,8 @@ package e2etest
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
+	"os"
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
@@ -194,11 +194,11 @@ func addTestingTsfBlocks(bc blockchain.Blockchain, ap actpool.ActPool) error {
 }
 
 func copyDB(srcDB, dstDB string) error {
-	input, err := ioutil.ReadFile(srcDB)
+	input, err := os.ReadFile(srcDB)
 	if err != nil {
 		return errors.Wrap(err, "failed to read source db file")
 	}
-	if err := ioutil.WriteFile(dstDB, input, 0644); err != nil {
+	if err := os.WriteFile(dstDB, input, 0644); err != nil {
 		return errors.Wrap(err, "failed to copy db file")
 	}
 	return nil

--- a/ioctl/cmd/account/account.go
+++ b/ioctl/cmd/account/account.go
@@ -12,7 +12,6 @@ import (
 	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -310,7 +309,7 @@ func newAccountByKey(alias string, privateKey string, walletDir string) (string,
 }
 
 func newAccountByKeyStore(alias, passwordOfKeyStore, keyStorePath string, walletDir string) (string, error) {
-	keyJSON, err := ioutil.ReadFile(keyStorePath)
+	keyJSON, err := os.ReadFile(keyStorePath)
 	if err != nil {
 		return "", output.NewError(output.ReadFileError,
 			fmt.Sprintf("keystore file \"%s\" read error", keyStorePath), nil)
@@ -385,7 +384,7 @@ func findSm2PemFile(addr address.Address) (string, error) {
 
 func listSm2Account() ([]string, error) {
 	sm2Accounts := make([]string, 0)
-	files, err := ioutil.ReadDir(config.ReadConfig.Wallet)
+	files, err := os.ReadDir(config.ReadConfig.Wallet)
 	if err != nil {
 		return nil, output.NewError(output.ReadFileError, "failed to read files in wallet", err)
 	}

--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -8,7 +8,7 @@ package account
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -81,7 +81,7 @@ func accountCreateAdd(args []string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/account/accountdelete.go
+++ b/ioctl/cmd/account/accountdelete.go
@@ -9,7 +9,6 @@ package account
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -108,7 +107,7 @@ func accountDelete(arg string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("Failed to write to config file %s.", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/account/accountimport.go
+++ b/ioctl/cmd/account/accountimport.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -116,7 +115,7 @@ func writeToFile(alias, addr string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/alias/alias_test.go
+++ b/ioctl/cmd/alias/alias_test.go
@@ -64,7 +64,7 @@ func TestAlias(t *testing.T) {
 }
 
 func testInit() error {
-	testPathd, _ := ioutil.TempDir(os.TempDir(), "kstest")
+	testPathd, _ := os.MkdirTemp(os.TempDir(), "kstest")
 	config.ConfigDir = testPathd
 	var err error
 	config.DefaultConfigFile = config.ConfigDir + "/config.default"

--- a/ioctl/cmd/alias/alias_test.go
+++ b/ioctl/cmd/alias/alias_test.go
@@ -7,7 +7,6 @@
 package alias
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -77,7 +76,7 @@ func testInit() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return err
 	}
 	return nil

--- a/ioctl/cmd/alias/aliasimport.go
+++ b/ioctl/cmd/alias/aliasimport.go
@@ -9,7 +9,7 @@ package alias
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
@@ -97,7 +97,7 @@ func aliasImport(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/alias/aliasremove.go
+++ b/ioctl/cmd/alias/aliasremove.go
@@ -8,7 +8,7 @@ package alias
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -53,7 +53,7 @@ func remove(arg string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/alias/aliasset.go
+++ b/ioctl/cmd/alias/aliasset.go
@@ -8,7 +8,7 @@ package alias
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
@@ -62,7 +62,7 @@ func set(args []string) error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}

--- a/ioctl/cmd/contract/contract.go
+++ b/ioctl/cmd/contract/contract.go
@@ -9,7 +9,7 @@ package contract
 import (
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common/compiler"
@@ -105,7 +105,7 @@ func checkCompilerVersion(solc *compiler.Solidity) bool {
 }
 
 func readAbiFile(abiFile string) (*abi.ABI, error) {
-	abiBytes, err := ioutil.ReadFile(abiFile)
+	abiBytes, err := os.ReadFile(abiFile)
 	if err != nil {
 		return nil, output.NewError(output.ReadFileError, "failed to read abi file", err)
 	}

--- a/ioctl/cmd/contract/contractcompile.go
+++ b/ioctl/cmd/contract/contractcompile.go
@@ -9,7 +9,7 @@ package contract
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -68,7 +68,7 @@ func compile(args []string) error {
 
 	files := args[1:]
 	if len(files) == 0 {
-		dirInfo, err := ioutil.ReadDir("./")
+		dirInfo, err := os.ReadDir("./")
 		if err != nil {
 			return output.NewError(output.ReadFileError, "failed to get current directory", err)
 		}
@@ -119,13 +119,13 @@ func compile(args []string) error {
 
 	if binOut != "" {
 		// bin file starts with "0x" prefix
-		if err := ioutil.WriteFile(binOut, []byte(contract.Code), 0600); err != nil {
+		if err := os.WriteFile(binOut, []byte(contract.Code), 0600); err != nil {
 			return output.NewError(output.WriteFileError, "failed to write bin file", err)
 		}
 	}
 
 	if abiOut != "" {
-		if err := ioutil.WriteFile(abiOut, abiByte, 0600); err != nil {
+		if err := os.WriteFile(abiOut, abiByte, 0600); err != nil {
 			return output.NewError(output.WriteFileError, "failed to write abi file", err)
 		}
 	}

--- a/ioctl/cmd/contract/contractdeploybin.go
+++ b/ioctl/cmd/contract/contractdeploybin.go
@@ -7,7 +7,7 @@
 package contract
 
 import (
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -46,7 +46,7 @@ func init() {
 }
 
 func contractDeployBin(args []string) error {
-	bin, err := ioutil.ReadFile(args[0])
+	bin, err := os.ReadFile(args[0])
 	if err != nil {
 		return output.NewError(output.ReadFileError, "failed to read bin file", err)
 	}

--- a/ioctl/cmd/contract/contractdeploysol.go
+++ b/ioctl/cmd/contract/contractdeploysol.go
@@ -9,7 +9,7 @@ package contract
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -54,7 +54,7 @@ func contractDeploySol(args []string) error {
 
 	files := args[1:]
 	if len(files) == 0 {
-		dirInfo, err := ioutil.ReadDir("./")
+		dirInfo, err := os.ReadDir("./")
 		if err != nil {
 			return output.NewError(output.ReadFileError, "failed to get current directory", err)
 		}

--- a/ioctl/cmd/contract/contractshare.go
+++ b/ioctl/cmd/contract/contractshare.go
@@ -8,7 +8,6 @@ package contract
 
 import (
 	"flag"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -199,7 +198,7 @@ func share(args []string) error {
 				t := request.Payload
 				getPayload := reflect.ValueOf(t).Index(0).Interface().(map[string]interface{})
 				getPayloadPath := getPayload["path"].(string)
-				upload, err := ioutil.ReadFile(givenPath + "/" + getPayloadPath)
+				upload, err := os.ReadFile(givenPath + "/" + getPayloadPath)
 				if err != nil {
 					log.Println("read file failed: ", err)
 				}
@@ -231,7 +230,7 @@ func share(args []string) error {
 				setPayload := reflect.ValueOf(t).Index(0).Interface().(map[string]interface{})
 				setPath := setPayload["path"].(string)
 				content := setPayload["content"].(string)
-				err := ioutil.WriteFile(givenPath+"/"+setPath, []byte(content), 0777)
+				err := os.WriteFile(givenPath+"/"+setPath, []byte(content), 0777)
 				if err != nil {
 					log.Println("set file failed: ", err)
 				}

--- a/ioctl/cmd/hdwallet/hdwalletcreate.go
+++ b/ioctl/cmd/hdwallet/hdwalletcreate.go
@@ -8,7 +8,7 @@ package hdwallet
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/tyler-smith/go-bip39"
@@ -73,7 +73,7 @@ func hdwalletCreate() error {
 		return output.NewError(output.ValidationError, "failed to encrypting mnemonic", nil)
 	}
 
-	if err := ioutil.WriteFile(hdWalletConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(hdWalletConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", hdWalletConfigFile), err)
 	}

--- a/ioctl/cmd/hdwallet/hdwalletderive.go
+++ b/ioctl/cmd/hdwallet/hdwalletderive.go
@@ -9,7 +9,7 @@ package hdwallet
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	ecrypt "github.com/ethereum/go-ethereum/crypto"
 	hdwallet "github.com/miguelmota/go-ethereum-hdwallet"
@@ -75,7 +75,7 @@ func DeriveKey(account, change, index uint32, password string) (string, crypto.P
 		return "", nil, output.NewError(output.InputError, "Run 'ioctl hdwallet create' to create your HDWallet first.", nil)
 	}
 
-	enctxt, err := ioutil.ReadFile(hdWalletConfigFile)
+	enctxt, err := os.ReadFile(hdWalletConfigFile)
 	if err != nil {
 		return "", nil, output.NewError(output.InputError, "failed to read config", err)
 	}

--- a/ioctl/cmd/hdwallet/hdwalletexport.go
+++ b/ioctl/cmd/hdwallet/hdwalletexport.go
@@ -9,7 +9,7 @@ package hdwallet
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/spf13/cobra"
 
@@ -55,7 +55,7 @@ func hdwalletExport() error {
 		return output.NewError(output.InputError, "failed to get password", err)
 	}
 
-	enctxt, err := ioutil.ReadFile(hdWalletConfigFile)
+	enctxt, err := os.ReadFile(hdWalletConfigFile)
 	if err != nil {
 		return output.NewError(output.InputError, "failed to read config", err)
 	}

--- a/ioctl/cmd/hdwallet/hdwalletimport.go
+++ b/ioctl/cmd/hdwallet/hdwalletimport.go
@@ -9,7 +9,6 @@ package hdwallet
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -86,7 +85,7 @@ func hdwalletImport() error {
 		return output.NewError(output.ValidationError, "failed to encrypting mnemonic", nil)
 	}
 
-	if err := ioutil.WriteFile(hdWalletConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(hdWalletConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", hdWalletConfigFile), err)
 	}

--- a/ioctl/config/config.go
+++ b/ioctl/config/config.go
@@ -8,7 +8,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -138,7 +137,7 @@ func LoadConfig() (Config, error) {
 	ReadConfig := Config{
 		Aliases: make(map[string]string),
 	}
-	in, err := ioutil.ReadFile(DefaultConfigFile)
+	in, err := os.ReadFile(DefaultConfigFile)
 	if err == nil {
 		if err := yaml.Unmarshal(in, &ReadConfig); err != nil {
 			return ReadConfig, err

--- a/ioctl/config/configsetget.go
+++ b/ioctl/config/configsetget.go
@@ -8,7 +8,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -209,7 +209,7 @@ func writeConfig() error {
 	if err != nil {
 		return output.NewError(output.SerializationError, "failed to marshal config", err)
 	}
-	if err := ioutil.WriteFile(DefaultConfigFile, out, 0600); err != nil {
+	if err := os.WriteFile(DefaultConfigFile, out, 0600); err != nil {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", DefaultConfigFile), err)
 	}

--- a/ioctl/newcmd/account/accountdelete.go
+++ b/ioctl/newcmd/account/accountdelete.go
@@ -110,23 +110,6 @@ func NewAccountDelete(c ioctl.Client) *cobra.Command {
 						filePath = v.URL.Path
 						break
 					}
-
-					aliases := make(map[string]string)
-					for name, addr := range c.Config().Aliases {
-						aliases[addr] = name
-					}
-
-					delete(config.ReadConfig.Aliases, aliases[addr])
-					out, err := yaml.Marshal(&config.ReadConfig)
-					if err != nil {
-						return output.NewError(output.SerializationError, "", err)
-					}
-					if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-						return output.NewError(output.WriteFileError,
-							fmt.Sprintf(failToWriteToConfigFile, config.DefaultConfigFile), err)
-					}
-					output.PrintResult(fmt.Sprintf(resultSuccess, addr))
-					return nil
 				}
 			}
 

--- a/ioctl/newcmd/account/accountdelete.go
+++ b/ioctl/newcmd/account/accountdelete.go
@@ -110,6 +110,23 @@ func NewAccountDelete(c ioctl.Client) *cobra.Command {
 						filePath = v.URL.Path
 						break
 					}
+
+					aliases := make(map[string]string)
+					for name, addr := range c.Config().Aliases {
+						aliases[addr] = name
+					}
+
+					delete(config.ReadConfig.Aliases, aliases[addr])
+					out, err := yaml.Marshal(&config.ReadConfig)
+					if err != nil {
+						return output.NewError(output.SerializationError, "", err)
+					}
+					if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
+						return output.NewError(output.WriteFileError,
+							fmt.Sprintf(failToWriteToConfigFile, config.DefaultConfigFile), err)
+					}
+					output.PrintResult(fmt.Sprintf(resultSuccess, addr))
+					return nil
 				}
 			}
 

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"os/signal"
@@ -170,7 +169,7 @@ func Address(in string) (string, error) {
 // JwtAuth used for ioctl set auth and send for every grpc request
 func JwtAuth() (jwt metadata.MD, err error) {
 	jwtFile := os.Getenv("HOME") + "/.config/ioctl/default/auth.jwt"
-	jwtString, err := ioutil.ReadFile(jwtFile)
+	jwtString, err := os.ReadFile(jwtFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compress/compress.go
+++ b/pkg/compress/compress.go
@@ -9,7 +9,7 @@ package compress
 import (
 	"bytes"
 	"compress/gzip"
-	"io/ioutil"
+	"io"
 
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
@@ -78,7 +78,7 @@ func DecompGzip(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	r.Close()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 // CompSnappy uses Snappy to compress the input bytes

--- a/testutil/file.go
+++ b/testutil/file.go
@@ -7,7 +7,6 @@
 package testutil
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -16,7 +15,7 @@ import (
 
 // PathOfTempFile returns path of a new temporary file
 func PathOfTempFile(dirName string) (string, error) {
-	tempFile, err := ioutil.TempFile(os.TempDir(), dirName)
+	tempFile, err := os.CreateTemp(os.TempDir(), dirName)
 	if err != nil {
 		return "", err
 	}

--- a/tools/actioninjector.v2/internal/cmd/inject.go
+++ b/tools/actioninjector.v2/internal/cmd/inject.go
@@ -13,9 +13,9 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -112,7 +112,7 @@ func (p *injectProcessor) randAccounts(num int) error {
 }
 
 func (p *injectProcessor) loadAccounts(keypairsPath string) error {
-	keyPairBytes, err := ioutil.ReadFile(keypairsPath)
+	keyPairBytes, err := os.ReadFile(keypairsPath)
 	if err != nil {
 		return errors.Wrap(err, "failed to read key pairs file")
 	}

--- a/tools/addrgen/internal/cmd/createconfig.go
+++ b/tools/addrgen/internal/cmd/createconfig.go
@@ -8,7 +8,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/spf13/cobra"
@@ -37,7 +37,7 @@ var createConfigCmd = &cobra.Command{
 			priKeyBytes,
 			pubKeyBytes,
 		)
-		if err := ioutil.WriteFile(_outputFile, []byte(cfgStr), 0666); err != nil {
+		if err := os.WriteFile(_outputFile, []byte(cfgStr), 0666); err != nil {
 			log.L().Fatal("failed to write file", zap.Error(err))
 		}
 	},

--- a/tools/util/injectorutil.go
+++ b/tools/util/injectorutil.go
@@ -9,9 +9,9 @@ package util
 import (
 	"context"
 	"encoding/hex"
-	"io/ioutil"
 	"math/big"
 	"math/rand"
+	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -81,7 +81,7 @@ func GetTotalTsfFailed() uint64 {
 // LoadAddresses loads key pairs from key pair path and construct addresses
 func LoadAddresses(keypairsPath string, chainID uint32) ([]*AddressKey, error) {
 	// Load Senders' public/private key pairs
-	keyPairBytes, err := ioutil.ReadFile(keypairsPath)
+	keyPairBytes, err := os.ReadFile(keypairsPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read key pairs file")
 	}


### PR DESCRIPTION
This PR replaces the io/ioutil deprecated package with os and io packages methods. This works on issue #2994 