### PR TITLE
[ioctl] Build hdwallet create command line into new ioctl

### DIFF
--- a/ioctl/newcmd/hdwallet/hdwalletcreate.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate.go
@@ -7,8 +7,6 @@
 package hdwallet
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tyler-smith/go-bip39"
@@ -58,15 +56,21 @@ func NewHdwalletCreateCmd(client ioctl.Client) *cobra.Command {
 				return ErrPasswdNotMatch
 			}
 
-			entropy, _ := bip39.NewEntropy(128)
-			mnemonic, _ := bip39.NewMnemonic(entropy)
+			entropy, err := bip39.NewEntropy(128)
+			if err != nil {
+				return err
+			}
+			mnemonic, err := bip39.NewMnemonic(entropy)
+			if err != nil {
+				return err
+			}
 
 			if err = client.WriteHdWalletConfigFile(password, mnemonic); err != nil {
 				return err
 			}
 
-			cmd.Println(fmt.Sprintf("Mnemonic phrase: %s\n"+
-				"It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.", mnemonic))
+			cmd.Printf("Mnemonic phrase: %s\n"+
+				"It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.", mnemonic)
 			return nil
 		},
 	}

--- a/ioctl/newcmd/hdwallet/hdwalletcreate.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate.go
@@ -65,12 +65,12 @@ func NewHdwalletCreateCmd(client ioctl.Client) *cobra.Command {
 				return err
 			}
 
-			if err = client.WriteHdWalletConfigFile(password, mnemonic); err != nil {
+			if err = client.WriteHdWalletConfigFile(mnemonic, password); err != nil {
 				return err
 			}
 
 			cmd.Printf("Mnemonic phrase: %s\n"+
-				"It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.", mnemonic)
+				"It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.\n", mnemonic)
 			return nil
 		},
 	}

--- a/ioctl/newcmd/hdwallet/hdwalletcreate.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package hdwallet
+
+import (
+	"fmt"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// Multi-language support
+var (
+	_createByMnemonicCmdShorts = map[config.Language]string{
+		config.English: "create hdwallet using mnemonic",
+		config.Chinese: "通过助记词创建新钱包",
+	}
+	_createByMnemonicCmdUses = map[config.Language]string{
+		config.English: "create",
+		config.Chinese: "create 创建",
+	}
+)
+
+// NewHdwalletCreateCmd represents the hdwallet create command
+func NewHdwalletCreateCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_createByMnemonicCmdUses)
+	short, _ := client.SelectTranslation(_createByMnemonicCmdShorts)
+
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			if client.IsHdWalletConfigFileExist() {
+				cmd.Println("Please run 'ioctl hdwallet delete' before import")
+				return nil
+			}
+			cmd.Println("Set password")
+			password, err := client.ReadSecret()
+			if err != nil {
+				return errors.Wrap(err, "failed to get password")
+			}
+			cmd.Println("Enter password again")
+			passwordAgain, err := client.ReadSecret()
+			if err != nil {
+				return errors.Wrap(err, "failed to get password")
+			}
+			if password != passwordAgain {
+				return errors.New(ErrPasswdNotMatch.Error())
+			}
+
+			entropy, _ := bip39.NewEntropy(128)
+			mnemonic, _ := bip39.NewMnemonic(entropy)
+
+			if err = client.WriteHdWalletConfigFile(password, mnemonic); err != nil {
+				return err
+			}
+
+			cmd.Println(fmt.Sprintf("Mnemonic phrase: %s\n"+
+				"It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.", mnemonic))
+			return nil
+		},
+	}
+}

--- a/ioctl/newcmd/hdwallet/hdwalletcreate.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate.go
@@ -9,11 +9,12 @@ package hdwallet
 import (
 	"fmt"
 
-	"github.com/iotexproject/iotex-core/ioctl"
-	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tyler-smith/go-bip39"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
 )
 
 // Multi-language support
@@ -54,7 +55,7 @@ func NewHdwalletCreateCmd(client ioctl.Client) *cobra.Command {
 				return errors.Wrap(err, "failed to get password")
 			}
 			if password != passwordAgain {
-				return errors.New(ErrPasswdNotMatch.Error())
+				return ErrPasswdNotMatch
 			}
 
 			entropy, _ := bip39.NewEntropy(128)

--- a/ioctl/newcmd/hdwallet/hdwalletcreate_test.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate_test.go
@@ -10,11 +10,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewHdwalletCreateCmd(t *testing.T) {
@@ -27,8 +28,7 @@ func TestNewHdwalletCreateCmd(t *testing.T) {
 	client.EXPECT().IsHdWalletConfigFileExist().Return(false).Times(3)
 
 	t.Run("create hdwallet", func(t *testing.T) {
-		client.EXPECT().ReadSecret().Return(password, nil)
-		client.EXPECT().ReadSecret().Return(password, nil)
+		client.EXPECT().ReadSecret().Return(password, nil).Times(2)
 		client.EXPECT().WriteHdWalletConfigFile(gomock.Any(), gomock.Any()).Return(nil)
 
 		cmd := NewHdwalletCreateCmd(client)

--- a/ioctl/newcmd/hdwallet/hdwalletcreate_test.go
+++ b/ioctl/newcmd/hdwallet/hdwalletcreate_test.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package hdwallet
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewHdwalletCreateCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	password := "123"
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).Times(9)
+	client.EXPECT().IsHdWalletConfigFileExist().Return(false).Times(3)
+
+	t.Run("create hdwallet", func(t *testing.T) {
+		client.EXPECT().ReadSecret().Return(password, nil)
+		client.EXPECT().ReadSecret().Return(password, nil)
+		client.EXPECT().WriteHdWalletConfigFile(gomock.Any(), gomock.Any()).Return(nil)
+
+		cmd := NewHdwalletCreateCmd(client)
+		result, err := util.ExecuteCmd(cmd)
+		require.NoError(err)
+		require.Contains(result, "It is used to recover your wallet in case you forgot the password. Write them down and store it in a safe place.")
+	})
+
+	t.Run("failed to get password", func(t *testing.T) {
+		expectedErr := errors.New("failed to get password")
+		client.EXPECT().ReadSecret().Return("", expectedErr)
+
+		cmd := NewHdwalletCreateCmd(client)
+		_, err := util.ExecuteCmd(cmd)
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("password not match", func(t *testing.T) {
+		expectedErr := errors.New("password doesn't match")
+		client.EXPECT().ReadSecret().Return(password, nil)
+		client.EXPECT().ReadSecret().Return("test", nil)
+
+		cmd := NewHdwalletCreateCmd(client)
+		_, err := util.ExecuteCmd(cmd)
+		require.Equal(err.Error(), expectedErr.Error())
+	})
+}

--- a/ioctl/newcmd/node/node.go
+++ b/ioctl/newcmd/node/node.go
@@ -2,7 +2,7 @@ package node
 
 import (
 	"github.com/spf13/cobra"
-	
+
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 )


### PR DESCRIPTION
# Description
Refactor `hdwalletcreate` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3283

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewHdwalletCreateCmd

**Test Configuration**:
- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules