### PR TITLE
[ioctl] Build did deregister command line into new ioctl

### DIFF
--- a/ioctl/newcmd/did/didderegister.go
+++ b/ioctl/newcmd/did/didderegister.go
@@ -20,8 +20,8 @@ import (
 // Multi-language support
 var (
 	_deregisterCmdUses = map[config.Language]string{
-		config.English: "deregister (CONTRACT_ADDRESS|ALIAS)",
-		config.Chinese: "deregister (合约地址|别名)",
+		config.English: "deregister (CONTRACT_ADDRESS|ALIAS) [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "deregister (合约地址|别名) IOTX数量 [-s 签署人] [-n NONCE] [-l GAS限制] [-P GAS价格] [-P 密码] [-y]",
 	}
 	_deregisterCmdShorts = map[config.Language]string{
 		config.English: "Deregister DID on IoTeX blockchain",

--- a/ioctl/newcmd/did/didderegister.go
+++ b/ioctl/newcmd/did/didderegister.go
@@ -7,7 +7,6 @@
 package did
 
 import (
-	"encoding/hex"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -20,38 +19,32 @@ import (
 
 // Multi-language support
 var (
-	_registerCmdUses = map[config.Language]string{
-		config.English: "register (CONTRACT_ADDRESS|ALIAS) hash uri",
-		config.Chinese: "register (合约地址|别名) hash uri",
+	_deregisterCmdUses = map[config.Language]string{
+		config.English: "deregister (CONTRACT_ADDRESS|ALIAS)",
+		config.Chinese: "deregister (合约地址|别名)",
 	}
-	_registerCmdShorts = map[config.Language]string{
-		config.English: "Register DID on IoTeX blockchain",
-		config.Chinese: "Register 在IoTeX链上注册DID",
+	_deregisterCmdShorts = map[config.Language]string{
+		config.English: "Deregister DID on IoTeX blockchain",
+		config.Chinese: "Deregister 在IoTeX链上注销DID",
 	}
 )
 
-// NewDidRegisterCmd represents the did register command
-func NewDidRegisterCmd(client ioctl.Client) *cobra.Command {
-	use, _ := client.SelectTranslation(_registerCmdUses)
-	short, _ := client.SelectTranslation(_registerCmdShorts)
+// NewDeregisterCmd represents the contract invoke deregister command
+func NewDeregisterCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_deregisterCmdUses)
+	short, _ := client.SelectTranslation(_deregisterCmdShorts)
 
 	cmd := &cobra.Command{
 		Use:   use,
 		Short: short,
-		Args:  cobra.ExactArgs(3),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
 			contract, err := client.Address(args[0])
 			if err != nil {
 				return errors.Wrap(err, "failed to get contract address")
 			}
-			hashSlice, err := hex.DecodeString(args[1])
-			if err != nil {
-				return errors.Wrap(err, "failed to decode data")
-			}
-			var hashArray [32]byte
-			copy(hashArray[:], hashSlice)
-			bytecode, err := _didABI.Pack(_registerDIDName, hashArray, []byte(args[2]))
+			bytecode, err := _didABI.Pack(_deregisterDIDName)
 			if err != nil {
 				return errors.Wrap(err, "invalid bytecode")
 			}

--- a/ioctl/newcmd/did/didderegister.go
+++ b/ioctl/newcmd/did/didderegister.go
@@ -25,7 +25,7 @@ var (
 	}
 	_deregisterCmdShorts = map[config.Language]string{
 		config.English: "Deregister DID on IoTeX blockchain",
-		config.Chinese: "Deregister 在IoTeX链上注销DID",
+		config.Chinese: "在IoTeX链上注销DID",
 	}
 )
 

--- a/ioctl/newcmd/did/didderegister_test.go
+++ b/ioctl/newcmd/did/didderegister_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package did
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDeregisterCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+
+	ks := keystore.NewKeyStore(t.TempDir(), 2, 1)
+	acc, err := ks.NewAccount("")
+	require.NoError(err)
+	accAddr, err := address.FromBytes(acc.Address.Bytes())
+	require.NoError(err)
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("did", config.English).AnyTimes()
+	client.EXPECT().Address(gomock.Any()).Return(accAddr.String(), nil).Times(2)
+	client.EXPECT().Alias(gomock.Any()).Return("producer", nil).AnyTimes()
+	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).AnyTimes()
+	client.EXPECT().IsCryptoSm2().Return(false).Times(3)
+	client.EXPECT().ReadSecret().Return("", nil).Times(1)
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(accAddr.String(), nil).Times(1)
+	client.EXPECT().NewKeyStore().Return(ks).Times(2)
+	client.EXPECT().AskToConfirm(gomock.Any()).Return(true, nil).Times(1)
+	client.EXPECT().Config().Return(config.Config{
+		Explorer: "iotexscan",
+		Endpoint: "testnet1",
+	}).Times(2)
+
+	accountResp := &iotexapi.GetAccountResponse{
+		AccountMeta: &iotextypes.AccountMeta{
+			IsContract:   false,
+			PendingNonce: 10,
+			Balance:      "100000000000000000000",
+		},
+	}
+	chainMetaResp := &iotexapi.GetChainMetaResponse{
+		ChainMeta: &iotextypes.ChainMeta{
+			ChainID: 0,
+		},
+	}
+	sendActionResp := &iotexapi.SendActionResponse{}
+	apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(accountResp, nil).Times(2)
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(chainMetaResp, nil).AnyTimes()
+	apiServiceClient.EXPECT().SendAction(gomock.Any(), gomock.Any()).Return(sendActionResp, nil).Times(1)
+
+	t.Run("deregister did", func(t *testing.T) {
+		cmd := NewDeregisterCmd(client)
+		result, err := util.ExecuteCmd(cmd, accAddr.String(), "--signer", accAddr.String())
+		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain")
+	})
+}

--- a/ioctl/newcmd/did/didderegister_test.go
+++ b/ioctl/newcmd/did/didderegister_test.go
@@ -11,12 +11,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
 
-	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"

--- a/ioctl/newcmd/did/didderegister_test.go
+++ b/ioctl/newcmd/did/didderegister_test.go
@@ -11,14 +11,15 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-core/ioctl/config"
-	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
 )
 
 func TestNewDeregisterCmd(t *testing.T) {

--- a/ioctl/newcmd/did/didgethash.go
+++ b/ioctl/newcmd/did/didgethash.go
@@ -27,7 +27,7 @@ var (
 	}
 	_getHashCmdShorts = map[config.Language]string{
 		config.English: "Gethash get DID doc's hash on IoTeX blockchain",
-		config.Chinese: "Gethash 在IoTeX链上获取相应DID的doc hash",
+		config.Chinese: "在IoTeX链上获取相应DID的doc hash",
 	}
 )
 

--- a/ioctl/newcmd/did/didgeturi.go
+++ b/ioctl/newcmd/did/didgeturi.go
@@ -27,7 +27,7 @@ var (
 	}
 	_getURICmdShorts = map[config.Language]string{
 		config.English: "Geturi get DID URI on IoTeX blockchain",
-		config.Chinese: "Geturi 在IoTeX链上获取相应DID的uri",
+		config.Chinese: "在IoTeX链上获取相应DID的uri",
 	}
 )
 

--- a/ioctl/newcmd/did/didregister.go
+++ b/ioctl/newcmd/did/didregister.go
@@ -21,8 +21,8 @@ import (
 // Multi-language support
 var (
 	_registerCmdUses = map[config.Language]string{
-		config.English: "register (CONTRACT_ADDRESS|ALIAS) hash uri",
-		config.Chinese: "register (合约地址|别名) hash uri",
+		config.English: "register (CONTRACT_ADDRESS|ALIAS) hash uri [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "register (合约地址|别名) hash uri [-s 签署人] [-n NONCE] [-l GAS限制] [-P GAS价格] [-P 密码] [-y]",
 	}
 	_registerCmdShorts = map[config.Language]string{
 		config.English: "Register DID on IoTeX blockchain",

--- a/ioctl/newcmd/did/didregister.go
+++ b/ioctl/newcmd/did/didregister.go
@@ -49,12 +49,6 @@ func NewDidRegisterCmd(client ioctl.Client) *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to decode data")
 			}
-			var hashArray [32]byte
-			copy(hashArray[:], hashSlice)
-			bytecode, err := _didABI.Pack(_registerDIDName, hashArray, []byte(args[2]))
-			if err != nil {
-				return errors.Wrap(err, "invalid bytecode")
-			}
 			gasPrice, signer, password, nonce, gasLimit, assumeYes, err := action.GetWriteCommandFlag(cmd)
 			if err != nil {
 				return err

--- a/ioctl/newcmd/did/didregister.go
+++ b/ioctl/newcmd/did/didregister.go
@@ -26,7 +26,7 @@ var (
 	}
 	_registerCmdShorts = map[config.Language]string{
 		config.English: "Register DID on IoTeX blockchain",
-		config.Chinese: "Register 在IoTeX链上注册DID",
+		config.Chinese: "在IoTeX链上注册DID",
 	}
 )
 


### PR DESCRIPTION
# Description

Refactor `didderegister` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3667  

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewDeregisterCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
****