### PR TITLE
[ioctl] Build action claim command line into new ioctl

### DIFF
--- a/ioctl/newcmd/action/actionclaim.go
+++ b/ioctl/newcmd/action/actionclaim.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+// Multi-language support
+var (
+	_claimCmdShorts = map[config.Language]string{
+		config.English: "Claim rewards from rewarding fund",
+		config.Chinese: "从奖励基金中获取奖励",
+	}
+	_claimCmdUses = map[config.Language]string{
+		config.English: "claim AMOUNT_IOTX [DATA] [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "claim IOTX数量 [数据] [-s 签署人] [-n NONCE] [-l GAS限制] [-p GAS价格] [-P 密码] [-y]",
+	}
+)
+
+// NewActionClaimCmd represents the action claim command
+func NewActionClaimCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_claimCmdUses)
+	short, _ := client.SelectTranslation(_claimCmdShorts)
+
+	cmd := &cobra.Command{
+		Use:   use,
+		Short: short,
+		Args:  cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			amount, err := util.StringToRau(args[0], util.IotxDecimalNum)
+			if err != nil {
+				return errors.Wrap(err, "invalid amount")
+			}
+			payload := make([]byte, 0)
+			if len(args) == 2 {
+				payload = []byte(args[1])
+			}
+			gasPrice, signer, password, nonce, gasLimit, assumeYes, err := GetWriteCommandFlag(cmd)
+			if err != nil {
+				return err
+			}
+			sender, err := Signer(client, signer)
+			if err != nil {
+				return errors.Wrap(err, "failed to get signer address")
+			}
+			if gasLimit == 0 {
+				gasLimit = action.ClaimFromRewardingFundBaseGas +
+					action.ClaimFromRewardingFundGasPerByte*uint64(len(payload))
+			}
+			gasPriceRau, err := gasPriceInRau(client, gasPrice)
+			if err != nil {
+				return errors.Wrap(err, "failed to get gasPriceRau")
+			}
+			nonce, err = checkNonce(client, nonce, sender)
+			if err != nil {
+				return errors.Wrap(err, "failed to get nonce")
+			}
+			act := (&action.ClaimFromRewardingFundBuilder{}).SetAmount(amount).SetData(payload).Build()
+			return SendAction(
+				client,
+				cmd,
+				(&action.EnvelopeBuilder{}).SetNonce(nonce).
+					SetGasPrice(gasPriceRau).
+					SetGasLimit(gasLimit).
+					SetAction(&act).Build(),
+				sender,
+				password,
+				nonce,
+				assumeYes,
+			)
+		},
+	}
+	RegisterWriteCommand(client, cmd)
+	return cmd
+}

--- a/ioctl/newcmd/action/actionclaim_test.go
+++ b/ioctl/newcmd/action/actionclaim_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+)
+
+func TestNewActionClaimCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiServiceClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+
+	ks := keystore.NewKeyStore(t.TempDir(), 2, 1)
+	acc, err := ks.NewAccount("")
+	require.NoError(err)
+	accAddr, err := address.FromBytes(acc.Address.Bytes())
+	require.NoError(err)
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("mockTranslationString", config.English).AnyTimes()
+	client.EXPECT().Alias(gomock.Any()).Return("producer", nil).Times(2)
+	client.EXPECT().APIServiceClient().Return(apiServiceClient, nil).AnyTimes()
+	client.EXPECT().IsCryptoSm2().Return(false).Times(7)
+	client.EXPECT().ReadSecret().Return("", nil).Times(2)
+	client.EXPECT().Address(gomock.Any()).Return(accAddr.String(), nil).Times(2)
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return(accAddr.String(), nil).Times(3)
+	client.EXPECT().NewKeyStore().Return(ks).Times(4)
+	client.EXPECT().AskToConfirm(gomock.Any()).Return(true, nil).Times(2)
+	client.EXPECT().Config().Return(config.Config{
+		Explorer: "iotexscan",
+		Endpoint: "testnet1",
+	}).Times(10)
+
+	accountResp := &iotexapi.GetAccountResponse{
+		AccountMeta: &iotextypes.AccountMeta{
+			IsContract:   false,
+			PendingNonce: 10,
+			Balance:      "100000000000000000000",
+		},
+	}
+	chainMetaResp := &iotexapi.GetChainMetaResponse{
+		ChainMeta: &iotextypes.ChainMeta{
+			ChainID: 0,
+		},
+	}
+	sendActionResp := &iotexapi.SendActionResponse{}
+	apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(accountResp, nil).Times(4)
+	apiServiceClient.EXPECT().GetChainMeta(gomock.Any(), gomock.Any()).Return(chainMetaResp, nil).Times(2)
+	apiServiceClient.EXPECT().SendAction(gomock.Any(), gomock.Any()).Return(sendActionResp, nil).Times(2)
+
+	t.Run("action claim", func(t *testing.T) {
+		cmd := NewActionClaimCmd(client)
+		result, err := util.ExecuteCmd(cmd, "0")
+		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain")
+	})
+
+	t.Run("action claim with payload", func(t *testing.T) {
+		payload := "0a10080118a08d062202313062040a023130124104dc4c548c3a478278a6a09ffa8b5c4b384368e49654b35a6961ee8288fc889cdc39e9f8194e41abdbfac248ef9dc3f37b131a36ee2c052d974c21c1d2cd56730b1a4161e219c2c5d5987f8a9efa33e8df0cde9d5541689fff05784cdc24f12e9d9ee8283a5aa720f494b949535b7969c07633dfb68c4ef9359eb16edb9abc6ebfadc801"
+		cmd := NewActionClaimCmd(client)
+		result, err := util.ExecuteCmd(cmd, "0", payload, "--gas-limit", "0")
+		require.NoError(err)
+		require.Contains(result, "Action has been sent to blockchain")
+	})
+
+	t.Run("failed to get nonce", func(t *testing.T) {
+		expectedErr := errors.New("failed to get nonce")
+		apiServiceClient.EXPECT().GetAccount(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+		cmd := NewActionClaimCmd(client)
+		_, err := util.ExecuteCmd(cmd, "0")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("failed to get signer address", func(t *testing.T) {
+		expectedErr := errors.New("failed to get signer address")
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", expectedErr)
+		cmd := NewActionClaimCmd(client)
+		_, err := util.ExecuteCmd(cmd, "0")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+
+	t.Run("invalid amount", func(t *testing.T) {
+		expectedErr := errors.New("invalid amount")
+		cmd := NewActionClaimCmd(client)
+		_, err := util.ExecuteCmd(cmd, "")
+		require.Contains(err.Error(), expectedErr.Error())
+	})
+}


### PR DESCRIPTION
# Description

Refactor `actionclaim` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3316 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewActionClaimCmd

**Test Configuration**:
- Firmware version: Windows 10 (WSL Version: Ubuntu 18.04)
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
****