### PR TITLE
[ioctl] Build action sendraw command line into new ioctl

### DIFF
--- a/ioctl/newcmd/action/actionsendraw.go
+++ b/ioctl/newcmd/action/actionsendraw.go
@@ -3,6 +3,7 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
 // License 2.0 that can be found in the LICENSE file.
+
 package action
 
 import (
@@ -29,6 +30,7 @@ var (
 	}
 )
 
+// NewActionSendRawCmd represents the action send raw transaction command
 func NewActionSendRawCmd(client ioctl.Client) *cobra.Command {
 	use, _ := client.SelectTranslation(_sendRawCmdUses)
 	short, _ := client.SelectTranslation(_sendRawCmdShorts)

--- a/ioctl/newcmd/action/actionsendraw.go
+++ b/ioctl/newcmd/action/actionsendraw.go
@@ -25,8 +25,8 @@ var (
 		config.Chinese: "在IoTeX区块链上发送原始行为",
 	}
 	_sendRawCmdUses = map[config.Language]string{
-		config.English: "sendraw DATA [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
-		config.Chinese: "sendraw 数据 [-s 签署人] [-n NONCE] [-l GAS限制] [-p GAS价格] [-P 密码] [-y]",
+		config.English: "sendraw DATA",
+		config.Chinese: "sendraw 数据",
 	}
 )
 

--- a/ioctl/newcmd/action/actionsendraw.go
+++ b/ioctl/newcmd/action/actionsendraw.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+package action
+
+import (
+	"encoding/hex"
+
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+)
+
+// Multi-language support
+var (
+	_sendRawCmdShorts = map[config.Language]string{
+		config.English: "Send raw action on IoTeX blokchain",
+		config.Chinese: "在IoTeX区块链上发送原始行为",
+	}
+	_sendRawCmdUses = map[config.Language]string{
+		config.English: "sendraw DATA [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "sendraw 数据 [-s 签署人] [-n NONCE] [-l GAS限制] [-p GAS价格] [-P 密码] [-y]",
+	}
+)
+
+func NewActionSendRawCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_sendRawCmdUses)
+	short, _ := client.SelectTranslation(_sendRawCmdShorts)
+
+	return &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			actBytes, err := hex.DecodeString(args[0])
+			if err != nil {
+				return errors.Wrap(err, "failed to decode data")
+			}
+			act := &iotextypes.Action{}
+			if err := proto.Unmarshal(actBytes, act); err != nil {
+				return errors.Wrap(err, "failed to unmarshal data bytes")
+			}
+			return SendRaw(client, cmd, act)
+		},
+	}
+}

--- a/ioctl/newcmd/action/actionsendraw_test.go
+++ b/ioctl/newcmd/action/actionsendraw_test.go
@@ -3,6 +3,7 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
 // License 2.0 that can be found in the LICENSE file.
+
 package action
 
 import (
@@ -13,7 +14,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
-	
+
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"

--- a/ioctl/newcmd/action/actionsendraw_test.go
+++ b/ioctl/newcmd/action/actionsendraw_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/iotex-core/ioctl/config"
-	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 )
 
 func TestNewActionSendRawCmd(t *testing.T) {

--- a/ioctl/newcmd/action/actionsendraw_test.go
+++ b/ioctl/newcmd/action/actionsendraw_test.go
@@ -36,8 +36,9 @@ func TestNewActionSendRawCmd(t *testing.T) {
 		apiServiceClient.EXPECT().SendAction(gomock.Any(), gomock.Any()).Return(&iotexapi.SendActionResponse{}, nil)
 		actBytes := "0a12080118a08d0622023130280162040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a41328c6912fa0e36414c38089c03e2fa8c88bba82ccc4ce5fb8ac4ef9f529dfce249a5b2f93a45b818e7f468a742b4e87be3b8077f95d1b3c49e9165b971848ead01"
 		cmd := NewActionSendRawCmd(client)
-		_, err := util.ExecuteCmd(cmd, actBytes)
+		result, err := util.ExecuteCmd(cmd, actBytes)
 		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain")
 	})
 
 	t.Run("failed to unmarshal data bytes", func(t *testing.T) {

--- a/ioctl/newcmd/action/actionsendraw_test.go
+++ b/ioctl/newcmd/action/actionsendraw_test.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+package action
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewActionSendRawCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).Times(8)
+
+	t.Run("action send raw", func(t *testing.T) {
+		client.EXPECT().APIServiceClient().Return(apiServiceClient, nil)
+		client.EXPECT().Config().Return(config.Config{
+			Explorer: "iotexscan",
+			Endpoint: "testnet1",
+		}).Times(2)
+		apiServiceClient.EXPECT().SendAction(gomock.Any(), gomock.Any()).Return(&iotexapi.SendActionResponse{}, nil)
+		actBytes := "0a12080118a08d0622023130280162040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a41328c6912fa0e36414c38089c03e2fa8c88bba82ccc4ce5fb8ac4ef9f529dfce249a5b2f93a45b818e7f468a742b4e87be3b8077f95d1b3c49e9165b971848ead01"
+		cmd := NewActionSendRawCmd(client)
+		_, err := util.ExecuteCmd(cmd, actBytes)
+		require.NoError(err)
+	})
+
+	t.Run("failed to unmarshal data bytes", func(t *testing.T) {
+		expectedErr := errors.New("failed to unmarshal data bytes")
+		cmd := NewActionSendRawCmd(client)
+		_, err := util.ExecuteCmd(cmd, "02e940dd0fd5b5df4cfb8d6bcd9c74ec433e9a5c21acb72cbcb5be9e711b678f")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to decode data", func(t *testing.T) {
+		expectedErr := errors.New("failed to decode data")
+		cmd := NewActionSendRawCmd(client)
+		_, err := util.ExecuteCmd(cmd, "test")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+}


### PR DESCRIPTION
# Description

Refactor `actionsendraw` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3322 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewActionSendRawCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
