### PR TITLE
[ioctl] Build did generate command line into new ioctl

### DIFF
--- a/ioctl/newcmd/did/diddoc.go
+++ b/ioctl/newcmd/did/diddoc.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+const (
+	// DIDPrefix is the prefix string
+	DIDPrefix = "did:io:"
+	// DIDAuthType is the authentication type
+	DIDAuthType = "EcdsaSecp256k1VerificationKey2019"
+	// DIDOwner is the suffix string
+	DIDOwner = "#owner"
+)
+
+type (
+	authenticationStruct struct {
+		ID           string `json:"id,omitempty"`
+		Type         string `json:"type,omitempty"`
+		Controller   string `json:"controller,omitempty"`
+		PublicKeyHex string `json:"publicKeyHex,omitempty"`
+	}
+	// Doc is the DID document struct
+	Doc struct {
+		Context        string                 `json:"@context,omitempty"`
+		ID             string                 `json:"id,omitempty"`
+		Authentication []authenticationStruct `json:"authentication,omitempty"`
+	}
+)
+
+func newDIDDoc() *Doc {
+	return &Doc{
+		Context: "https://www.w3.org/ns/did/v1",
+	}
+}

--- a/ioctl/newcmd/did/diddoc.go
+++ b/ioctl/newcmd/did/diddoc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 IoTeX Foundation
+// Copyright (c) 2022 IoTeX Foundation
 // This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache

--- a/ioctl/newcmd/did/didgenerate.go
+++ b/ioctl/newcmd/did/didgenerate.go
@@ -57,15 +57,15 @@ func NewDidGenerateCmd(client ioctl.Client) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to get password")
 			}
-			pri, err := account.PrivateKeyFromSigner(client, cmd, addr, password)
-			if err != nil {
-				return err
-			}
-			doc := newDIDDoc()
 			ethAddress, err := addrutil.IoAddrToEvmAddr(addr)
 			if err != nil {
-				return errors.Wrap(err, "")
+				return errors.Wrap(err, "failed to convert IoTeX address to EVM address")
 			}
+			pri, err := account.PrivateKeyFromSigner(client, cmd, addr, password)
+			if err != nil {
+				return errors.Wrap(err, "failed to get private key from signer")
+			}
+			doc := newDIDDoc()
 			doc.ID = DIDPrefix + ethAddress.String()
 			authentication := authenticationStruct{
 				ID:         doc.ID + DIDOwner,

--- a/ioctl/newcmd/did/didgenerate.go
+++ b/ioctl/newcmd/did/didgenerate.go
@@ -57,15 +57,15 @@ func NewDidGenerateCmd(client ioctl.Client) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to get password")
 			}
-			ethAddress, err := addrutil.IoAddrToEvmAddr(addr)
-			if err != nil {
-				return errors.Wrap(err, "failed to convert IoTeX address to EVM address")
-			}
 			pri, err := account.PrivateKeyFromSigner(client, cmd, addr, password)
 			if err != nil {
 				return errors.Wrap(err, "failed to get private key from signer")
 			}
 			doc := newDIDDoc()
+			ethAddress, err := addrutil.IoAddrToEvmAddr(addr)
+			if err != nil {
+				return errors.Wrap(err, "failed to convert IoTeX address to EVM address")
+			}
 			doc.ID = DIDPrefix + ethAddress.String()
 			authentication := authenticationStruct{
 				ID:         doc.ID + DIDOwner,
@@ -90,15 +90,11 @@ func NewDidGenerateCmd(client ioctl.Client) *cobra.Command {
 			doc.Authentication = append(doc.Authentication, authentication)
 			msg, err := json.MarshalIndent(doc, "", "  ")
 			if err != nil {
-				return errors.Wrap(err, "")
+				return err
 			}
 
 			sum := sha256.Sum256(msg)
-			generatedMessage := string(msg) + "\n\nThe hex encoded SHA256 hash of the DID doc is:" + hex.EncodeToString(sum[:])
-			if err != nil {
-				return errors.Wrap(err, "failed to sign message")
-			}
-			cmd.Println(generatedMessage)
+			cmd.Printf("%s\n\nThe hex encoded SHA256 hash of the DID doc is:%s", string(msg), hex.EncodeToString(sum[:]))
 			return nil
 		},
 	}

