### PR TITLE
[action] expose chainID in the transaction

### DIFF
--- a/action/action_deserializer.go
+++ b/action/action_deserializer.go
@@ -6,31 +6,15 @@
 
 package action
 
-import (
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
-)
+import "github.com/iotexproject/iotex-proto/golang/iotextypes"
 
 // Deserializer de-serializes an action
 type Deserializer struct {
-	withChainID bool
 }
 
 // ActionToSealedEnvelope converts protobuf to SealedEnvelope
 func (ad *Deserializer) ActionToSealedEnvelope(pbAct *iotextypes.Action) (SealedEnvelope, error) {
-	var (
-		selp SealedEnvelope
-		err  error
-	)
-	if ad.withChainID {
-		err = selp.LoadProtoWithChainID(pbAct)
-	} else {
-		err = selp.LoadProto(pbAct)
-	}
+	var selp SealedEnvelope
+	err := selp.LoadProto(pbAct)
 	return selp, err
-}
-
-// WithChainID sets whether or not to use chainID
-func (ad *Deserializer) WithChainID(with bool) *Deserializer {
-	ad.withChainID = with
-	return ad
 }

--- a/action/action_deserializer_test.go
+++ b/action/action_deserializer_test.go
@@ -10,22 +10,57 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestActionDeserializer(t *testing.T) {
 	r := require.New(t)
-	se, err := createSealedEnvelope()
-	r.NoError(err)
-	rHash, err := se.Hash()
-	r.NoError(err)
-	r.Equal("322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395", hex.EncodeToString(rHash[:]))
-	r.Equal(_publicKey, se.SrcPubkey().HexString())
-	r.Equal(_signByte, se.Signature())
-	r.Zero(se.Encoding())
+	for _, v := range []struct {
+		id   uint32
+		hash string
+	}{
+		{0, "322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395"},
+		{1, "80af7840d73772d3022d8bdc46278fb755352e5e9d5f2a1f12ee7ec4f1ea98e9"},
+	} {
+		se, err := createSealedEnvelope(v.id)
+		r.NoError(err)
+		rHash, err := se.Hash()
+		r.NoError(err)
+		r.Equal(v.hash, hex.EncodeToString(rHash[:]))
+		r.Equal(v.id, se.ChainID())
+		r.Equal(_publicKey, se.SrcPubkey().HexString())
+		r.Equal(_signByte, se.Signature())
+		r.Zero(se.Encoding())
 
-	se.signature = _validSig
-	se1, err := (&Deserializer{}).ActionToSealedEnvelope(se.Proto())
-	r.NoError(err)
-	r.Equal(se, se1)
+		se.signature = _validSig
+		se1, err := (&Deserializer{}).ActionToSealedEnvelope(se.Proto())
+		r.NoError(err)
+		r.Equal(se, se1)
+	}
+}
+
+func TestProtoWithChainID(t *testing.T) {
+	r := require.New(t)
+	txID0, _ := hex.DecodeString("0a10080118a08d062202313062040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a4161e219c2c5d5987f8a9efa33e8df0cde9d5541689fff05784cdc24f12e9d9ee8283a5aa720f494b949535b7969c07633dfb68c4ef9359eb16edb9abc6ebfadc801")
+	txID1, _ := hex.DecodeString("0a12080118a08d0622023130280162040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a41328c6912fa0e36414c38089c03e2fa8c88bba82ccc4ce5fb8ac4ef9f529dfce249a5b2f93a45b818e7f468a742b4e87be3b8077f95d1b3c49e9165b971848ead01")
+	var ad Deserializer
+	for _, v := range []struct {
+		data    []byte
+		chainID uint32
+		err     error
+	}{
+		{txID0, 0, nil},
+		{txID1, 1, nil},
+	} {
+		tx := iotextypes.Action{}
+		r.NoError(proto.Unmarshal(v.data, &tx))
+		selp, err := ad.ActionToSealedEnvelope(&tx)
+		r.NoError(err)
+		r.Equal(v.chainID, selp.Envelope.ChainID())
+		_, err = selp.Hash()
+		r.NoError(err)
+		r.Equal(v.err, selp.VerifySignature())
+	}
 }

