### PR TITLE
[blockchain] Remove BoltDBDaoOption

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -145,18 +145,6 @@ func BlockValidatorOption(blockValidator block.Validator) Option {
 	}
 }
 
-// BoltDBDaoOption sets blockchain's dao with BoltDB from config.Chain.ChainDBPath
-func BoltDBDaoOption(indexers ...blockdao.BlockIndexer) Option {
-	return func(bc *blockchain, cfg config.Config) error {
-		if bc.dao != nil {
-			return nil
-		}
-		cfg.DB.DbPath = cfg.Chain.ChainDBPath // TODO: remove this after moving TrieDBPath from cfg.Chain to cfg.DB
-		bc.dao = blockdao.NewBlockDAO(indexers, cfg.DB)
-		return nil
-	}
-}
-
 // ClockOption overrides the default clock
 func ClockOption(clk clock.Clock) Option {
 	return func(bc *blockchain, conf config.Config) error {

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -152,7 +152,6 @@ func BoltDBDaoOption(indexers ...blockdao.BlockIndexer) Option {
 			return nil
 		}
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath // TODO: remove this after moving TrieDBPath from cfg.Chain to cfg.DB
-		cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 		bc.dao = blockdao.NewBlockDAO(indexers, cfg.DB)
 		return nil
 	}

--- a/blockchain/integrity/benchmark_test.go
+++ b/blockchain/integrity/benchmark_test.go
@@ -258,7 +258,6 @@ func newChainInDB() (blockchain.Blockchain, actpool.ActPool, error) {
 	cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(1000000000000).String()
 	// create BlockDAO
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	dao := blockdao.NewBlockDAO(indexers, cfg.DB)
 	if dao == nil {
 		return nil, nil, errors.New("pointer is nil")

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -1407,11 +1407,13 @@ func TestBlockchainInitialCandidate(t *testing.T) {
 	require.NoError(err)
 	accountProtocol := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(accountProtocol.Register(registry))
+	dbcfg := cfg.DB
+	dbcfg.DbPath = cfg.Chain.ChainDBPath
+	dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf}, dbcfg)
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		factory.NewMinter(sf, ap),
-		blockchain.BoltDBDaoOption(sf),
 		blockchain.BlockValidatorOption(sf),
 	)
 	rolldposProtocol := rolldpos.NewProtocol(
@@ -1494,9 +1496,12 @@ func TestBlocks(t *testing.T) {
 	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(err)
+	dbcfg := cfg.DB
+	dbcfg.DbPath = cfg.Chain.ChainDBPath
+	dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf}, dbcfg)
 
 	// Create a blockchain from scratch
-	bc := blockchain.NewBlockchain(cfg, nil, factory.NewMinter(sf, ap), blockchain.BoltDBDaoOption(sf))
+	bc := blockchain.NewBlockchain(cfg, dao, factory.NewMinter(sf, ap))
 	require.NoError(bc.Start(context.Background()))
 	defer func() {
 		require.NoError(bc.Stop(context.Background()))
@@ -1563,12 +1568,14 @@ func TestActions(t *testing.T) {
 	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(err)
+	dbcfg := cfg.DB
+	dbcfg.DbPath = cfg.Chain.ChainDBPath
+	dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf}, dbcfg)
 	// Create a blockchain from scratch
 	bc := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		factory.NewMinter(sf, ap),
-		blockchain.BoltDBDaoOption(sf),
 		blockchain.BlockValidatorOption(block.NewValidator(
 			sf,
 			protocol.NewGenericValidator(sf, accountutil.AccountState),

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -866,7 +866,6 @@ func TestConstantinople(t *testing.T) {
 		require.NoError(err)
 		// create BlockDAO
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 		dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf, indexer}, cfg.DB)
 		require.NotNil(dao)
 		bc := blockchain.NewBlockchain(
@@ -1112,7 +1111,6 @@ func TestLoadBlockchainfromDB(t *testing.T) {
 		cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
 		// create BlockDAO
 		cfg.DB.DbPath = cfg.Chain.ChainDBPath
-		cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 		dao := blockdao.NewBlockDAO(indexers, cfg.DB)
 		require.NotNil(dao)
 		bc := blockchain.NewBlockchain(
@@ -1850,7 +1848,6 @@ func newChain(t *testing.T, stateTX bool) (blockchain.Blockchain, factory.Factor
 	cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
 	// create BlockDAO
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	dao := blockdao.NewBlockDAO(indexers, cfg.DB)
 	require.NotNil(dao)
 	bc := blockchain.NewBlockchain(

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -250,8 +250,6 @@ func (builder *Builder) buildBlockDAO(forTest bool) error {
 	} else {
 		dbConfig := builder.cfg.DB
 		dbConfig.DbPath = builder.cfg.Chain.ChainDBPath
-		dbConfig.CompressLegacy = builder.cfg.Chain.CompressBlock
-
 		builder.cs.blockdao = blockdao.NewBlockDAO(indexers, dbConfig)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -101,7 +101,6 @@ var (
 			EnableSystemLogIndexer:        false,
 			EnableStakingProtocol:         true,
 			EnableStakingIndexer:          false,
-			CompressBlock:                 false,
 			AllowedBlockGasResidue:        10000,
 			MaxCacheSize:                  0,
 			PollInitialCandidatesInterval: 10 * time.Second,
@@ -239,8 +238,6 @@ type (
 		EnableStakingProtocol bool `yaml:"enableStakingProtocol"`
 		// EnableStakingIndexer enables staking indexer
 		EnableStakingIndexer bool `yaml:"enableStakingIndexer"`
-		// deprecated by DB.CompressBlock
-		CompressBlock bool `yaml:"compressBlock"`
 		// AllowedBlockGasResidue is the amount of gas remained when block producer could stop processing more actions
 		AllowedBlockGasResidue uint64 `yaml:"allowedBlockGasResidue"`
 		// MaxCacheSize is the max number of blocks that will be put into an LRU cache. 0 means disabled

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/unit"
@@ -183,11 +184,13 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, actpool.Ac
 	require.NoError(err)
 	ap, err := actpool.NewActPool(sf, cfg.ActPool)
 	require.NoError(err)
+	dbcfg := cfg.DB
+	dbcfg.DbPath = cfg.Chain.ChainDBPath
+	dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf}, dbcfg)
 	chain := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		factory.NewMinter(sf, ap),
-		blockchain.BoltDBDaoOption(sf),
 		blockchain.BlockValidatorOption(block.NewValidator(
 			sf,
 			protocol.NewGenericValidator(sf, accountutil.AccountState),

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -159,11 +159,13 @@ func TestLocalCommit(t *testing.T) {
 	require.NoError(err)
 	ap2, err := actpool.NewActPool(sf2, cfg.ActPool)
 	require.NoError(err)
+	dbcfg := cfg.DB
+	dbcfg.DbPath = cfg.Chain.ChainDBPath
+	dao := blockdao.NewBlockDAO([]blockdao.BlockIndexer{sf2}, dbcfg)
 	chain := blockchain.NewBlockchain(
 		cfg,
-		nil,
+		dao,
 		factory.NewMinter(sf2, ap2),
-		blockchain.BoltDBDaoOption(sf2),
 		blockchain.BlockValidatorOption(block.NewValidator(
 			sf2,
 			protocol.NewGenericValidator(sf2, accountutil.AccountState),

--- a/e2etest/local_test.go
+++ b/e2etest/local_test.go
@@ -474,7 +474,6 @@ func TestStartExistingBlockchain(t *testing.T) {
 
 	// Recover to height 3 from empty state DB
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	dao := blockdao.NewBlockDAO(nil, cfg.DB)
 	require.NoError(dao.Start(protocol.WithBlockchainCtx(
 		genesis.WithGenesisContext(ctx, cfg.Genesis),
@@ -497,7 +496,6 @@ func TestStartExistingBlockchain(t *testing.T) {
 	// Recover to height 2 from an existing state DB with Height 3
 	require.NoError(svr.Stop(ctx))
 	cfg.DB.DbPath = cfg.Chain.ChainDBPath
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	dao = blockdao.NewBlockDAO(nil, cfg.DB)
 	require.NoError(dao.Start(protocol.WithBlockchainCtx(
 		genesis.WithGenesisContext(ctx, cfg.Genesis),

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -585,7 +585,6 @@ func newConfig(
 	cfg.Chain.ChainDBPath = chainDBPath
 	cfg.Chain.TrieDBPath = trieDBPath
 	cfg.Chain.IndexDBPath = indexDBPath
-	cfg.Chain.CompressBlock = true
 	cfg.Chain.ProducerPrivKey = producerPriKey.HexString()
 	cfg.Chain.EnableAsyncIndexWrite = false
 
@@ -607,9 +606,10 @@ func newConfig(
 	cfg.Genesis.Blockchain.NumDelegates = numNodes
 	cfg.Genesis.Blockchain.TimeBasedRotation = true
 	cfg.Genesis.Delegates = cfg.Genesis.Delegates[0:numNodes]
-
 	cfg.Genesis.BlockInterval = 500 * time.Millisecond
 	cfg.Genesis.EnableGravityChainVoting = true
 	cfg.Genesis.Rewarding.FoundationBonusLastEpoch = 2
+
+	cfg.DB.CompressLegacy = true
 	return cfg
 }

--- a/e2etest/rewarding_test.go
+++ b/e2etest/rewarding_test.go
@@ -610,6 +610,5 @@ func newConfig(
 	cfg.Genesis.EnableGravityChainVoting = true
 	cfg.Genesis.Rewarding.FoundationBonusLastEpoch = 2
 
-	cfg.DB.CompressLegacy = true
 	return cfg
 }

--- a/tools/iomigrater/cmds/check-height.go
+++ b/tools/iomigrater/cmds/check-height.go
@@ -53,7 +53,6 @@ func checkDbFileHeight(filePath string) (uint64, error) {
 	}
 
 	cfg.DB.DbPath = filePath
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	blockDao := blockdao.NewBlockDAO(nil, cfg.DB)
 
 	// Load height value.

--- a/tools/iomigrater/cmds/migrate-db.go
+++ b/tools/iomigrater/cmds/migrate-db.go
@@ -113,7 +113,6 @@ func migrateDbFile() error {
 	}
 
 	cfg.DB.DbPath = oldFile
-	cfg.DB.CompressLegacy = cfg.Chain.CompressBlock
 	oldDAO := blockdao.NewBlockDAO(nil, cfg.DB)
 
 	cfg.DB.DbPath = newFile

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -438,6 +438,5 @@ func newConfig(
 	cfg.Genesis.EnableGravityChainVoting = false
 	cfg.Genesis.PollMode = "lifeLong"
 
-	cfg.DB.CompressLegacy = true
 	return cfg
 }

--- a/tools/minicluster/minicluster.go
+++ b/tools/minicluster/minicluster.go
@@ -412,7 +412,6 @@ func newConfig(
 	cfg.Network.BootstrapNodes = []string{"/ip4/127.0.0.1/tcp/4689/ipfs/12D3KooWJwW6pUpTkxPTMv84RPLPMQVEAjZ6fvJuX4oZrvW5DAGQ"}
 
 	cfg.Chain.ID = 1
-	cfg.Chain.CompressBlock = true
 	cfg.Chain.ProducerPrivKey = producerPriKey.HexString()
 
 	cfg.ActPool.MinGasPriceStr = big.NewInt(0).String()
@@ -438,5 +437,7 @@ func newConfig(
 	cfg.Genesis.Delegates = cfg.Genesis.Delegates[3 : _numNodes+3]
 	cfg.Genesis.EnableGravityChainVoting = false
 	cfg.Genesis.PollMode = "lifeLong"
+
+	cfg.DB.CompressLegacy = true
 	return cfg
 }


### PR DESCRIPTION
# Description
 - deprecate config.Chain.CompressBlock, which is replaced by config.DB.CompressLegacy
 - remove BoltDBDaoOption, which is only used in tests.

Fixes #(issue)
fix #3461 

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