--- a/ioctl/newcmd/did/didgenerate.go
+++ b/ioctl/newcmd/did/didgenerate.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/newcmd/account"
+	"github.com/iotexproject/iotex-core/ioctl/newcmd/action"
+	"github.com/iotexproject/iotex-core/pkg/util/addrutil"
+)
+
+// Multi-language support
+var (
+	_generateCmdShorts = map[config.Language]string{
+		config.English: "Generate DID document using private key from wallet",
+		config.Chinese: "用钱包中的私钥产生DID document",
+	}
+	_generateCmdUses = map[config.Language]string{
+		config.English: "generate [-s SIGNER]",
+		config.Chinese: "generate [-s 签署人]",
+	}
+)
+
+// NewDidGenerateCmd represents the did generate command
+func NewDidGenerateCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_generateCmdUses)
+	short, _ := client.SelectTranslation(_generateCmdShorts)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(0),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			signer, err := cmd.Flags().GetString("signer")
+			if err != nil {
+				return errors.Wrap(err, "failed to get flag signer")
+			}
+			addr, err := action.Signer(client, signer)
+			if err != nil {
+				return errors.Wrap(err, "failed to get signer addr")
+			}
+			cmd.Printf("Enter password #%s:\n", addr)
+			password, err := client.ReadSecret()
+			if err != nil {
+				return errors.Wrap(err, "failed to get password")
+			}
+			pri, err := account.PrivateKeyFromSigner(client, cmd, addr, password)
+			if err != nil {
+				return err
+			}
+			doc := newDIDDoc()
+			ethAddress, err := addrutil.IoAddrToEvmAddr(addr)
+			if err != nil {
+				return errors.Wrap(err, "")
+			}
+			doc.ID = DIDPrefix + ethAddress.String()
+			authentication := authenticationStruct{
+				ID:         doc.ID + DIDOwner,
+				Type:       DIDAuthType,
+				Controller: doc.ID,
+			}
+			uncompressed := pri.PublicKey().Bytes()
+			if len(uncompressed) == 33 && (uncompressed[0] == 2 || uncompressed[0] == 3) {
+				authentication.PublicKeyHex = hex.EncodeToString(uncompressed)
+			} else if len(uncompressed) == 65 && uncompressed[0] == 4 {
+				lastNum := uncompressed[64]
+				authentication.PublicKeyHex = hex.EncodeToString(uncompressed[1:33])
+				if lastNum%2 == 0 {
+					authentication.PublicKeyHex = "02" + authentication.PublicKeyHex
+				} else {
+					authentication.PublicKeyHex = "03" + authentication.PublicKeyHex
+				}
+			} else {
+				return errors.New("invalid public key")
+			}
+
+			doc.Authentication = append(doc.Authentication, authentication)
+			msg, err := json.MarshalIndent(doc, "", "  ")
+			if err != nil {
+				return errors.Wrap(err, "")
+			}
+
+			sum := sha256.Sum256(msg)
+			generatedMessage := string(msg) + "\n\nThe hex encoded SHA256 hash of the DID doc is:" + hex.EncodeToString(sum[:])
+			if err != nil {
+				return errors.Wrap(err, "failed to sign message")
+			}
+			cmd.Println(generatedMessage)
+			return nil
+		},
+	}
+	action.RegisterWriteCommand(client, cmd)
+	return cmd
+}

--- a/ioctl/newcmd/did/didgenerate.go
+++ b/ioctl/newcmd/did/didgenerate.go
@@ -94,7 +94,7 @@ func NewDidGenerateCmd(client ioctl.Client) *cobra.Command {
 			}
 
 			sum := sha256.Sum256(msg)
-			cmd.Printf("%s\n\nThe hex encoded SHA256 hash of the DID doc is:%s", string(msg), hex.EncodeToString(sum[:]))
+			cmd.Printf("%s\n\nThe hex encoded SHA256 hash of the DID doc is:%s\n", string(msg), hex.EncodeToString(sum[:]))
 			return nil
 		},
 	}

--- a/ioctl/newcmd/did/didgenerate_test.go
+++ b/ioctl/newcmd/did/didgenerate_test.go
@@ -11,17 +11,17 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 )
 
