### PR TITLE
[ioctl] build node command into new ioctl

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -1,0 +1,2 @@
+export GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
+export PATH="$PATH:$GEM_HOME/bin"

--- a/.bashrc
+++ b/.bashrc
@@ -1,2 +1,0 @@
-export GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
-export PATH="$PATH:$GEM_HOME/bin"

--- a/ioctl/newcmd/node/nodeprobationlist.go
+++ b/ioctl/newcmd/node/nodeprobationlist.go
@@ -1,0 +1,113 @@
+package node
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/action/protocol/vote"
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/newcmd/bc"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+)
+
+// Multi-language support
+var (
+	_probationlistCmdUses = map[config.Language]string{
+		config.English: "probationlist [-e epoch-num]",
+		config.Chinese: "probationlist [-e epoch数]",
+	}
+	_probationlistCmdShorts = map[config.Language]string{
+		config.English: "Print probation list at given epoch",
+		config.Chinese: "",
+	}
+
+	_epochNum uint64
+)
+
+type probationListMessage struct {
+	EpochNumber   uint64   `json:"epochnumber"`
+	IntensityRate uint32   `json:"intensityrate"`
+	DelegateList  []string `json:"delegatelist"`
+}
+
+// String is a string representation of the probationListMessage struct.
+func (m *probationListMessage) String() string {
+	if output.Format == "" {
+		message := fmt.Sprintf("EpochNumber : %d, IntensityRate : %d%%\nProbationList : %s",
+			m.EpochNumber,
+			m.IntensityRate,
+			output.JSONString(m.DelegateList),
+		)
+		return message
+	}
+
+	return output.FormatString(output.Result, m)
+}
+
+// NewNodeProbationListCmd prints the probation list at the given epoch.
+func NewNodeProbationListCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_probationlistCmdUses)
+	short, _ := client.SelectTranslation(_probationlistCmdShorts)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		// Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+
+			if _epochNum == 0 {
+				chainMeta, err := bc.GetChainMeta(client)
+				if err != nil {
+					return errors.Wrap(err, "failed to get chain meta")
+				}
+
+				epochData := chainMeta.GetEpoch()
+				if epochData == nil {
+					return errors.New("ROLLDPOS is not registered")
+				}
+
+				_epochNum = epochData.Num
+			}
+
+			probationlist, err := getProbationList(client, _epochNum)
+			if err != nil {
+				return errors.Wrap(err, "failed to get probation list")
+			}
+
+			message := &probationListMessage{
+				EpochNumber:   _epochNum,
+				IntensityRate: probationlist.IntensityRate,
+				DelegateList:  make([]string, 0),
+			}
+
+			for addr := range probationlist.ProbationInfo {
+				message.DelegateList = append(message.DelegateList, addr)
+			}
+
+			fmt.Println(message.String())
+			return nil
+		},
+	}
+
+	return cmd
+}
+
+func getProbationList(client ioctl.Client, _epochNum uint64) (*vote.ProbationList, error) {
+	probationListRes, err := bc.GetProbationList(client, _epochNum)
+	if err != nil {
+		return nil, err
+	}
+
+	probationList := &vote.ProbationList{}
+	if probationListRes != nil {
+		if err := probationList.Deserialize(probationListRes.Data); err != nil {
+			return nil, err
+		}
+	}
+
+	return probationList, nil
+}

--- a/ioctl/newcmd/node/nodeprobationlist_test.go
+++ b/ioctl/newcmd/node/nodeprobationlist_test.go
@@ -1,0 +1,109 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/action/protocol/vote"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+)
+
+func Test_NewNodeProbationListCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return(
+		"mockTranslationString", config.English).AnyTimes()
+	client.EXPECT().Config().Return(config.ReadConfig).AnyTimes()
+	client.EXPECT().AliasMap().Return(map[string]string{
+		"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		"b": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+		"c": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542s1",
+		"io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+	}).AnyTimes()
+
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	client.EXPECT().APIServiceClient(gomock.Any()).Return(
+		apiServiceClient, nil).AnyTimes()
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(
+		&iotexapi.GetChainMetaResponse{ChainMeta: &iotextypes.ChainMeta{Epoch: &iotextypes.EpochData{Num: 4}}}, nil,
+	)
+
+	pbInfo := make(map[string]uint32, 1)
+	pbInfo["test"] = 2
+	pbInfo["test2"] = 4
+	pb := &vote.ProbationList{ProbationInfo: pbInfo, IntensityRate: 100}
+	serializedData, err := pb.Serialize()
+	require.NoError(err)
+
+	probationList := &iotexapi.ReadStateResponse{Data: serializedData}
+	apiServiceClient.EXPECT().ReadState(gomock.Any(), gomock.Any()).Return(probationList, nil).AnyTimes()
+
+	cmd := NewNodeProbationListCmd(client)
+	result, err := util.ExecuteCmd(cmd)
+	require.NotNil(t, result)
+	require.NoError(err)
+}
+
+func Test_NewNodeProbationListCmd_ROLLDPOSNotRegistered(t *testing.T) {
+	// previous test sets the epoch num, so we have to reset to check the error
+	_epochNum = 0
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return(
+		"mockTranslationString", config.English).AnyTimes()
+	client.EXPECT().Config().Return(config.ReadConfig).AnyTimes()
+	client.EXPECT().AliasMap().Return(map[string]string{
+		"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+	}).AnyTimes()
+
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	client.EXPECT().APIServiceClient(gomock.Any()).Return(
+		apiServiceClient, nil).AnyTimes()
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(
+		&iotexapi.GetChainMetaResponse{ChainMeta: &iotextypes.ChainMeta{}}, nil,
+	)
+
+	cmd := NewNodeProbationListCmd(client)
+	result, err := util.ExecuteCmd(cmd)
+	require.NotNil(t, result)
+	require.Contains(err.Error(), "ROLLDPOS is not registered")
+}
+
+func Test_NewNodeProbationListCmd_ChainMetaError(t *testing.T) {
+	// previous test sets the epoch num, so we have to reset to check the error
+	_epochNum = 0
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return(
+		"mockTranslationString", config.English).AnyTimes()
+	client.EXPECT().Config().Return(config.ReadConfig).AnyTimes()
+	client.EXPECT().AliasMap().Return(map[string]string{
+		"a": "io1uwnr55vqmhf3xeg5phgurlyl702af6eju542sx",
+	}).AnyTimes()
+
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	client.EXPECT().APIServiceClient(gomock.Any()).Return(
+		apiServiceClient, nil).AnyTimes()
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(
+		nil, errors.New("problem fetching chain meta"),
+	)
+
+	cmd := NewNodeProbationListCmd(client)
+	result, err := util.ExecuteCmd(cmd)
+	require.NotNil(t, result)
+	require.Contains(err.Error(), "failed to get chain meta")
+}


### PR DESCRIPTION
# Description

There is no command for the probation list in the `newcmd` node package. The other 2 commands in the issue have already been implemented in the package.

Fixes #3428 

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
