### PR TITLE
[evm] Change the type of evm statuscode from uint64 to int32

### DIFF
--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -293,12 +293,12 @@ func TestEvmError(t *testing.T) {
 		{errors.New("unknown"), iotextypes.ReceiptStatus_ErrUnknown},
 	}
 	for _, v := range beringTests {
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), uint64(iotextypes.ReceiptStatus_Failure))
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), iotextypes.ReceiptStatus_Failure)
 	}
 
 	jutlandTests := []struct {
@@ -312,12 +312,12 @@ func TestEvmError(t *testing.T) {
 		{errors.New("unknown"), iotextypes.ReceiptStatus_ErrUnknown},
 	}
 	for _, v := range jutlandTests {
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), uint64(iotextypes.ReceiptStatus_Failure))
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), iotextypes.ReceiptStatus_Failure)
 	}
 
 	newTests := []struct {
@@ -327,12 +327,12 @@ func TestEvmError(t *testing.T) {
 		{vm.ErrInvalidCode, iotextypes.ReceiptStatus_ErrInvalidCode},
 	}
 	for _, v := range newTests {
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), uint64(v.status))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), uint64(iotextypes.ReceiptStatus_ErrUnknown))
-		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), uint64(iotextypes.ReceiptStatus_Failure))
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight), v.status)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.ToBeEnabledBlockHeight-1), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.JutlandBlockHeight-1), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight), iotextypes.ReceiptStatus_ErrUnknown)
+		r.Equal(evmErrToErrStatusCode(v.evmError, g, g.BeringBlockHeight-1), iotextypes.ReceiptStatus_Failure)
 	}
 }
 


### PR DESCRIPTION
# Description

Change the return value of `executeInEVM` from 
https://github.com/iotexproject/iotex-core/blob/5a1fe5d978d45b07446e3750a177f5fba6876e96/action/protocol/execution/evm/evm.go#L343
to 
https://github.com/iotexproject/iotex-core/blob/fcd0379b143c032a8b1cbbfa52d10a5ec674cf24/action/protocol/execution/evm/evm.go#L335
There are too many type conversions in `executeInEVM` and it's sub function `evmErrToErrStatusCode`, which can be done once in `ExecuteContract` by
https://github.com/iotexproject/iotex-core/blob/fcd0379b143c032a8b1cbbfa52d10a5ec674cf24/action/protocol/execution/evm/evm.go#L217


Fixes #3240 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestExecuteContractFailure
- [x] TestEvmError

**Test Configuration**:

- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
