### PR TITLE
[actpool] Simplify reset() in PendingActionMap()

### DIFF
--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -174,11 +174,10 @@ func (ap *actPool) PendingActionMap() map[string][]action.SealedEnvelope {
 	ap.mutex.Lock()
 	defer ap.mutex.Unlock()
 
-	// Remove the actions that are already timeout
-	ap.reset()
-
 	actionMap := make(map[string][]action.SealedEnvelope)
 	for from, queue := range ap.accountActs {
+		// Remove the actions that are already timeout
+		ap.updateAccount(from)
 		actionMap[from] = append(actionMap[from], queue.PendingActs()...)
 	}
 	return actionMap


### PR DESCRIPTION
# Description

As the comment indicates, only timeout acts would be removed. So `ap.updateAccount(from)` is enough for the job.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
