### PR TITLE
[ioctl] Build action read command line into new ioctl

### DIFF
--- a/ioctl/newcmd/action/actionread.go
+++ b/ioctl/newcmd/action/actionread.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+package action
+
+import (
+	"encoding/hex"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/newcmd/alias"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+// Multi-language support
+var (
+	_readCmdShorts = map[config.Language]string{
+		config.English: "read smart contract on IoTeX blockchain",
+		config.Chinese: "读取IoTeX区块链上的智能合约",
+	}
+	_readCmdUses = map[config.Language]string{
+		config.English: "read (ALIAS|CONTRACT_ADDRESS) -b BYTE_CODE [-s SIGNER]",
+		config.Chinese: "reads (别名|联系人地址) -b 类型码 [-s 签署人]",
+	}
+)
+
+func NewActionReadCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_readCmdUses)
+	short, _ := client.SelectTranslation(_readCmdShorts)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			contract, err := alias.IOAddress(client, args[0])
+			if err != nil {
+				return errors.Wrap(err, "failed to get contract address")
+			}
+			bytecodeFlag, err := cmd.Flags().GetString(bytecodeFlagLabel)
+			if err != nil {
+				return errors.Wrap(err, "failed to get flag bytecode")
+			}
+			bytecode, err := hex.DecodeString(util.TrimHexPrefix(bytecodeFlag))
+			if err != nil {
+				return errors.Wrap(err, "invalid bytecode")
+			}
+			_, signer, _, _, gasLimit, _, err := GetWriteCommandFlag(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := Read(client, contract, "0", bytecode, signer, gasLimit)
+			if err != nil {
+				return errors.Wrap(err, "failed to Read contract")
+			}
+			cmd.Println(result)
+			return err
+		},
+	}
+	registerBytecodeFlag(client, cmd)
+	return cmd
+}

--- a/ioctl/newcmd/action/actionread.go
+++ b/ioctl/newcmd/action/actionread.go
@@ -3,6 +3,7 @@
 // warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
 // permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
 // License 2.0 that can be found in the LICENSE file.
+
 package action
 
 import (
@@ -29,6 +30,7 @@ var (
 	}
 )
 
+// NewActionReadCmd represents the action Read command
 func NewActionReadCmd(client ioctl.Client) *cobra.Command {
 	use, _ := client.SelectTranslation(_readCmdUses)
 	short, _ := client.SelectTranslation(_readCmdShorts)

--- a/ioctl/newcmd/action/actionread.go
+++ b/ioctl/newcmd/action/actionread.go
@@ -8,6 +8,7 @@ package action
 
 import (
 	"encoding/hex"
+	"fmt"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -48,6 +49,7 @@ func NewActionReadCmd(client ioctl.Client) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to get flag bytecode")
 			}
+			fmt.Println(bytecodeFlag)
 			bytecode, err := hex.DecodeString(util.TrimHexPrefix(bytecodeFlag))
 			if err != nil {
 				return errors.Wrap(err, "invalid bytecode")
@@ -65,5 +67,6 @@ func NewActionReadCmd(client ioctl.Client) *cobra.Command {
 		},
 	}
 	registerBytecodeFlag(client, cmd)
+	RegisterWriteCommand(client, cmd)
 	return cmd
 }

--- a/ioctl/newcmd/action/actionread_test.go
+++ b/ioctl/newcmd/action/actionread_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+)
+
+func TestNewActionReadCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+	addr := identityset.Address(0).String()
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).Times(36)
+	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).Times(2)
+	client.EXPECT().Address(gomock.Any()).Return(addr, nil).Times(3)
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(addr, nil).Times(2)
+
+	t.Run("read action", func(t *testing.T) {
+		expectedVal := "36306665343762313030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030\n"
+		apiServiceClient.EXPECT().ReadContract(gomock.Any(), gomock.Any()).Return(&iotexapi.ReadContractResponse{
+			Data: hex.EncodeToString([]byte("60fe47b100000000000000000000000000000000000000000000000000000000")),
+		}, nil)
+		cmd := NewActionReadCmd(client)
+		result, err := util.ExecuteCmd(cmd, addr, "--bytecode", "0x60fe47b100000000000000000000000000000000000000000000000000000000")
+		require.NoError(err)
+		require.Equal(expectedVal, result)
+	})
+
+	t.Run("failed to Read contract", func(t *testing.T) {
+		expectedErr := errors.New("failed to Read contract")
+		apiServiceClient.EXPECT().ReadContract(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+		cmd := NewActionReadCmd(client)
+		_, err := util.ExecuteCmd(cmd, addr, "--bytecode", "0x60fe47b100000000000000000000000000000000000000000000000000000000")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("invalid bytecode", func(t *testing.T) {
+		expectedErr := errors.New("invalid bytecode")
+		cmd := NewActionReadCmd(client)
+		_, err := util.ExecuteCmd(cmd, addr, "--bytecode", "test")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get contract address", func(t *testing.T) {
+		expectedErr := errors.New("failed to get contract address")
+		client.EXPECT().Address(gomock.Any()).Return("", expectedErr)
+		cmd := NewActionReadCmd(client)
+		_, err := util.ExecuteCmd(cmd, "test")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+}


### PR DESCRIPTION
# Description

Refactor `actionread` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3321 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewActionReadCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
****