### PR TITLE
[api] Replace iotextypes.Log with action.Log in the return from LogsInRange()

### DIFF
--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-core/action"
 	logfilter "github.com/iotexproject/iotex-core/api/logfilter"
 	"github.com/iotexproject/iotex-core/test/mock/mock_blockindex"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
 func TestLogsInRange(t *testing.T) {
@@ -75,7 +75,7 @@ func TestLogsInRange(t *testing.T) {
 
 		logs, err := svr.web3Server.coreService.LogsInRange(logfilter.NewLogFilter(&filter, nil, nil), from, to, uint64(0))
 		expectedErr := errors.New("invalid start and end height")
-		expectedValue := []*iotextypes.Log(nil)
+		expectedValue := []*action.Log(nil)
 		require.Error(err)
 		require.Equal(expectedErr.Error(), err.Error())
 		require.Equal(expectedValue, logs)
@@ -91,7 +91,7 @@ func TestLogsInRange(t *testing.T) {
 
 		logs, err := svr.web3Server.coreService.LogsInRange(logfilter.NewLogFilter(&filter, nil, nil), from, to, uint64(0))
 		expectedErr := errors.New("start block > tip height")
-		expectedValue := []*iotextypes.Log(nil)
+		expectedValue := []*action.Log(nil)
 		require.Error(err)
 		require.Equal(expectedErr.Error(), err.Error())
 		require.Equal(expectedValue, logs)

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -238,18 +238,28 @@ func (svr *Web3Server) getLogsWithFilter(from uint64, to uint64, addrs []string,
 	ret := make([]logsObjectRaw, 0)
 	for _, l := range logs {
 		topics := make([]string, 0)
-		for _, val := range l.Topics {
+		logTopics := [][]byte{}
+		for _, topic := range l.Topics {
+			if l.NotFixTopicCopyBug {
+				logTopics = append(logTopics, topic[:])
+			} else {
+				data := make([]byte, len(topic))
+				copy(data, topic[:])
+				logTopics = append(logTopics, data)
+			}
+		}
+		for _, val := range logTopics {
 			topics = append(topics, byteToHex(val))
 		}
-		contractAddr, err := ioAddrToEthAddr(l.ContractAddress)
+		contractAddr, err := ioAddrToEthAddr(l.Address)
 		if err != nil {
 			return nil, err
 		}
 		ret = append(ret, logsObjectRaw{
-			BlockHash:        byteToHex(l.BlkHash),
-			TransactionHash:  byteToHex(l.ActHash),
+			// BlockHash:        byteToHex(l.BlkHash),
+			TransactionHash:  byteToHex(l.ActionHash[:]),
 			LogIndex:         uint64ToHex(uint64(l.Index)),
-			BlockNumber:      uint64ToHex(l.BlkHeight),
+			BlockNumber:      uint64ToHex(l.BlockHeight),
 			TransactionIndex: uint64ToHex(uint64(l.TxIndex)),
 			Address:          contractAddr,
 			Data:             byteToHex(l.Data),

--- a/test/mock/mock_apicoreservice/mock_apicoreservice.go
+++ b/test/mock/mock_apicoreservice/mock_apicoreservice.go
@@ -348,10 +348,10 @@ func (mr *MockCoreServiceMockRecorder) LogsInBlockByHash(filter, blockHash inter
 }
 
 // LogsInRange mocks base method.
-func (m *MockCoreService) LogsInRange(filter *logfilter.LogFilter, start, end, paginationSize uint64) ([]*iotextypes.Log, error) {
+func (m *MockCoreService) LogsInRange(filter *logfilter.LogFilter, start, end, paginationSize uint64) ([]*action.Log, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "LogsInRange", filter, start, end, paginationSize)
-	ret0, _ := ret[0].([]*iotextypes.Log)
+	ret0, _ := ret[0].([]*action.Log)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
# Description

`iotextypes.Log` can be simplified and replaced by `action.Log` in `LogsInRange`.

Fixes #3255 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestLogsInRange
- [x] TestGrpcServer_GetLogsIntegrity
- [x] TestGetLogsIntegrity
- [x] BenchmarkLogsInRange

**Test Configuration**:

- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