--- a/action/action_deserializer_test.go
+++ b/action/action_deserializer_test.go
@@ -10,60 +10,22 @@ import (
 	"encoding/hex"
 	"testing"
 
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 )
 
 func TestActionDeserializer(t *testing.T) {
 	r := require.New(t)
-	for _, v := range []struct {
-		id   uint32
-		hash string
-	}{
-		{0, "322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395"},
-		{1, "80af7840d73772d3022d8bdc46278fb755352e5e9d5f2a1f12ee7ec4f1ea98e9"},
-	} {
-		se, err := createSealedEnvelope(v.id)
-		r.NoError(err)
-		rHash, err := se.Hash()
-		r.NoError(err)
-		r.Equal(v.hash, hex.EncodeToString(rHash[:]))
-		r.Equal(v.id, se.ChainID())
-		r.Equal(_publicKey, se.SrcPubkey().HexString())
-		r.Equal(_signByte, se.Signature())
-		r.Zero(se.Encoding())
+	se, err := createSealedEnvelope()
+	r.NoError(err)
+	rHash, err := se.Hash()
+	r.NoError(err)
+	r.Equal("322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395", hex.EncodeToString(rHash[:]))
+	r.Equal(_publicKey, se.SrcPubkey().HexString())
+	r.Equal(_signByte, se.Signature())
+	r.Zero(se.Encoding())
 
-		se.signature = _validSig
-		se1, err := (&Deserializer{}).WithChainID(true).ActionToSealedEnvelope(se.Proto())
-		r.NoError(err)
-		r.Equal(se, se1)
-	}
-}
-
-func TestProtoWithChainID(t *testing.T) {
-	r := require.New(t)
-	txID0, _ := hex.DecodeString("0a10080118a08d062202313062040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a4161e219c2c5d5987f8a9efa33e8df0cde9d5541689fff05784cdc24f12e9d9ee8283a5aa720f494b949535b7969c07633dfb68c4ef9359eb16edb9abc6ebfadc801")
-	txID1, _ := hex.DecodeString("0a12080118a08d0622023130280162040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a41328c6912fa0e36414c38089c03e2fa8c88bba82ccc4ce5fb8ac4ef9f529dfce249a5b2f93a45b818e7f468a742b4e87be3b8077f95d1b3c49e9165b971848ead01")
-	var ad Deserializer
-	for _, v := range []struct {
-		data    []byte
-		honor   bool
-		chainID uint32
-		err     error
-	}{
-		{txID0, false, 0, nil}, // b/c chainID = 0, no error regardless of honorChainID or not
-		{txID0, true, 0, nil},
-		{txID1, false, 0, ErrInvalidSender}, // chainID = 1, fail to verify tx in case honorChainID = false
-		{txID1, true, 1, nil},
-	} {
-		tx := iotextypes.Action{}
-		r.NoError(proto.Unmarshal(v.data, &tx))
-		selp, err := ad.WithChainID(v.honor).ActionToSealedEnvelope(&tx)
-		r.NoError(err)
-		r.Equal(v.chainID, selp.Envelope.ChainID())
-		_, err = selp.Hash()
-		r.NoError(err)
-		r.Equal(v.err, selp.VerifySignature())
-	}
+	se.signature = _validSig
+	se1, err := (&Deserializer{}).ActionToSealedEnvelope(se.Proto())
+	r.NoError(err)
+	r.Equal(se, se1)
 }

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -87,6 +87,7 @@ func (elp *envelope) Proto() *iotextypes.ActionCore {
 		Version:  elp.version,
 		Nonce:    elp.nonce,
 		GasLimit: elp.gasLimit,
+		ChainID:  elp.chainID,
 	}
 	if elp.gasPrice != nil {
 		actCore.GasPrice = elp.gasPrice.String()
@@ -142,6 +143,7 @@ func (elp *envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
 	elp.version = pbAct.GetVersion()
 	elp.nonce = pbAct.GetNonce()
 	elp.gasLimit = pbAct.GetGasLimit()
+	elp.chainID = pbAct.GetChainID()
 	if pbAct.GetGasPrice() == "" {
 		elp.gasPrice = big.NewInt(0)
 	} else {

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -87,7 +87,6 @@ func (elp *envelope) Proto() *iotextypes.ActionCore {
 		Version:  elp.version,
 		Nonce:    elp.nonce,
 		GasLimit: elp.gasLimit,
-		ChainID:  elp.chainID,
 	}
 	if elp.gasPrice != nil {
 		actCore.GasPrice = elp.gasPrice.String()
@@ -133,10 +132,6 @@ func (elp *envelope) Proto() *iotextypes.ActionCore {
 
 // LoadProto loads fields from protobuf format.
 func (elp *envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
-	return elp.loadProto(pbAct, false)
-}
-
-func (elp *envelope) loadProto(pbAct *iotextypes.ActionCore, withChain bool) error {
 	if pbAct == nil {
 		return ErrNilProto
 	}
@@ -145,9 +140,6 @@ func (elp *envelope) loadProto(pbAct *iotextypes.ActionCore, withChain bool) err
 	}
 	*elp = envelope{}
 	elp.version = pbAct.GetVersion()
-	if withChain {
-		elp.chainID = pbAct.GetChainID()
-	}
 	elp.nonce = pbAct.GetNonce()
 	elp.gasLimit = pbAct.GetGasLimit()
 	if pbAct.GetGasPrice() == "" {
@@ -264,7 +256,3 @@ func (elp *envelope) SetNonce(n uint64) { elp.nonce = n }
 
 // SetChainID sets the chainID value
 func (elp *envelope) SetChainID(chainID uint32) { elp.chainID = chainID }
-
-func (elp *envelope) LoadProtoWithChainID(pbAct *iotextypes.ActionCore) error {
-	return elp.loadProto(pbAct, true)
-}

--- a/action/envelope_test.go
+++ b/action/envelope_test.go
@@ -49,20 +49,13 @@ func TestEnvelope_Proto(t *testing.T) {
 		Version:  evlp.version,
 		Nonce:    evlp.nonce,
 		GasLimit: evlp.gasLimit,
-		ChainID:  evlp.chainID,
 	}
 	actCore.GasPrice = evlp.gasPrice.String()
 	actCore.Action = &iotextypes.ActionCore_Transfer{Transfer: tsf.Proto()}
 	req.Equal(actCore, proto)
 
-	evlp2 := &envelope{}
-	req.NoError(evlp2.LoadProtoWithChainID(proto))
-	req.Equal(evlp.version, evlp2.version)
-	req.Equal(evlp.chainID, evlp2.chainID)
-	req.Equal(evlp.nonce, evlp2.nonce)
-	req.Equal(evlp.gasLimit, evlp2.gasLimit)
-	req.Equal(evlp.gasPrice, evlp2.gasPrice)
-	tsf2, ok := evlp2.Action().(*Transfer)
+	req.NoError(evlp.LoadProto(proto))
+	tsf2, ok := evlp.Action().(*Transfer)
 	req.True(ok)
 	req.Equal(tsf.amount, tsf2.amount)
 	req.Equal(tsf.recipient, tsf2.recipient)
@@ -131,10 +124,12 @@ func TestEnvelope_Actions(t *testing.T) {
 		elp := bd.SetNonce(1).
 			SetAction(test).
 			SetGasLimit(100000).
-			SetChainID(1).Build()
+			Build()
 		evlp, ok := elp.(*envelope)
 		require.True(ok)
-		require.NoError(evlp.LoadProto(evlp.Proto()))
+		err = evlp.LoadProto(evlp.Proto())
+
+		require.NoError(err)
 		require.Equal(elp.Version(), evlp.Version())
 		require.Equal(elp.Nonce(), evlp.Nonce())
 		require.Equal(elp.ChainID(), evlp.ChainID())

--- a/action/envelope_test.go
+++ b/action/envelope_test.go
@@ -49,13 +49,20 @@ func TestEnvelope_Proto(t *testing.T) {
 		Version:  evlp.version,
 		Nonce:    evlp.nonce,
 		GasLimit: evlp.gasLimit,
+		ChainID:  evlp.chainID,
 	}
 	actCore.GasPrice = evlp.gasPrice.String()
 	actCore.Action = &iotextypes.ActionCore_Transfer{Transfer: tsf.Proto()}
 	req.Equal(actCore, proto)
 
-	req.NoError(evlp.LoadProto(proto))
-	tsf2, ok := evlp.Action().(*Transfer)
+	evlp2 := &envelope{}
+	req.NoError(evlp2.LoadProto(proto))
+	req.Equal(evlp.version, evlp2.version)
+	req.Equal(evlp.chainID, evlp2.chainID)
+	req.Equal(evlp.nonce, evlp2.nonce)
+	req.Equal(evlp.gasLimit, evlp2.gasLimit)
+	req.Equal(evlp.gasPrice, evlp2.gasPrice)
+	tsf2, ok := evlp2.Action().(*Transfer)
 	req.True(ok)
 	req.Equal(tsf.amount, tsf2.amount)
 	req.Equal(tsf.recipient, tsf2.recipient)
@@ -124,12 +131,10 @@ func TestEnvelope_Actions(t *testing.T) {
 		elp := bd.SetNonce(1).
 			SetAction(test).
 			SetGasLimit(100000).
-			Build()
+			SetChainID(1).Build()
 		evlp, ok := elp.(*envelope)
 		require.True(ok)
-		err = evlp.LoadProto(evlp.Proto())
-
-		require.NoError(err)
+		require.NoError(evlp.LoadProto(evlp.Proto()))
 		require.Equal(elp.Version(), evlp.Version())
 		require.Equal(elp.Nonce(), evlp.Nonce())
 		require.Equal(elp.ChainID(), evlp.ChainID())

--- a/action/sealedenvelope.go
+++ b/action/sealedenvelope.go
@@ -93,10 +93,6 @@ func (sealed *SealedEnvelope) Proto() *iotextypes.Action {
 
 // LoadProto loads from proto scheme.
 func (sealed *SealedEnvelope) LoadProto(pbAct *iotextypes.Action) error {
-	return sealed.loadProto(pbAct, false)
-}
-
-func (sealed *SealedEnvelope) loadProto(pbAct *iotextypes.Action, withChainID bool) error {
 	if pbAct == nil {
 		return ErrNilProto
 	}
@@ -108,16 +104,8 @@ func (sealed *SealedEnvelope) loadProto(pbAct *iotextypes.Action, withChainID bo
 		return errors.Errorf("invalid signature length = %d, expecting 65", sigSize)
 	}
 
-	var (
-		elp = &envelope{}
-		err error
-	)
-	if withChainID {
-		err = elp.LoadProtoWithChainID(pbAct.GetCore())
-	} else {
-		err = elp.LoadProto(pbAct.GetCore())
-	}
-	if err != nil {
+	var elp Envelope = &envelope{}
+	if err := elp.LoadProto(pbAct.GetCore()); err != nil {
 		return err
 	}
 	// populate pubkey and signature
@@ -172,9 +160,4 @@ func (sealed *SealedEnvelope) VerifySignature() error {
 		return ErrInvalidSender
 	}
 	return nil
-}
-
-// LoadProtoWithChainID use chainID while loading protobuf
-func (sealed *SealedEnvelope) LoadProtoWithChainID(pbAct *iotextypes.Action) error {
-	return sealed.loadProto(pbAct, true)
 }

--- a/action/sealedenvelope_test.go
+++ b/action/sealedenvelope_test.go
@@ -28,28 +28,19 @@ var (
 
 func TestSealedEnvelope_Basic(t *testing.T) {
 	req := require.New(t)
-	for _, v := range []struct {
-		id   uint32
-		hash string
-	}{
-		{0, "322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395"},
-		{1, "80af7840d73772d3022d8bdc46278fb755352e5e9d5f2a1f12ee7ec4f1ea98e9"},
-	} {
-		se, err := createSealedEnvelope(v.id)
-		req.NoError(err)
-		rHash, err := se.Hash()
-		req.NoError(err)
-		req.Equal(v.id, se.ChainID())
-		req.Equal(v.hash, hex.EncodeToString(rHash[:]))
-		req.Equal(_publicKey, se.SrcPubkey().HexString())
-		req.Equal(_signByte, se.Signature())
-		req.Zero(se.Encoding())
+	se, err := createSealedEnvelope()
+	req.NoError(err)
+	rHash, err := se.Hash()
+	req.NoError(err)
+	req.Equal("322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395", hex.EncodeToString(rHash[:]))
+	req.Equal(_publicKey, se.SrcPubkey().HexString())
+	req.Equal(_signByte, se.Signature())
+	req.Zero(se.Encoding())
 
-		var se1 SealedEnvelope
-		se.signature = _validSig
-		req.NoError(se1.LoadProtoWithChainID(se.Proto()))
-		req.Equal(se.Envelope, se1.Envelope)
-	}
+	var se1 SealedEnvelope
+	se.signature = _validSig
+	req.NoError(se1.LoadProto(se.Proto()))
+	req.Equal(se, se1)
 }
 
 func TestSealedEnvelope_InvalidType(t *testing.T) {
@@ -130,7 +121,7 @@ func TestSealedEnvelope_Actions(t *testing.T) {
 func TestSealedEnvelope_Proto(t *testing.T) {
 	config.SetEVMNetworkID(config.Default.Chain.EVMNetworkID)
 	req := require.New(t)
-	se, err := createSealedEnvelope(0)
+	se, err := createSealedEnvelope()
 	req.NoError(err)
 	tsf, ok := se.Envelope.Action().(*Transfer)
 	req.True(ok)
@@ -178,7 +169,7 @@ func TestSealedEnvelope_Proto(t *testing.T) {
 	}
 }
 
-func createSealedEnvelope(chainID uint32) (SealedEnvelope, error) {
+func createSealedEnvelope() (SealedEnvelope, error) {
 	tsf, _ := NewTransfer(
 		uint64(10),
 		unit.ConvertIotxToRau(1000+int64(10)),
@@ -194,7 +185,7 @@ func createSealedEnvelope(chainID uint32) (SealedEnvelope, error) {
 		SetGasPrice(tsf.GasPrice()).
 		SetNonce(tsf.Nonce()).
 		SetVersion(1).
-		SetChainID(chainID).Build()
+		Build()
 
 	cPubKey, err := crypto.HexStringToPublicKey(_publicKey)
 	se := SealedEnvelope{}

--- a/action/sealedenvelope_test.go
+++ b/action/sealedenvelope_test.go
@@ -28,19 +28,28 @@ var (
 
 func TestSealedEnvelope_Basic(t *testing.T) {
 	req := require.New(t)
-	se, err := createSealedEnvelope()
-	req.NoError(err)
-	rHash, err := se.Hash()
-	req.NoError(err)
-	req.Equal("322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395", hex.EncodeToString(rHash[:]))
-	req.Equal(_publicKey, se.SrcPubkey().HexString())
-	req.Equal(_signByte, se.Signature())
-	req.Zero(se.Encoding())
+	for _, v := range []struct {
+		id   uint32
+		hash string
+	}{
+		{0, "322884fb04663019be6fb461d9453827487eafdd57b4de3bd89a7d77c9bf8395"},
+		{1, "80af7840d73772d3022d8bdc46278fb755352e5e9d5f2a1f12ee7ec4f1ea98e9"},
+	} {
+		se, err := createSealedEnvelope(v.id)
+		req.NoError(err)
+		rHash, err := se.Hash()
+		req.NoError(err)
+		req.Equal(v.id, se.ChainID())
+		req.Equal(v.hash, hex.EncodeToString(rHash[:]))
+		req.Equal(_publicKey, se.SrcPubkey().HexString())
+		req.Equal(_signByte, se.Signature())
+		req.Zero(se.Encoding())
 
-	var se1 SealedEnvelope
-	se.signature = _validSig
-	req.NoError(se1.LoadProto(se.Proto()))
-	req.Equal(se, se1)
+		var se1 SealedEnvelope
+		se.signature = _validSig
+		req.NoError(se1.LoadProto(se.Proto()))
+		req.Equal(se.Envelope, se1.Envelope)
+	}
 }
 
 func TestSealedEnvelope_InvalidType(t *testing.T) {
@@ -121,7 +130,7 @@ func TestSealedEnvelope_Actions(t *testing.T) {
 func TestSealedEnvelope_Proto(t *testing.T) {
 	config.SetEVMNetworkID(config.Default.Chain.EVMNetworkID)
 	req := require.New(t)
-	se, err := createSealedEnvelope()
+	se, err := createSealedEnvelope(0)
 	req.NoError(err)
 	tsf, ok := se.Envelope.Action().(*Transfer)
 	req.True(ok)
@@ -169,7 +178,7 @@ func TestSealedEnvelope_Proto(t *testing.T) {
 	}
 }
 
-func createSealedEnvelope() (SealedEnvelope, error) {
+func createSealedEnvelope(chainID uint32) (SealedEnvelope, error) {
 	tsf, _ := NewTransfer(
 		uint64(10),
 		unit.ConvertIotxToRau(1000+int64(10)),
@@ -185,7 +194,7 @@ func createSealedEnvelope() (SealedEnvelope, error) {
 		SetGasPrice(tsf.GasPrice()).
 		SetNonce(tsf.Nonce()).
 		SetVersion(1).
-		Build()
+		SetChainID(chainID).Build()
 
 	cPubKey, err := crypto.HexStringToPublicKey(_publicKey)
 	se := SealedEnvelope{}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -372,8 +372,7 @@ func (core *coreService) ServerMeta() (packageVersion string, packageCommitID st
 // SendAction is the API to send an action to blockchain.
 func (core *coreService) SendAction(ctx context.Context, in *iotextypes.Action) (string, error) {
 	log.Logger("api").Debug("receive send action request")
-	g := core.bc.Genesis()
-	selp, err := (&action.Deserializer{}).WithChainID(g.IsNewfoundland(core.bc.TipHeight())).ActionToSealedEnvelope(in)
+	selp, err := (&action.Deserializer{}).ActionToSealedEnvelope(in)
 	if err != nil {
 		return "", status.Error(codes.InvalidArgument, err.Error())
 	}

--- a/blockchain/block/block_deserializer.go
+++ b/blockchain/block/block_deserializer.go
@@ -14,24 +14,15 @@ import (
 
 // Deserializer de-serializes a block
 type Deserializer struct {
-	withChainID bool
 }
 
 // FromBlockProto converts protobuf to block
 func (bd *Deserializer) FromBlockProto(pbBlock *iotextypes.Block) (*Block, error) {
-	var (
-		b   = Block{}
-		err error
-	)
+	b := Block{}
 	if err := b.Header.LoadFromBlockHeaderProto(pbBlock.GetHeader()); err != nil {
 		return nil, errors.Wrap(err, "failed to deserialize block header")
 	}
-	if bd.withChainID {
-		err = b.Body.LoadProtoWithChainID(pbBlock.GetBody())
-	} else {
-		err = b.Body.LoadProto(pbBlock.GetBody())
-	}
-	if err != nil {
+	if err := b.Body.LoadProto(pbBlock.GetBody()); err != nil {
 		return nil, errors.Wrap(err, "failed to deserialize block body")
 	}
 	if err := b.ConvertFromBlockFooterPb(pbBlock.GetFooter()); err != nil {
@@ -59,16 +50,8 @@ func (bd *Deserializer) DeserializeBlock(buf []byte) (*Block, error) {
 
 // FromBodyProto converts protobuf to body
 func (bd *Deserializer) FromBodyProto(pbBody *iotextypes.BlockBody) (*Body, error) {
-	var (
-		b   = Body{}
-		err error
-	)
-	if bd.withChainID {
-		err = b.LoadProtoWithChainID(pbBody)
-	} else {
-		err = b.LoadProto(pbBody)
-	}
-	if err != nil {
+	b := Body{}
+	if err := b.LoadProto(pbBody); err != nil {
 		return nil, errors.Wrap(err, "failed to deserialize block body")
 	}
 	return &b, nil
@@ -81,10 +64,4 @@ func (bd *Deserializer) DeserializeBody(buf []byte) (*Body, error) {
 		return nil, errors.Wrap(err, "failed to unmarshal block body")
 	}
 	return bd.FromBodyProto(&pb)
-}
-
-// WithChainID sets whether or not to use chainID
-func (bd *Deserializer) WithChainID(with bool) *Deserializer {
-	bd.withChainID = with
-	return bd
 }

--- a/blockchain/block/block_deserializer_test.go
+++ b/blockchain/block/block_deserializer_test.go
@@ -34,4 +34,6 @@ func TestBlockDeserializer(t *testing.T) {
 	newblk, err := (&Deserializer{}).DeserializeBlock(raw)
 	r.NoError(err)
 	r.Equal(blk, newblk)
+	r.Equal(_pbBlock.Body.Actions[0].Core.ChainID, blk.Actions[0].ChainID())
+	r.Equal(_pbBlock.Body.Actions[1].Core.ChainID, blk.Actions[1].ChainID())
 }

--- a/blockchain/block/block_deserializer_test.go
+++ b/blockchain/block/block_deserializer_test.go
@@ -17,25 +17,21 @@ import (
 func TestBlockDeserializer(t *testing.T) {
 	r := require.New(t)
 	bd := Deserializer{}
-	for _, with := range []bool{false, true} {
-		blk, err := bd.WithChainID(with).FromBlockProto(&_pbBlock)
-		r.NoError(err)
-		body, err := bd.WithChainID(with).FromBodyProto(_pbBlock.Body)
-		r.NoError(err)
-		r.Equal(body, &blk.Body)
+	blk, err := bd.FromBlockProto(&_pbBlock)
+	r.NoError(err)
+	body, err := bd.FromBodyProto(_pbBlock.Body)
+	r.NoError(err)
+	r.Equal(body, &blk.Body)
 
-		txHash, err := blk.CalculateTxRoot()
-		r.NoError(err)
-		blk.Header.txRoot = txHash
-		blk.Header.receiptRoot = hash.Hash256b(([]byte)("test"))
-		pb := blk.ConvertToBlockPb()
-		raw, err := proto.Marshal(pb)
-		r.NoError(err)
+	txHash, err := blk.CalculateTxRoot()
+	r.NoError(err)
+	blk.Header.txRoot = txHash
+	blk.Header.receiptRoot = hash.Hash256b(([]byte)("test"))
+	pb := blk.ConvertToBlockPb()
+	raw, err := proto.Marshal(pb)
+	r.NoError(err)
 
-		newblk, err := (&Deserializer{}).WithChainID(with).DeserializeBlock(raw)
-		r.NoError(err)
-		r.Equal(blk, newblk)
-		r.Equal(with, blk.Actions[0].ChainID() != 0)
-		r.Equal(with, blk.Actions[1].ChainID() != 0)
-	}
+	newblk, err := (&Deserializer{}).DeserializeBlock(raw)
+	r.NoError(err)
+	r.Equal(blk, newblk)
 }

--- a/blockchain/block/blockstore.go
+++ b/blockchain/block/blockstore.go
@@ -41,7 +41,7 @@ func (in *Store) ToProto() *iotextypes.BlockStore {
 
 // FromProto converts from proto message
 func (in *Store) FromProto(pb *iotextypes.BlockStore) error {
-	blk, err := (&Deserializer{}).WithChainID(true).FromBlockProto(pb.Block)
+	blk, err := (&Deserializer{}).FromBlockProto(pb.Block)
 	if err != nil {
 		return err
 	}

--- a/blockchain/block/body.go
+++ b/blockchain/block/body.go
@@ -47,19 +47,7 @@ func (b *Body) LoadProto(pbBlock *iotextypes.BlockBody) error {
 		}
 		b.Actions = append(b.Actions, act)
 	}
-	return nil
-}
 
-// LoadProtoWithChainID loads body from proto
-func (b *Body) LoadProtoWithChainID(pbBlock *iotextypes.BlockBody) error {
-	b.Actions = []action.SealedEnvelope{}
-	for _, actPb := range pbBlock.Actions {
-		act := action.SealedEnvelope{}
-		if err := act.LoadProtoWithChainID(actPb); err != nil {
-			return err
-		}
-		b.Actions = append(b.Actions, act)
-	}
 	return nil
 }
 

--- a/blockchain/filedao/filedao_legacy.go
+++ b/blockchain/filedao/filedao_legacy.go
@@ -262,7 +262,7 @@ func (fd *fileDAOLegacy) body(h hash.Hash256) (*block.Body, error) {
 		// block body could be empty
 		return &block.Body{}, nil
 	}
-	return (&block.Deserializer{}).WithChainID(true).DeserializeBody(value)
+	return (&block.Deserializer{}).DeserializeBody(value)
 }
 
 func (fd *fileDAOLegacy) footer(h hash.Hash256) (*block.Footer, error) {

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -71,8 +71,7 @@ func (cs *ChainService) ReportFullness(_ context.Context, _ iotexrpc.MessageType
 
 // HandleAction handles incoming action request.
 func (cs *ChainService) HandleAction(ctx context.Context, actPb *iotextypes.Action) error {
-	g := cs.chain.Genesis()
-	act, err := (&action.Deserializer{}).WithChainID(g.IsNewfoundland(cs.chain.TipHeight())).ActionToSealedEnvelope(actPb)
+	act, err := (&action.Deserializer{}).ActionToSealedEnvelope(actPb)
 	if err != nil {
 		return err
 	}
@@ -86,8 +85,7 @@ func (cs *ChainService) HandleAction(ctx context.Context, actPb *iotextypes.Acti
 
 // HandleBlock handles incoming block request.
 func (cs *ChainService) HandleBlock(ctx context.Context, peer string, pbBlock *iotextypes.Block) error {
-	g := cs.chain.Genesis()
-	blk, err := (&block.Deserializer{}).WithChainID(g.IsNewfoundland(pbBlock.Header.Core.Height)).FromBlockProto(pbBlock)
+	blk, err := (&block.Deserializer{}).FromBlockProto(pbBlock)
 	if err != nil {
 		return err
 	}

--- a/consensus/scheme/rolldpos/blockproposal.go
+++ b/consensus/scheme/rolldpos/blockproposal.go
@@ -61,8 +61,8 @@ func (bp *blockProposal) ProposerAddress() string {
 	return bp.block.ProducerAddress()
 }
 
-func (bp *blockProposal) LoadProto(msg *iotextypes.BlockProposal, withChainID bool) error {
-	blk, err := (&block.Deserializer{}).WithChainID(withChainID).FromBlockProto(msg.Block)
+func (bp *blockProposal) LoadProto(msg *iotextypes.BlockProposal) error {
+	blk, err := (&block.Deserializer{}).FromBlockProto(msg.Block)
 	if err != nil {
 		return err
 	}

--- a/consensus/scheme/rolldpos/blockproposal_test.go
+++ b/consensus/scheme/rolldpos/blockproposal_test.go
@@ -39,7 +39,7 @@ func TestNewBlockProposal(t *testing.T) {
 	require.NoError(err)
 
 	bp3 := newBlockProposal(nil, nil)
-	require.NoError(bp3.LoadProto(pro, true))
+	require.NoError(bp3.LoadProto(pro))
 	pro3, err := bp3.Proto()
 	require.NoError(err)
 	require.EqualValues(pro, pro3)

--- a/consensus/scheme/rolldpos/endorsedconsensusmessage.go
+++ b/consensus/scheme/rolldpos/endorsedconsensusmessage.go
@@ -79,7 +79,7 @@ func (ecm *EndorsedConsensusMessage) Proto() (*iotextypes.ConsensusMessage, erro
 }
 
 // LoadProto creates an endorsement message from protobuf message
-func (ecm *EndorsedConsensusMessage) LoadProto(msg *iotextypes.ConsensusMessage, checker chainIDChecker) error {
+func (ecm *EndorsedConsensusMessage) LoadProto(msg *iotextypes.ConsensusMessage) error {
 	switch {
 	case msg.GetVote() != nil:
 		vote := &ConsensusVote{}
@@ -89,8 +89,7 @@ func (ecm *EndorsedConsensusMessage) LoadProto(msg *iotextypes.ConsensusMessage,
 		ecm.message = vote
 	case msg.GetBlockProposal() != nil:
 		proposal := &blockProposal{}
-		pb := msg.GetBlockProposal()
-		if err := proposal.LoadProto(pb, checker(pb.Block.Header.Core.Height)); err != nil {
+		if err := proposal.LoadProto(msg.GetBlockProposal()); err != nil {
 			return err
 		}
 		ecm.message = proposal

--- a/consensus/scheme/rolldpos/endorsedconsensusmessage_test.go
+++ b/consensus/scheme/rolldpos/endorsedconsensusmessage_test.go
@@ -33,7 +33,7 @@ func TestEndorsedConsensusMessage(t *testing.T) {
 	pb, err := endorsedMessage.Proto()
 	require.NoError(err)
 	cem := &EndorsedConsensusMessage{}
-	require.NoError(cem.LoadProto(pb, dummyChainIDChecker))
+	require.NoError(cem.LoadProto(pb))
 	require.Equal(uint64(10), cem.Height())
 	cvote, ok := cem.Document().(*ConsensusVote)
 	require.True(ok)

--- a/consensus/scheme/rolldpos/endorsementmanager.go
+++ b/consensus/scheme/rolldpos/endorsementmanager.go
@@ -120,12 +120,12 @@ func newBlockEndorsementCollection(blk *block.Block) *blockEndorsementCollection
 	}
 }
 
-func (bc *blockEndorsementCollection) fromProto(blockPro *endorsementpb.BlockEndorsementCollection, withChainID bool) error {
+func (bc *blockEndorsementCollection) fromProto(blockPro *endorsementpb.BlockEndorsementCollection) error {
 	bc.endorsers = make(map[string]*endorserEndorsementCollection)
 	if blockPro.Blk == nil {
 		bc.blk = nil
 	} else {
-		blk, err := (&block.Deserializer{}).WithChainID(withChainID).FromBlockProto(blockPro.Blk)
+		blk, err := (&block.Deserializer{}).FromBlockProto(blockPro.Blk)
 		if err != nil {
 			return err
 		}
@@ -224,7 +224,7 @@ type endorsementManager struct {
 	cachedMintedBlk *block.Block
 }
 
-func newEndorsementManager(eManagerDB db.KVStore, checker chainIDChecker) (*endorsementManager, error) {
+func newEndorsementManager(eManagerDB db.KVStore) (*endorsementManager, error) {
 	if eManagerDB == nil {
 		return &endorsementManager{
 			eManagerDB:      nil,
@@ -241,7 +241,7 @@ func newEndorsementManager(eManagerDB db.KVStore, checker chainIDChecker) (*endo
 		if err = proto.Unmarshal(bytes, managerProto); err != nil {
 			return nil, err
 		}
-		if err = manager.fromProto(managerProto, checker); err != nil {
+		if err = manager.fromProto(managerProto); err != nil {
 			return nil, err
 		}
 		manager.eManagerDB = eManagerDB
@@ -279,18 +279,17 @@ func (m *endorsementManager) SetIsMarjorityFunc(isMajorityFunc EndorsedByMajorit
 	m.isMajorityFunc = isMajorityFunc
 }
 
-func (m *endorsementManager) fromProto(managerPro *endorsementpb.EndorsementManager, checker chainIDChecker) error {
+func (m *endorsementManager) fromProto(managerPro *endorsementpb.EndorsementManager) error {
 	m.collections = make(map[string]*blockEndorsementCollection)
 	for i, block := range managerPro.BlockEndorsements {
 		bc := &blockEndorsementCollection{}
-		if err := bc.fromProto(block, checker(block.Blk.Header.Core.Height)); err != nil {
+		if err := bc.fromProto(block); err != nil {
 			return err
 		}
 		m.collections[managerPro.BlkHash[i]] = bc
 	}
 	if managerPro.CachedMintedBlk != nil {
-		withChainID := checker(managerPro.CachedMintedBlk.Header.Core.Height)
-		blk, err := (&block.Deserializer{}).WithChainID(withChainID).FromBlockProto(managerPro.CachedMintedBlk)
+		blk, err := (&block.Deserializer{}).FromBlockProto(managerPro.CachedMintedBlk)
 		if err != nil {
 			return err
 		}

--- a/consensus/scheme/rolldpos/endorsementmanager_test.go
+++ b/consensus/scheme/rolldpos/endorsementmanager_test.go
@@ -95,7 +95,7 @@ func TestBlockEndorsementCollection(t *testing.T) {
 
 func TestEndorsementManager(t *testing.T) {
 	require := require.New(t)
-	em, err := newEndorsementManager(nil, dummyChainIDChecker)
+	em, err := newEndorsementManager(nil)
 	require.NoError(err)
 	require.NotNil(em)
 	require.Equal(0, em.Size())
@@ -178,7 +178,7 @@ func TestEndorsementManager(t *testing.T) {
 
 func TestEndorsementManagerProto(t *testing.T) {
 	require := require.New(t)
-	em, err := newEndorsementManager(nil, dummyChainIDChecker)
+	em, err := newEndorsementManager(nil)
 	require.NoError(err)
 	require.NotNil(em)
 
@@ -203,9 +203,9 @@ func TestEndorsementManagerProto(t *testing.T) {
 	//test converting emanager pb
 	emProto, err := em.toProto()
 	require.NoError(err)
-	em2, err := newEndorsementManager(nil, dummyChainIDChecker)
+	em2, err := newEndorsementManager(nil)
 	require.NoError(err)
-	require.NoError(em2.fromProto(emProto, dummyChainIDChecker))
+	require.NoError(em2.fromProto(emProto))
 
 	require.Equal(len(em.collections), len(em2.collections))
 	encoded := encodeToString(cv.BlockHash())

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -116,7 +116,7 @@ func (r *RollDPoS) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
 		return nil
 	}
 	endorsedMessage := &EndorsedConsensusMessage{}
-	if err := endorsedMessage.LoadProto(msg, r.ctx.roundCalc.checker); err != nil {
+	if err := endorsedMessage.LoadProto(msg); err != nil {
 		return errors.Wrapf(err, "failed to decode endorsed consensus message")
 	}
 	if !endorsement.VerifyEndorsedDocument(endorsedMessage) {
@@ -297,8 +297,6 @@ func (b *Builder) RegisterProtocol(rp *rolldpos.Protocol) *Builder {
 	return b
 }
 
-type chainIDChecker func(h uint64) bool
-
 // Build builds a RollDPoS consensus module
 func (b *Builder) Build() (*RollDPoS, error) {
 	if b.chain == nil {
@@ -325,9 +323,6 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.priKey,
 		b.clock,
 		b.cfg.Genesis.BeringBlockHeight,
-		func(h uint64) bool {
-			return b.cfg.Genesis.IsNewfoundland(h)
-		},
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing consensus context")

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/facebookgo/clock"
-	"github.com/iotexproject/go-fsm"
+	fsm "github.com/iotexproject/go-fsm"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -102,7 +102,6 @@ func newRollDPoSCtx(
 	priKey crypto.PrivateKey,
 	clock clock.Clock,
 	beringHeight uint64,
-	checker chainIDChecker,
 ) (*rollDPoSCtx, error) {
 	if chain == nil {
 		return nil, errors.New("chain cannot be nil")
@@ -136,7 +135,6 @@ func newRollDPoSCtx(
 		rp:                   rp,
 		timeBasedRotation:    timeBasedRotation,
 		beringHeight:         beringHeight,
-		checker:              checker,
 	}
 	return &rollDPoSCtx{
 		ConsensusConfig:   cfg,
@@ -158,7 +156,7 @@ func (ctx *rollDPoSCtx) Start(c context.Context) (err error) {
 		if err := ctx.eManagerDB.Start(c); err != nil {
 			return errors.Wrap(err, "Error when starting the collectionDB")
 		}
-		eManager, err = newEndorsementManager(ctx.eManagerDB, ctx.roundCalc.checker)
+		eManager, err = newEndorsementManager(ctx.eManagerDB)
 	}
 	ctx.round, err = ctx.roundCalc.NewRoundWithToleration(0, ctx.BlockInterval(0), ctx.clock.Now(), eManager, ctx.toleratedOvertime)
 

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -29,10 +29,7 @@ import (
 	"github.com/iotexproject/iotex-core/test/identityset"
 )
 
-var (
-	dummyCandidatesByHeightFunc = func(uint64) ([]string, error) { return nil, nil }
-	dummyChainIDChecker         = func(h uint64) bool { return true }
-)
+var dummyCandidatesByHeightFunc = func(uint64) ([]string, error) { return nil, nil }
 
 func TestRollDPoSCtx(t *testing.T) {
 	require := require.New(t)
@@ -42,12 +39,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, _, _, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, nil, nil, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0, dummyChainIDChecker)
+		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, nil, nil, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, nil, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0, dummyChainIDChecker)
+		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, nil, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -57,7 +54,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		config.Default.Genesis.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0, dummyChainIDChecker)
+		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -67,19 +64,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.Consensus.RollDPoS.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, c, 0, dummyChainIDChecker)
+		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, c, 0)
 		require.Error(err)
 	})
 
 	cfg.Genesis.Blockchain.BlockInterval = time.Second * 20
 	t.Run("case 5:panic because of nil CandidatesByHeight function", func(t *testing.T) {
-		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, nil, "", nil, c, 0, dummyChainIDChecker)
+		_, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, nil, "", nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 6:normal", func(t *testing.T) {
 		bh := config.Default.Genesis.BeringBlockHeight
-		rctx, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, c, bh, dummyChainIDChecker)
+		rctx, err := newRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg), dbConfig, true, time.Second, true, b, rp, nil, dummyCandidatesByHeightFunc, "", nil, c, bh)
 		require.NoError(err)
 		require.Equal(bh, rctx.roundCalc.beringHeight)
 		require.NotNil(rctx)
@@ -142,7 +139,6 @@ func TestCheckVoteEndorser(t *testing.T) {
 		nil,
 		c,
 		config.Default.Genesis.BeringBlockHeight,
-		dummyChainIDChecker,
 	)
 	require.NoError(err)
 	require.NotNil(rctx)
@@ -215,7 +211,6 @@ func TestCheckBlockProposer(t *testing.T) {
 		nil,
 		c,
 		config.Default.Genesis.BeringBlockHeight,
-		dummyChainIDChecker,
 	)
 	require.NoError(err)
 	require.NotNil(rctx)
@@ -327,7 +322,6 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		identityset.PrivateKey(10),
 		c,
 		config.Default.Genesis.BeringBlockHeight,
-		dummyChainIDChecker,
 	)
 	require.NoError(err)
 	require.NotNil(rctx)

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -24,7 +24,6 @@ type roundCalculator struct {
 	rp                   *rolldpos.Protocol
 	delegatesByEpochFunc DelegatesByEpochFunc
 	beringHeight         uint64
-	checker              chainIDChecker
 }
 
 // UpdateRound updates previous roundCtx
@@ -225,7 +224,7 @@ func (c *roundCalculator) newRound(
 		}
 	}
 	if eManager == nil {
-		if eManager, err = newEndorsementManager(nil, c.checker); err != nil {
+		if eManager, err = newEndorsementManager(nil); err != nil {
 			return nil, err
 		}
 	}

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -263,6 +263,5 @@ func makeRoundCalculator(t *testing.T) *roundCalculator {
 			return addrs, nil
 		},
 		0,
-		dummyChainIDChecker,
 	}
 }

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -615,6 +615,7 @@ func lenPendingActionMap(acts map[string][]action.SealedEnvelope) int {
 }
 
 func TestEnforceChainID(t *testing.T) {
+	require := require.New(t)
 
 	testCase := []struct {
 		chainID uint32
@@ -643,21 +644,21 @@ func TestEnforceChainID(t *testing.T) {
 	cfg.Genesis.MidwayBlockHeight = 3
 	registry := protocol.NewRegistry()
 	acc := account.NewProtocol(rewarding.DepositGas)
-	require.NoError(t, acc.Register(registry))
+	require.NoError(acc.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption(), factory.RegistryOption(registry))
-	require.NoError(t, err)
+	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
-	require.NoError(t, err)
+	require.NoError(err)
 	blkMemDao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf})
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blkMemDao,
 		factory.NewMinter(sf, ap),
 	)
-	require.NoError(t, bc.Start(ctx))
+	require.NoError(bc.Start(ctx))
 
 	defer func() {
-		require.NoError(t, bc.Stop(ctx))
+		require.NoError(bc.Stop(ctx))
 	}()
 	for i, c := range testCase {
 		tsf, err := action.NewTransfer(
@@ -667,7 +668,7 @@ func TestEnforceChainID(t *testing.T) {
 			[]byte{}, uint64(100000),
 			big.NewInt(1).Mul(big.NewInt(int64(i)+10), big.NewInt(unit.Qev)),
 		)
-		require.NoError(t, err)
+		require.NoError(err)
 
 		bd := &action.EnvelopeBuilder{}
 		elp1 := bd.SetAction(tsf).
@@ -675,16 +676,28 @@ func TestEnforceChainID(t *testing.T) {
 			SetNonce(uint64(i) + 1).
 			SetGasLimit(100000).
 			SetGasPrice(big.NewInt(1).Mul(big.NewInt(int64(i)+10), big.NewInt(unit.Qev))).Build()
-		selp1, err := action.Sign(elp1, identityset.PrivateKey(0))
-		require.NoError(t, err)
+		selp, err := action.Sign(elp1, identityset.PrivateKey(0))
+		require.NoError(err)
 
-		err = ap.Add(context.Background(), selp1)
-		require.NoError(t, err)
+		// simulate API receives tx
+		selp1, err := (&action.Deserializer{}).ActionToSealedEnvelope(selp.Proto())
+		require.NoError(err)
+
+		// mint block using received tx
+		require.NoError(ap.Add(context.Background(), selp1))
 		blk, err := bc.MintNewBlock(testutil.TimestampNow())
-		require.NoError(t, err)
-		err = bc.CommitBlock(blk)
-		require.NoError(t, err)
-		require.Equal(t, c.success, len(blk.Actions) == 1)
-		require.Equal(t, c.success, len(blk.Receipts) == 1)
+		require.NoError(err)
+		require.NoError(bc.CommitBlock(blk))
+		require.Equal(c.success, len(blk.Actions) == 1)
+		require.Equal(c.success, len(blk.Receipts) == 1)
+
+		// verify action has valid chainID
+		if c.success {
+			act := blk.Actions[0]
+			tsf, ok := act.Action().(*action.Transfer)
+			require.True(ok)
+			require.Equal(c.chainID, act.ChainID())
+			require.Equal(c.chainID, tsf.ChainID())
+		}
 	}
 }

--- a/e2etest/local_transfer_test.go
+++ b/e2etest/local_transfer_test.go
@@ -615,7 +615,6 @@ func lenPendingActionMap(acts map[string][]action.SealedEnvelope) int {
 }
 
 func TestEnforceChainID(t *testing.T) {
-	require := require.New(t)
 
 	testCase := []struct {
 		chainID uint32
@@ -644,21 +643,21 @@ func TestEnforceChainID(t *testing.T) {
 	cfg.Genesis.MidwayBlockHeight = 3
 	registry := protocol.NewRegistry()
 	acc := account.NewProtocol(rewarding.DepositGas)
-	require.NoError(acc.Register(registry))
+	require.NoError(t, acc.Register(registry))
 	sf, err := factory.NewFactory(cfg, factory.InMemTrieOption(), factory.RegistryOption(registry))
-	require.NoError(err)
+	require.NoError(t, err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
-	require.NoError(err)
+	require.NoError(t, err)
 	blkMemDao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf})
 	bc := blockchain.NewBlockchain(
 		cfg,
 		blkMemDao,
 		factory.NewMinter(sf, ap),
 	)
-	require.NoError(bc.Start(ctx))
+	require.NoError(t, bc.Start(ctx))
 
 	defer func() {
-		require.NoError(bc.Stop(ctx))
+		require.NoError(t, bc.Stop(ctx))
 	}()
 	for i, c := range testCase {
 		tsf, err := action.NewTransfer(
@@ -668,7 +667,7 @@ func TestEnforceChainID(t *testing.T) {
 			[]byte{}, uint64(100000),
 			big.NewInt(1).Mul(big.NewInt(int64(i)+10), big.NewInt(unit.Qev)),
 		)
-		require.NoError(err)
+		require.NoError(t, err)
 
 		bd := &action.EnvelopeBuilder{}
 		elp1 := bd.SetAction(tsf).
@@ -676,34 +675,16 @@ func TestEnforceChainID(t *testing.T) {
 			SetNonce(uint64(i) + 1).
 			SetGasLimit(100000).
 			SetGasPrice(big.NewInt(1).Mul(big.NewInt(int64(i)+10), big.NewInt(unit.Qev))).Build()
-		selp, err := action.Sign(elp1, identityset.PrivateKey(0))
-		require.NoError(err)
+		selp1, err := action.Sign(elp1, identityset.PrivateKey(0))
+		require.NoError(t, err)
 
-		// simulate API receives tx
-		withChainID := uint64(i) >= cfg.Genesis.MidwayBlockHeight
-		selp1, err := (&action.Deserializer{}).WithChainID(withChainID).ActionToSealedEnvelope(selp.Proto())
-		require.NoError(err)
-
-		// mint block using received tx
-		require.NoError(ap.Add(context.Background(), selp1))
+		err = ap.Add(context.Background(), selp1)
+		require.NoError(t, err)
 		blk, err := bc.MintNewBlock(testutil.TimestampNow())
-		require.NoError(err)
-		require.NoError(bc.CommitBlock(blk))
-		require.Equal(c.success, len(blk.Actions) == 1)
-		require.Equal(c.success, len(blk.Receipts) == 1)
-
-		// verify action has valid chainID
-		if c.success {
-			act := blk.Actions[0]
-			tsf, ok := act.Action().(*action.Transfer)
-			require.True(ok)
-			if withChainID {
-				require.Equal(c.chainID, act.ChainID())
-				require.Equal(c.chainID, tsf.ChainID())
-			} else {
-				require.Zero(act.ChainID())
-				require.Zero(tsf.ChainID())
-			}
-		}
+		require.NoError(t, err)
+		err = bc.CommitBlock(blk)
+		require.NoError(t, err)
+		require.Equal(t, c.success, len(blk.Actions) == 1)
+		require.Equal(t, c.success, len(blk.Receipts) == 1)
 	}
 }

--- a/ioctl/cmd/action/action.go
+++ b/ioctl/cmd/action/action.go
@@ -266,10 +266,7 @@ func SendAction(elp action.Envelope, signer string) error {
 	if err != nil {
 		return output.NewError(0, "failed to get chain meta", err)
 	}
-	if util.IsNewfoundland(chainMeta.GetChainID(), chainMeta.Height) {
-		// starting Newfoundland, sending tx with correct ChainID
-		elp.SetChainID(chainMeta.GetChainID())
-	}
+	elp.SetChainID(chainMeta.GetChainID())
 
 	if util.AliasIsHdwalletKey(signer) {
 		addr := prvKey.PublicKey().Address()

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"math"
 	"math/big"
 	"os"
 	"os/signal"
@@ -221,17 +220,4 @@ func ParseHdwPath(addressOrAlias string) (uint32, uint32, uint32, error) {
 // AliasIsHdwalletKey check whether to use hdwallet key
 func AliasIsHdwalletKey(addressOrAlias string) bool {
 	return strings.HasPrefix(strings.ToLower(addressOrAlias), "hdw::")
-}
-
-// IsNewfoundland returns whether the height passed NewfoundlandHeight
-func IsNewfoundland(chainID uint32, h uint64) bool {
-	var newfoundland uint64 = math.MaxUint64
-	// TODO: when make next release, update newfoundland to correct HF block number
-	switch chainID {
-	case 1:
-		newfoundland = 20027641
-	case 2:
-		newfoundland = 17057281
-	}
-	return h >= newfoundland
 }

--- a/ioctl/util/util_test.go
+++ b/ioctl/util/util_test.go
@@ -94,22 +94,3 @@ func TestParseHdwPath(t *testing.T) {
 		}
 	}
 }
-
-func TestNewfoundland(t *testing.T) {
-	r := require.New(t)
-
-	for _, v := range []struct {
-		id uint32
-		h  uint64
-		is bool
-	}{
-		{1, 20027640, false},
-		{1, 20027641, true},
-		{2, 17057280, false},
-		{2, 17057281, true},
-		{3, 1, false},
-		{3, 1000000000000000000, false},
-	} {
-		r.Equal(v.is, IsNewfoundland(v.id, v.h))
-	}
-}

--- a/tools/actioninjector.v2/internal/client/client_test.go
+++ b/tools/actioninjector.v2/internal/client/client_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/api"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
@@ -40,7 +39,7 @@ func TestClient(t *testing.T) {
 	cfg.API.GRPCPort = testutil.RandomPort()
 	cfg.API.HTTPPort = testutil.RandomPort()
 	cfg.API.WebSocketPort = testutil.RandomPort()
-	ctx := genesis.WithGenesisContext(context.Background(), config.Default.Genesis)
+	ctx := context.Background()
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -64,7 +63,6 @@ func TestClient(t *testing.T) {
 	bc.EXPECT().Genesis().Return(cfg.Genesis).AnyTimes()
 	bc.EXPECT().ChainID().Return(chainID).AnyTimes()
 	bc.EXPECT().TipHeight().Return(uint64(4)).AnyTimes()
-	bc.EXPECT().Context(gomock.Any()).Return(ctx, nil).AnyTimes()
 	bc.EXPECT().AddSubscriber(gomock.Any()).Return(nil).AnyTimes()
 	bh := &iotextypes.BlockHeader{Core: &iotextypes.BlockHeaderCore{
 		Version:          chainID,


### PR DESCRIPTION
# Description
1. in v1.8, we add a hard-fork protection to make sure all nodes accept/expose chainID at the same height
2. this protection can be removed post v1.8

## Type of change
- [x] Code refactor or improvement

# How Has This Been Tested?
- [x] make test
- [x] fullsync

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
