### PR TITLE
[trie] Remove syncmode in trie

### DIFF
--- a/action/protocol/execution/evm/contract.go
+++ b/action/protocol/execution/evm/contract.go
@@ -198,9 +198,6 @@ func newContract(addr hash.Hash160, account *state.Account, sm protocol.StateMan
 	if account.Root != hash.ZeroHash256 {
 		options = append(options, mptrie.RootHashOption(account.Root[:]))
 	}
-	if enableAsync {
-		options = append(options, mptrie.AsyncOption())
-	}
 
 	tr, err := mptrie.New(options...)
 	if err != nil {

--- a/db/trie/mptrie/branchnode.go
+++ b/db/trie/mptrie/branchnode.go
@@ -37,11 +37,6 @@ func newBranchNode(
 		indices:  NewSortList(children),
 	}
 	bnode.cacheNode.serializable = bnode
-	if len(bnode.children) != 0 {
-		if !mpt.async {
-			return bnode.store()
-		}
-	}
 	return bnode, nil
 }
 
@@ -227,17 +222,7 @@ func (b *branchNode) updateChild(key byte, child node, hashnode bool) (node, err
 		b.children[key] = child
 	}
 	b.dirty = true
-	if len(b.children) != 0 {
-		if !b.mpt.async {
-			hn, err := b.store()
-			if err != nil {
-				return nil, err
-			}
-			if !b.isRoot && hashnode {
-				return hn, nil // return hashnode
-			}
-		}
-	} else {
+	if len(b.children) == 0 {
 		if _, err := b.hash(false); err != nil {
 			return nil, err
 		}

--- a/db/trie/mptrie/extensionnode.go
+++ b/db/trie/mptrie/extensionnode.go
@@ -34,10 +34,6 @@ func newExtensionNode(
 		child: child,
 	}
 	e.cacheNode.serializable = e
-
-	if !mpt.async {
-		return e.store()
-	}
 	return e, nil
 }
 
@@ -174,16 +170,6 @@ func (e *extensionNode) updatePath(path []byte, hashnode bool) (node, error) {
 	}
 	e.path = path
 	e.dirty = true
-
-	if !e.mpt.async {
-		hn, err := e.store()
-		if err != nil {
-			return nil, err
-		}
-		if hashnode {
-			return hn, nil
-		}
-	}
 	return e, nil
 }
 
@@ -194,15 +180,5 @@ func (e *extensionNode) updateChild(newChild node, hashnode bool) (node, error) 
 	}
 	e.child = newChild
 	e.dirty = true
-
-	if !e.mpt.async {
-		hn, err := e.store()
-		if err != nil {
-			return nil, err
-		}
-		if hashnode {
-			return hn, nil
-		}
-	}
 	return e, nil
 }

--- a/db/trie/mptrie/leafiterator_test.go
+++ b/db/trie/mptrie/leafiterator_test.go
@@ -28,7 +28,7 @@ func TestIterator(t *testing.T) {
 		memStore = trie.NewMemKVStore()
 	)
 
-	mpt, err := New(KVStoreOption(memStore), KeyLengthOption(5), AsyncOption())
+	mpt, err := New(KVStoreOption(memStore), KeyLengthOption(5))
 	require.NoError(err)
 	err = mpt.Start(context.Background())
 	require.NoError(err)

--- a/db/trie/mptrie/leafnode.go
+++ b/db/trie/mptrie/leafnode.go
@@ -35,9 +35,6 @@ func newLeafNode(
 		value: value,
 	}
 	l.cacheNode.serializable = l
-	if !mpt.async {
-		return l.store()
-	}
 	return l, nil
 }
 
@@ -82,15 +79,7 @@ func (l *leafNode) Upsert(key keyType, offset uint8, value []byte) (node, error)
 	if err != nil {
 		return nil, err
 	}
