### PR TITLE
[api] Implement TestGrpcServer_ReadContract by gomock CoreService int…

### DIFF
--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -140,19 +140,19 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 	core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil).Times(2)
 
 	t.Run("read contract from empty address", func(t *testing.T) {
-		result, err := grpcSvr.ReadContract(context.Background(), request)
+		res, err := grpcSvr.ReadContract(context.Background(), request)
 		require.NoError(err)
-		require.Equal([]byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"), result.Receipt.ActHash)
-		require.Equal(10100, int(result.Receipt.GasConsumed))
+		require.Equal([]byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"), res.Receipt.ActHash)
+		require.Equal(10100, int(res.Receipt.GasConsumed))
 	})
 
 	t.Run("read contract", func(t *testing.T) {
 		request.CallerAddress = identityset.Address(0).String()
 
-		result, err := grpcSvr.ReadContract(context.Background(), request)
+		res, err := grpcSvr.ReadContract(context.Background(), request)
 		require.NoError(err)
-		require.Equal([]byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"), result.Receipt.ActHash)
-		require.Equal(10100, int(result.Receipt.GasConsumed))
+		require.Equal([]byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"), res.Receipt.ActHash)
+		require.Equal(10100, int(res.Receipt.GasConsumed))
 	})
 
 	t.Run("failed to read contract", func(t *testing.T) {

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -288,9 +288,9 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 		GasConsumed: 10100,
 	}
 
-	core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil).Times(2)
-
 	t.Run("read contract from empty address", func(t *testing.T) {
+		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil)
+
 		res, err := grpcSvr.ReadContract(context.Background(), request)
 		require.NoError(err)
 		require.Equal([]byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"), res.Receipt.ActHash)
@@ -299,6 +299,7 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 
 	t.Run("read contract", func(t *testing.T) {
 		request.CallerAddress = identityset.Address(0).String()
+		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil)
 
 		res, err := grpcSvr.ReadContract(context.Background(), request)
 		require.NoError(err)
@@ -308,7 +309,6 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 
 	t.Run("failed to read contract", func(t *testing.T) {
 		expectedErr := errors.New("failed to read contract")
-
 		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil, expectedErr)
 
 		_, err := grpcSvr.ReadContract(context.Background(), request)

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -276,19 +276,19 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 	defer ctrl.Finish()
 	core := mock_apicoreservice.NewMockCoreService(ctrl)
 	grpcSvr := newGRPCHandler(core)
-	request := &iotexapi.ReadContractRequest{
-		Execution: &iotextypes.Execution{
-			Data: _executionHash1[:],
-		},
-		CallerAddress: "",
-		GasLimit:      10100,
-	}
 	response := &iotextypes.Receipt{
 		ActHash:     []byte("08b0066e10b5607e47159c2cf7ba36e36d0c980f5108dfca0ec20547a7adace4"),
 		GasConsumed: 10100,
 	}
 
-	t.Run("read contract from empty address", func(t *testing.T) {
+	t.Run("read contract", func(t *testing.T) {
+		request := &iotexapi.ReadContractRequest{
+			Execution: &iotextypes.Execution{
+				Data: _executionHash1[:],
+			},
+			CallerAddress: identityset.Address(0).String(),
+			GasLimit:      10100,
+		}
 		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil)
 
 		res, err := grpcSvr.ReadContract(context.Background(), request)
@@ -297,8 +297,14 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 		require.Equal(10100, int(res.Receipt.GasConsumed))
 	})
 
-	t.Run("read contract", func(t *testing.T) {
-		request.CallerAddress = identityset.Address(0).String()
+	t.Run("read contract from empty address", func(t *testing.T) {
+		request := &iotexapi.ReadContractRequest{
+			Execution: &iotextypes.Execution{
+				Data: _executionHash1[:],
+			},
+			CallerAddress: "",
+			GasLimit:      10100,
+		}
 		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", response, nil)
 
 		res, err := grpcSvr.ReadContract(context.Background(), request)
@@ -309,6 +315,13 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 
 	t.Run("failed to read contract", func(t *testing.T) {
 		expectedErr := errors.New("failed to read contract")
+		request := &iotexapi.ReadContractRequest{
+			Execution: &iotextypes.Execution{
+				Data: _executionHash1[:],
+			},
+			CallerAddress: "",
+			GasLimit:      10100,
+		}
 		core.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil, expectedErr)
 
 		_, err := grpcSvr.ReadContract(context.Background(), request)
@@ -317,7 +330,7 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 
 	t.Run("failed to load execution", func(t *testing.T) {
 		expectedErr := errors.New("empty action proto to load")
-		request = &iotexapi.ReadContractRequest{
+		request := &iotexapi.ReadContractRequest{
 			CallerAddress: "",
 			GasLimit:      10100,
 		}
@@ -328,7 +341,13 @@ func TestGrpcServer_ReadContract(t *testing.T) {
 
 	t.Run("invalid caller address", func(t *testing.T) {
 		expectedErr := errors.New("invalid address")
-		request.CallerAddress = "9254d943485d0fb859ff63c5581acc44f00fc2110343ac0445b99dfe39a6f1a5"
+		request := &iotexapi.ReadContractRequest{
+			Execution: &iotextypes.Execution{
+				Data: _executionHash1[:],
+			},
+			CallerAddress: "9254d943485d0fb859ff63c5581acc44f00fc2110343ac0445b99dfe39a6f1a5",
+			GasLimit:      10100,
+		}
 
 		_, err := grpcSvr.ReadContract(context.Background(), request)
 		require.Contains(err.Error(), expectedErr.Error())


### PR DESCRIPTION
# Description

impletment `TestGrpcServer_ReadContract` in `./api/grpcserver_test.go` by gomock [CoreService interface](https://github.com/iotexproject/iotex-core/blob/master/api/coreservice.go#L61)

Fixes #3530 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestGrpcServer_ReadContract

**Test Configuration**:
- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
