### PR TITLE
adding fix for usecase where iotex-core is added as a submodule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN go mod download
 
 COPY . .
 
+RUN rm -r ./.git
+
 RUN mkdir -p $GOPATH/pkg/linux_amd64/github.com/iotexproject/ && \
     make clean build-all
 


### PR DESCRIPTION
# Description
The issue occurs when iotex-core is used as a submodule of a project. The Dockerfile copies the entire contents of the iotex-core folder into itself, but if it is added as a submodule, the parent of the git repository is incorrectly determined. If this fix is not applied, the following error occurs.

 > [build 8/8] RUN mkdir -p /go/pkg/linux_amd64/github.com/iotexproject/ &&     make clean build-all:
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.681 error obtaining VCS status: exit status 128
#0 0.681        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 0.999 error obtaining VCS status: exit status 128
#0 0.999        Use -buildvcs=false to disable VCS stamping.
#0 1.001 fatal: not a git repository: /go/apps/iotex-core/../../.git/modules/external/iotex-core
#0 1.002 fatal: not a git repository: /go/apps/iotex-core/../../.git/modules/external/iotex-core
#0 1.002 fatal: not a git repository: /go/apps/iotex-core/../../.git/modules/external/iotex-core
#0 1.007 Cleaning...
#0 1.021 go build -ldflags "-X 'github.com/iotexproject/iotex-core/pkg/version.PackageVersion=' -X 'github.com/iotexproject/iotex-core/pkg/version.PackageCommitID=' -X 'github.com/iotexproject/iotex-core/pkg/version.GitStatus="clean"' -X 'github.com/iotexproject/iotex-core/pkg/version.GoVersion=go version go1.18.5 linux/amd64' -X 'github.com/iotexproject/iotex-core/pkg/version.BuildTime=2022-11-06-UTC/18:41:39' -s -w" -o ./bin/ioctl -v ./tools/ioctl
#0 1.202 # cd /go/apps/iotex-core; git status --porcelain
#0 1.202 fatal: not a git repository: /go/apps/iotex-core/../../.git/modules/external/iotex-core
#0 1.202 error obtaining VCS status: exit status 128
#0 1.202        Use -buildvcs=false to disable VCS stamping.
#0 1.204 make: *** [Makefile:233: ioctl] Error 1
------
`failed to solve: executor failed running [/bin/sh -c mkdir -p $GOPATH/pkg/linux_amd64/github.com/iotexproject/ &&     make clean build-all]: exit code: 2`

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] Other test (please specify)
Build project as a submodule

**Test Configuration**:
System Information for:  JEREMI
Manufacturer: Micro-Star International Co., Ltd.
Model: MS-7C31
CPU: Intel(R) Core(TM) i7-9700F CPU @ 3.00GHz
HDD Capacity: 310.31GB
HDD Space: 32.91% Free (102.11GB)
RAM: 15.94GB
Operating System: Microsoft Windows 11 Home, Service Pack: 0

running in WSL2 Ubuntu

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
