### PR TITLE
[context] add public key size into ActionCtx

### DIFF
--- a/action/actctx.go
+++ b/action/actctx.go
@@ -62,9 +62,6 @@ func (act *AbstractAction) SetGasPrice(val *big.Int) {
 func (act *AbstractAction) BasicActionSize() uint32 {
 	// VersionSizeInBytes + NonceSizeInBytes + GasSizeInBytes
 	size := 4 + 8 + 8
-	if act.srcPubkey != nil {
-		size += len(act.srcPubkey.Bytes())
-	}
 	if act.gasPrice != nil && len(act.gasPrice.Bytes()) > 0 {
 		size += len(act.gasPrice.Bytes())
 	}

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -28,6 +28,8 @@ func TestExecutionSignVerify(t *testing.T) {
 	ex, err := NewExecution(contractAddr.String(), 2, big.NewInt(10), uint64(100000), big.NewInt(10), data)
 	require.NoError(err)
 	require.Nil(ex.srcPubkey)
+	require.EqualValues(21, ex.BasicActionSize())
+	require.EqualValues(22, ex.TotalSize())
 
 	bd := &EnvelopeBuilder{}
 	eb := bd.SetNonce(ex.nonce).

--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -150,7 +150,7 @@ func (p *Protocol) validateTransfer(ctx context.Context, act action.Action) erro
 		return nil
 	}
 	// Reject oversized transfer
-	if tsf.TotalSize()+protocol.MustGetActionCtx(ctx).PubkeySize > TransferSizeLimit {
+	if tsf.TotalSize()+protocol.PubkeySizeForTxSizeEstimation(ctx) > TransferSizeLimit {
 		return action.ErrOversizedData
 	}
 

--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -144,13 +144,13 @@ func (p *Protocol) handleTransfer(ctx context.Context, act action.Action, sm pro
 }
 
 // validateTransfer validates a transfer
-func (p *Protocol) validateTransfer(_ context.Context, act action.Action) error {
+func (p *Protocol) validateTransfer(ctx context.Context, act action.Action) error {
 	tsf, ok := act.(*action.Transfer)
 	if !ok {
 		return nil
 	}
 	// Reject oversized transfer
-	if tsf.TotalSize() > TransferSizeLimit {
+	if tsf.TotalSize()+protocol.MustGetActionCtx(ctx).PubkeySize > TransferSizeLimit {
 		return action.ErrOversizedData
 	}
 

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -35,11 +35,11 @@ func TestProtocol_ValidateTransfer(t *testing.T) {
 	require := require.New(t)
 	p := NewProtocol(rewarding.DepositGas)
 	t.Run("Oversized data", func(t *testing.T) {
-		tmpPayload := [32769]byte{}
-		payload := tmpPayload[:]
-		tsf, err := action.NewTransfer(uint64(1), big.NewInt(1), "2", payload, uint64(0), big.NewInt(0))
+		tsf, err := action.NewTransfer(uint64(1), big.NewInt(1), "2", make([]byte, 32683), uint64(0), big.NewInt(0))
 		require.NoError(err)
-		ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{PubkeySize: 65})
+		ctx := protocol.WithActionCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(),
+			genesis.Default),
+			protocol.BlockCtx{BlockHeight: 1000}), protocol.ActionCtx{PubkeySize: 65})
 		require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(ctx, tsf, nil)))
 	})
 }

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -39,7 +39,8 @@ func TestProtocol_ValidateTransfer(t *testing.T) {
 		payload := tmpPayload[:]
 		tsf, err := action.NewTransfer(uint64(1), big.NewInt(1), "2", payload, uint64(0), big.NewInt(0))
 		require.NoError(err)
-		require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(context.Background(), tsf, nil)))
+		ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{PubkeySize: 65})
+		require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(ctx, tsf, nil)))
 	})
 }
 

