### PR TITLE
[action] Replace actionPayload with Action in envelope

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -30,8 +30,6 @@ type (
 	actionPayload interface {
 		Cost() (*big.Int, error)
 		IntrinsicGas() (uint64, error)
-		SetEnvelopeContext(SealedEnvelope)
-		SanityCheck() error
 	}
 
 	hasDestination interface {

--- a/action/builder.go
+++ b/action/builder.go
@@ -117,8 +117,8 @@ func (b *EnvelopeBuilder) SetGasPriceByBytes(buf []byte) *EnvelopeBuilder {
 	return b
 }
 
-// SetAction sets the action payload for the Envelope Builder is building.
-func (b *EnvelopeBuilder) SetAction(action actionPayload) *EnvelopeBuilder {
+// SetAction sets the Action for the Envelope Builder is building.
+func (b *EnvelopeBuilder) SetAction(action Action) *EnvelopeBuilder {
 	b.elp.payload = action
 	return b
 }

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -33,7 +33,7 @@ type (
 		nonce    uint64
 		gasLimit uint64
 		gasPrice *big.Int
-		payload  actionPayload
+		payload  Action
 	}
 )
 
@@ -67,12 +67,20 @@ func (elp *envelope) GasPrice() *big.Int {
 
 // Cost returns cost of actions
 func (elp *envelope) Cost() (*big.Int, error) {
-	return elp.payload.Cost()
+	act, ok := elp.payload.(actionPayload)
+	if !ok {
+		return nil, errors.New("cost is unavailable")
+	}
+	return act.Cost()
 }
 
 // IntrinsicGas returns intrinsic gas of action.
 func (elp *envelope) IntrinsicGas() (uint64, error) {
-	return elp.payload.IntrinsicGas()
+	act, ok := elp.payload.(actionPayload)
+	if !ok {
+		return 0, errors.New("intrinsicGas is unavailable")
+	}
+	return act.IntrinsicGas()
 }
 
 // Action returns the action payload.

--- a/action/envelope_test.go
+++ b/action/envelope_test.go
@@ -103,7 +103,7 @@ func TestEnvelope_Actions(t *testing.T) {
 	cf := DepositToRewardingFundBuilder{}
 	depositToRewardingFund := cf.SetAmount(big.NewInt(1)).Build()
 
-	tests := []actionPayload{
+	tests := []Action{
 		putPollResult,
 		createStake,
 		depositToStake,

--- a/action/rlp_tx_test.go
+++ b/action/rlp_tx_test.go
@@ -360,7 +360,7 @@ func convertToNativeProto(tx *types.Transaction, actType string) *iotextypes.Act
 	case "stakeCreate", "stakeAddDeposit", "changeCandidate", "unstake", "withdrawStake", "restake",
 		"transferStake", "candidateRegister", "candidateUpdate":
 		act, _ := NewStakingActionFromABIBinary(tx.Data())
-		elpBuilder.SetAction(act.(actionPayload))
+		elpBuilder.SetAction(act)
 	default:
 		panic("unsupported")
 	}

--- a/action/sealedenvelope_test.go
+++ b/action/sealedenvelope_test.go
@@ -88,7 +88,7 @@ func TestSealedEnvelope_Actions(t *testing.T) {
 	candidateUpdate, err := NewCandidateUpdate(nonce, candidate1Name, cand1Addr, cand1Addr, gasLimit, gasPrice)
 	require.NoError(err)
 
-	tests := []actionPayload{
+	tests := []Action{
 		createStake,
 		depositToStake,
 		changeCandidate,


### PR DESCRIPTION
 - Every `Action` could be signed into a sealed envelope, so it is reasonable to have `Action` as the payload of envelope. This will also make possible that `EnvelopeBuilder` construct an envelope with an `Action ` outside of `action` pkg.
 - `actionPayload` interface is used to assert those which have `Cost()` method ( If every `Action` should be of  `Cost()` method, it should be added into `Action` interface)