### PR TITLE
[ioctl] Refactor aliasexport command in new ioctl

### DIFF
--- a/ioctl/cmd/alias/aliasexport.go
+++ b/ioctl/cmd/alias/aliasexport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 202 IoTeX Foundation
+// Copyright (c) 2022 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/ioctl/cmd/alias/aliasexport.go
+++ b/ioctl/cmd/alias/aliasexport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 IoTeX Foundation
+// Copyright (c) 202 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/ioctl/newcmd/alias/aliasexport.go
+++ b/ioctl/newcmd/alias/aliasexport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 IoTeX Foundation
+// Copyright (c) 2019 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
@@ -48,20 +48,16 @@ func NewAliasExport(c ioctl.Client) *cobra.Command {
 	ec := &cobra.Command{
 		Use:   use,
 		Short: short,
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
+
 			cmd.SilenceUsage = true
-			format = args[0]
 			exportAliases := aliases{}
 			for name, address := range c.Config().Aliases {
 				exportAliases.Aliases = append(exportAliases.Aliases, alias{Name: name, Address: address})
 			}
 
 			switch format {
-
-			default:
-				cmd.SilenceUsage = false
-				return errors.Errorf(_invalidFlag, format)
 			case "json":
 				output, err := json.Marshal(exportAliases)
 				if err != nil {
@@ -76,8 +72,9 @@ func NewAliasExport(c ioctl.Client) *cobra.Command {
 				}
 				cmd.Println(string(output))
 				return nil
+			default:
+				return errors.Errorf(_invalidFlag, format)
 			}
-
 		},
 	}
 	ec.Flags().StringVarP(&format,

--- a/ioctl/newcmd/alias/aliasexport.go
+++ b/ioctl/newcmd/alias/aliasexport.go
@@ -48,11 +48,12 @@ func NewAliasExport(c ioctl.Client) *cobra.Command {
 	ec := &cobra.Command{
 		Use:   use,
 		Short: short,
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
+			format = args[0]
 			exportAliases := aliases{}
-			for name, address := range config.ReadConfig.Aliases {
+			for name, address := range c.Config().Aliases {
 				exportAliases.Aliases = append(exportAliases.Aliases, alias{Name: name, Address: address})
 			}
 

--- a/ioctl/newcmd/alias/aliasexport.go
+++ b/ioctl/newcmd/alias/aliasexport.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 IoTeX Foundation
+// Copyright (c) 2022 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
@@ -8,8 +8,8 @@ package alias
 
 import (
 	"encoding/json"
-	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
 
@@ -50,7 +50,6 @@ func NewAliasExport(c ioctl.Client) *cobra.Command {
 		Short: short,
 		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			cmd.SilenceUsage = true
 			exportAliases := aliases{}
 			for name, address := range config.ReadConfig.Aliases {
@@ -61,20 +60,20 @@ func NewAliasExport(c ioctl.Client) *cobra.Command {
 
 			default:
 				cmd.SilenceUsage = false
-				return fmt.Errorf(_invalidFlag, format)
+				return errors.Errorf(_invalidFlag, format)
 			case "json":
 				output, err := json.Marshal(exportAliases)
 				if err != nil {
 					return nil
 				}
-				println(string(output))
+				cmd.Println(string(output))
 				return nil
 			case "yaml":
 				output, err := yaml.Marshal(exportAliases)
 				if err != nil {
 					return nil
 				}
-				println(string(output))
+				cmd.Println(string(output))
 				return nil
 			}
 

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -18,12 +18,36 @@ import (
 )
 
 func TestNewAliasExport(t *testing.T) {
+	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslation",
-		config.English).Times(4)
-	cmd := NewAliasExport(client)
-	result, err := util.ExecuteCmd(cmd)
-	require.NoError(t, err)
-	require.NotNil(t, result)
+		config.English).Times(12)
+	client.EXPECT().Config().Return(config.Config{}).Times(3)
+	client.EXPECT().AliasMap().Return(map[string]string{
+		"aaa": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		"bbb": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		cmd := NewAliasExport(client)
+		_, err := util.ExecuteCmd(cmd, "")
+		require.Error(err)
+	})
+
+	t.Run("export alias with json format", func(t *testing.T) {
+		cmd := NewAliasExport(client)
+		_, err := util.ExecuteCmd(cmd, "json")
+		require.NoError(err)
+	})
+
+	t.Run("export alias with yaml format", func(t *testing.T) {
+		cmd := NewAliasExport(client)
+		_, err := util.ExecuteCmd(cmd, "yaml")
+		require.NoError(err)
+	})
+	// 	cmd := NewAliasExport(client)
+	// 	result, err := util.ExecuteCmd(cmd)
+	// 	require.NoError(t, err)
+	// 	require.NotNil(t, result)
 }

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 IoTeX Foundation
+// Copyright (c) 2019 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
@@ -23,31 +23,42 @@ func TestNewAliasExport(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslation",
 		config.English).Times(12)
-	client.EXPECT().Config().Return(config.Config{}).Times(3)
+	cfg := config.Config{
+		Aliases: map[string]string{
+			"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+			"b": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+			"c": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
+			"io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		},
+	}
 	client.EXPECT().AliasMap().Return(map[string]string{
-		"aaa": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
-		"bbb": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
-	})
+		"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		"b": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		"c": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
+		"io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+	}).AnyTimes()
+	client.EXPECT().Config().Return(cfg).AnyTimes()
 
 	t.Run("invalid flag", func(t *testing.T) {
 		cmd := NewAliasExport(client)
-		_, err := util.ExecuteCmd(cmd, "")
+		_, err := util.ExecuteCmd(cmd, "-f", "")
 		require.Error(err)
+		require.Contains(err.Error(), "EXTRA string=")
 	})
 
 	t.Run("export alias with json format", func(t *testing.T) {
 		cmd := NewAliasExport(client)
-		_, err := util.ExecuteCmd(cmd, "json")
+		result, err := util.ExecuteCmd(cmd)
 		require.NoError(err)
+		require.NotNil(result)
+		require.Contains(result, "alias")
 	})
 
 	t.Run("export alias with yaml format", func(t *testing.T) {
 		cmd := NewAliasExport(client)
-		_, err := util.ExecuteCmd(cmd, "yaml")
+		result, err := util.ExecuteCmd(cmd, "-f", "yaml")
 		require.NoError(err)
+		require.NotNil(result)
+		require.Contains(result, "alias")
 	})
-	// 	cmd := NewAliasExport(client)
-	// 	result, err := util.ExecuteCmd(cmd)
-	// 	require.NoError(t, err)
-	// 	require.NotNil(t, result)
 }

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -33,13 +33,6 @@ func TestNewAliasExport(t *testing.T) {
 	}
 	client.EXPECT().Config().Return(cfg).AnyTimes()
 
-	t.Run("invalid flag", func(t *testing.T) {
-		cmd := NewAliasExport(client)
-		_, err := util.ExecuteCmd(cmd, "-f", "")
-		require.Error(err)
-		require.Contains(err.Error(), "EXTRA string=")
-	})
-
 	t.Run("export alias with json format", func(t *testing.T) {
 		cmd := NewAliasExport(client)
 		result, err := util.ExecuteCmd(cmd)
@@ -54,5 +47,12 @@ func TestNewAliasExport(t *testing.T) {
 		require.NoError(err)
 		require.NotNil(result)
 		require.Contains(result, "alias")
+	})
+
+	t.Run("invalid flag", func(t *testing.T) {
+		cmd := NewAliasExport(client)
+		_, err := util.ExecuteCmd(cmd, "-f", "")
+		require.Error(err)
+		require.Contains(err.Error(), "EXTRA string=")
 	})
 }

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 IoTeX Foundation
+// Copyright (c) 2022 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/ioctl/newcmd/alias/aliasexport_test.go
+++ b/ioctl/newcmd/alias/aliasexport_test.go
@@ -31,12 +31,6 @@ func TestNewAliasExport(t *testing.T) {
 			"io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
 		},
 	}
-	client.EXPECT().AliasMap().Return(map[string]string{
-		"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
-		"b": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
-		"c": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
-		"io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
-	}).AnyTimes()
 	client.EXPECT().Config().Return(cfg).AnyTimes()
 
 	t.Run("invalid flag", func(t *testing.T) {


### PR DESCRIPTION
# Description

Refactor `aliasexport` command in new ioctl, with the following note.

* Use [function of client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) .
* Replace `fmt.Println` with `cmd.Println`
* [Output package](https://github.com/iotexproject/iotex-core/blob/master/ioctl/output) is deprecated. e.g. output.PrintError could be replaced with errors.Wrap.
* Global variables (config.ReadConfig config.DefaultConfigFile etc.) have been wrapped into [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go). Please use client interface to access them if needed
* Refactor unit test to cover the modification.

Fixes #3272 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] TestNewAliasExport

**Test Configuration**:

- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
