### PR TITLE
clean up temp files in tests using ClenFileV2

### DIFF
--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -31,8 +31,8 @@ func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	testTriePath, err := testutil.PathOfTempFile("trie")
-	defer testutil.CleanupPathV2(testTriePath)
 	require.NoError(err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -31,6 +31,7 @@ func TestCreateContract(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	testTriePath, err := testutil.PathOfTempFile("trie")
+	defer testutil.CleanupPathV2(testTriePath)
 	require.NoError(err)
 
 	cfg := config.Default
@@ -205,7 +206,7 @@ func TestLoadStoreCommit(t *testing.T) {
 		testTriePath, err := testutil.PathOfTempFile("trie")
 		require.NoError(err)
 		defer func() {
-			testutil.CleanupPath(t, testTriePath)
+			testutil.CleanupPathV2(testTriePath)
 		}()
 
 		cfg.Chain.TrieDBPath = testTriePath
@@ -215,7 +216,7 @@ func TestLoadStoreCommit(t *testing.T) {
 		testTriePath, err := testutil.PathOfTempFile("trie")
 		require.NoError(err)
 		defer func() {
-			testutil.CleanupPath(t, testTriePath)
+			testutil.CleanupPathV2(testTriePath)
 		}()
 
 		cfg := config.Default
@@ -227,7 +228,7 @@ func TestLoadStoreCommit(t *testing.T) {
 		testTriePath2, err := testutil.PathOfTempFile("trie")
 		require.NoError(err)
 		defer func() {
-			testutil.CleanupPath(t, testTriePath2)
+			testutil.CleanupPathV2(testTriePath2)
 		}()
 		cfg.Chain.EnableTrielessStateDB = false
 		cfg.Chain.TrieDBPath = testTriePath2
@@ -237,7 +238,7 @@ func TestLoadStoreCommit(t *testing.T) {
 		testTriePath2, err := testutil.PathOfTempFile("trie")
 		require.NoError(err)
 		defer func() {
-			testutil.CleanupPath(t, testTriePath2)
+			testutil.CleanupPathV2(testTriePath2)
 		}()
 		cfg.Chain.EnableTrielessStateDB = false
 		cfg.Chain.TrieDBPath = testTriePath2

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -352,8 +352,8 @@ func (sct *SmartContractTest) prepareBlockchain(
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.EnableGravityChainVoting = false
 	testTriePath, err := testutil.PathOfTempFile("trie")
-	defer testutil.CleanupPathV2(testTriePath)
 	r.NoError(err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.ActPool.MinGasPriceStr = "0"
@@ -583,14 +583,16 @@ func TestProtocol_Handle(t *testing.T) {
 		}()
 
 		testTriePath, err := testutil.PathOfTempFile("trie")
-		defer testutil.CleanupPathV2(testTriePath)
 		require.NoError(err)
 		testDBPath, err := testutil.PathOfTempFile("db")
-		defer testutil.CleanupPathV2(testDBPath)
 		require.NoError(err)
 		testIndexPath, err := testutil.PathOfTempFile("index")
-		defer testutil.CleanupPathV2(testIndexPath)
 		require.NoError(err)
+		defer func() {
+			testutil.CleanupPathV2(testTriePath)
+			testutil.CleanupPathV2(testDBPath)
+			testutil.CleanupPathV2(testIndexPath)
+		}()
 
 		cfg.Plugins[config.GatewayPlugin] = true
 		cfg.Chain.TrieDBPath = testTriePath

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -352,6 +352,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.EnableGravityChainVoting = false
 	testTriePath, err := testutil.PathOfTempFile("trie")
+	defer testutil.CleanupPathV2(testTriePath)
 	r.NoError(err)
 
 	cfg.Chain.TrieDBPath = testTriePath
@@ -582,10 +583,13 @@ func TestProtocol_Handle(t *testing.T) {
 		}()
 
 		testTriePath, err := testutil.PathOfTempFile("trie")
+		defer testutil.CleanupPathV2(testTriePath)
 		require.NoError(err)
 		testDBPath, err := testutil.PathOfTempFile("db")
+		defer testutil.CleanupPathV2(testDBPath)
 		require.NoError(err)
 		testIndexPath, err := testutil.PathOfTempFile("index")
+		defer testutil.CleanupPathV2(testIndexPath)
 		require.NoError(err)
 
 		cfg.Plugins[config.GatewayPlugin] = true

--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -18,7 +18,7 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-candidate")
 	require.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig
@@ -153,7 +153,7 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-bucket")
 	require.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig

--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -152,9 +152,7 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 
 	testPath, err := testutil.PathOfTempFile("test-bucket")
 	require.NoError(err)
-	defer func() {
-		testutil.CleanupPathV2(testPath)
-	}()
+	defer testutil.CleanupPathV2(testPath)
 
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -236,7 +236,7 @@ func Test_CreatePreStatesWithRegisterProtocol(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-bucket")
 	require.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -2716,17 +2716,19 @@ func newConfig(t *testing.T) config.Config {
 	cfg := config.Default
 
 	testTriePath, err := testutil.PathOfTempFile("trie")
-	defer testutil.CleanupPathV2(testTriePath)
 	r.NoError(err)
 	testDBPath, err := testutil.PathOfTempFile("db")
-	defer testutil.CleanupPathV2(testDBPath)
 	r.NoError(err)
 	testIndexPath, err := testutil.PathOfTempFile("index")
-	defer testutil.CleanupPathV2(testIndexPath)
 	r.NoError(err)
 	testSystemLogPath, err := testutil.PathOfTempFile("systemlog")
-	defer testutil.CleanupPathV2(testSystemLogPath)
 	r.NoError(err)
+	defer func() {
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
+		testutil.CleanupPathV2(testSystemLogPath)
+	}()
 
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.TrieDBPath = testTriePath

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -2667,6 +2667,7 @@ func setupChain(cfg config.Config) (blockchain.Blockchain, blockdao.BlockDAO, bl
 	}
 	defer func() {
 		delete(cfg.Plugins, config.GatewayPlugin)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	acc := account.NewProtocol(rewarding.DepositGas)
@@ -2715,12 +2716,16 @@ func newConfig(t *testing.T) config.Config {
 	cfg := config.Default
 
 	testTriePath, err := testutil.PathOfTempFile("trie")
+	defer testutil.CleanupPathV2(testTriePath)
 	r.NoError(err)
 	testDBPath, err := testutil.PathOfTempFile("db")
+	defer testutil.CleanupPathV2(testDBPath)
 	r.NoError(err)
 	testIndexPath, err := testutil.PathOfTempFile("index")
+	defer testutil.CleanupPathV2(testIndexPath)
 	r.NoError(err)
 	testSystemLogPath, err := testutil.PathOfTempFile("systemlog")
+	defer testutil.CleanupPathV2(testSystemLogPath)
 	r.NoError(err)
 
 	cfg.Plugins[config.GatewayPlugin] = true

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -369,9 +369,8 @@ func TestBlockDAO(t *testing.T) {
 
 	testPath, err := testutil.PathOfTempFile("test-kv-store")
 	require.NoError(err)
-	testutil.CleanupPath(t, testPath)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	daoList := []struct {
@@ -442,6 +441,8 @@ func BenchmarkBlockCache(b *testing.B) {
 		defer func() {
 			require.NoError(b, os.RemoveAll(testPath))
 			require.NoError(b, os.RemoveAll(indexPath))
+			testutil.CleanupPathV2(testPath)
+			testutil.CleanupPathV2(indexPath)
 		}()
 		cfg.DbPath = indexPath
 		cfg.DbPath = testPath

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"hash/fnv"
 	"math/big"
-	"os"
 	"testing"
 	"time"
 
@@ -439,8 +438,6 @@ func BenchmarkBlockCache(b *testing.B) {
 			NumRetries: 1,
 		}
 		defer func() {
-			require.NoError(b, os.RemoveAll(testPath))
-			require.NoError(b, os.RemoveAll(indexPath))
 			testutil.CleanupPathV2(testPath)
 			testutil.CleanupPathV2(indexPath)
 		}()

--- a/blockchain/filedao/filedao_header_test.go
+++ b/blockchain/filedao/filedao_header_test.go
@@ -89,7 +89,7 @@ func TestFileReadWrite(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-header")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig

--- a/blockchain/filedao/filedao_legacy_test.go
+++ b/blockchain/filedao/filedao_legacy_test.go
@@ -70,7 +70,7 @@ func TestFileDAOLegacy_PutBlock(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("filedao-legacy")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig

--- a/blockchain/filedao/filedao_v2_test.go
+++ b/blockchain/filedao/filedao_v2_test.go
@@ -88,7 +88,7 @@ func TestNewFileDAOv2(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-newfd")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig
@@ -251,7 +251,7 @@ func TestNewFdInterface(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-interface")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig
@@ -334,7 +334,7 @@ func TestNewFdStart(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-start")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := db.DefaultConfig

--- a/blockchain/integrity/benchmark_test.go
+++ b/blockchain/integrity/benchmark_test.go
@@ -201,17 +201,19 @@ func newChainInDB() (blockchain.Blockchain, actpool.ActPool, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	defer testutil.CleanupPathV2(testTriePath)
 	testDBPath, err := testutil.PathOfTempFile("db")
 	if err != nil {
 		return nil, nil, err
 	}
-	defer testutil.CleanupPathV2(testDBPath)
 	testIndexPath, err := testutil.PathOfTempFile("index")
 	if err != nil {
 		return nil, nil, err
 	}
-	defer testutil.CleanupPathV2(testIndexPath)
+	defer func() {
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
+	}()
 
 	cfg.DB.DbPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/blockchain/integrity/benchmark_test.go
+++ b/blockchain/integrity/benchmark_test.go
@@ -198,19 +198,16 @@ func injectExecution(nonceMap map[string]uint64, ap actpool.ActPool) error {
 func newChainInDB() (blockchain.Blockchain, actpool.ActPool, error) {
 	cfg := config.Default
 	testTriePath, err := testutil.PathOfTempFile("trie")
-	defer testutil.CleanupPathV2(testTriePath)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer testutil.CleanupPathV2(testTriePath)
 	testDBPath, err := testutil.PathOfTempFile("db")
-	defer testutil.CleanupPathV2(testDBPath)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer testutil.CleanupPathV2(testDBPath)
 	testIndexPath, err := testutil.PathOfTempFile("index")
-	defer testutil.CleanupPathV2(testIndexPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blockchain/integrity/benchmark_test.go
+++ b/blockchain/integrity/benchmark_test.go
@@ -198,16 +198,19 @@ func injectExecution(nonceMap map[string]uint64, ap actpool.ActPool) error {
 func newChainInDB() (blockchain.Blockchain, actpool.ActPool, error) {
 	cfg := config.Default
 	testTriePath, err := testutil.PathOfTempFile("trie")
+	defer testutil.CleanupPathV2(testTriePath)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer testutil.CleanupPathV2(testTriePath)
 	testDBPath, err := testutil.PathOfTempFile("db")
+	defer testutil.CleanupPathV2(testDBPath)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer testutil.CleanupPathV2(testDBPath)
 	testIndexPath, err := testutil.PathOfTempFile("index")
+	defer testutil.CleanupPathV2(testIndexPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -1142,9 +1142,9 @@ func TestConstantinople(t *testing.T) {
 	require.NoError(err)
 
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 		// clear the gateway
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -1392,9 +1392,9 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	require.NoError(err)
 
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 
 	cfg := config.Default
@@ -1418,9 +1418,9 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 	require.NoError(err)
 
 	defer func() {
-		testutil.CleanupPath(t, testTriePath2)
-		testutil.CleanupPath(t, testDBPath2)
-		testutil.CleanupPath(t, testIndexPath2)
+		testutil.CleanupPathV2(testTriePath2)
+		testutil.CleanupPathV2(testDBPath2)
+		testutil.CleanupPathV2(testIndexPath2)
 		// clear the gateway
 		delete(cfg.Plugins, config.GatewayPlugin)
 	}()
@@ -1512,6 +1512,9 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 	candidate, _, err := candidatesutil.CandidatesFromDB(sf, 1, true, false)
 	require.NoError(err)
@@ -1580,6 +1583,9 @@ func TestBlocks(t *testing.T) {
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 
 	gasLimit := testutil.TestGasLimit
@@ -1654,6 +1660,9 @@ func TestActions(t *testing.T) {
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 
 	gasLimit := testutil.TestGasLimit
@@ -1879,6 +1888,11 @@ func newChain(t *testing.T, stateTX bool) (blockchain.Blockchain, factory.Factor
 	require.NoError(err)
 	testIndexPath, err := testutil.PathOfTempFile("index")
 	require.NoError(err)
+	defer func() {
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
+	}()
 
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/blockindex/bloomfilterindexer_test.go
+++ b/blockindex/bloomfilterindexer_test.go
@@ -278,6 +278,7 @@ func TestBloomfilterIndexer(t *testing.T) {
 
 	path := "test-indexer"
 	testPath, err := testutil.PathOfTempFile(path)
+	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath
@@ -350,6 +351,7 @@ func BenchmarkBloomfilterIndexer(b *testing.B) {
 	require.NoError(indexer.Start(ctx))
 	defer func() {
 		require.NoError(indexer.Stop(ctx))
+		testutil.CleanupPathV2(testPath)
 	}()
 	for i := 0; i < len(blks); i++ {
 		require.NoError(indexer.PutBlock(context.Background(), &blks[i]))

--- a/blockindex/bloomfilterindexer_test.go
+++ b/blockindex/bloomfilterindexer_test.go
@@ -278,8 +278,8 @@ func TestBloomfilterIndexer(t *testing.T) {
 
 	path := "test-indexer"
 	testPath, err := testutil.PathOfTempFile(path)
-	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath
 

--- a/blockindex/indexbuilder_test.go
+++ b/blockindex/indexbuilder_test.go
@@ -156,8 +156,6 @@ func TestIndexBuilder(t *testing.T) {
 	require.NoError(err)
 	indexPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testutil.CleanupPath(t, testPath)
-	testutil.CleanupPath(t, indexPath)
 	defer func() {
 		testutil.CleanupPathV2(testPath)
 		testutil.CleanupPathV2(indexPath)

--- a/blockindex/indexbuilder_test.go
+++ b/blockindex/indexbuilder_test.go
@@ -159,8 +159,8 @@ func TestIndexBuilder(t *testing.T) {
 	testutil.CleanupPath(t, testPath)
 	testutil.CleanupPath(t, indexPath)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
-		testutil.CleanupPath(t, indexPath)
+		testutil.CleanupPathV2(testPath)
+		testutil.CleanupPathV2(indexPath)
 	}()
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath

--- a/blockindex/indexer_test.go
+++ b/blockindex/indexer_test.go
@@ -313,8 +313,8 @@ func TestIndexer(t *testing.T) {
 	})
 	path := "test-indexer"
 	testPath, err := testutil.PathOfTempFile(path)
-	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath
 

--- a/blockindex/indexer_test.go
+++ b/blockindex/indexer_test.go
@@ -313,6 +313,7 @@ func TestIndexer(t *testing.T) {
 	})
 	path := "test-indexer"
 	testPath, err := testutil.PathOfTempFile(path)
+	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
 	cfg := db.DefaultConfig
 	cfg.DbPath = testPath

--- a/blocksync/blocksync_test.go
+++ b/blocksync/blocksync_test.go
@@ -477,6 +477,10 @@ func newTestConfig() (config.Config, error) {
 	if err != nil {
 		return config.Config{}, err
 	}
+	defer func() {
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+	}()
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -151,9 +151,9 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, actpool.Ac
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = testIndexPath
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 
 	cfg.Consensus.Scheme = config.RollDPoSScheme

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -152,7 +152,7 @@ func TestCountingIndex(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 

--- a/db/counting_index_test.go
+++ b/db/counting_index_test.go
@@ -151,7 +151,6 @@ func TestCountingIndex(t *testing.T) {
 	path := "test-counting.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath

--- a/db/db_bolt_test.go
+++ b/db/db_bolt_test.go
@@ -8,9 +8,10 @@ package db
 
 import (
 	"context"
-	"github.com/iotexproject/iotex-core/db/batch"
 	"math/rand"
 	"testing"
+
+	"github.com/iotexproject/iotex-core/db/batch"
 
 	"github.com/stretchr/testify/require"
 
@@ -61,7 +62,7 @@ func TestBucketExists(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile("test-bucket")
 	r.NoError(err)
 	defer func() {
-		testutil.CleanupPath(t, testPath)
+		testutil.CleanupPathV2(testPath)
 	}()
 
 	cfg := DefaultConfig
@@ -78,6 +79,7 @@ func TestBucketExists(t *testing.T) {
 func BenchmarkBoltDB_Get(b *testing.B) {
 	runBenchmark := func(b *testing.B, size int) {
 		path, err := testutil.PathOfTempFile("boltdb")
+		defer testutil.CleanupPathV2(path)
 		require.NoError(b, err)
 		db := BoltDB{
 			path:   path,

--- a/db/db_bolt_test.go
+++ b/db/db_bolt_test.go
@@ -79,8 +79,8 @@ func TestBucketExists(t *testing.T) {
 func BenchmarkBoltDB_Get(b *testing.B) {
 	runBenchmark := func(b *testing.B, size int) {
 		path, err := testutil.PathOfTempFile("boltdb")
-		defer testutil.CleanupPathV2(path)
 		require.NoError(b, err)
+		defer testutil.CleanupPathV2(path)
 		db := BoltDB{
 			path:   path,
 			config: DefaultConfig,

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -58,7 +58,7 @@ func TestKVStorePutGet(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 
@@ -117,7 +117,7 @@ func TestBatchRollback(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 
@@ -240,7 +240,7 @@ func TestDBBatch(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 
@@ -293,7 +293,7 @@ func TestCacheKV(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 
@@ -339,7 +339,7 @@ func TestDeleteBucket(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 
@@ -441,7 +441,7 @@ func TestFilter(t *testing.T) {
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -57,7 +57,6 @@ func TestKVStorePutGet(t *testing.T) {
 	path := "test-kv-store.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -116,7 +115,6 @@ func TestBatchRollback(t *testing.T) {
 	path := "test-batch-rollback.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -239,7 +237,6 @@ func TestDBBatch(t *testing.T) {
 	path := "test-batch-commit.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -292,7 +289,6 @@ func TestCacheKV(t *testing.T) {
 	path := "test-cache-kv.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -338,7 +334,6 @@ func TestDeleteBucket(t *testing.T) {
 	path := "test-delete.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(t, err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -440,7 +435,6 @@ func TestFilter(t *testing.T) {
 	path := "test-filter.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
 	require.NoError(err)
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -36,7 +36,7 @@ func TestRangeIndex(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 
 	kv := NewBoltDB(cfg)
 	require.NotNil(kv)
@@ -165,7 +165,7 @@ func TestRangeIndex2(t *testing.T) {
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
 	testutil.CleanupPath(t, testPath)
-	defer testutil.CleanupPath(t, testPath)
+	defer testutil.CleanupPathV2(testPath)
 
 	kv := NewBoltDB(cfg)
 	require.NotNil(kv)

--- a/db/range_index_test.go
+++ b/db/range_index_test.go
@@ -35,7 +35,6 @@ func TestRangeIndex(t *testing.T) {
 	require.NoError(err)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 
 	kv := NewBoltDB(cfg)
@@ -164,7 +163,6 @@ func TestRangeIndex2(t *testing.T) {
 	require.NoError(err)
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
-	testutil.CleanupPath(t, testPath)
 	defer testutil.CleanupPathV2(testPath)
 
 	kv := NewBoltDB(cfg)

--- a/db/sql/sqlite3_test.go
+++ b/db/sql/sqlite3_test.go
@@ -21,6 +21,7 @@ const (
 func TestSQLite3StorePutGet(t *testing.T) {
 	testRDSStorePutGet := TestStorePutGet
 	testPath, err := testutil.PathOfTempFile(path)
+	defer testutil.CleanupPathV2(testPath)
 	require.NoError(t, err)
 	cfg := CQLITE3{
 		SQLite3File: testPath,
@@ -33,6 +34,7 @@ func TestSQLite3StorePutGet(t *testing.T) {
 func TestSQLite3StoreTransaction(t *testing.T) {
 	testSQLite3StoreTransaction := TestStoreTransaction
 	testPath, err := testutil.PathOfTempFile(path)
+	defer testutil.CleanupPathV2(testPath)
 	require.NoError(t, err)
 	cfg := CQLITE3{
 		SQLite3File: testPath,

--- a/db/sql/sqlite3_test.go
+++ b/db/sql/sqlite3_test.go
@@ -21,8 +21,8 @@ const (
 func TestSQLite3StorePutGet(t *testing.T) {
 	testRDSStorePutGet := TestStorePutGet
 	testPath, err := testutil.PathOfTempFile(path)
-	defer testutil.CleanupPathV2(testPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := CQLITE3{
 		SQLite3File: testPath,
 	}
@@ -34,8 +34,8 @@ func TestSQLite3StorePutGet(t *testing.T) {
 func TestSQLite3StoreTransaction(t *testing.T) {
 	testSQLite3StoreTransaction := TestStoreTransaction
 	testPath, err := testutil.PathOfTempFile(path)
-	defer testutil.CleanupPathV2(testPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testPath)
 	cfg := CQLITE3{
 		SQLite3File: testPath,
 	}

--- a/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
@@ -37,8 +37,8 @@ func benchTrieGet(b *testing.B, async, withDB bool) {
 	}
 	if withDB {
 		testPath, err := testutil.PathOfTempFile(fmt.Sprintf("test-kv-store-%t.bolt", async))
-		defer testutil.CleanupPathV2(testPath)
 		require.NoError(err)
+		defer testutil.CleanupPathV2(testPath)
 		cfg := db.DefaultConfig
 		cfg.DbPath = testPath
 		dao := db.NewBoltDB(cfg)

--- a/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
@@ -37,6 +37,7 @@ func benchTrieGet(b *testing.B, async, withDB bool) {
 	}
 	if withDB {
 		testPath, err := testutil.PathOfTempFile(fmt.Sprintf("test-kv-store-%t.bolt", async))
+		defer testutil.CleanupPathV2(testPath)
 		require.NoError(err)
 		cfg := db.DefaultConfig
 		cfg.DbPath = testPath

--- a/db/trie/mptrie/merklepatriciatrie_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_test.go
@@ -450,6 +450,7 @@ func TestHistoryTrie(t *testing.T) {
 	AccountKVNamespace := "Account"
 	path := "test-history-trie.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
+	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
 
 	cfg.DbPath = testPath

--- a/db/trie/mptrie/merklepatriciatrie_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_test.go
@@ -450,8 +450,8 @@ func TestHistoryTrie(t *testing.T) {
 	AccountKVNamespace := "Account"
 	path := "test-history-trie.bolt"
 	testPath, err := testutil.PathOfTempFile(path)
-	defer testutil.CleanupPathV2(testPath)
 	require.NoError(err)
+	defer testutil.CleanupPathV2(testPath)
 
 	cfg.DbPath = testPath
 	opts := []db.KVStoreFlusherOption{

--- a/e2etest/local_actpool_test.go
+++ b/e2etest/local_actpool_test.go
@@ -183,6 +183,12 @@ func newActPoolConfig(t *testing.T) (config.Config, error) {
 	testIndexPath, err := testutil.PathOfTempFile("index")
 	r.NoError(err)
 
+	defer func() {
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
+	}()
+
 	cfg.Chain.TrieDBPatchFile = ""
 	cfg.Chain.TrieDBPath = testTriePath
 	cfg.Chain.ChainDBPath = testDBPath

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -65,9 +65,9 @@ func TestLocalCommit(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, indexDBPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(indexDBPath)
 	}()
 
 	// create server
@@ -143,6 +143,11 @@ func TestLocalCommit(t *testing.T) {
 	require.NoError(err)
 	indexDBPath2, err := testutil.PathOfTempFile(dBPath2)
 	require.NoError(err)
+	defer func() {
+		testutil.CleanupPathV2(testTriePath2)
+		testutil.CleanupPathV2(testDBPath2)
+		testutil.CleanupPathV2(indexDBPath2)
+	}()
 	cfg.Chain.TrieDBPath = testTriePath2
 	cfg.Chain.ChainDBPath = testDBPath2
 	cfg.Chain.IndexDBPath = indexDBPath2
@@ -316,9 +321,9 @@ func TestLocalSync(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, indexDBPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(indexDBPath)
 	}()
 
 	// bootnode
@@ -375,9 +380,9 @@ func TestLocalSync(t *testing.T) {
 	cfg.Chain.ChainDBPath = testDBPath2
 	cfg.Chain.IndexDBPath = indexDBPath2
 	defer func() {
-		testutil.CleanupPath(t, testTriePath2)
-		testutil.CleanupPath(t, testDBPath2)
-		testutil.CleanupPath(t, indexDBPath2)
+		testutil.CleanupPathV2(testTriePath2)
+		testutil.CleanupPathV2(testDBPath2)
+		testutil.CleanupPathV2(indexDBPath2)
 	}()
 
 	// Create client
@@ -449,9 +454,9 @@ func TestStartExistingBlockchain(t *testing.T) {
 	require.NotNil(cs.BlockDAO())
 
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, testIndexPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
 	}()
 
 	require.NoError(addTestingTsfBlocks(bc, ap))

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -303,12 +303,12 @@ func TestLocalTransfer(t *testing.T) {
 	require.NoError(err)
 
 	defer func() {
-		testutil.CleanupPath(t, testTriePath)
-		testutil.CleanupPath(t, testDBPath)
-		testutil.CleanupPath(t, testIndexPath)
-		testutil.CleanupPath(t, testSystemLogPath)
-		testutil.CleanupPath(t, testBloomfilterIndexPath)
-		testutil.CleanupPath(t, testCandidateIndexPath)
+		testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testDBPath)
+		testutil.CleanupPathV2(testIndexPath)
+		testutil.CleanupPathV2(testSystemLogPath)
+		testutil.CleanupPathV2(testBloomfilterIndexPath)
+		testutil.CleanupPathV2(testCandidateIndexPath)
 	}()
 
 	networkPort := 4689

--- a/server/itx/heartbeat_test.go
+++ b/server/itx/heartbeat_test.go
@@ -28,8 +28,8 @@ func TestNewHeartbeatHandler(t *testing.T) {
 	require.NoError(err)
 	testutil.CleanupPath(t, triePath)
 	defer func() {
-		testutil.CleanupPath(t, dbPath)
-		testutil.CleanupPath(t, triePath)
+		testutil.CleanupPathV2(dbPath)
+		testutil.CleanupPathV2(triePath)
 	}()
 	cfg := config.Default
 	cfg.API.Port = testutil.RandomPort()

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -84,6 +84,7 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(sf.Start(ctx))
 	defer func() {
 		require.NoError(sf.Stop(ctx))
+		defer testutil.CleanupPathV2(testTriePath)
 	}()
 	ws, err := sf.(workingSetCreator).newWorkingSet(ctx, 1)
 	require.NoError(err)
@@ -94,6 +95,7 @@ func TestSnapshot(t *testing.T) {
 func TestSDBSnapshot(t *testing.T) {
 	require := require.New(t)
 	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
+	defer testutil.CleanupPathV2(testStateDBPath)
 	require.NoError(err)
 
 	cfg := config.Default
@@ -336,6 +338,7 @@ func testCandidates(sf Factory, t *testing.T) {
 
 func TestState(t *testing.T) {
 	testTriePath, err := testutil.PathOfTempFile(triePath)
+	defer testutil.CleanupPathV2(testTriePath)
 	require.NoError(t, err)
 
 	cfg := config.Default
@@ -378,6 +381,9 @@ func TestHistoryState(t *testing.T) {
 	sf, err = NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	r.NoError(err)
 	testHistoryState(sf, t, true, cfg.Chain.EnableArchiveMode)
+	defer func() {
+		testutil.CleanupPathV2(cfg.Chain.TrieDBPath)
+	}()
 }
 
 func TestFactoryStates(t *testing.T) {
@@ -398,11 +404,13 @@ func TestFactoryStates(t *testing.T) {
 	sf, err = NewStateDB(cfg, CachedStateDBOption(), SkipBlockValidationStateDBOption())
 	r.NoError(err)
 	testFactoryStates(sf, t)
+	defer testutil.CleanupPathV2(cfg.Chain.TrieDBPath)
 }
 
 func TestSDBState(t *testing.T) {
 	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testDBPath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -669,6 +677,7 @@ func testFactoryStates(sf Factory, t *testing.T) {
 func TestNonce(t *testing.T) {
 	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath
@@ -680,6 +689,7 @@ func TestNonce(t *testing.T) {
 func TestSDBNonce(t *testing.T) {
 	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testDBPath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -775,6 +785,7 @@ func testNonce(sf Factory, t *testing.T) {
 func TestLoadStoreHeight(t *testing.T) {
 	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -787,6 +798,7 @@ func TestLoadStoreHeight(t *testing.T) {
 func TestLoadStoreHeightInMem(t *testing.T) {
 	testTriePath, err := testutil.PathOfTempFile(triePath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testTriePath
@@ -798,6 +810,7 @@ func TestLoadStoreHeightInMem(t *testing.T) {
 func TestSDBLoadStoreHeight(t *testing.T) {
 	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testDBPath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
@@ -810,6 +823,7 @@ func TestSDBLoadStoreHeight(t *testing.T) {
 func TestSDBLoadStoreHeightInMem(t *testing.T) {
 	testDBPath, err := testutil.PathOfTempFile(stateDBPath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testDBPath)
 	cfg := config.Default
 	cfg.Chain.TrieDBPath = testDBPath
 	db, err := NewStateDB(cfg, InMemStateDBOption(), SkipBlockValidationStateDBOption())
@@ -872,6 +886,7 @@ func TestRunActions(t *testing.T) {
 	require.NoError(sf.Start(ctx))
 	defer func() {
 		require.NoError(sf.Stop(ctx))
+		testutil.CleanupPathV2(testTriePath)
 	}()
 	testCommit(sf, t)
 }
@@ -898,6 +913,7 @@ func TestSTXRunActions(t *testing.T) {
 	require.NoError(sdb.Start(ctx))
 	defer func() {
 		require.NoError(sdb.Stop(ctx))
+		testutil.CleanupPathV2(testStateDBPath)
 	}()
 	testCommit(sdb, t)
 }
@@ -978,6 +994,7 @@ func TestPickAndRunActions(t *testing.T) {
 	require.NoError(sf.Start(ctx))
 	defer func() {
 		require.NoError(sf.Stop(ctx))
+		testutil.CleanupPathV2(testTriePath)
 	}()
 	testNewBlockBuilder(sf, t)
 }
@@ -1004,6 +1021,7 @@ func TestSTXPickAndRunActions(t *testing.T) {
 	require.NoError(sdb.Start(ctx))
 	defer func() {
 		require.NoError(sdb.Stop(ctx))
+		testutil.CleanupPathV2(testStateDBPath)
 	}()
 	testNewBlockBuilder(sdb, t)
 }
@@ -1084,6 +1102,7 @@ func TestSimulateExecution(t *testing.T) {
 	require.NoError(sf.Start(ctx))
 	defer func() {
 		require.NoError(sf.Stop(ctx))
+		testutil.CleanupPathV2(testTriePath)
 	}()
 	testSimulateExecution(ctx, sf, t)
 }
@@ -1113,6 +1132,7 @@ func TestSTXSimulateExecution(t *testing.T) {
 	require.NoError(sdb.Start(ctx))
 	defer func() {
 		require.NoError(sdb.Stop(ctx))
+		testutil.CleanupPathV2(testStateDBPath)
 	}()
 	testSimulateExecution(ctx, sdb, t)
 }
@@ -1276,6 +1296,8 @@ func TestStateDBPatch(t *testing.T) {
 	require.NoError(sdb.Start(ctx))
 	defer func() {
 		require.NoError(sdb.Stop(ctx))
+		testutil.CleanupPathV2(patchFile)
+		testutil.CleanupPathV2(testDBPath)
 	}()
 	ctx = protocol.WithBlockchainCtx(protocol.WithBlockCtx(ctx,
 		protocol.BlockCtx{

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -84,7 +84,7 @@ func TestSnapshot(t *testing.T) {
 	require.NoError(sf.Start(ctx))
 	defer func() {
 		require.NoError(sf.Stop(ctx))
-		defer testutil.CleanupPathV2(testTriePath)
+		testutil.CleanupPathV2(testTriePath)
 	}()
 	ws, err := sf.(workingSetCreator).newWorkingSet(ctx, 1)
 	require.NoError(err)
@@ -95,8 +95,8 @@ func TestSnapshot(t *testing.T) {
 func TestSDBSnapshot(t *testing.T) {
 	require := require.New(t)
 	testStateDBPath, err := testutil.PathOfTempFile(stateDBPath)
-	defer testutil.CleanupPathV2(testStateDBPath)
 	require.NoError(err)
+	defer testutil.CleanupPathV2(testStateDBPath)
 
 	cfg := config.Default
 	cfg.Chain.TrieDBPatchFile = ""
@@ -338,8 +338,8 @@ func testCandidates(sf Factory, t *testing.T) {
 
 func TestState(t *testing.T) {
 	testTriePath, err := testutil.PathOfTempFile(triePath)
-	defer testutil.CleanupPathV2(testTriePath)
 	require.NoError(t, err)
+	defer testutil.CleanupPathV2(testTriePath)
 
 	cfg := config.Default
 	cfg.DB.DbPath = testTriePath

--- a/state/factory/patchstore_test.go
+++ b/state/factory/patchstore_test.go
@@ -18,6 +18,7 @@ func TestPatchStore(t *testing.T) {
 	}
 
 	filePath, _ := testutil.PathOfTempFile("test")
+	defer testutil.CleanupPathV2(filePath)
 	f, err := os.Create(filePath)
 	require.NoError(err)
 
@@ -72,6 +73,7 @@ func TestPatchStore(t *testing.T) {
 
 	for _, test := range patchTest2 {
 		filePath, _ = testutil.PathOfTempFile("test")
+		defer testutil.CleanupPathV2(filePath)
 		f, err = os.Create(filePath)
 		require.NoError(err)
 


### PR DESCRIPTION
Signed-off-by: DiptoChakrabarty <diptochuck123@gmail.com>

This PR cleans up the temp files created in the tests using the CleanFileV2 function present in the testutil package of the project

Works on issue #3060 