### PR TITLE
[ioctl] fix cannot open test file when make test

### DIFF
--- a/ioctl/client_test.go
+++ b/ioctl/client_test.go
@@ -9,6 +9,7 @@ package ioctl
 import (
 	"context"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -114,7 +115,7 @@ func TestGetAddress(t *testing.T) {
 	for _, test := range tests {
 		r := require.New(t)
 		configFilePath := writeTempConfig(t, &test.cfg)
-		defer testutil.CleanupPath(configFilePath)
+		defer testutil.CleanupPath(path.Dir(configFilePath))
 		cfgload := loadTempConfig(t, configFilePath)
 		r.Equal(test.cfg, cfgload)
 
@@ -129,7 +130,7 @@ func TestGetAddress(t *testing.T) {
 
 func TestNewKeyStore(t *testing.T) {
 	r := require.New(t)
-	testWallet, err := os.MkdirTemp(os.TempDir(), "ksTest")
+	testWallet, err := os.MkdirTemp(os.TempDir(), "testKeyStore")
 	r.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -158,7 +159,7 @@ func TestAliasMap(t *testing.T) {
 	}
 
 	configFilePath := writeTempConfig(t, &cfg)
-	defer testutil.CleanupPath(configFilePath)
+	defer testutil.CleanupPath(path.Dir(configFilePath))
 	cfgload := loadTempConfig(t, configFilePath)
 	r.Equal(cfg, cfgload)
 
@@ -325,7 +326,7 @@ func TestDeleteAlias(t *testing.T) {
 
 func writeTempConfig(t *testing.T, cfg *config.Config) string {
 	r := require.New(t)
-	testPathd, err := os.MkdirTemp(os.TempDir(), "kstest")
+	testPathd, err := os.MkdirTemp(os.TempDir(), "testConfig")
 	r.NoError(err)
 	configFilePath := testPathd + "/config.default"
 	out, err := yaml.Marshal(cfg)

--- a/ioctl/cmd/account/account_test.go
+++ b/ioctl/cmd/account/account_test.go
@@ -10,7 +10,6 @@ import (
 	"crypto/ecdsa"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -32,7 +31,8 @@ const (
 func TestAccount(t *testing.T) {
 	r := require.New(t)
 
-	testWallet := filepath.Join(os.TempDir(), _testPath)
+	testWallet, err := os.MkdirTemp(os.TempDir(), _testPath)
+	r.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 	config.ReadConfig.Wallet = testWallet
 

--- a/ioctl/cmd/alias/alias_test.go
+++ b/ioctl/cmd/alias/alias_test.go
@@ -15,12 +15,15 @@ import (
 
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/validator"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestAlias(t *testing.T) {
 	require := require.New(t)
 
-	require.NoError(testInit())
+	testPathd, err := testInit()
+	require.NoError(err)
+	defer testutil.CleanupPath(testPathd)
 
 	raullen := "raullen"
 	qevan := "qevan"
@@ -62,22 +65,24 @@ func TestAlias(t *testing.T) {
 	require.Equal(jing, aliases["io1kmpejl35lys5pxcpk74g8am0kwmzwwuvsvqrp8"])
 }
 
-func testInit() error {
-	testPathd, _ := os.MkdirTemp(os.TempDir(), "kstest")
+func testInit() (string, error) {
+	testPathd, err := os.MkdirTemp(os.TempDir(), "kstest")
+	if err != nil {
+		return testPathd, err
+	}
 	config.ConfigDir = testPathd
-	var err error
 	config.DefaultConfigFile = config.ConfigDir + "/config.default"
 	config.ReadConfig, err = config.LoadConfig()
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return testPathd, err
 	}
 	config.ReadConfig.Wallet = config.ConfigDir
 	out, err := yaml.Marshal(&config.ReadConfig)
 	if err != nil {
-		return err
+		return testPathd, err
 	}
 	if err := os.WriteFile(config.DefaultConfigFile, out, 0600); err != nil {
-		return err
+		return testPathd, err
 	}
-	return nil
+	return testPathd, nil
 }

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path/filepath"
 	"strconv"
 	"testing"
 
@@ -36,7 +35,7 @@ import (
 )
 
 const (
-	_testPath = "ksTest"
+	_testPath = "testNewAccount"
 )
 
 func TestNewAccountCmd(t *testing.T) {
@@ -121,8 +120,8 @@ func TestSign(t *testing.T) {
 func TestAccount(t *testing.T) {
 	require := require.New(t)
 	testWallet, ks, passwd, nonce, err := newTestAccount()
-	defer testutil.CleanupPath(testWallet)
 	require.NoError(err)
+	defer testutil.CleanupPath(testWallet)
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -238,7 +237,8 @@ func TestMeta(t *testing.T) {
 
 func TestAccountError(t *testing.T) {
 	require := require.New(t)
-	testFilePath := filepath.Join(os.TempDir(), _testPath)
+	testFilePath, err := os.MkdirTemp(os.TempDir(), _testPath)
+	require.NoError(err)
 	defer testutil.CleanupPath(testFilePath)
 	alias := "aaa"
 	passwordOfKeyStore := "123456"
@@ -258,7 +258,7 @@ func TestAccountError(t *testing.T) {
 		})
 	cmd := &cobra.Command{}
 	cmd.SetOut(new(bytes.Buffer))
-	_, err := newAccountByKeyStore(client, cmd, alias, passwordOfKeyStore, keyStorePath)
+	_, err = newAccountByKeyStore(client, cmd, alias, passwordOfKeyStore, keyStorePath)
 	require.Error(err)
 	require.Contains(err.Error(), fmt.Sprintf("keystore file \"%s\" read error", keyStorePath))
 
@@ -407,8 +407,8 @@ func TestNewAccountByKey(t *testing.T) {
 }
 
 func newTestAccount() (string, *keystore.KeyStore, string, string, error) {
-	testWallet := filepath.Join(os.TempDir(), _testPath)
-	if err := os.MkdirAll(testWallet, os.ModePerm); err != nil {
+	testWallet, err := os.MkdirTemp(os.TempDir(), _testPath)
+	if err != nil {
 		return testWallet, nil, "", "", err
 	}
 

--- a/ioctl/newcmd/account/accountdelete_test.go
+++ b/ioctl/newcmd/account/accountdelete_test.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -20,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountDelete(t *testing.T) {
@@ -30,11 +30,9 @@ func TestNewAccountDelete(t *testing.T) {
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString",
 		config.English).Times(30)
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testAccount")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountDelete")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
 
 	t.Run("CryptoSm2 is false", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false).Times(2)

--- a/ioctl/newcmd/account/accountexport_test.go
+++ b/ioctl/newcmd/account/accountexport_test.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -20,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountExport(t *testing.T) {
@@ -28,11 +28,10 @@ func TestNewAccountExport(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testNewAccountExport")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountExport")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
+
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 

--- a/ioctl/newcmd/account/accountexportpublic_test.go
+++ b/ioctl/newcmd/account/accountexportpublic_test.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -20,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountExportPublic(t *testing.T) {
@@ -28,11 +28,9 @@ func TestNewAccountExportPublic(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testNewAccountExportPublic")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountExportPublic")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 

--- a/ioctl/newcmd/account/accountlist_test.go
+++ b/ioctl/newcmd/account/accountlist_test.go
@@ -9,7 +9,6 @@ package account
 import (
 	"errors"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -20,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountList(t *testing.T) {
@@ -30,11 +30,9 @@ func TestNewAccountList(t *testing.T) {
 
 	t.Run("When NewAccountList returns no error", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false)
-		testAccountFolder := filepath.Join(os.TempDir(), "testAccount")
-		require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-		defer func() {
-			require.NoError(os.RemoveAll(testAccountFolder))
-		}()
+		testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountList")
+		require.NoError(err)
+		defer testutil.CleanupPath(testAccountFolder)
 
 		ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 		genAccount := func(passwd string) string {

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -8,7 +8,6 @@ package account
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -19,6 +18,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountSign(t *testing.T) {
@@ -27,11 +27,9 @@ func TestNewAccountSign(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testNewAccountSign")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountSign")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 

--- a/ioctl/newcmd/account/accountupdate_test.go
+++ b/ioctl/newcmd/account/accountupdate_test.go
@@ -77,7 +77,7 @@ func TestNewAccountUpdate_FindPemFile(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate")
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate_FindPemFile")
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)

--- a/ioctl/newcmd/account/accountupdate_test.go
+++ b/ioctl/newcmd/account/accountupdate_test.go
@@ -9,7 +9,6 @@ package account
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -21,6 +20,7 @@ import (
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-core/testutil"
 )
 
 func TestNewAccountUpdate_FindKeystore(t *testing.T) {
@@ -29,11 +29,9 @@ func TestNewAccountUpdate_FindKeystore(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testNewAccountUpdate")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
@@ -79,11 +77,9 @@ func TestNewAccountUpdate_FindPemFile(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testAccountFolder := filepath.Join(os.TempDir(), "testNewAccountUpdate")
-	require.NoError(os.MkdirAll(testAccountFolder, os.ModePerm))
-	defer func() {
-		require.NoError(os.RemoveAll(testAccountFolder))
-	}()
+	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate")
+	require.NoError(err)
+	defer testutil.CleanupPath(testAccountFolder)
 	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
@@ -99,9 +95,6 @@ func TestNewAccountUpdate_FindPemFile(t *testing.T) {
 	k, ok := sk.EcdsaPrivateKey().(*crypto.P256sm2PrvKey)
 	require.True(ok)
 	require.NoError(crypto.WritePrivateKeyToPem(skPemPath, k, pwd))
-	defer func() {
-		require.NoError(os.Remove(skPemPath))
-	}()
 	client.EXPECT().IsCryptoSm2().Return(true).Times(3)
 
 	t.Run("invalid_current_password", func(t *testing.T) {


### PR DESCRIPTION
# Description

when executing `make test`, it may be fail in newcmd/account_test.go because creating test file is removed in cmd/account_test.go ahead.
1. add os.MkdirTemp in cmd/account_test.go to distinguish tempDir names.
2. make the same processing for MkdirTemp and CleanupPath in newcmd

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] Test A
- [] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
