### PR TITLE
[statedb] Refactor func (st *Account) AddBalance()

### DIFF
--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -109,9 +109,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, act action.Action, sm pro
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load or create the account of recipient %s", tsf.Recipient())
 	}
-	if err := recipient.AddBalance(tsf.Amount()); err != nil {
-		return nil, errors.Wrapf(err, "failed to update the Balance of recipient %s", tsf.Recipient())
-	}
+	recipient.AddBalance(tsf.Amount())
 	// put updated recipient's state to trie
 	if err := accountutil.StoreAccount(sm, recipientAddr, recipient); err != nil {
 		return nil, errors.Wrap(err, "failed to update pending account changes to trie")

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -264,7 +264,7 @@ func TestSnapshot(t *testing.T) {
 		require.NoError(err)
 		require.NoError(_c1.SetState(_k2b, _v2[:]))
 		_c2 := _c1.Snapshot()
-		require.NoError(_c1.SelfState().AddBalance(big.NewInt(7)))
+		_c1.SelfState().AddBalance(big.NewInt(7))
 		require.NoError(_c1.SetState(_k1b, _v1[:]))
 		require.Equal(big.NewInt(12), _c1.SelfState().Balance)
 		require.Equal(big.NewInt(5), _c2.SelfState().Balance)

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -239,11 +239,7 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, amount *big.In
 			return
 		}
 	}
-	if err := state.AddBalance(amount); err != nil {
-		log.L().Error("Failed to add balance.", zap.Error(err))
-		stateDB.logError(err)
-		return
-	}
+	state.AddBalance(amount)
 	if err := accountutil.StoreAccount(stateDB.sm, addr, state); err != nil {
 		log.L().Error("Failed to update pending account changes to trie.", zap.Error(err))
 		stateDB.logError(err)

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -254,12 +254,7 @@ func (p *Protocol) handleWithdrawStake(ctx context.Context, act *action.Withdraw
 	}
 
 	// update withdrawer balance
-	if err := withdrawer.AddBalance(bucket.StakedAmount); err != nil {
-		return log, nil, &handleError{
-			err:           errors.Wrapf(err, "failed to update the balance of withdrawer %s", actionCtx.Caller.String()),
-			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketAmount,
-		}
-	}
+	withdrawer.AddBalance(bucket.StakedAmount)
 	// put updated withdrawer's account state to trie
 	if err := accountutil.StoreAccount(csm, actionCtx.Caller, withdrawer); err != nil {
 		return log, nil, errors.Wrapf(err, "failed to store account %s", actionCtx.Caller.String())

--- a/state/account.go
+++ b/state/account.go
@@ -94,9 +94,8 @@ func (st *Account) Deserialize(buf []byte) error {
 }
 
 // AddBalance adds balance for account state
-func (st *Account) AddBalance(amount *big.Int) error {
+func (st *Account) AddBalance(amount *big.Int) {
 	st.Balance.Add(st.Balance, amount)
-	return nil
 }
 
 // SubBalance subtracts balance for account state

--- a/state/account_test.go
+++ b/state/account_test.go
@@ -55,7 +55,7 @@ func TestBalance(t *testing.T) {
 
 	state := &Account{Balance: big.NewInt(20)}
 	// Add 10 to the balance
-	require.NoError(state.AddBalance(big.NewInt(10)))
+	state.AddBalance(big.NewInt(10))
 	// Balance should == 30 now
 	require.Equal(0, state.Balance.Cmp(big.NewInt(30)))
 	// Sub 40 to the balance
@@ -71,7 +71,7 @@ func TestClone(t *testing.T) {
 	account := ss.Clone()
 	require.Equal(big.NewInt(200), account.Balance)
 
-	require.NoError(account.AddBalance(big.NewInt(100)))
+	account.AddBalance(big.NewInt(100))
 	require.Equal(big.NewInt(200), ss.Balance)
 	require.Equal(big.NewInt(200+100), account.Balance)
 }

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -193,7 +193,7 @@ func testSnapshot(ws *workingSet, t *testing.T) {
 	require.Equal(big.NewInt(7), s.Balance)
 	s2 := ws.Snapshot()
 	require.Equal(2, s2)
-	require.NoError(s.AddBalance(big.NewInt(6)))
+	s.AddBalance(big.NewInt(6))
 	require.Equal(big.NewInt(13), s.Balance)
 	_, err = ws.PutState(s, protocol.LegacyKeyOption(tHash))
 	require.NoError(err)


### PR DESCRIPTION
# Description

The return value (error) of `AddBalance` never triggered, which can be removed.

Fixes #3239 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestBalance
- [x] TestClone
- [x] TestProtocol_HandleTransfer
- [x] TestSnapshot
- [x] TestClearSnapshots
- [x] TestProtocol_HandleWithdrawStake
- [x] TestSnapshotRevertAndCommit

**Test Configuration**:

- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
