### PR TITLE
[api] Remove iotextypes.BlockMeta from coreservice

### DIFF
--- a/action/action_deserializer.go
+++ b/action/action_deserializer.go
@@ -14,7 +14,6 @@ import "github.com/iotexproject/iotex-proto/golang/iotextypes"
 // Currently the parameter is EVM network ID for tx in web3 format, it is called like
 //
 // act, err := (&Deserializer{}).SetEvmNetworkID(id).ActionToSealedEnvelope(pbAction)
-//
 type Deserializer struct {
 	evmNetworkID uint32
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -341,7 +341,7 @@ func getChainConfig(g genesis.Blockchain, height uint64, id uint32) *params.Chai
 	return &chainConfig
 }
 
-//Error in executeInEVM is a consensus issue
+// Error in executeInEVM is a consensus issue
 func executeInEVM(ctx context.Context, evmParams *Params, stateDB *StateDBAdapter, g genesis.Blockchain, gasLimit uint64, blockHeight uint64) ([]byte, uint64, uint64, string, iotextypes.ReceiptStatus, error) {
 	remainingGas := evmParams.gas
 	if err := securityDeposit(evmParams, stateDB, gasLimit); err != nil {

--- a/action/protocol/vote/probationlist.go
+++ b/action/protocol/vote/probationlist.go
@@ -15,7 +15,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
-//ProbationList defines a map where key is candidate's name and value is the counter which counts the unproductivity during probation epoch.
+// ProbationList defines a map where key is candidate's name and value is the counter which counts the unproductivity during probation epoch.
 type ProbationList struct {
 	ProbationInfo map[string]uint32
 	IntensityRate uint32

--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -361,9 +361,9 @@ func (ap *actPool) validate(ctx context.Context, selp action.SealedEnvelope) err
 	return nil
 }
 
-//======================================
+// ======================================
 // private functions
-//======================================
+// ======================================
 func (ap *actPool) enqueueAction(ctx context.Context, addr address.Address, act action.SealedEnvelope, actHash hash.Hash256, actNonce uint64) error {
 	span := tracer.SpanFromContext(ctx)
 	defer span.End()

--- a/api/blocklistener.go
+++ b/api/blocklistener.go
@@ -79,7 +79,7 @@ func NewWeb3BlockListener(handler streamHandler) apitypes.Responder {
 func (bl *web3BlockListener) Respond(id string, blk *block.Block) error {
 	res := &streamResponse{
 		id: id,
-		result: &getBlockResultV2{
+		result: &getBlockResult{
 			blk: blk,
 		},
 	}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -107,11 +107,11 @@ type (
 		// ActPoolActions returns the all Transaction Identifiers in the actpool
 		ActionsInActPool(actHashes []string) ([]action.SealedEnvelope, error)
 		// BlockByHeightRange returns blocks within the height range
-		BlockByHeightRange(uint64, uint64) ([]*block.Store, error)
+		BlockByHeightRange(uint64, uint64) ([]*apitypes.BlockWithReceipts, error)
 		// BlockByHeight returns the block and its receipt from block height
-		BlockByHeight(uint64) (*block.Store, error)
+		BlockByHeight(uint64) (*apitypes.BlockWithReceipts, error)
 		// BlockByHash returns the block and its receipt
-		BlockByHash(string) (*block.Store, error)
+		BlockByHash(string) (*apitypes.BlockWithReceipts, error)
 		// UnconfirmedActionsByAddress returns all unconfirmed actions in actpool associated with an address
 		UnconfirmedActionsByAddress(address string, start uint64, count uint64) ([]*iotexapi.ActionInfo, error)
 		// EstimateGasForNonExecution  estimates action gas except execution
@@ -1025,7 +1025,7 @@ func (core *coreService) UnconfirmedActionsByAddress(address string, start uint6
 }
 
 // BlockByHash returns the block and its receipt from block hash
-func (core *coreService) BlockByHash(blkHash string) (*block.Store, error) {
+func (core *coreService) BlockByHash(blkHash string) (*apitypes.BlockWithReceipts, error) {
 	if err := core.checkActionIndex(); err != nil {
 		return nil, err
 	}
@@ -1041,14 +1041,14 @@ func (core *coreService) BlockByHash(blkHash string) (*block.Store, error) {
 	if err != nil {
 		return nil, errors.Wrap(ErrNotFound, err.Error())
 	}
-	return &block.Store{
+	return &apitypes.BlockWithReceipts{
 		Block:    blk,
 		Receipts: receipts,
 	}, nil
 }
 
 // BlockByHeightRange returns blocks within the height range
-func (core *coreService) BlockByHeightRange(start uint64, count uint64) ([]*block.Store, error) {
+func (core *coreService) BlockByHeightRange(start uint64, count uint64) ([]*apitypes.BlockWithReceipts, error) {
 	if count == 0 {
 		return nil, errors.Wrap(errInvalidFormat, "count must be greater than zero")
 	}
@@ -1058,7 +1058,7 @@ func (core *coreService) BlockByHeightRange(start uint64, count uint64) ([]*bloc
 
 	var (
 		tipHeight = core.bc.TipHeight()
-		res       = make([]*block.Store, 0)
+		res       = make([]*apitypes.BlockWithReceipts, 0)
 	)
 	if start > tipHeight {
 		return nil, errors.Wrap(errInvalidFormat, "start height should not exceed tip height")
@@ -1075,11 +1075,11 @@ func (core *coreService) BlockByHeightRange(start uint64, count uint64) ([]*bloc
 }
 
 // BlockByHeight returns the block and its receipt from block height
-func (core *coreService) BlockByHeight(height uint64) (*block.Store, error) {
+func (core *coreService) BlockByHeight(height uint64) (*apitypes.BlockWithReceipts, error) {
 	return core.getBlockByHeight(height)
 }
 
-func (core *coreService) getBlockByHeight(height uint64) (*block.Store, error) {
+func (core *coreService) getBlockByHeight(height uint64) (*apitypes.BlockWithReceipts, error) {
 	if height > core.bc.TipHeight() {
 		return nil, ErrNotFound
 	}
@@ -1095,7 +1095,7 @@ func (core *coreService) getBlockByHeight(height uint64) (*block.Store, error) {
 			return nil, errors.Wrap(ErrNotFound, err.Error())
 		}
 	}
-	return &block.Store{
+	return &apitypes.BlockWithReceipts{
 		Block:    blk,
 		Receipts: receipts,
 	}, nil

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -106,6 +106,10 @@ type (
 		ActionByActionHash(h hash.Hash256) (action.SealedEnvelope, hash.Hash256, uint64, uint32, error)
 		// ActPoolActions returns the all Transaction Identifiers in the actpool
 		ActionsInActPool(actHashes []string) ([]action.SealedEnvelope, error)
+		// BlockByHeightRange returns blocks within the height range
+		BlockByHeightRange(uint64, uint64) ([]*block.Store, error)
+		// BlockByHeight returns the block and its receipt from block height
+		BlockByHeight(uint64) (*block.Store, error)
 		// BlockByHash returns the block and its receipt
 		BlockByHash(string) (*block.Store, error)
 		// UnconfirmedActionsByAddress returns all unconfirmed actions in actpool associated with an address
@@ -114,10 +118,6 @@ type (
 		EstimateGasForNonExecution(action.Action) (uint64, error)
 		// EstimateExecutionGasConsumption estimate gas consumption for execution action
 		EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address) (uint64, error)
-		// BlockMetas returns blockmetas response within the height range
-		BlockMetas(start uint64, count uint64) ([]*iotextypes.BlockMeta, error)
-		// BlockMetaByHash returns blockmeta response by block hash
-		BlockMetaByHash(blkHash string) (*iotextypes.BlockMeta, error)
 		// LogsInBlockByHash filter logs in the block by hash
 		LogsInBlockByHash(filter *logfilter.LogFilter, blockHash hash.Hash256) ([]*action.Log, error)
 		// LogsInRange filter logs among [start, end] blocks
@@ -331,21 +331,21 @@ func (core *coreService) ChainMeta() (*iotextypes.ChainMeta, string, error) {
 	if int64(tipHeight) < blockLimit {
 		blockLimit = int64(tipHeight)
 	}
-	blks, err := core.BlockMetas(tipHeight-uint64(blockLimit)+1, uint64(blockLimit))
+	blkStores, err := core.BlockByHeightRange(tipHeight-uint64(blockLimit)+1, uint64(blockLimit))
 	if err != nil {
 		return nil, "", status.Error(codes.NotFound, err.Error())
 	}
-	if len(blks) == 0 {
+	if len(blkStores) == 0 {
 		return nil, "", status.Error(codes.NotFound, "get 0 blocks! not able to calculate aps")
 	}
 
-	var numActions int64
-	for _, blk := range blks {
-		numActions += blk.NumActions
+	var numActions uint64
+	for _, blkStore := range blkStores {
+		numActions += uint64(len(blkStore.Block.Actions))
 	}
 
-	t1 := time.Unix(blks[0].Timestamp.GetSeconds(), int64(blks[0].Timestamp.GetNanos()))
-	t2 := time.Unix(blks[len(blks)-1].Timestamp.GetSeconds(), int64(blks[len(blks)-1].Timestamp.GetNanos()))
+	t1 := blkStores[0].Block.Timestamp()
+	t2 := blkStores[len(blkStores)-1].Block.Timestamp()
 	// duration of time difference in milli-seconds
 	// TODO: use config.Genesis.BlockInterval after PR1289 merges
 	timeDiff := (t2.Sub(t1) + 10*time.Second) / time.Millisecond
@@ -1024,7 +1024,7 @@ func (core *coreService) UnconfirmedActionsByAddress(address string, start uint6
 	return res, nil
 }
 
-// BlockByHash returns the block and its receipt
+// BlockByHash returns the block and its receipt from block hash
 func (core *coreService) BlockByHash(blkHash string) (*block.Store, error) {
 	if err := core.checkActionIndex(); err != nil {
 		return nil, err
@@ -1047,75 +1047,58 @@ func (core *coreService) BlockByHash(blkHash string) (*block.Store, error) {
 	}, nil
 }
 
-// BlockMetas returns blockmetas response within the height range
-func (core *coreService) BlockMetas(start uint64, count uint64) ([]*iotextypes.BlockMeta, error) {
+// BlockByHeightRange returns blocks within the height range
+func (core *coreService) BlockByHeightRange(start uint64, count uint64) ([]*block.Store, error) {
 	if count == 0 {
-		return nil, status.Error(codes.InvalidArgument, "count must be greater than zero")
+		return nil, errors.Wrap(errInvalidFormat, "count must be greater than zero")
 	}
 	if count > core.cfg.RangeQueryLimit {
-		return nil, status.Error(codes.InvalidArgument, "range exceeds the limit")
+		return nil, errors.Wrap(errInvalidFormat, "range exceeds the limit")
 	}
 
 	var (
 		tipHeight = core.bc.TipHeight()
-		res       = make([]*iotextypes.BlockMeta, 0)
+		res       = make([]*block.Store, 0)
 	)
 	if start > tipHeight {
-		return nil, status.Error(codes.InvalidArgument, "start height should not exceed tip height")
+		return nil, errors.Wrap(errInvalidFormat, "start height should not exceed tip height")
 	}
 	for height := start; height <= tipHeight && count > 0; height++ {
-		blockMeta, err := core.getBlockMetaByHeight(height)
+		blkStore, err := core.getBlockByHeight(height)
 		if err != nil {
 			return nil, err
 		}
-		res = append(res, blockMeta)
+		res = append(res, blkStore)
 		count--
 	}
 	return res, nil
 }
 
-// BlockMetaByHash returns blockmeta response by block hash
-func (core *coreService) BlockMetaByHash(blkHash string) (*iotextypes.BlockMeta, error) {
-	hash, err := hash.HexStringToHash256(blkHash)
-	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	height, err := core.dao.GetBlockHeight(hash)
-	if err != nil {
-		if errors.Cause(err) == db.ErrNotExist {
-			return nil, status.Error(codes.NotFound, err.Error())
-		}
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	return core.getBlockMetaByHeight(height)
+// BlockByHeight returns the block and its receipt from block height
+func (core *coreService) BlockByHeight(height uint64) (*block.Store, error) {
+	return core.getBlockByHeight(height)
 }
 
-// getBlockMetaByHeight gets BlockMeta by height
-func (core *coreService) getBlockMetaByHeight(height uint64) (*iotextypes.BlockMeta, error) {
+func (core *coreService) getBlockByHeight(height uint64) (*block.Store, error) {
+	if height > core.bc.TipHeight() {
+		return nil, ErrNotFound
+	}
 	blk, err := core.dao.GetBlockByHeight(height)
 	if err != nil {
-		return nil, status.Error(codes.NotFound, err.Error())
+		return nil, errors.Wrap(ErrNotFound, err.Error())
 	}
-	// get block's receipt
+	receipts := []*action.Receipt{}
 	if blk.Height() > 0 {
-		blk.Receipts, err = core.dao.GetReceipts(height)
+		var err error
+		receipts, err = core.dao.GetReceipts(height)
 		if err != nil {
-			return nil, status.Error(codes.NotFound, err.Error())
+			return nil, errors.Wrap(ErrNotFound, err.Error())
 		}
 	}
-	return generateBlockMeta(blk), nil
-}
-
-// GasLimitAndUsed returns the gas limit and used in a block
-func gasLimitAndUsed(b *block.Block) (uint64, uint64) {
-	var gasLimit, gasUsed uint64
-	for _, tx := range b.Actions {
-		gasLimit += tx.GasLimit()
-	}
-	for _, r := range b.Receipts {
-		gasUsed += r.GasConsumed
-	}
-	return gasLimit, gasUsed
+	return &block.Store{
+		Block:    blk,
+		Receipts: receipts,
+	}, nil
 }
 
 func (core *coreService) getGravityChainStartHeight(epochHeight uint64) (uint64, error) {

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/action"
+	apitypes "github.com/iotexproject/iotex-core/api/types"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/pkg/version"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -185,7 +186,7 @@ func TestGrpcServer_GetActions(t *testing.T) {
 				gasConsumed = big.NewInt(0)
 			}
 
-			response := &block.Store{
+			response := &apitypes.BlockWithReceipts{
 				Block:    &block.Block{},
 				Receipts: []*action.Receipt{},
 			}

--- a/api/types/types.go
+++ b/api/types/types.go
@@ -1,6 +1,7 @@
 package apitypes
 
 import (
+	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 )
 
@@ -23,6 +24,12 @@ type (
 		ReceiveBlock(*block.Block) error
 		AddResponder(Responder) (string, error)
 		RemoveResponder(string) (bool, error)
+	}
+
+	// BlockWithReceipts includes block and its receipts
+	BlockWithReceipts struct {
+		Block    *block.Block
+		Receipts []*action.Receipt
 	}
 )
 

--- a/api/web3server.go
+++ b/api/web3server.go
@@ -19,8 +19,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/iotexproject/iotex-core/action"
 	apitypes "github.com/iotexproject/iotex-core/api/types"
@@ -265,18 +263,14 @@ func (svr *web3Handler) getBlockByNumber(in *gjson.Result) (interface{}, error) 
 		return nil, err
 	}
 
-	blkMetas, err := svr.coreService.BlockMetas(num, 1)
+	blk, err := svr.coreService.BlockByHeight(num)
 	if err != nil {
-		st, ok := status.FromError(err)
-		if ok && st.Code() == codes.InvalidArgument {
+		if errors.Cause(err) == ErrNotFound {
 			return nil, nil
 		}
 		return nil, err
 	}
-	if len(blkMetas) == 0 {
-		return nil, nil
-	}
-	return svr.getBlockWithTransactions(blkMetas[0], isDetailed.Bool())
+	return svr.getBlockWithTransactions(blk, isDetailed.Bool())
 }
 
 func (svr *web3Handler) getBalance(in *gjson.Result) (interface{}, error) {
@@ -455,11 +449,11 @@ func (svr *web3Handler) getBlockTransactionCountByHash(in *gjson.Result) (interf
 	if !txHash.Exists() {
 		return nil, errInvalidFormat
 	}
-	blkMeta, err := svr.coreService.BlockMetaByHash(util.Remove0xPrefix(txHash.String()))
+	res, err := svr.coreService.BlockByHash(util.Remove0xPrefix(txHash.String()))
 	if err != nil {
 		return nil, errors.Wrap(err, "the block is not found")
 	}
-	return uint64ToHex(uint64(blkMeta.NumActions)), nil
+	return uint64ToHex(uint64(len(res.Block.Actions))), nil
 }
 
 func (svr *web3Handler) getBlockByHash(in *gjson.Result) (interface{}, error) {
@@ -467,15 +461,14 @@ func (svr *web3Handler) getBlockByHash(in *gjson.Result) (interface{}, error) {
 	if !blkHash.Exists() || !isDetailed.Exists() {
 		return nil, errInvalidFormat
 	}
-	blkMeta, err := svr.coreService.BlockMetaByHash(util.Remove0xPrefix(blkHash.String()))
+	blkStore, err := svr.coreService.BlockByHash(util.Remove0xPrefix(blkHash.String()))
 	if err != nil {
-		st, ok := status.FromError(err)
-		if ok && st.Code() == codes.NotFound {
+		if errors.Cause(err) == ErrNotFound {
 			return nil, nil
 		}
 		return nil, err
 	}
-	return svr.getBlockWithTransactions(blkMeta, isDetailed.Bool())
+	return svr.getBlockWithTransactions(blkStore, isDetailed.Bool())
 }
 
 func (svr *web3Handler) getTransactionByHash(in *gjson.Result) (interface{}, error) {
@@ -502,7 +495,7 @@ func (svr *web3Handler) getTransactionByHash(in *gjson.Result) (interface{}, err
 		}
 		return nil, err
 	}
-	return svr.getTransactionFromActionInfo(hex.EncodeToString(blkHash[:]), selp, receipt)
+	return svr.getTransactionFromActionInfo(blkHash, selp, receipt)
 }
 
 func (svr *web3Handler) getLogs(filter *filterObject) (interface{}, error) {
@@ -546,9 +539,14 @@ func (svr *web3Handler) getTransactionReceipt(in *gjson.Result) (interface{}, er
 
 	// acquire logsBloom from blockMeta
 	blkHash := hex.EncodeToString(blockHash[:])
-	blkMeta, err := svr.coreService.BlockMetaByHash(blkHash)
+	blkStore, err := svr.coreService.BlockByHash(blkHash)
 	if err != nil {
 		return nil, err
+	}
+
+	var logsBloomStr string
+	if logsBloom := blkStore.Block.LogsBloomfilter(); logsBloom != nil {
+		logsBloomStr = hex.EncodeToString(logsBloom.Bytes())
 	}
 
 	return &getReceiptResult{
@@ -556,7 +554,7 @@ func (svr *web3Handler) getTransactionReceipt(in *gjson.Result) (interface{}, er
 		from:            selp.SenderAddress(),
 		to:              to,
 		contractAddress: contractAddr,
-		logsBloom:       blkMeta.LogsBloom,
+		logsBloom:       logsBloomStr,
 		receipt:         receipt,
 	}, nil
 
@@ -571,14 +569,14 @@ func (svr *web3Handler) getBlockTransactionCountByNumber(in *gjson.Result) (inte
 	if err != nil {
 		return nil, err
 	}
-	blkMetas, err := svr.coreService.BlockMetas(num, 1)
+	res, err := svr.coreService.BlockByHeight(num)
 	if err != nil {
+		if errors.Cause(err) == ErrNotFound {
+			return nil, nil
+		}
 		return nil, err
 	}
-	if len(blkMetas) == 0 {
-		return nil, errInvalidBlock
-	}
-	return uint64ToHex(uint64(blkMetas[0].NumActions)), nil
+	return uint64ToHex(uint64(len(res.Block.Actions))), nil
 }
 
 func (svr *web3Handler) getTransactionByBlockHashAndIndex(in *gjson.Result) (interface{}, error) {
@@ -590,11 +588,15 @@ func (svr *web3Handler) getTransactionByBlockHashAndIndex(in *gjson.Result) (int
 	if err != nil {
 		return nil, err
 	}
-	blkHash := util.Remove0xPrefix(blkHashStr.String())
-	blkStore, err := svr.coreService.BlockByHash(blkHash)
+	blkHashHex := util.Remove0xPrefix(blkHashStr.String())
+	blkStore, err := svr.coreService.BlockByHash(blkHashHex)
 	if errors.Cause(err) == ErrNotFound || idx >= uint64(len(blkStore.Receipts)) || len(blkStore.Receipts) == 0 {
 		return nil, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	blkHash, err := hash.HexStringToHash256(blkHashHex)
 	if err != nil {
 		return nil, err
 	}
@@ -614,25 +616,14 @@ func (svr *web3Handler) getTransactionByBlockNumberAndIndex(in *gjson.Result) (i
 	if err != nil {
 		return nil, err
 	}
-	blkMetas, err := svr.coreService.BlockMetas(num, 1)
-	if err != nil {
-		st, ok := status.FromError(err)
-		if ok && st.Code() == codes.InvalidArgument {
-			return nil, nil
-		}
-		return nil, err
-	}
-	if len(blkMetas) == 0 {
-		return nil, nil
-	}
-	blkStore, err := svr.coreService.BlockByHash(blkMetas[0].Hash)
+	blkStore, err := svr.coreService.BlockByHeight(num)
 	if errors.Cause(err) == ErrNotFound || idx >= uint64(len(blkStore.Receipts)) || len(blkStore.Receipts) == 0 {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	return svr.getTransactionFromActionInfo(blkMetas[0].Hash, blkStore.Block.Actions[idx], blkStore.Receipts[idx])
+	return svr.getTransactionFromActionInfo(blkStore.Block.HashBlock(), blkStore.Block.Actions[idx], blkStore.Receipts[idx])
 }
 
 func (svr *web3Handler) getStorageAt(in *gjson.Result) (interface{}, error) {
@@ -751,13 +742,14 @@ func (svr *web3Handler) getFilterChanges(in *gjson.Result) (interface{}, error) 
 			return []string{}, nil
 		}
 		queryCount := tipHeight - filterObj.LogHeight + 1
-		blkMetas, err := svr.coreService.BlockMetas(filterObj.LogHeight, queryCount)
+		blkStores, err := svr.coreService.BlockByHeightRange(filterObj.LogHeight, queryCount)
 		if err != nil {
 			return nil, err
 		}
 		hashArr := make([]string, 0)
-		for _, v := range blkMetas {
-			hashArr = append(hashArr, "0x"+v.Hash)
+		for _, blkStore := range blkStores {
+			blkHash := blkStore.Block.HashBlock()
+			hashArr = append(hashArr, "0x"+hex.EncodeToString(blkHash[:]))
 		}
 		ret, newLogHeight = hashArr, filterObj.LogHeight+queryCount
 	default:

--- a/api/web3server_integrity_test.go
+++ b/api/web3server_integrity_test.go
@@ -287,7 +287,7 @@ func TestGetBlockByHashIntegrity(t *testing.T) {
 	ret, err := svr.getBlockByHash(&testData)
 	require.NoError(err)
 	ans := ret.(*getBlockResult)
-	require.Equal(hex.EncodeToString(blkHash[:]), ans.blkMeta.Hash)
+	require.Equal(blkHash, ans.blk.HashBlock())
 	require.Equal(2, len(ans.transactions))
 
 	testData2 := gjson.Parse(`{"params":["0xa2e8e0c9cafbe93f2b7f7c9d32534bc6fde95f2185e5f2aaa6bf7ebdf1a6610a", false]}`)

--- a/api/web3server_marshal.go
+++ b/api/web3server_marshal.go
@@ -8,7 +8,6 @@ import (
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -44,12 +43,6 @@ type (
 	}
 
 	getBlockResult struct {
-		blkMeta      *iotextypes.BlockMeta
-		transactions []interface{}
-	}
-
-	// TODO: repalce getBlockResult with getBlockResultV2 after BlockMeta is removed in coreservice
-	getBlockResultV2 struct {
 		blk          *block.Block
 		transactions []interface{}
 	}
@@ -126,63 +119,6 @@ func (obj *web3Response) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (obj *getBlockResult) MarshalJSON() ([]byte, error) {
-	if obj.blkMeta == nil {
-		return nil, errInvalidObject
-	}
-	producerAddr, err := ioAddrToEthAddr(obj.blkMeta.ProducerAddress)
-	if err != nil {
-		return nil, err
-	}
-	txs := make([]interface{}, 0)
-	if len(obj.transactions) > 0 {
-		txs = obj.transactions
-	}
-	return json.Marshal(&struct {
-		Author           string        `json:"author"`
-		Number           string        `json:"number"`
-		Hash             string        `json:"hash"`
-		ParentHash       string        `json:"parentHash"`
-		Sha3Uncles       string        `json:"sha3Uncles"`
-		LogsBloom        string        `json:"logsBloom"`
-		TransactionsRoot string        `json:"transactionsRoot"`
-		StateRoot        string        `json:"stateRoot"`
-		ReceiptsRoot     string        `json:"receiptsRoot"`
-		Miner            string        `json:"miner"`
-		Difficulty       string        `json:"difficulty"`
-		TotalDifficulty  string        `json:"totalDifficulty"`
-		ExtraData        string        `json:"extraData"`
-		Size             string        `json:"size"`
-		GasLimit         string        `json:"gasLimit"`
-		GasUsed          string        `json:"gasUsed"`
-		Timestamp        string        `json:"timestamp"`
-		Transactions     []interface{} `json:"transactions"`
-		Step             string        `json:"step"`
-		Uncles           []string      `json:"uncles"`
-	}{
-		Author:           producerAddr,
-		Number:           uint64ToHex(obj.blkMeta.Height),
-		Hash:             "0x" + obj.blkMeta.Hash,
-		ParentHash:       "0x" + obj.blkMeta.PreviousBlockHash,
-		Sha3Uncles:       "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-		LogsBloom:        getLogsBloomHex(obj.blkMeta.LogsBloom),
-		TransactionsRoot: "0x" + obj.blkMeta.TxRoot,
-		StateRoot:        "0x" + obj.blkMeta.DeltaStateDigest,
-		ReceiptsRoot:     "0x" + obj.blkMeta.ReceiptRoot,
-		Miner:            producerAddr,
-		Difficulty:       "0xfffffffffffffffffffffffffffffffe",
-		TotalDifficulty:  "0xff14700000000000000000000000486001d72",
-		ExtraData:        "0x",
-		Size:             uint64ToHex(uint64(obj.blkMeta.NumActions)),
-		GasLimit:         uint64ToHex(obj.blkMeta.GasLimit),
-		GasUsed:          uint64ToHex(obj.blkMeta.GasUsed),
-		Timestamp:        uint64ToHex(uint64(obj.blkMeta.Timestamp.Seconds)),
-		Transactions:     txs,
-		Step:             "373422302",
-		Uncles:           []string{},
-	})
-}
-
 func getLogsBloomHex(logsbloom string) string {
 	if len(logsbloom) == 0 {
 		return _zeroLogsBloom
@@ -190,7 +126,7 @@ func getLogsBloomHex(logsbloom string) string {
 	return "0x" + logsbloom
 }
 
-func (obj *getBlockResultV2) MarshalJSON() ([]byte, error) {
+func (obj *getBlockResult) MarshalJSON() ([]byte, error) {
 	if obj.blk == nil {
 		return nil, errInvalidObject
 	}

--- a/api/web3server_marshal_test.go
+++ b/api/web3server_marshal_test.go
@@ -71,7 +71,7 @@ func TestWeb3ResponseMarshal(t *testing.T) {
 	})
 }
 
-func TestBlockObjectV2Marshal(t *testing.T) {
+func TestBlockObjectMarshal(t *testing.T) {
 	require := require.New(t)
 
 	var (

--- a/api/web3server_marshal_test.go
+++ b/api/web3server_marshal_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -73,130 +71,6 @@ func TestWeb3ResponseMarshal(t *testing.T) {
 	})
 }
 
-func TestBlockObjectMarshal(t *testing.T) {
-	require := require.New(t)
-
-	emptyBytes := make([]byte, 256)
-	blkMeta := &iotextypes.BlockMeta{
-		Hash:              "a52101ae81a5cf4e054709456adb5e8fcbb0c707f02e5f292d0bd22ddd817076",
-		Height:            1,
-		Timestamp:         timestamppb.New(time.Date(2011, 1, 26, 0, 0, 0, 0, time.UTC)),
-		NumActions:        2,
-		ProducerAddress:   "io1juvx5g063eu4ts832nukp4vgcwk2gnc5cu9ayd",
-		TransferAmount:    "10",
-		TxRoot:            "2a4e3b26aa302bf1974b850397e4ec24aa77517e4ea367e3f7f764b2c59f1eb5",
-		ReceiptRoot:       "0c26064b778ca775ed2f4220882ce20ced34f806ceb5edf67a7fb4cdb7b1a5dc",
-		DeltaStateDigest:  "900d80ab3bb6d12a98ae177268610b28a14c9ef84fb891a9c809d6d863d79cd3",
-		LogsBloom:         hex.EncodeToString(emptyBytes),
-		PreviousBlockHash: "1f20ad92a25748c2459aa6820a4fe5a25a1c57702045f4ab910dc88df5a04fce",
-		GasLimit:          20000,
-		GasUsed:           10000,
-	}
-
-	t.Run("BlockWithoutDetail", func(t *testing.T) {
-		res, err := json.Marshal(&getBlockResult{
-			blkMeta:      blkMeta,
-			transactions: []interface{}{string("0x2133ee7ff4562535166e3f16fd7407c19e5ed1acd036f78d3528a5a40e40ad42")},
-		})
-		require.NoError(err)
-		require.JSONEq(`
-		{
-			"author":"0x97186A21fA8E7955C0f154f960d588C3ACA44f14",
-			"number":"0x1",
-			"hash":"0xa52101ae81a5cf4e054709456adb5e8fcbb0c707f02e5f292d0bd22ddd817076",
-			"parentHash":"0x1f20ad92a25748c2459aa6820a4fe5a25a1c57702045f4ab910dc88df5a04fce",
-			"sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-			"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-			"transactionsRoot":"0x2a4e3b26aa302bf1974b850397e4ec24aa77517e4ea367e3f7f764b2c59f1eb5",
-			"stateRoot":"0x900d80ab3bb6d12a98ae177268610b28a14c9ef84fb891a9c809d6d863d79cd3",
-			"receiptsRoot":"0x0c26064b778ca775ed2f4220882ce20ced34f806ceb5edf67a7fb4cdb7b1a5dc",
-			"miner":"0x97186A21fA8E7955C0f154f960d588C3ACA44f14",
-			"difficulty":"0xfffffffffffffffffffffffffffffffe",
-			"totalDifficulty":"0xff14700000000000000000000000486001d72",
-			"extraData":"0x",
-			"size":"0x2",
-			"gasLimit":"0x4e20",
-			"gasUsed":"0x2710",
-			"timestamp":"0x4d3f6400",
-			"transactions":[
-			   "0x2133ee7ff4562535166e3f16fd7407c19e5ed1acd036f78d3528a5a40e40ad42"
-			],
-			"step":"373422302",
-			"uncles":[
-			   
-			]
-		 }
-		`, string(res))
-	})
-
-	t.Run("BlockWithDetail", func(t *testing.T) {
-		receipt := &action.Receipt{
-			Status:          1,
-			BlockHeight:     16,
-			ActionHash:      _testTxHash,
-			GasConsumed:     21000,
-			ContractAddress: _testContractIoAddr,
-			TxIndex:         1,
-		}
-		tx := &getTransactionResult{
-			blockHash: _testBlkHash,
-			to:        nil,
-			ethTx:     types.NewContractCreation(1, big.NewInt(10), 21000, big.NewInt(0), []byte{}),
-			receipt:   receipt,
-			pubkey:    _testPubKey,
-			signature: []byte("69d89a0af27dcaa67f1b62a383594d97599aadd2b7b164cb4112aa8ddfd42f895649075cae1b7216c43a491c5e9be68d1d9a27b863d71155ecdd7c95dab5394f01"),
-		}
-		res, err := json.Marshal(&getBlockResult{
-			blkMeta:      blkMeta,
-			transactions: []interface{}{tx},
-		})
-		require.NoError(err)
-		require.JSONEq(`
-		{
-			"author":"0x97186A21fA8E7955C0f154f960d588C3ACA44f14",
-			"number":"0x1",
-			"hash":"0xa52101ae81a5cf4e054709456adb5e8fcbb0c707f02e5f292d0bd22ddd817076",
-			"parentHash":"0x1f20ad92a25748c2459aa6820a4fe5a25a1c57702045f4ab910dc88df5a04fce",
-			"sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
-			"logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-			"transactionsRoot":"0x2a4e3b26aa302bf1974b850397e4ec24aa77517e4ea367e3f7f764b2c59f1eb5",
-			"stateRoot":"0x900d80ab3bb6d12a98ae177268610b28a14c9ef84fb891a9c809d6d863d79cd3",
-			"receiptsRoot":"0x0c26064b778ca775ed2f4220882ce20ced34f806ceb5edf67a7fb4cdb7b1a5dc",
-			"miner":"0x97186A21fA8E7955C0f154f960d588C3ACA44f14",
-			"difficulty":"0xfffffffffffffffffffffffffffffffe",
-			"totalDifficulty":"0xff14700000000000000000000000486001d72",
-			"extraData":"0x",
-			"size":"0x2",
-			"gasLimit":"0x4e20",
-			"gasUsed":"0x2710",
-			"timestamp":"0x4d3f6400",
-			"transactions":[
-			   {
-				  "hash":"0x25bef7a7e20402a625973613b19bbc1793ed3a38cad270abf623222120a10fd0",
-				  "nonce":"0x1",
-				  "blockHash":"0xc4aace64c1f4d7c0b6ebe74ba01e00e27c7ff4b2552c36ef617f38f0f2b1ebb3",
-				  "blockNumber":"0x10",
-				  "transactionIndex":"0x1",
-				  "from":"0x0666dba65b0ef88d11cdcbe857ffb6618310dcfa",
-				  "to":null,
-				  "value":"0xa",
-				  "gasPrice":"0x0",
-				  "gas":"0x5208",
-				  "input":"0x",
-				  "r":"0x3639643839613061663237646361613637663162363261333833353934643937",
-				  "s":"0x3539396161646432623762313634636234313132616138646466643432663839",
-				  "v":"0x35"
-			   }
-			],
-			"step":"373422302",
-			"uncles":[
-			   
-			]
-		 }
-		`, string(res))
-	})
-}
-
 func TestBlockObjectV2Marshal(t *testing.T) {
 	require := require.New(t)
 
@@ -244,7 +118,7 @@ func TestBlockObjectV2Marshal(t *testing.T) {
 	}}
 
 	t.Run("BlockWithoutDetail", func(t *testing.T) {
-		res, err := json.Marshal(&getBlockResultV2{
+		res, err := json.Marshal(&getBlockResult{
 			blk:          &blk,
 			transactions: []interface{}{string("0x2133ee7ff4562535166e3f16fd7407c19e5ed1acd036f78d3528a5a40e40ad42")},
 		})
@@ -288,7 +162,7 @@ func TestBlockObjectV2Marshal(t *testing.T) {
 			pubkey:    sevlp.SrcPubkey(),
 			signature: sevlp.Signature(),
 		}
-		res, err := json.Marshal(&getBlockResultV2{
+		res, err := json.Marshal(&getBlockResult{
 			blk:          &blk,
 			transactions: []interface{}{tx},
 		})

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -62,14 +62,14 @@ func intStrToHex(str string) (string, error) {
 	return "0x" + fmt.Sprintf("%x", amount), nil
 }
 
-func (svr *web3Handler) getBlockWithTransactions(blkStore *block.Store, isDetailed bool) (*getBlockResult, error) {
-	if blkStore == nil || blkStore.Block == nil || blkStore.Receipts == nil {
+func (svr *web3Handler) getBlockWithTransactions(blk *block.Block, receipts []*action.Receipt, isDetailed bool) (*getBlockResult, error) {
+	if blk == nil || receipts == nil {
 		return nil, errInvalidBlock
 	}
 	transactions := make([]interface{}, 0)
-	for i, selp := range blkStore.Block.Actions {
+	for i, selp := range blk.Actions {
 		if isDetailed {
-			tx, err := svr.getTransactionFromActionInfo(blkStore.Block.HashBlock(), selp, blkStore.Receipts[i])
+			tx, err := svr.getTransactionFromActionInfo(blk.HashBlock(), selp, receipts[i])
 			if err != nil {
 				if errors.Cause(err) != errUnsupportedAction {
 					h, _ := selp.Hash()
@@ -87,7 +87,7 @@ func (svr *web3Handler) getBlockWithTransactions(blkStore *block.Store, isDetail
 		}
 	}
 	return &getBlockResult{
-		blk:          blkStore.Block,
+		blk:          blk,
 		transactions: transactions,
 	}, nil
 }

--- a/blockchain/block/block_deserializer.go
+++ b/blockchain/block/block_deserializer.go
@@ -21,7 +21,6 @@ import (
 //
 // blk, err := (&Deserializer{}).SetEvmNetworkID(id).FromBlockProto(pbBlock)
 // blk, err := (&Deserializer{}).SetEvmNetworkID(id).DeserializeBlock(buf)
-//
 type Deserializer struct {
 	evmNetworkID uint32
 }

--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -399,7 +399,7 @@ func (bc *blockchain) MintNewBlock(timestamp time.Time) (*block.Block, error) {
 	return &blk, nil
 }
 
-//  CommitBlock validates and appends a block to the chain
+// CommitBlock validates and appends a block to the chain
 func (bc *blockchain) CommitBlock(blk *block.Block) error {
 	bc.mu.Lock()
 	defer bc.mu.Unlock()

--- a/consensus/scheme/rolldpos/endorsementmanager.go
+++ b/consensus/scheme/rolldpos/endorsementmanager.go
@@ -31,7 +31,7 @@ var (
 	_statusKey            = []byte("status")
 )
 
-//EndorsedByMajorityFunc defines a function to give an information of consensus status
+// EndorsedByMajorityFunc defines a function to give an information of consensus status
 type EndorsedByMajorityFunc func(blockHash []byte, topics []ConsensusVoteTopic) bool
 
 type endorserEndorsementCollection struct {

--- a/go.mod
+++ b/go.mod
@@ -57,6 +57,7 @@ require (
 require (
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible
 	github.com/shirou/gopsutil/v3 v3.22.2
+	golang.org/x/text v0.3.7
 )
 
 require (
@@ -177,7 +178,6 @@ require (
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect
 	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 // indirect
-	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/natefinch/npipe.v2 v2.0.0-20160621034901-c1b8fa8bdcce // indirect

--- a/ioctl/cmd/action/stake2.go
+++ b/ioctl/cmd/action/stake2.go
@@ -38,7 +38,7 @@ var (
 
 var _stake2AutoStake bool
 
-//Stake2Cmd represent stake2 command
+// Stake2Cmd represent stake2 command
 var Stake2Cmd = &cobra.Command{
 	Use:   "stake2",
 	Short: config.TranslateInLang(_stake2CmdShorts, config.UILanguage),

--- a/ioctl/cmd/action/xrc20.go
+++ b/ioctl/cmd/action/xrc20.go
@@ -42,7 +42,7 @@ var (
 	}
 )
 
-//Xrc20Cmd represent xrc20 standard command-line
+// Xrc20Cmd represent xrc20 standard command-line
 var Xrc20Cmd = &cobra.Command{
 	Use:   "xrc20",
 	Short: config.TranslateInLang(_xrc20CmdShorts, config.UILanguage),

--- a/pkg/fastrand/fastrand.go
+++ b/pkg/fastrand/fastrand.go
@@ -11,10 +11,12 @@ import (
 )
 
 // Uint32 returns a random 32-bit
+//
 //go:linkname Uint32 runtime.fastrand
 func Uint32() uint32
 
 // Uint32n returns a random 32-bit in the range [0..n).
+//
 //go:linkname Uint32n runtime.fastrandn
 func Uint32n(n uint32) uint32
 

--- a/test/mock/mock_apicoreservice/mock_apicoreservice.go
+++ b/test/mock/mock_apicoreservice/mock_apicoreservice.go
@@ -137,10 +137,10 @@ func (mr *MockCoreServiceMockRecorder) ActionsInActPool(actHashes interface{}) *
 }
 
 // BlockByHash mocks base method.
-func (m *MockCoreService) BlockByHash(arg0 string) (*block.Store, error) {
+func (m *MockCoreService) BlockByHash(arg0 string) (*apitypes.BlockWithReceipts, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockByHash", arg0)
-	ret0, _ := ret[0].(*block.Store)
+	ret0, _ := ret[0].(*apitypes.BlockWithReceipts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -152,10 +152,10 @@ func (mr *MockCoreServiceMockRecorder) BlockByHash(arg0 interface{}) *gomock.Cal
 }
 
 // BlockByHeight mocks base method.
-func (m *MockCoreService) BlockByHeight(arg0 uint64) (*block.Store, error) {
+func (m *MockCoreService) BlockByHeight(arg0 uint64) (*apitypes.BlockWithReceipts, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockByHeight", arg0)
-	ret0, _ := ret[0].(*block.Store)
+	ret0, _ := ret[0].(*apitypes.BlockWithReceipts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -167,10 +167,10 @@ func (mr *MockCoreServiceMockRecorder) BlockByHeight(arg0 interface{}) *gomock.C
 }
 
 // BlockByHeightRange mocks base method.
-func (m *MockCoreService) BlockByHeightRange(arg0, arg1 uint64) ([]*block.Store, error) {
+func (m *MockCoreService) BlockByHeightRange(arg0, arg1 uint64) ([]*apitypes.BlockWithReceipts, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BlockByHeightRange", arg0, arg1)
-	ret0, _ := ret[0].([]*block.Store)
+	ret0, _ := ret[0].([]*apitypes.BlockWithReceipts)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/test/mock/mock_apicoreservice/mock_apicoreservice.go
+++ b/test/mock/mock_apicoreservice/mock_apicoreservice.go
@@ -151,6 +151,36 @@ func (mr *MockCoreServiceMockRecorder) BlockByHash(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHash", reflect.TypeOf((*MockCoreService)(nil).BlockByHash), arg0)
 }
 
+// BlockByHeight mocks base method.
+func (m *MockCoreService) BlockByHeight(arg0 uint64) (*block.Store, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockByHeight", arg0)
+	ret0, _ := ret[0].(*block.Store)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockByHeight indicates an expected call of BlockByHeight.
+func (mr *MockCoreServiceMockRecorder) BlockByHeight(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHeight", reflect.TypeOf((*MockCoreService)(nil).BlockByHeight), arg0)
+}
+
+// BlockByHeightRange mocks base method.
+func (m *MockCoreService) BlockByHeightRange(arg0, arg1 uint64) ([]*block.Store, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlockByHeightRange", arg0, arg1)
+	ret0, _ := ret[0].([]*block.Store)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BlockByHeightRange indicates an expected call of BlockByHeightRange.
+func (mr *MockCoreServiceMockRecorder) BlockByHeightRange(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockByHeightRange", reflect.TypeOf((*MockCoreService)(nil).BlockByHeightRange), arg0, arg1)
+}
+
 // BlockHashByBlockHeight mocks base method.
 func (m *MockCoreService) BlockHashByBlockHeight(blkHeight uint64) (hash.Hash256, error) {
 	m.ctrl.T.Helper()
@@ -164,36 +194,6 @@ func (m *MockCoreService) BlockHashByBlockHeight(blkHeight uint64) (hash.Hash256
 func (mr *MockCoreServiceMockRecorder) BlockHashByBlockHeight(blkHeight interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockHashByBlockHeight", reflect.TypeOf((*MockCoreService)(nil).BlockHashByBlockHeight), blkHeight)
-}
-
-// BlockMetaByHash mocks base method.
-func (m *MockCoreService) BlockMetaByHash(blkHash string) (*iotextypes.BlockMeta, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockMetaByHash", blkHash)
-	ret0, _ := ret[0].(*iotextypes.BlockMeta)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockMetaByHash indicates an expected call of BlockMetaByHash.
-func (mr *MockCoreServiceMockRecorder) BlockMetaByHash(blkHash interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockMetaByHash", reflect.TypeOf((*MockCoreService)(nil).BlockMetaByHash), blkHash)
-}
-
-// BlockMetas mocks base method.
-func (m *MockCoreService) BlockMetas(start, count uint64) ([]*iotextypes.BlockMeta, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockMetas", start, count)
-	ret0, _ := ret[0].([]*iotextypes.BlockMeta)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BlockMetas indicates an expected call of BlockMetas.
-func (mr *MockCoreServiceMockRecorder) BlockMetas(start, count interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockMetas", reflect.TypeOf((*MockCoreService)(nil).BlockMetas), start, count)
 }
 
 // ChainID mocks base method.

--- a/tools/executiontester/blockchain/erc721_token.go
+++ b/tools/executiontester/blockchain/erc721_token.go
@@ -53,7 +53,6 @@ func (f *erc721Token) CreateToken(tokenid, creditor string) (string, error) {
 	return h, nil
 }
 
-//
 func (f *erc721Token) Transfer(token, sender, prvkey, receiver string, tokenid string) (string, error) {
 	TokenID, ok := new(big.Int).SetString(tokenid, 10)
 	if !ok {


### PR DESCRIPTION
# Description

 - Two deprecated methods `BlockMetas` and `BlockMetaByHash` are replaced with `BlockByHeightRange`, `BlockByHeight` and `BlockByHash`

 - Old `getBlockResult` struct is removed 

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
