### PR TITLE
[ioctl] Build stake2 withdraw command line into new ioctl

### DIFF
--- a/ioctl/newcmd/action/stake2withdraw.go
+++ b/ioctl/newcmd/action/stake2withdraw.go
@@ -72,7 +72,7 @@ func NewStake2WithdrawCmd(client ioctl.Client) *cobra.Command {
 			}
 			nonce, err := nonce(client, cmd, sender)
 			if err != nil {
-				return errors.Wrap(err, "failed to get nonce ")
+				return errors.Wrap(err, "failed to get nonce")
 			}
 
 			s2w, err := action.NewWithdrawStake(nonce, bucketIndex, data, gasLimit, gasPriceRau)

--- a/ioctl/newcmd/action/stake2withdraw.go
+++ b/ioctl/newcmd/action/stake2withdraw.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"encoding/hex"
+	"strconv"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+)
+
+// Multi-language support
+var (
+	_stake2WithDrawCmdUses = map[config.Language]string{
+		config.English: "withdraw BUCKET_INDEX [DATA]" +
+			" [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "withdraw 票索引 [数据]" +
+			" [-s 签署人] [-n NONCE] [-l GAS限制] [-p GAS价格] [-P 密码] [-y]",
+	}
+	_stake2WithDrawCmdShorts = map[config.Language]string{
+		config.English: "Withdraw bucket from IoTeX blockchain",
+		config.Chinese: "提取IoTeX区块链上的投票",
+	}
+)
+
+// NewStake2WithdrawCmd represents the stake2 withdraw command
+func NewStake2WithdrawCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_stake2WithDrawCmdUses)
+	short, _ := client.SelectTranslation(_stake2WithDrawCmdShorts)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			bucketIndex, err := strconv.ParseUint(args[0], 10, 64)
+			if err != nil {
+				return errors.Wrap(err, "failed to convert bucket index")
+			}
+
+			var data []byte
+			if len(args) == 2 {
+				data, err = hex.DecodeString(args[1])
+				if err != nil {
+					return errors.Wrap(err, "failed to decode data")
+				}
+			}
+
+			sender, err := Signer(client, cmd)
+			if err != nil {
+				return errors.Wrap(err, "failed to get signed address")
+			}
+
+			gasLimit := gasLimitFlagValue(cmd)
+			if gasLimit == 0 {
+				gasLimit = action.ReclaimStakeBaseIntrinsicGas + action.ReclaimStakePayloadGas*uint64(len(data))
+			}
+
+			gasPriceRau, err := gasPriceInRau(client, cmd)
+			if err != nil {
+				return errors.Wrap(err, "failed to get gas price")
+			}
+			nonce, err := nonce(client, cmd, sender)
+			if err != nil {
+				return errors.Wrap(err, "failed to get nonce ")
+			}
+
+			s2w, err := action.NewWithdrawStake(nonce, bucketIndex, data, gasLimit, gasPriceRau)
+			if err != nil {
+				return errors.Wrap(err, "failed to make a changeCandidate instance")
+			}
+			SendAction(
+				client,
+				cmd,
+				(&action.EnvelopeBuilder{}).
+					SetNonce(nonce).
+					SetGasPrice(gasPriceRau).
+					SetGasLimit(gasLimit).
+					SetAction(s2w).Build(),
+				sender)
+			return nil
+		},
+	}
+	RegisterWriteCommand(client, cmd)
+	return cmd
+}

--- a/ioctl/newcmd/action/stake2withdraw.go
+++ b/ioctl/newcmd/action/stake2withdraw.go
@@ -79,7 +79,7 @@ func NewStake2WithdrawCmd(client ioctl.Client) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to make a changeCandidate instance")
 			}
-			SendAction(
+			return SendAction(
 				client,
 				cmd,
 				(&action.EnvelopeBuilder{}).
@@ -88,7 +88,6 @@ func NewStake2WithdrawCmd(client ioctl.Client) *cobra.Command {
 					SetGasLimit(gasLimit).
 					SetAction(s2w).Build(),
 				sender)
-			return nil
 		},
 	}
 	RegisterWriteCommand(client, cmd)

