### PR TITLE
[ioctl] Build diddoc command line into new ioctl

### DIFF
--- a/ioctl/newcmd/did/diddoc.go
+++ b/ioctl/newcmd/did/diddoc.go
@@ -6,6 +6,12 @@
 
 package did
 
+import (
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/spf13/cobra"
+)
+
 const (
 	// DIDPrefix is the prefix string
 	DIDPrefix = "did:io:"
@@ -13,6 +19,14 @@ const (
 	DIDAuthType = "EcdsaSecp256k1VerificationKey2019"
 	// DIDOwner is the suffix string
 	DIDOwner = "#owner"
+)
+
+// Multi-language support
+var (
+	_dIDDocCmdShorts = map[config.Language]string{
+		config.English: "Manage DID Settings IoTeX blockchain",
+		config.Chinese: "管理IoTeX区块链上的DID设定",
+	}
 )
 
 type (
@@ -29,6 +43,16 @@ type (
 		Authentication []authenticationStruct `json:"authentication,omitempty"`
 	}
 )
+
+// NewDidDocCmd represents the did doc command
+func NewDidDocCmd(client ioctl.Client) *cobra.Command {
+	short, _ := client.SelectTranslation(_dIDDocCmdShorts)
+	cmd := &cobra.Command{
+		Use:   "did doc",
+		Short: short,
+	}
+	return cmd
+}
 
 func newDIDDoc() *Doc {
 	return &Doc{

--- a/ioctl/newcmd/did/diddoc_test.go
+++ b/ioctl/newcmd/did/diddoc_test.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+)
+
+func TestNewDidDocCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("did", config.English)
+	cmd := NewDidDocCmd(client)
+	_, err := util.ExecuteCmd(cmd)
+	require.NoError(err)
+}


### PR DESCRIPTION
# Description

Refactor `diddoc` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3289

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewDidDocCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
