### PR TITLE
[accountutil] LoadOrCreateAccount() use address.Address as input

### DIFF
--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -32,7 +32,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, act action.Action, sm pro
 		return nil, nil
 	}
 	// check sender
-	sender, err := accountutil.LoadOrCreateAccount(sm, actionCtx.Caller.String())
+	sender, err := accountutil.LoadOrCreateAccount(sm, actionCtx.Caller)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load or create the account of sender %s", actionCtx.Caller.String())
 	}
@@ -117,7 +117,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, act action.Action, sm pro
 		return nil, errors.Wrap(err, "failed to update pending account changes to trie")
 	}
 	// check recipient
-	recipient, err := accountutil.LoadOrCreateAccount(sm, tsf.Recipient())
+	recipient, err := accountutil.LoadOrCreateAccount(sm, recipientAddr)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to load or create the account of recipient %s", tsf.Recipient())
 	}

--- a/action/protocol/account/util/util.go
+++ b/action/protocol/account/util/util.go
@@ -30,15 +30,12 @@ func SetNonce(i noncer, state *state.Account) {
 }
 
 // LoadOrCreateAccount either loads an account state or creates an account state
-func LoadOrCreateAccount(sm protocol.StateManager, encodedAddr string) (*state.Account, error) {
-	var account state.Account
-	addr, err := address.FromString(encodedAddr)
-	if err != nil {
-		account = state.EmptyAccount()
-		return &account, errors.Wrap(err, "failed to get address public key hash from encoded address")
-	}
-	addrHash := hash.BytesToHash160(addr.Bytes())
-	_, err = sm.State(&account, protocol.LegacyKeyOption(addrHash))
+func LoadOrCreateAccount(sm protocol.StateManager, addr address.Address) (*state.Account, error) {
+	var (
+		account  state.Account
+		addrHash = hash.BytesToHash160(addr.Bytes())
+	)
+	_, err := sm.State(&account, protocol.LegacyKeyOption(addrHash))
 	if err == nil {
 		return &account, nil
 	}

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -65,7 +65,7 @@ func TestCreateContract(t *testing.T) {
 		}).AnyTimes()
 
 	addr := identityset.Address(28)
-	_, err = accountutil.LoadOrCreateAccount(sm, addr.String())
+	_, err = accountutil.LoadOrCreateAccount(sm, addr)
 	require.NoError(err)
 	stateDB := NewStateDBAdapter(sm, 0, hash.ZeroHash256, NotFixTopicCopyBugOption())
 
@@ -89,7 +89,7 @@ func TestCreateContract(t *testing.T) {
 	require.NoError(stateDB.CommitContracts())
 	stateDB.clear()
 	// reload same contract
-	contract1, err := accountutil.LoadOrCreateAccount(sm, addr.String())
+	contract1, err := accountutil.LoadOrCreateAccount(sm, addr)
 	require.NoError(err)
 	require.Equal(codeHash[:], contract1.CodeHash)
 }

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -176,7 +176,7 @@ func (stateDB *StateDBAdapter) CreateAccount(evmAddr common.Address) {
 		log.L().Error("Failed to convert evm address.", zap.Error(err))
 		return
 	}
-	_, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String())
+	_, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr)
 	if err != nil {
 		log.L().Error("Failed to create account.", zap.Error(err))
 		stateDB.logError(err)
@@ -232,7 +232,7 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, amount *big.In
 	if contract, ok := stateDB.cachedContract[addrHash]; ok {
 		state = contract.SelfState()
 	} else {
-		state, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr.String())
+		state, err = accountutil.LoadOrCreateAccount(stateDB.sm, addr)
 		if err != nil {
 			log.L().Error("Failed to add balance.", log.Hex("addrHash", evmAddr[:]))
 			stateDB.logError(err)

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -169,7 +169,11 @@ func setCandidates(
 	}
 	loadCandidatesLegacy := featureCtx.LoadCandidatesLegacy(height)
 	for _, candidate := range candidates {
-		delegate, err := accountutil.LoadOrCreateAccount(sm, candidate.Address)
+		addr, err := address.FromString(candidate.Address)
+		if err != nil {
+			return errors.Wrapf(err, "failed to decode delegate address %s", candidate.Address)
+		}
+		delegate, err := accountutil.LoadOrCreateAccount(sm, addr)
 		if err != nil {
 			return errors.Wrapf(err, "failed to load or create the account for delegate %s", candidate.Address)
 		}

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -393,7 +393,7 @@ func (p *Protocol) settleAction(
 }
 
 func (p *Protocol) increaseNonce(sm protocol.StateManager, addr address.Address, nonce uint64) error {
-	acc, err := accountutil.LoadOrCreateAccount(sm, addr.String())
+	acc, err := accountutil.LoadOrCreateAccount(sm, addr)
 	if err != nil {
 		return err
 	}

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -390,7 +390,7 @@ func (p *Protocol) claimFromAccount(ctx context.Context, sm protocol.StateManage
 	}
 
 	// Update primary account
-	primAcc, err := accountutil.LoadOrCreateAccount(sm, addr.String())
+	primAcc, err := accountutil.LoadOrCreateAccount(sm, addr)
 	if err != nil {
 		return err
 	}

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -2656,7 +2656,7 @@ func setupAccount(sm protocol.StateManager, addr address.Address, balance int64)
 	if balance < 0 {
 		return errors.New("balance cannot be negative")
 	}
-	account, err := accountutil.LoadOrCreateAccount(sm, addr.String())
+	account, err := accountutil.LoadOrCreateAccount(sm, addr)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
This PR servers 2 purposes:
1. by passing in `address.Address`, it saves 1 conversion from string to `address.Address`, and also consistent with other funcs in `util.go` using `address.Address` as input
2. a small patch for the legacy address PR: https://github.com/iotexproject/iotex-core/commit/5a1fe5d978d45b07446e3750a177f5fba6876e96#diff-9c655a6b1d90598fa3fa865bf5235dd04787e0005d400508212bad3503c893a9R68-R73, see comment in transfer.go

Fixes # (issue)
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] make test

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
