### PR TITLE
[p2p] Fix p2p agent start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.0
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/iotexproject/go-fsm v1.0.0
-	github.com/iotexproject/go-p2p v0.3.4
+	github.com/iotexproject/go-p2p v0.3.5
 	github.com/iotexproject/go-pkgs v0.1.13
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,10 @@ github.com/iotexproject/go-ethereum v1.7.4-0.20220515212948-4dae4279da68 h1:UGqA
 github.com/iotexproject/go-ethereum v1.7.4-0.20220515212948-4dae4279da68/go.mod h1:pJNuIUYfX5+JKzSD/BTdNsvJSZ1TJqmz0dVyXMAbf6M=
 github.com/iotexproject/go-fsm v1.0.0 h1:Zrg9JnNDUZg4Anpj6oa0Tk4+sXbHTpJzI0v5/Cj5N6A=
 github.com/iotexproject/go-fsm v1.0.0/go.mod h1:t3aYXtCCcQxyS7oduQZyuUpPnVI4ddFTwbAagHN7fT0=
-github.com/iotexproject/go-p2p v0.3.4 h1:V+Hq4K4lbEI9gAjHqKLpzS4lqCPqjeosRY/LnIpCVhU=
-github.com/iotexproject/go-p2p v0.3.4/go.mod h1:P32N/mwLUWMQ/okMcNLlfBO7iD5ITyBOvN41roKdPdg=
+github.com/iotexproject/go-p2p v0.3.5-0.20220729194339-ed324cc1d794 h1:7Hl3HnBcyjtPT66wY/0zAyPj7sOreJLiVIAyHxp99zA=
+github.com/iotexproject/go-p2p v0.3.5-0.20220729194339-ed324cc1d794/go.mod h1:P32N/mwLUWMQ/okMcNLlfBO7iD5ITyBOvN41roKdPdg=
+github.com/iotexproject/go-p2p v0.3.5 h1:F71XxYQtR25youD+dCXnMgtfiCKGUFh8KDIqU7u5xOk=
+github.com/iotexproject/go-p2p v0.3.5/go.mod h1:P32N/mwLUWMQ/okMcNLlfBO7iD5ITyBOvN41roKdPdg=
 github.com/iotexproject/go-pkgs v0.1.5-0.20210604060651-be5ee19f2575/go.mod h1:ttXhcwrtODyh7JozpJlCml09CjP0pcKqTe2B0MbTGc8=
 github.com/iotexproject/go-pkgs v0.1.6/go.mod h1:E+Fl0XQZz56EzXFajFET2yFoRGsIbL6wQooVIkSim3o=
 github.com/iotexproject/go-pkgs v0.1.12/go.mod h1:t5X9kQ1VL5H+L+DC5GmohXnFKlcxaTcRnIBBuydcsTQ=

--- a/go.sum
+++ b/go.sum
@@ -442,8 +442,6 @@ github.com/iotexproject/go-ethereum v1.7.4-0.20220515212948-4dae4279da68 h1:UGqA
 github.com/iotexproject/go-ethereum v1.7.4-0.20220515212948-4dae4279da68/go.mod h1:pJNuIUYfX5+JKzSD/BTdNsvJSZ1TJqmz0dVyXMAbf6M=
 github.com/iotexproject/go-fsm v1.0.0 h1:Zrg9JnNDUZg4Anpj6oa0Tk4+sXbHTpJzI0v5/Cj5N6A=
 github.com/iotexproject/go-fsm v1.0.0/go.mod h1:t3aYXtCCcQxyS7oduQZyuUpPnVI4ddFTwbAagHN7fT0=
