### PR TITLE
[ioctl/newcmd] delete NewKeyStore parameteres in ioctl.Client

### DIFF
--- a/ioctl/client.go
+++ b/ioctl/client.go
@@ -49,8 +49,8 @@ type (
 		GetAddress(in string) (string, error)
 		// doing
 		Address(in string) (string, error)
-		// doing
-		NewKeyStore(string, int, int) *keystore.KeyStore
+		// NewKeyStore creates a keystore by default walletdir
+		NewKeyStore() *keystore.KeyStore
 		// AliasMap returns the alias map: accountAddr-aliasName
 		AliasMap() map[string]string
 		// doing
@@ -185,8 +185,8 @@ func (c *client) Address(in string) (string, error) {
 	return "", output.NewError(output.ConfigError, "cannot find address from "+in, nil)
 }
 
-func (c *client) NewKeyStore(keydir string, scryptN, scryptP int) *keystore.KeyStore {
-	return keystore.NewKeyStore(keydir, scryptN, scryptP)
+func (c *client) NewKeyStore() *keystore.KeyStore {
+	return keystore.NewKeyStore(c.cfg.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
 }
 
 func (c *client) AliasMap() map[string]string {

--- a/ioctl/client.go
+++ b/ioctl/client.go
@@ -200,6 +200,9 @@ func (c *client) DecryptPrivateKey(passwordOfKeyStore, keyStorePath string) (*ec
 	}
 
 	key, err := keystore.DecryptKey(keyJSON, passwordOfKeyStore)
+	if err != nil {
+		return nil, output.NewError(output.KeystoreError, "failed to decrypt key", err)
+	}
 	if key != nil && key.PrivateKey != nil {
 		// clear private key in memory prevent from attack
 		defer func(k *ecdsa.PrivateKey) {
@@ -208,9 +211,6 @@ func (c *client) DecryptPrivateKey(passwordOfKeyStore, keyStorePath string) (*ec
 				b[i] = 0
 			}
 		}(key.PrivateKey)
-	}
-	if err != nil {
-		return nil, output.NewError(output.KeystoreError, "failed to decrypt key", err)
 	}
 	return key.PrivateKey, nil
 }

--- a/ioctl/client_test.go
+++ b/ioctl/client_test.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
@@ -134,22 +133,17 @@ func TestNewKeyStore(t *testing.T) {
 	r.NoError(err)
 	defer testutil.CleanupPath(t, testWallet)
 
+	config.ReadConfig.Wallet = testWallet
 	c := NewClient(false)
 	defer c.Stop(context.Background())
 
-	tests := [][]int{
-		{keystore.StandardScryptN, keystore.StandardScryptP},
-		{keystore.LightScryptN, keystore.LightScryptP},
-	}
-	for _, test := range tests {
-		ks := c.NewKeyStore(testWallet, test[0], test[1])
-		acc, err := ks.NewAccount("test")
-		r.NoError(err)
-		_, err = os.Stat(acc.URL.Path)
-		r.NoError(err)
-		r.True(strings.HasPrefix(acc.URL.Path, testWallet))
-		r.True(ks.HasAddress(acc.Address))
-	}
+	ks := c.NewKeyStore()
+	acc, err := ks.NewAccount("test")
+	r.NoError(err)
+	_, err = os.Stat(acc.URL.Path)
+	r.NoError(err)
+	r.True(strings.HasPrefix(acc.URL.Path, testWallet))
+	r.True(ks.HasAddress(acc.Address))
 }
 
 func TestAliasMap(t *testing.T) {

--- a/ioctl/newcmd/account/account.go
+++ b/ioctl/newcmd/account/account.go
@@ -305,7 +305,7 @@ func newAccountByKey(client ioctl.Client, alias string, privateKey string, walle
 		return "", output.NewError(output.ValidationError, ErrPasswdNotMatch.Error(), nil)
 	}
 
-	return storeKey(client, privateKey, walletDir, password)
+	return storeKey(client, privateKey, password)
 }
 
 func newAccountByKeyStore(client ioctl.Client, alias, passwordOfKeyStore, keyStorePath string, walletDir string) (string, error) {
@@ -339,7 +339,7 @@ func newAccountByPem(client ioctl.Client, alias, passwordOfPem, pemFilePath stri
 	return newAccountByKey(client, alias, prvKey.HexString(), walletDir)
 }
 
-func storeKey(client ioctl.Client, privateKey, walletDir, password string) (string, error) {
+func storeKey(client ioctl.Client, privateKey, password string) (string, error) {
 	priKey, err := crypto.HexStringToPrivateKey(privateKey)
 	if err != nil {
 		return "", output.NewError(output.CryptoError, "failed to generate private key from hex string ", err)

--- a/ioctl/newcmd/account/account.go
+++ b/ioctl/newcmd/account/account.go
@@ -136,8 +136,7 @@ func keyStoreAccountToPrivateKey(client ioctl.Client, signer, password string) (
 		}
 	} else {
 		// find the account in keystore
-		ks := client.NewKeyStore(config.ReadConfig.Wallet,
-			keystore.StandardScryptN, keystore.StandardScryptP)
+		ks := client.NewKeyStore()
 		for _, account := range ks.Accounts() {
 			if bytes.Equal(addr.Bytes(), account.Address.Bytes()) {
 				return crypto.KeystoreToPrivateKey(account, password)
@@ -223,8 +222,7 @@ func IsSignerExist(client ioctl.Client, signer string) bool {
 	}
 
 	// find the account in keystore
-	ks := client.NewKeyStore(config.ReadConfig.Wallet,
-		keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := client.NewKeyStore()
 	for _, ksAccount := range ks.Accounts() {
 		if address.Equal(addr, ksAccount.Address) {
 			return true
@@ -248,7 +246,7 @@ func newAccount(client ioctl.Client, alias string) (string, error) {
 	if password != passwordAgain {
 		return "", output.NewError(output.ValidationError, ErrPasswdNotMatch.Error(), nil)
 	}
-	ks := client.NewKeyStore(config.ReadConfig.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := client.NewKeyStore()
 	account, err := ks.NewAccount(password)
 	if err != nil {
 		return "", output.NewError(output.KeystoreError, "failed to create new keystore", err)
@@ -355,7 +353,7 @@ func storeKey(client ioctl.Client, privateKey, walletDir, password string) (stri
 
 	switch sk := priKey.EcdsaPrivateKey().(type) {
 	case *ecdsa.PrivateKey:
-		ks := client.NewKeyStore(walletDir, keystore.StandardScryptN, keystore.StandardScryptP)
+		ks := client.NewKeyStore()
 		if _, err := ks.ImportECDSA(sk, password); err != nil {
 			return "", output.NewError(output.KeystoreError, "failed to import private key into keystore ", err)
 		}

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -245,6 +245,13 @@ func TestAccountError(t *testing.T) {
 	testWallet, _, _, _, _ := newTestAccount()
 	defer testutil.CleanupPath(t, testWallet)
 
+	client.EXPECT().DecryptPrivateKey(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(passwordOfKeyStore, keyStorePath string) (*ecdsa.PrivateKey, error) {
+			_, err := os.ReadFile(keyStorePath)
+			require.Error(err)
+			return nil, output.NewError(output.ReadFileError,
+				fmt.Sprintf("keystore file \"%s\" read error", keyStorePath), nil)
+		})
 	result, err := newAccountByKeyStore(client, alias, passwordOfKeyStore, keyStorePath, walletDir)
 	require.Error(err)
 	require.Contains(err.Error(), fmt.Sprintf("keystore file \"%s\" read error", keyStorePath))

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -59,10 +59,8 @@ func TestSign(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
-	client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(keydir string, scryptN, scryptP int) *keystore.KeyStore {
-			return keystore.NewKeyStore(keydir, scryptN, scryptP)
-		}).Times(15)
+	config.ReadConfig.Wallet = testWallet
+	client.EXPECT().NewKeyStore().Return(ks).Times(15)
 	client.EXPECT().IsCryptoSm2().Return(false).Times(15)
 
 	account, err := ks.NewAccount(passwd)
@@ -130,10 +128,7 @@ func TestAccount(t *testing.T) {
 
 	t.Run("CryptoSm2 is false", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false).Times(2)
-		client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(keydir string, scryptN, scryptP int) *keystore.KeyStore {
-				return keystore.NewKeyStore(keydir, scryptN, scryptP)
-			}).Times(2)
+		client.EXPECT().NewKeyStore().Return(ks).Times(2)
 
 		// test new account by ks
 		account, err := ks.NewAccount(passwd)
@@ -288,10 +283,7 @@ func TestStoreKey(t *testing.T) {
 
 	t.Run("CryptoSm2 is false", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false).Times(4)
-		client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-			func(keydir string, scryptN, scryptP int) *keystore.KeyStore {
-				return keystore.NewKeyStore(keydir, scryptN, scryptP)
-			}).Times(6)
+		client.EXPECT().NewKeyStore().Return(ks).Times(6)
 
 		account, err := ks.NewAccount(passwd)
 		require.NoError(err)

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -167,7 +167,7 @@ func TestAccount(t *testing.T) {
 		_, err = keyStoreAccountToPrivateKey(client, addr2.String(), passwd)
 		require.Contains(err.Error(), "does not match all local keys")
 		filePath := sm2KeyPath(addr2)
-		addrString, err := storeKey(client, account2.HexString(), config.ReadConfig.Wallet, passwd)
+		addrString, err := storeKey(client, account2.HexString(), passwd)
 		require.NoError(err)
 		require.Equal(addr2.String(), addrString)
 		require.True(IsSignerExist(client, addr2.String()))
@@ -293,7 +293,7 @@ func TestStoreKey(t *testing.T) {
 		require.True(IsSignerExist(client, addr.String()))
 
 		// invalid private key
-		addrString, err := storeKey(client, account.Address.String(), config.ReadConfig.Wallet, passwd)
+		addrString, err := storeKey(client, account.Address.String(), passwd)
 		require.Error(err)
 		require.Contains(err.Error(), "failed to generate private key from hex string")
 		require.Equal("", addrString)
@@ -302,7 +302,7 @@ func TestStoreKey(t *testing.T) {
 		prvKey, err := keyStoreAccountToPrivateKey(client, addr.String(), passwd)
 		require.NoError(err)
 		// import the existed account addr
-		addrString, err = storeKey(client, prvKey.HexString(), config.ReadConfig.Wallet, passwd)
+		addrString, err = storeKey(client, prvKey.HexString(), passwd)
 		require.Error(err)
 		require.Contains(err.Error(), "failed to import private key into keystore")
 		require.Equal("", addrString)
@@ -313,7 +313,7 @@ func TestStoreKey(t *testing.T) {
 		addr = prvKey.PublicKey().Address()
 		require.NotNil(addr)
 		require.False(IsSignerExist(client, addr.String()))
-		addrString, err = storeKey(client, prvKey.HexString(), config.ReadConfig.Wallet, passwd)
+		addrString, err = storeKey(client, prvKey.HexString(), passwd)
 		require.NoError(err)
 		require.Equal(addr.String(), addrString)
 		t.Log(addr.String())
@@ -332,7 +332,7 @@ func TestStoreKey(t *testing.T) {
 		require.NoError(crypto.WritePrivateKeyToPem(pemFilePath, priKey2.(*crypto.P256sm2PrvKey), passwd))
 		require.True(IsSignerExist(client, addr2.String()))
 
-		addrString2, err := storeKey(client, priKey2.HexString(), config.ReadConfig.Wallet, passwd)
+		addrString2, err := storeKey(client, priKey2.HexString(), passwd)
 		require.NoError(err)
 		require.Equal(addr2.String(), addrString2)
 	})

--- a/ioctl/newcmd/account/accountdelete.go
+++ b/ioctl/newcmd/account/accountdelete.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -104,7 +103,7 @@ func NewAccountDelete(c ioctl.Client) *cobra.Command {
 					filePath = filepath.Join(c.Config().Wallet, "sm2sk-"+account.String()+".pem")
 				}
 			} else {
-				ks := c.NewKeyStore(c.Config().Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
+				ks := c.NewKeyStore()
 				for _, v := range ks.Accounts() {
 					if bytes.Equal(account.Bytes(), v.Address.Bytes()) {
 						filePath = v.URL.Path

--- a/ioctl/newcmd/account/accountdelete_test.go
+++ b/ioctl/newcmd/account/accountdelete_test.go
@@ -42,7 +42,7 @@ func TestNewAccountDelete(t *testing.T) {
 		acc, _ := ks.NewAccount("test")
 		accAddr, _ := address.FromBytes(acc.Address.Bytes())
 		client.EXPECT().GetAddress(gomock.Any()).Return(accAddr.String(), nil).Times(2)
-		client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(ks).Times(2)
+		client.EXPECT().NewKeyStore().Return(ks).Times(2)
 
 		client.EXPECT().AliasMap().Return(map[string]string{
 			accAddr.String(): "aaa",
@@ -58,7 +58,7 @@ func TestNewAccountDelete(t *testing.T) {
 					"ccc": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
 				}
 				return config.ReadConfig
-			}).Times(3)
+			})
 
 		client.EXPECT().AskToConfirm(gomock.Any()).Return(false)
 		cmd := NewAccountDelete(client)

--- a/ioctl/newcmd/account/accountlist.go
+++ b/ioctl/newcmd/account/accountlist.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/spf13/cobra"
 
@@ -55,8 +54,7 @@ func NewAccountList(c ioctl.Client) *cobra.Command {
 					})
 				}
 			} else {
-				ks := c.NewKeyStore(config.ReadConfig.Wallet,
-					keystore.StandardScryptN, keystore.StandardScryptP)
+				ks := c.NewKeyStore()
 				for _, v := range ks.Accounts() {
 					addr, err := address.FromBytes(v.Address.Bytes())
 					if err != nil {

--- a/ioctl/newcmd/account/accountlist_test.go
+++ b/ioctl/newcmd/account/accountlist_test.go
@@ -42,7 +42,7 @@ func TestNewAccountList(t *testing.T) {
 		_, _ = ks.NewAccount("test")
 		_, _ = ks.NewAccount("test2")
 
-		client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(ks)
+		client.EXPECT().NewKeyStore().Return(ks)
 		cmd := NewAccountList(client)
 		_, err := util.ExecuteCmd(cmd)
 		require.NoError(t, err)

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -33,7 +33,7 @@ func TestNewAccountSign(t *testing.T) {
 		require.NoError(os.RemoveAll(testAccountFolder))
 	}()
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
-	client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(ks).AnyTimes()
+	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 
 	t.Run("invalid_account", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false).Times(2)

--- a/ioctl/newcmd/account/accountupdate.go
+++ b/ioctl/newcmd/account/accountupdate.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
@@ -83,7 +82,7 @@ func NewAccountUpdate(client ioctl.Client) *cobra.Command {
 				}
 			} else {
 				// find the keystore and update
-				ks := client.NewKeyStore(config.ReadConfig.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
+				ks := client.NewKeyStore()
 				for _, v := range ks.Accounts() {
 					if bytes.Equal(addr.Bytes(), v.Address.Bytes()) {
 						if err = readSecretAndUpdate(client, acc,

--- a/ioctl/newcmd/account/accountupdate_test.go
+++ b/ioctl/newcmd/account/accountupdate_test.go
@@ -34,7 +34,7 @@ func TestNewAccountUpdate_FindKeystore(t *testing.T) {
 		require.NoError(os.RemoveAll(testAccountFolder))
 	}()
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
-	client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(ks).AnyTimes()
+	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
 	acc, err := ks.NewAccount(pwd)
 	require.NoError(err)
@@ -83,7 +83,7 @@ func TestNewAccountUpdate_FindPemFile(t *testing.T) {
 		require.NoError(os.RemoveAll(testAccountFolder))
 	}()
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
-	client.EXPECT().NewKeyStore(gomock.Any(), gomock.Any(), gomock.Any()).Return(ks).AnyTimes()
+	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
 	acc, err := ks.NewAccount(pwd)
 	require.NoError(err)

--- a/test/mock/mock_ioctlclient/mock_ioctlclient.go
+++ b/test/mock/mock_ioctlclient/mock_ioctlclient.go
@@ -6,6 +6,7 @@ package mock_ioctlclient
 
 import (
 	context "context"
+	ecdsa "crypto/ecdsa"
 	reflect "reflect"
 
 	keystore "github.com/ethereum/go-ethereum/accounts/keystore"
@@ -108,6 +109,21 @@ func (m *MockClient) Config() config.Config {
 func (mr *MockClientMockRecorder) Config() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Config", reflect.TypeOf((*MockClient)(nil).Config))
+}
+
+// DecryptPrivateKey mocks base method.
+func (m *MockClient) DecryptPrivateKey(arg0, arg1 string) (*ecdsa.PrivateKey, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DecryptPrivateKey", arg0, arg1)
+	ret0, _ := ret[0].(*ecdsa.PrivateKey)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DecryptPrivateKey indicates an expected call of DecryptPrivateKey.
+func (mr *MockClientMockRecorder) DecryptPrivateKey(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DecryptPrivateKey", reflect.TypeOf((*MockClient)(nil).DecryptPrivateKey), arg0, arg1)
 }
 
 // Execute mocks base method.

--- a/test/mock/mock_ioctlclient/mock_ioctlclient.go
+++ b/test/mock/mock_ioctlclient/mock_ioctlclient.go
@@ -154,17 +154,17 @@ func (mr *MockClientMockRecorder) IsCryptoSm2() *gomock.Call {
 }
 
 // NewKeyStore mocks base method.
-func (m *MockClient) NewKeyStore(arg0 string, arg1, arg2 int) *keystore.KeyStore {
+func (m *MockClient) NewKeyStore() *keystore.KeyStore {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewKeyStore", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewKeyStore")
 	ret0, _ := ret[0].(*keystore.KeyStore)
 	return ret0
 }
 
 // NewKeyStore indicates an expected call of NewKeyStore.
-func (mr *MockClientMockRecorder) NewKeyStore(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) NewKeyStore() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewKeyStore", reflect.TypeOf((*MockClient)(nil).NewKeyStore), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewKeyStore", reflect.TypeOf((*MockClient)(nil).NewKeyStore))
 }
 
 // PrintError mocks base method.


### PR DESCRIPTION
callers use the same default wallet dir and StandardScryptN  StandardScryptP.  