### PR TITLE
HandleBroadcast use message.(type) directly

### DIFF
--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -411,26 +411,23 @@ func (d *IotxDispatcher) dispatchBlockSyncReq(ctx context.Context, chainID uint3
 
 // HandleBroadcast handles incoming broadcast message
 func (d *IotxDispatcher) HandleBroadcast(ctx context.Context, chainID uint32, peer string, message proto.Message) {
-	msgType, err := goproto.GetTypeFromRPCMsg(message)
-	if err != nil {
-		log.L().Warn("Unexpected message handled by HandleBroadcast.", zap.Error(err))
-	}
 	subscriber := d.subscriber(chainID)
 	if subscriber == nil {
 		log.L().Warn("chainID has not been registered in dispatcher.", zap.Uint32("chainID", chainID))
 		return
 	}
 
-	switch msgType {
-	case iotexrpc.MessageType_CONSENSUS:
-		if err := subscriber.HandleConsensusMsg(message.(*iotextypes.ConsensusMessage)); err != nil {
+	switch msg := message.(type) {
+	case *iotextypes.ConsensusMessage:
+		if err := subscriber.HandleConsensusMsg(msg); err != nil {
 			log.L().Debug("Failed to handle consensus message.", zap.Error(err))
 		}
-	case iotexrpc.MessageType_ACTION:
+	case *iotextypes.Action:
 		d.dispatchAction(ctx, chainID, message)
-	case iotexrpc.MessageType_BLOCK:
+	case *iotextypes.Block:
 		d.dispatchBlock(ctx, chainID, peer, message)
 	default:
+		msgType, _ := goproto.GetTypeFromRPCMsg(message)
 		log.L().Warn("Unexpected msgType handled by HandleBroadcast.", zap.Any("msgType", msgType))
 	}
 }


### PR DESCRIPTION
# Description
replace `msgType, err := goproto.GetTypeFromRPCMsg(message)` with `switch (msg).(type) {}`

Fixes #3575

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
- [x] make test

**Test Configuration**:
- Firmware version: macOS Monterey arm64
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