-github.com/iotexproject/go-p2p v0.3.5-0.20220729194339-ed324cc1d794 h1:7Hl3HnBcyjtPT66wY/0zAyPj7sOreJLiVIAyHxp99zA=
-github.com/iotexproject/go-p2p v0.3.5-0.20220729194339-ed324cc1d794/go.mod h1:P32N/mwLUWMQ/okMcNLlfBO7iD5ITyBOvN41roKdPdg=
 github.com/iotexproject/go-p2p v0.3.5 h1:F71XxYQtR25youD+dCXnMgtfiCKGUFh8KDIqU7u5xOk=
 github.com/iotexproject/go-p2p v0.3.5/go.mod h1:P32N/mwLUWMQ/okMcNLlfBO7iD5ITyBOvN41roKdPdg=
 github.com/iotexproject/go-pkgs v0.1.5-0.20210604060651-be5ee19f2575/go.mod h1:ttXhcwrtODyh7JozpJlCml09CjP0pcKqTe2B0MbTGc8=

--- a/p2p/agent.go
+++ b/p2p/agent.go
@@ -333,13 +333,20 @@ func (p *agent) Start(ctx context.Context) error {
 		return err
 	}
 	host.JoinOverlay()
+	p.host = host
 
 	// connect to bootstrap nodes
-	p.host = host
-	if err := p.joinP2P(ctx); err != nil {
-		log.L().Error("fail to join p2p network", zap.Error(err))
+	if err := p.connectBootNode(ctx); err != nil {
+		log.L().Error("fail to connect bootnode", zap.Error(err))
 		return err
 	}
+	if err := p.host.AdvertiseAsync(); err != nil {
+		return err
+	}
+	if err := p.host.FindPeersAsync(); err != nil {
+		return err
+	}
+
 	close(ready)
 
 	// check network connectivity every 60 blocks, and reconnect in case of disconnection
@@ -484,22 +491,10 @@ func (p *agent) BlockPeer(pidStr string) {
 	p.host.BlockPeer(pid)
 }
 
-func (p *agent) joinP2P(ctx context.Context) error {
+func (p *agent) connectBootNode(ctx context.Context) error {
 	if len(p.cfg.BootstrapNodes) == 0 {
 		return nil
 	}
-	if err := p.connectBootNode(ctx); err != nil {
-		return err
-	}
-	// it might take a few seconds to establish handshake with bootstrap
-	if err := p.host.Advertise(); err != nil {
-		return err
-	}
-	p.host.FindPeers(ctx)
-	return nil
-}
-
-func (p *agent) connectBootNode(ctx context.Context) error {
 	var errNum, connNum, desiredConnNum int
 	conn := make(chan struct{}, len(p.cfg.BootstrapNodes))
 	connErrChan := make(chan error, len(p.cfg.BootstrapNodes))
@@ -550,13 +545,17 @@ func (p *agent) reconnect() {
 	if len(p.host.ConnectedPeers()) == 0 || p.qosMetrics.lostConnection() {
 		log.L().Info("network lost, try re-connecting.")
 		p.host.ClearBlocklist()
-		if err := p.joinP2P(context.Background()); err != nil {
-			log.L().Error("fail to join p2p network", zap.Error(err))
+		if err := p.connectBootNode(context.Background()); err != nil {
+			log.L().Error("fail to connect bootnode", zap.Error(err))
+			return
 		}
-		return
+		if err := p.host.AdvertiseAsync(); err != nil {
+			log.L().Error("fail to advertise", zap.Error(err))
+			return
+		}
 	}
-	if err := p.host.FindPeers(context.Background()); err != nil {
-		log.L().Error("fail to find peers", zap.Error(err))
+	if err := p.host.FindPeersAsync(); err != nil {
+		log.L().Error("fail to find peer", zap.Error(err))
 	}
 }
 


### PR DESCRIPTION
# Description
It takes a large amount of time for the host to find peers in a large p2p network (`host.FindPeers(ctx)`). Therefore, this peer finding action is changed to an asynchronous one which wouldn't block the main thread to start host's p2p component

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
tests are updated in https://github.com/iotexproject/go-p2p/pull/35

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