--- a/action/protocol/account/transfer_test.go
+++ b/action/protocol/account/transfer_test.go
@@ -107,6 +107,7 @@ func TestProtocol_HandleTransfer(t *testing.T) {
 		ctx = protocol.WithActionCtx(chainCtx, protocol.ActionCtx{
 			Caller:       v.caller,
 			IntrinsicGas: gas,
+			PubkeySize:   65,
 		})
 		ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
 			BlockHeight: 1,

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -72,6 +72,8 @@ type (
 		IntrinsicGas uint64
 		// Nonce is the nonce of the action
 		Nonce uint64
+		// PubkeySize is the size of pubkey
+		PubkeySize uint32
 	}
 
 	// CheckFunc is function type to check by height.

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -308,3 +308,14 @@ func GetVMConfigCtx(ctx context.Context) (vm.Config, bool) {
 	cfg, ok := ctx.Value(vmConfigContextKey{}).(vm.Config)
 	return cfg, ok
 }
+
+// PubkeySizeForTxSizeEstimation return the pubkey size for the purpose the tx size estimation
+func PubkeySizeForTxSizeEstimation(ctx context.Context) uint32 {
+	blkCtx := MustGetBlockCtx(ctx)
+	g := genesis.MustExtractGenesisContext(ctx)
+	if g.IsToBeEnabled(blkCtx.BlockHeight) {
+		return 0
+	}
+	actCtx := MustGetActionCtx(ctx)
+	return actCtx.PubkeySize
+}

--- a/action/protocol/context_test.go
+++ b/action/protocol/context_test.go
@@ -129,14 +129,20 @@ func TestGetActionCtx(t *testing.T) {
 		Caller:       addr,
 		ActionHash:   hash.ZeroHash256,
 		GasPrice:     nil,
-		IntrinsicGas: 0,
-		Nonce:        0,
+		IntrinsicGas: 10,
+		Nonce:        2,
+		PubkeySize:   65,
 	}
 	ctx := WithActionCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	ret, ok := GetActionCtx(ctx)
 	require.True(ok)
+	require.Equal("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms", ret.Caller.String())
 	require.Equal(hash.ZeroHash256, ret.ActionHash)
+	require.Nil(ret.GasPrice)
+	require.EqualValues(10, ret.IntrinsicGas)
+	require.EqualValues(2, ret.Nonce)
+	require.EqualValues(65, ret.PubkeySize)
 }
 
 func TestMustGetActionCtx(t *testing.T) {
@@ -147,14 +153,20 @@ func TestMustGetActionCtx(t *testing.T) {
 		Caller:       addr,
 		ActionHash:   hash.ZeroHash256,
 		GasPrice:     nil,
-		IntrinsicGas: 0,
-		Nonce:        0,
+		IntrinsicGas: 10,
+		Nonce:        2,
+		PubkeySize:   65,
 	}
 	ctx := WithActionCtx(context.Background(), actionCtx)
 	require.NotNil(ctx)
 	// Case I: Normal
 	ret := MustGetActionCtx(ctx)
+	require.Equal("io1mflp9m6hcgm2qcghchsdqj3z3eccrnekx9p0ms", ret.Caller.String())
 	require.Equal(hash.ZeroHash256, ret.ActionHash)
+	require.Nil(ret.GasPrice)
+	require.EqualValues(10, ret.IntrinsicGas)
+	require.EqualValues(2, ret.Nonce)
+	require.EqualValues(65, ret.PubkeySize)
 	// Case II: Panic
 	require.Panics(func() { MustGetActionCtx(context.Background()) }, "Miss action context")
 }

--- a/action/protocol/context_test.go
+++ b/action/protocol/context_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 )
 
 func TestRegistryCtx(t *testing.T) {
@@ -183,4 +185,27 @@ func TestGetVMConfigCtx(t *testing.T) {
 	ret, ok := GetVMConfigCtx(ctx)
 	require.True(ok)
 	require.True(ret.Debug)
+}
+
+func TestPubkeySizeForTxSize(t *testing.T) {
+	require := require.New(t)
+	g := genesis.Default
+	g.ToBeEnabledBlockHeight = 10
+	ctx := genesis.WithGenesisContext(context.Background(), g)
+	actionCtx := ActionCtx{
+		PubkeySize: 65,
+	}
+	for _, v := range []struct {
+		height uint64
+		size   uint32
+	}{
+		{5, 65},
+		{10, 0},
+		{11, 0},
+	} {
+		testCtx := WithActionCtx(WithBlockCtx(ctx, BlockCtx{
+			BlockHeight: v.height,
+		}), actionCtx)
+		require.Equal(v.size, PubkeySizeForTxSizeEstimation(testCtx))
+	}
 }

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -48,7 +48,8 @@ func TestExecuteContractFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
-		Caller: identityset.Address(27),
+		Caller:     identityset.Address(27),
+		PubkeySize: 65,
 	})
 	ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
 		Producer: identityset.Address(27),
@@ -76,7 +77,8 @@ func TestConstantinople(t *testing.T) {
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 
 	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
-		Caller: identityset.Address(27),
+		Caller:     identityset.Address(27),
+		PubkeySize: 65,
 	})
 
 	g := genesis.Default

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -76,13 +76,13 @@ func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.St
 }
 
 // Validate validates an execution