-	var oldLeaf node
-	if !l.mpt.async {
-		oldLeaf, err = l.store()
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		oldLeaf = l
-	}
+	oldLeaf := l
 	bnode, err := newBranchNode(
 		l.mpt,
 		map[byte]node{
@@ -140,8 +129,5 @@ func (l *leafNode) updateValue(value []byte) (node, error) {
 	}
 	l.value = value
 	l.dirty = true
-	if !l.mpt.async {
-		return l.store()
-	}
 	return l, nil
 }

--- a/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_benchmark_test.go
@@ -3,7 +3,6 @@ package mptrie
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,10 +13,10 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
-func BenchmarkTrie_Get(b *testing.B)            { benchTrieGet(b, false, false) }
-func BenchmarkTrie_GetWithAsync(b *testing.B)   { benchTrieGet(b, true, false) }
-func BenchmarkTrie_GetDB(b *testing.B)          { benchTrieGet(b, false, true) }
-func BenchmarkTrie_GetDBWithAsync(b *testing.B) { benchTrieGet(b, true, true) }
+func BenchmarkTrie_Get(b *testing.B)            { benchTrieGet(b, false) }
+func BenchmarkTrie_GetWithAsync(b *testing.B)   { benchTrieGet(b, false) }
+func BenchmarkTrie_GetDB(b *testing.B)          { benchTrieGet(b, true) }
+func BenchmarkTrie_GetDBWithAsync(b *testing.B) { benchTrieGet(b, true) }
 func BenchmarkTrie_UpsertLE(b *testing.B)       { benchTrieUpsert(b, binary.LittleEndian) }
 func BenchmarkTrie_UpsertBE(b *testing.B)       { benchTrieUpsert(b, binary.BigEndian) }
 
@@ -26,17 +25,14 @@ const (
 	keyLength      = 32
 )
 
-func benchTrieGet(b *testing.B, async, withDB bool) {
+func benchTrieGet(b *testing.B, withDB bool) {
 	var (
 		require = require.New(b)
 		opts    = []Option{KeyLengthOption(keyLength)}
 		flush   func() error
 	)
-	if async {
-		opts = append(opts, AsyncOption())
-	}
 	if withDB {
-		testPath, err := testutil.PathOfTempFile(fmt.Sprintf("test-kv-store-%t.bolt", async))
+		testPath, err := testutil.PathOfTempFile("test-kv-store.bolt")
 		require.NoError(err)
 		defer testutil.CleanupPathV2(testPath)
 		cfg := db.DefaultConfig

--- a/db/trie/mptrie/merklepatriciatrie_test.go
+++ b/db/trie/mptrie/merklepatriciatrie_test.go
@@ -63,7 +63,7 @@ func Test2Roots(t *testing.T) {
 
 	// first trie
 	trieDB := trie.NewMemKVStore()
-	tr, err := New(KVStoreOption(trieDB), KeyLengthOption(8), AsyncOption())
+	tr, err := New(KVStoreOption(trieDB), KeyLengthOption(8))
 	require.NoError(err)
 	require.NoError(tr.Start(context.Background()))
 	require.NoError(tr.Upsert(cat, testV[2]))
@@ -531,15 +531,12 @@ func Test4kEntries(t *testing.T) {
 	t.Run("test async mode", func(t *testing.T) {
 		test4kEntries(t, true)
 	})
-	t.Run("test sync mode", func(t *testing.T) {
-		test4kEntries(t, false)
-	})
 }
 
 func test4kEntries(t *testing.T, enableAsync bool) {
 	require := require.New(t)
 
-	tr, err := New(KeyLengthOption(4), AsyncOption())
+	tr, err := New(KeyLengthOption(4))
 	require.NoError(err)
 	require.NoError(tr.Start(context.Background()))
 	root, err := tr.RootHash()

--- a/db/trie/mptrie/twolayertrie.go
+++ b/db/trie/mptrie/twolayertrie.go
@@ -44,7 +44,7 @@ func (tlt *twoLayerTrie) layerTwoTrie(key []byte, layerTwoTrieKeyLen int) (*laye
 	if lt, ok := tlt.layerTwoMap[hk]; ok {
 		return lt, nil
 	}
-	opts := []Option{KVStoreOption(tlt.kvStore), KeyLengthOption(layerTwoTrieKeyLen), AsyncOption()}
+	opts := []Option{KVStoreOption(tlt.kvStore), KeyLengthOption(layerTwoTrieKeyLen)}
 	value, err := tlt.layerOne.Get(key)
 	switch errors.Cause(err) {
 	case trie.ErrNotExist:
@@ -84,7 +84,6 @@ func (tlt *twoLayerTrie) Start(ctx context.Context) error {
 	layerOne, err := New(
 		KVStoreOption(tlt.kvStore),
 		RootHashOption(rootHash),
-		AsyncOption(),
 	)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate trie for %s", tlt.rootKey)


### PR DESCRIPTION
Sync mode is inefficient in trie. It can be deprecated.