-func TestNewDidGenerate(t *testing.T) {
+func TestNewDidGenerateCmd(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -29,7 +29,7 @@ func TestNewDidGenerate(t *testing.T) {
 	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
 	passwd := "123456"
 
-	ks := keystore.NewKeyStore(t.TempDir(), 2, 103)
+	ks := keystore.NewKeyStore(t.TempDir(), 2, 1)
 	acc, err := ks.NewAccount(passwd)
 	require.NoError(err)
 	accAddr, err := address.FromBytes(acc.Address.Bytes())

--- a/ioctl/newcmd/did/didgenerate_test.go
+++ b/ioctl/newcmd/did/didgenerate_test.go
@@ -46,7 +46,7 @@ func TestNewDidGenerateCmd(t *testing.T) {
 		require.Contains(err.Error(), expectedErr.Error())
 	})
 
-	client.EXPECT().ReadSecret().Return(passwd, nil).Times(3)
+	client.EXPECT().ReadSecret().Return(passwd, nil).Times(2)
 	client.EXPECT().IsCryptoSm2().Return(false).Times(3)
 	client.EXPECT().NewKeyStore().Return(ks).Times(3)
 	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).AnyTimes()
@@ -62,14 +62,6 @@ func TestNewDidGenerateCmd(t *testing.T) {
 	t.Run("failed to get private key from signer", func(t *testing.T) {
 		expectedErr := errors.New("failed to get private key from signer")
 		client.EXPECT().Address(gomock.Any()).Return("", expectedErr)
-		cmd := NewDidGenerateCmd(client)
-		_, err := util.ExecuteCmd(cmd, "--signer", accAddr.String())
-		require.Contains(err.Error(), expectedErr.Error())
-	})
-
-	t.Run("failed to convert IoTeX address to EVM address", func(t *testing.T) {
-		expectedErr := errors.New("failed to convert IoTeX address to EVM address")
-		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("test", nil)
 		cmd := NewDidGenerateCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--signer", accAddr.String())
 		require.Contains(err.Error(), expectedErr.Error())

--- a/ioctl/newcmd/did/didgenerate_test.go
+++ b/ioctl/newcmd/did/didgenerate_test.go
@@ -1,0 +1,85 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+)
+
+func TestNewDidGenerate(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	passwd := "123456"
+
+	ks := keystore.NewKeyStore(t.TempDir(), 2, 103)
+	acc, err := ks.NewAccount(passwd)
+	require.NoError(err)
+	accAddr, err := address.FromBytes(acc.Address.Bytes())
+	require.NoError(err)
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("did", config.English).AnyTimes()
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(accAddr.String(), nil).Times(3)
+
+	t.Run("failed to get password", func(t *testing.T) {
+		expectedErr := errors.New("failed to get password")
+		client.EXPECT().ReadSecret().Return("", expectedErr)
+		cmd := NewDidGenerateCmd(client)
+		_, err := util.ExecuteCmd(cmd)
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	client.EXPECT().ReadSecret().Return(passwd, nil).Times(3)
+	client.EXPECT().IsCryptoSm2().Return(false).Times(3)
+	client.EXPECT().NewKeyStore().Return(ks).Times(3)
+	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).AnyTimes()
+
+	t.Run("generate did", func(t *testing.T) {
+		client.EXPECT().Address(gomock.Any()).Return(accAddr.String(), nil)
+		cmd := NewDidGenerateCmd(client)
+		result, err := util.ExecuteCmd(cmd, "--signer", accAddr.String())
+		require.NoError(err)
+		require.Contains(result, acc.Address.Hex())
+	})
+
+	t.Run("failed to get private key from signer", func(t *testing.T) {
+		expectedErr := errors.New("failed to get private key from signer")
+		client.EXPECT().Address(gomock.Any()).Return("", expectedErr)
+		cmd := NewDidGenerateCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to convert IoTeX address to EVM address", func(t *testing.T) {
+		expectedErr := errors.New("failed to convert IoTeX address to EVM address")
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("test", nil)
+		cmd := NewDidGenerateCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--signer", accAddr.String())
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get signer addr", func(t *testing.T) {
+		expectedErr := errors.New("failed to get signer addr")
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", expectedErr)
+		cmd := NewDidGenerateCmd(client)
+		_, err := util.ExecuteCmd(cmd)
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+}


### PR DESCRIPTION
# Description

Refactor `didgenerate` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3290 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewDidGenerateCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
