### PR TITLE
[evm] support opBasefee

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -148,7 +148,7 @@ func newParams(
 		BlockNumber: new(big.Int).SetUint64(blkCtx.BlockHeight),
 		Time:        new(big.Int).SetInt64(blkCtx.BlockTimeStamp.Unix()),
 		Difficulty:  new(big.Int).SetUint64(uint64(50)),
-		BaseFee:     new(big.Int).SetUint64(1), // in units of 10^-6 IOTX, current basefee is 1
+		BaseFee:     new(big.Int),
 	}
 
 	return &Params{

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -144,10 +144,11 @@ func newParams(
 		Transfer:    MakeTransfer,
 		GetHash:     getHashFn,
 		Coinbase:    common.BytesToAddress(blkCtx.Producer.Bytes()),
+		GasLimit:    gasLimit,
 		BlockNumber: new(big.Int).SetUint64(blkCtx.BlockHeight),
 		Time:        new(big.Int).SetInt64(blkCtx.BlockTimeStamp.Unix()),
 		Difficulty:  new(big.Int).SetUint64(uint64(50)),
-		GasLimit:    gasLimit,
+		BaseFee:     new(big.Int).SetUint64(1), // in units of 10^-6 IOTX, current basefee is 1
 	}
 
 	return &Params{

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -294,6 +294,9 @@ func TestConstantinople(t *testing.T) {
 		require.Equal(isOkhotsk, evmChainConfig.IsLondon(evm.Context.BlockNumber))
 		require.Equal(isOkhotsk, chainRules.IsLondon)
 		require.False(chainRules.IsMerge)
+
+		// test basefee
+		require.Equal(new(big.Int).SetUint64(1), evm.Context.BaseFee)
 	}
 }
 

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -296,7 +296,7 @@ func TestConstantinople(t *testing.T) {
 		require.False(chainRules.IsMerge)
 
 		// test basefee
-		require.Equal(new(big.Int).SetUint64(1), evm.Context.BaseFee)
+		require.Equal(new(big.Int), evm.Context.BaseFee)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -203,6 +203,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/ethereum/go-ethereum => github.com/iotexproject/go-ethereum v1.7.4-0.20220812094342-dcc10c72d176
+replace github.com/ethereum/go-ethereum => github.com/iotexproject/go-ethereum v0.4.1
 
 replace golang.org/x/xerrors => golang.org/x/xerrors v0.0.0-20190212162355-a5947ffaace3

--- a/go.sum
+++ b/go.sum
@@ -488,8 +488,8 @@ github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19y
 github.com/influxdata/roaring v0.4.13-0.20180809181101-fc520f41fab6/go.mod h1:bSgUQ7q5ZLSO+bKBGqJiCBGAl+9DxyW63zLTujjUlOE=
 github.com/influxdata/tdigest v0.0.0-20181121200506-bf2b5ad3c0a9/go.mod h1:Js0mqiSBE6Ffsg94weZZ2c+v/ciT8QRHFOap7EKDrR0=
 github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368/go.mod h1:Wbbw6tYNvwa5dlB6304Sd+82Z3f7PmVZHVKU637d4po=
-github.com/iotexproject/go-ethereum v1.7.4-0.20220812094342-dcc10c72d176 h1:2OnyJDqqfOjB2lXjIKEgr5aekQ5e4/cEvBl5jB2eXhw=
-github.com/iotexproject/go-ethereum v1.7.4-0.20220812094342-dcc10c72d176/go.mod h1:Lt5WzjM07XlXc95YzrhosmR4J9Ahd6X2wyEV2SvGhk0=
+github.com/iotexproject/go-ethereum v0.4.1 h1:8IdCOiMsuJQJl39ipBha0P+NMA60sqxAeYNiQVeshT4=
+github.com/iotexproject/go-ethereum v0.4.1/go.mod h1:Lt5WzjM07XlXc95YzrhosmR4J9Ahd6X2wyEV2SvGhk0=
 github.com/iotexproject/go-fsm v1.0.0 h1:Zrg9JnNDUZg4Anpj6oa0Tk4+sXbHTpJzI0v5/Cj5N6A=
 github.com/iotexproject/go-fsm v1.0.0/go.mod h1:t3aYXtCCcQxyS7oduQZyuUpPnVI4ddFTwbAagHN7fT0=
 github.com/iotexproject/go-p2p v0.3.5 h1:F71XxYQtR25youD+dCXnMgtfiCKGUFh8KDIqU7u5xOk=


### PR DESCRIPTION
# Description
EIP3198 is enabled in London EVM, which accesses `evm.Context.BaseFee`. See https://github.com/ethereum/go-ethereum/commit/94451c2788295901c302c9bf5fa2f7b021c924e2#diff-c21870801ba3133fda5991da046fbfd0f83999bda1008a4af84affca83ec5eb9R171

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] fullsync (WIP)
- [] Other test (please specify)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
