### PR TITLE
[ioctl] modify NewKeyStore arguments to shorten time of make test

### DIFF
--- a/ioctl/cmd/account/account_test.go
+++ b/ioctl/cmd/account/account_test.go
@@ -25,9 +25,7 @@ import (
 )
 
 const (
-	_testPath        = "ksTest"
-	veryLightScryptN = 2
-	veryLightScryptP = 1
+	_testPath = "ksTest"
 )
 
 func TestAccount(t *testing.T) {
@@ -38,7 +36,7 @@ func TestAccount(t *testing.T) {
 	defer testutil.CleanupPath(testWallet)
 	config.ReadConfig.Wallet = testWallet
 
-	ks := keystore.NewKeyStore(config.ReadConfig.Wallet, veryLightScryptN, veryLightScryptP)
+	ks := keystore.NewKeyStore(config.ReadConfig.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
 	r.NotNil(ks)
 
 	// create accounts

--- a/ioctl/cmd/account/account_test.go
+++ b/ioctl/cmd/account/account_test.go
@@ -25,7 +25,9 @@ import (
 )
 
 const (
-	_testPath = "ksTest"
+	_testPath        = "ksTest"
+	veryLightScryptN = 2
+	veryLightScryptP = 1
 )
 
 func TestAccount(t *testing.T) {
@@ -36,7 +38,7 @@ func TestAccount(t *testing.T) {
 	defer testutil.CleanupPath(testWallet)
 	config.ReadConfig.Wallet = testWallet
 
-	ks := keystore.NewKeyStore(config.ReadConfig.Wallet, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(config.ReadConfig.Wallet, veryLightScryptN, veryLightScryptP)
 	r.NotNil(ks)
 
 	// create accounts

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -35,7 +35,9 @@ import (
 )
 
 const (
-	_testPath = "testNewAccount"
+	_testPath        = "testNewAccount"
+	veryLightScryptN = 2
+	veryLightScryptP = 1
 )
 
 func TestNewAccountCmd(t *testing.T) {
@@ -413,7 +415,7 @@ func newTestAccount() (string, *keystore.KeyStore, string, string, error) {
 	}
 
 	// create accounts
-	ks := keystore.NewKeyStore(testWallet, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testWallet, veryLightScryptN, veryLightScryptP)
 	nonce := strconv.FormatInt(rand.Int63(), 10)
 	passwd := "3dj,<>@@SF{}rj0ZF#" + nonce
 	return testWallet, ks, passwd, nonce, nil

--- a/ioctl/newcmd/account/account_test.go
+++ b/ioctl/newcmd/account/account_test.go
@@ -55,7 +55,7 @@ func TestNewAccountCmd(t *testing.T) {
 
 func TestSign(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, _, err := newTestAccount()
+	testWallet, ks, passwd, _, err := newTestAccountWithKeyStore(keystore.StandardScryptN, keystore.StandardScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -121,7 +121,7 @@ func TestSign(t *testing.T) {
 
 func TestAccount(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, nonce, err := newTestAccount()
+	testWallet, ks, passwd, nonce, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -249,7 +249,8 @@ func TestAccountError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	client := mock_ioctlclient.NewMockClient(ctrl)
-	testWallet, _, _, _, _ := newTestAccount()
+	testWallet, err := os.MkdirTemp(os.TempDir(), _testPath)
+	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
 	client.EXPECT().DecryptPrivateKey(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -287,7 +288,7 @@ func TestAccountError(t *testing.T) {
 
 func TestStoreKey(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, _, err := newTestAccount()
+	testWallet, ks, passwd, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -355,7 +356,7 @@ func TestStoreKey(t *testing.T) {
 
 func TestNewAccount(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, _, err := newTestAccount()
+	testWallet, ks, passwd, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -372,7 +373,7 @@ func TestNewAccount(t *testing.T) {
 
 func TestNewAccountSm2(t *testing.T) {
 	require := require.New(t)
-	testWallet, _, passwd, _, err := newTestAccount()
+	testWallet, passwd, _, err := newTestAccount()
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -389,7 +390,7 @@ func TestNewAccountSm2(t *testing.T) {
 
 func TestNewAccountByKey(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, _, err := newTestAccount()
+	testWallet, ks, passwd, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -408,15 +409,21 @@ func TestNewAccountByKey(t *testing.T) {
 	require.Equal(prvKey.PublicKey().Address().String(), result)
 }
 
-func newTestAccount() (string, *keystore.KeyStore, string, string, error) {
+func newTestAccount() (string, string, string, error) {
 	testWallet, err := os.MkdirTemp(os.TempDir(), _testPath)
+	if err != nil {
+		return testWallet, "", "", err
+	}
+	nonce := strconv.FormatInt(rand.Int63(), 10)
+	passwd := "3dj,<>@@SF{}rj0ZF#" + nonce
+	return testWallet, passwd, nonce, nil
+}
+
+func newTestAccountWithKeyStore(scryptN, scryptP int) (string, *keystore.KeyStore, string, string, error) {
+	testWallet, passwd, nonce, err := newTestAccount()
 	if err != nil {
 		return testWallet, nil, "", "", err
 	}
-
-	// create accounts
-	ks := keystore.NewKeyStore(testWallet, veryLightScryptN, veryLightScryptP)
-	nonce := strconv.FormatInt(rand.Int63(), 10)
-	passwd := "3dj,<>@@SF{}rj0ZF#" + nonce
+	ks := keystore.NewKeyStore(testWallet, scryptN, scryptP)
 	return testWallet, ks, passwd, nonce, nil
 }

--- a/ioctl/newcmd/account/accountcreateadd_test.go
+++ b/ioctl/newcmd/account/accountcreateadd_test.go
@@ -26,7 +26,7 @@ func TestNewAccountCreateAdd(t *testing.T) {
 	client := mock_ioctlclient.NewMockClient(ctrl)
 	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
 
-	testWallet, ks, pwd, _, err := newTestAccount()
+	testWallet, ks, pwd, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 

--- a/ioctl/newcmd/account/accountdelete_test.go
+++ b/ioctl/newcmd/account/accountdelete_test.go
@@ -36,8 +36,7 @@ func TestNewAccountDelete(t *testing.T) {
 
 	t.Run("CryptoSm2 is false", func(t *testing.T) {
 		client.EXPECT().IsCryptoSm2().Return(false).Times(2)
-		ks := keystore.NewKeyStore(testAccountFolder,
-			keystore.StandardScryptN, keystore.StandardScryptP)
+		ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 		acc, _ := ks.NewAccount("test")
 		accAddr, _ := address.FromBytes(acc.Address.Bytes())
 		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(accAddr.String(), nil).Times(2)

--- a/ioctl/newcmd/account/accountexport_test.go
+++ b/ioctl/newcmd/account/accountexport_test.go
@@ -32,7 +32,7 @@ func TestNewAccountExport(t *testing.T) {
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
 
-	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 
 	t.Run("true AliasIsHdwalletKey", func(t *testing.T) {

--- a/ioctl/newcmd/account/accountexportpublic_test.go
+++ b/ioctl/newcmd/account/accountexportpublic_test.go
@@ -31,7 +31,7 @@ func TestNewAccountExportPublic(t *testing.T) {
 	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountExportPublic")
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
-	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 
 	t.Run("true AliasIsHdwalletKey", func(t *testing.T) {

--- a/ioctl/newcmd/account/accountimport_test.go
+++ b/ioctl/newcmd/account/accountimport_test.go
@@ -38,7 +38,7 @@ func TestNewAccountImportCmd(t *testing.T) {
 
 func TestNewAccountImportKeyCmd(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, _, _, err := newTestAccount()
+	testWallet, ks, _, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -63,7 +63,7 @@ func TestNewAccountImportKeyCmd(t *testing.T) {
 
 func TestNewAccountImportKeyStoreCmd(t *testing.T) {
 	require := require.New(t)
-	testWallet, ks, passwd, _, err := newTestAccount()
+	testWallet, ks, passwd, _, err := newTestAccountWithKeyStore(veryLightScryptN, veryLightScryptP)
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 
@@ -93,7 +93,7 @@ func TestNewAccountImportKeyStoreCmd(t *testing.T) {
 
 func TestNewAccountImportPemCmd(t *testing.T) {
 	require := require.New(t)
-	testWallet, _, passwd, _, err := newTestAccount()
+	testWallet, passwd, _, err := newTestAccount()
 	require.NoError(err)
 	defer testutil.CleanupPath(testWallet)
 

--- a/ioctl/newcmd/account/accountlist_test.go
+++ b/ioctl/newcmd/account/accountlist_test.go
@@ -34,7 +34,7 @@ func TestNewAccountList(t *testing.T) {
 		require.NoError(err)
 		defer testutil.CleanupPath(testAccountFolder)
 
-		ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+		ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 		genAccount := func(passwd string) string {
 			account, err := ks.NewAccount(passwd)
 			require.NoError(err)

--- a/ioctl/newcmd/account/accountsign_test.go
+++ b/ioctl/newcmd/account/accountsign_test.go
@@ -30,7 +30,7 @@ func TestNewAccountSign(t *testing.T) {
 	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountSign")
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
-	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 
 	t.Run("invalid_account", func(t *testing.T) {

--- a/ioctl/newcmd/account/accountupdate_test.go
+++ b/ioctl/newcmd/account/accountupdate_test.go
@@ -32,7 +32,7 @@ func TestNewAccountUpdate_FindKeystore(t *testing.T) {
 	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate")
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
-	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
 	acc, err := ks.NewAccount(pwd)
@@ -80,7 +80,7 @@ func TestNewAccountUpdate_FindPemFile(t *testing.T) {
 	testAccountFolder, err := os.MkdirTemp(os.TempDir(), "testNewAccountUpdate_FindPemFile")
 	require.NoError(err)
 	defer testutil.CleanupPath(testAccountFolder)
-	ks := keystore.NewKeyStore(testAccountFolder, keystore.StandardScryptN, keystore.StandardScryptP)
+	ks := keystore.NewKeyStore(testAccountFolder, veryLightScryptN, veryLightScryptP)
 	client.EXPECT().NewKeyStore().Return(ks).AnyTimes()
 	const pwd = "test"
 	acc, err := ks.NewAccount(pwd)


### PR DESCRIPTION
# Description

modify NewKeyStore arguments to shorten time of make test 

Fixes https://github.com/iotexproject/iotex-core/issues/3382

## Type of change

Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] Test A
- [] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
