### PR TITLE
[pkg] fix http issue

### DIFF
--- a/pkg/util/httputil/httputil.go
+++ b/pkg/util/httputil/httputil.go
@@ -28,9 +28,6 @@ func Server(addr string, handler http.Handler) http.Server {
 
 // LimitListener creates a tcp keep-alive listener with 400 maximum connections.
 func LimitListener(addr string) (net.Listener, error) {
-	if addr == "" {
-		addr = ":http"
-	}
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		return ln, err

--- a/pkg/util/httputil/httputil_test.go
+++ b/pkg/util/httputil/httputil_test.go
@@ -36,7 +36,8 @@ func TestLimitListener(t *testing.T) {
 	})
 
 	t.Run("input empty string", func(t *testing.T) {
-		_, err := LimitListener("")
+		listener, err := LimitListener("")
 		require.NoError(t, err)
+		defer listener.Close()
 	})
 }


### PR DESCRIPTION
There is an err when running unit tests under Ubuntu 20, which is caused by ":http" parameters.
```
--- FAIL: TestLimitListener (0.00s)
    --- FAIL: TestLimitListener/input_empty_string (0.00s)
        httputil_test.go:40:
                Error Trace:    httputil_test.go:40
                Error:          Received unexpected error:
                                listen tcp :80: bind: permission denied
                Test:           TestLimitListener/input_empty_string
FAIL
```
And to make the behavior consistent with `Listen()` in `net` pkg, the parameter could be moved
 > // Listen announces on the local network address.
// For TCP networks, if the host in the address parameter is empty or
// a literal unspecified IP address, Listen listens on all available
// unicast and anycast IP addresses of the local system.
// To only use IPv4, use network "tcp4".
// The address can use a host name, but this is not recommended,
// because it will create a listener for at most one of the host's IP
// addresses.
// If the port in the address parameter is empty or "0", as in
// "127.0.0.1:" or "[::1]:0", a port number is automatically chosen.
// The Addr method of Listener can be used to discover the chosen
// port.