### PR TITLE
[ioctl] deprecate cmd.SetOutput

### DIFF
--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -40,10 +40,9 @@ const (
 // ExecuteCmd executes cmd with args, and return system output, e.g., help info, and error
 func ExecuteCmd(cmd *cobra.Command, args ...string) (string, error) {
 	buf := new(bytes.Buffer)
-	cmd.SetOutput(buf)
+	cmd.SetOut(buf)
 	cmd.SetArgs(args)
-	_, err := cmd.ExecuteC()
-
+	err := cmd.Execute()
 	return buf.String(), err
 }
 


### PR DESCRIPTION
prefix for pr 3109
https://pkg.go.dev/github.com/spf13/cobra#Command.SetOutput