-func (p *Protocol) Validate(_ context.Context, act action.Action, _ protocol.StateReader) error {
+func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.StateReader) error {
 	exec, ok := act.(*action.Execution)
 	if !ok {
 		return nil
 	}
 	// Reject oversize execution
-	if exec.TotalSize() > ExecutionSizeLimit {
+	if exec.TotalSize()+protocol.MustGetActionCtx(ctx).PubkeySize > ExecutionSizeLimit {
 		return action.ErrOversizedData
 	}
 	return nil

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -82,7 +82,7 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.S
 		return nil
 	}
 	// Reject oversize execution
-	if exec.TotalSize()+protocol.MustGetActionCtx(ctx).PubkeySize > ExecutionSizeLimit {
+	if exec.TotalSize()+protocol.PubkeySizeForTxSizeEstimation(ctx) > ExecutionSizeLimit {
 		return action.ErrOversizedData
 	}
 	return nil

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
@@ -564,11 +565,11 @@ func TestProtocol_Validate(t *testing.T) {
 	p := NewProtocol(func(uint64) (hash.Hash256, error) {
 		return hash.ZeroHash256, nil
 	}, rewarding.DepositGas)
-	data := make([]byte, 32769)
-
-	ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), data)
+	ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), make([]byte, 32684))
 	require.NoError(err)
-	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{PubkeySize: 65})
+	ctx := protocol.WithActionCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(),
+		genesis.Default),
+		protocol.BlockCtx{BlockHeight: 1000}), protocol.ActionCtx{PubkeySize: 65})
 	require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(ctx, ex, nil)))
 }
 

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -568,7 +568,8 @@ func TestProtocol_Validate(t *testing.T) {
 
 	ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), data)
 	require.NoError(err)
-	require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(context.Background(), ex, nil)))
+	ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{PubkeySize: 65})
+	require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(ctx, ex, nil)))
 }
 
 func TestProtocol_Handle(t *testing.T) {

--- a/action/protocol/generic_validator_test.go
+++ b/action/protocol/generic_validator_test.go
@@ -43,7 +43,8 @@ func TestActionProtoAndGenericValidator(t *testing.T) {
 		})
 	ctx = WithActionCtx(ctx,
 		ActionCtx{
-			Caller: caller,
+			Caller:     caller,
+			PubkeySize: 65,
 		})
 
 	ctx = WithBlockchainCtx(

--- a/action/transfer_test.go
+++ b/action/transfer_test.go
@@ -24,6 +24,8 @@ func TestTransferSignVerify(t *testing.T) {
 	tsf, err := NewTransfer(1, big.NewInt(10), recipientAddr.String(), []byte{}, uint64(100000), big.NewInt(10))
 	require.NoError(err)
 	require.Nil(tsf.srcPubkey)
+	require.EqualValues(21, tsf.BasicActionSize())
+	require.EqualValues(22, tsf.TotalSize())
 
 	bd := &EnvelopeBuilder{}
 	eb := bd.SetNonce(tsf.nonce).
@@ -78,7 +80,7 @@ func TestTransfer(t *testing.T) {
 	require.Equal(senderKey.PublicKey().HexString(), w.SrcPubkey().HexString())
 	require.Equal(recipientAddr.String(), tsf.Recipient())
 	require.Equal(recipientAddr.String(), tsf.Destination())
-	require.Equal(uint32(87), tsf.TotalSize())
+	require.Equal(uint32(22), tsf.TotalSize())
 
 	gas, err := tsf.IntrinsicGas()
 	require.NoError(err)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -773,6 +773,7 @@ func testNonce(sf Factory, t *testing.T) {
 			GasPrice:     selp.GasPrice(),
 			Nonce:        selp.Nonce(),
 			IntrinsicGas: intrinsicGas,
+			PubkeySize:   uint32(len(selp.SrcPubkey().Bytes())),
 		},
 	)
 	ctx = protocol.WithBlockchainCtx(ctx, protocol.BlockchainCtx{

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -140,6 +140,7 @@ func withActionCtx(ctx context.Context, selp action.SealedEnvelope) (context.Con
 	}
 	actionCtx.IntrinsicGas = intrinsicGas
 	actionCtx.Nonce = selp.Nonce()
+	actionCtx.PubkeySize = uint32(len(selp.SrcPubkey().Bytes()))
 
 	return protocol.WithActionCtx(ctx, actionCtx), nil
 }


### PR DESCRIPTION
for #3096, it's not desired to add pubkey size into action struct, so add it to context (to be used at `Validate()` time)