--- a/ioctl/newcmd/action/stake2withdraw_test.go
+++ b/ioctl/newcmd/action/stake2withdraw_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2022 IoTeX
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+)
+
+func TestNewStake2WithdrawCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+
+	ks := keystore.NewKeyStore(t.TempDir(), 2, 1)
+	acc, err := ks.NewAccount("")
+	require.NoError(err)
+	accAddr, err := address.FromBytes(acc.Address.Bytes())
+	require.NoError(err)
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
+	client.EXPECT().Alias(gomock.Any()).Return("producer", nil).Times(2)
+	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).AnyTimes()
+	client.EXPECT().IsCryptoSm2().Return(false).Times(8)
+	client.EXPECT().ReadSecret().Return("", nil).Times(2)
+	client.EXPECT().Address(gomock.Any()).Return(accAddr.String(), nil).Times(2)
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(accAddr.String(), nil).Times(4)
+	client.EXPECT().NewKeyStore().Return(ks).Times(4)
+	client.EXPECT().AskToConfirm(gomock.Any()).Return(true, nil).Times(2)
+	client.EXPECT().Config().Return(config.Config{
+		Explorer: "iotexscan",
+		Endpoint: "testnet1",
+	}).Times(10)
+
+	accountResp := &iotexapi.GetAccountResponse{
+		AccountMeta: &iotextypes.AccountMeta{
+			IsContract:   false,
+			PendingNonce: 10,
+			Balance:      "100000000000000000000",
+		},
+	}
+	chainMetaResp := &iotexapi.GetChainMetaResponse{
+		ChainMeta: &iotextypes.ChainMeta{
+			ChainID: 0,
+		},
+	}
+	sendActionResp := &iotexapi.SendActionResponse{}
+	apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(accountResp, nil).Times(4)
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(chainMetaResp, nil).Times(2)
+	apiServiceClient.EXPECT().SendAction(gomock.Any(), gomock.Any()).Return(sendActionResp, nil).Times(2)
+
+	t.Run("stake to withdraw", func(t *testing.T) {
+		cmd := NewStake2WithdrawCmd(client)
+		result, err := util.ExecuteCmd(cmd, "10", "--signer", accAddr.String())
+		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain.")
+	})
+
+	t.Run("stake to withdraw with payload", func(t *testing.T) {
+		payload := "0a10080118a08d062202313062040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a4161e219c2c5d5987f8a9efa33e8df0cde9d5541689fff05784cdc24f12e9d9ee8283a5aa720f494b949535b7969c07633dfb68c4ef9359eb16edb9abc6ebfadc801"
+
+		cmd := NewStake2WithdrawCmd(client)
+		result, err := util.ExecuteCmd(cmd, "10", payload, "--signer", accAddr.String())
+		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain.")
+	})
+
+	t.Run("failed to convert bucket index", func(t *testing.T) {
+		expectedErr := errors.New("failed to convert bucket index")
+
+		cmd := NewStake2WithdrawCmd(client)
+		_, err := util.ExecuteCmd(cmd, "test", "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to decode data", func(t *testing.T) {
+		expectedErr := errors.New("failed to decode data")
+
+		cmd := NewStake2WithdrawCmd(client)
+		_, err := util.ExecuteCmd(cmd, "10", "test", "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get gas price", func(t *testing.T) {
+		expectedErr := errors.New("failed to get gas price")
+		apiServiceClient.EXPECT().SuggestGasPrice(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+
+		cmd := NewStake2WithdrawCmd(client)
+		_, err = util.ExecuteCmd(cmd, "10", "--signer", accAddr.String(), "--gas-price", "")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get nonce", func(t *testing.T) {
+		expectedErr := errors.New("failed to get nonce")
+		apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+
+		cmd := NewStake2WithdrawCmd(client)
+		_, err = util.ExecuteCmd(cmd, "10", "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get signed address", func(t *testing.T) {
+		expectedErr := errors.New("failed to get signed address")
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", expectedErr)
+		apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(accountResp, nil)
+
+		cmd := NewStake2WithdrawCmd(client)
+		_, err = util.ExecuteCmd(cmd, "10", "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+}


### PR DESCRIPTION
# Description
Build `stake2withdraw` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3333 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewStake2WithdrawCmd

**Test Configuration**:
- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules****