### PR TITLE
fix Dockerfile lograte permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,5 @@ RUN apk add logrotate
 COPY logrotate.conf /etc/logrotate.d/iotex
 RUN mkdir -p /var/lib/
 RUN touch /var/lib/logrotate.status
+RUN chmod -R u=rwX,go=rX /etc
 RUN logrotate /etc/logrotate.d/iotex


### PR DESCRIPTION
The lograte permissions are wrong, causing an error 

`Potentially dangerous mode on /etc/logrotate.d/iotex: 0664
error: Ignoring /etc/logrotate.d/iotex because it is writable by group or others.`

These permission changes fix this error