### PR TITLE
[ioctl] Build contract deploy command line into new ioctl

### DIFF
--- a/ioctl/newcmd/contract/contractdeploy.go
+++ b/ioctl/newcmd/contract/contractdeploy.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This is an alpha (internal) release and is not suitable for production. This source code is provided 'as is' and no
+// warranties are given as to title or non-infringement, merchantability or fitness for purpose and, to the extent
+// permitted by law, all liability for your use of the code is disclaimed. This source code is governed by Apache
+// License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/spf13/cobra"
+)
+
+// Multi-language support
+var (
+	_deployCmdShorts = map[config.Language]string{
+		config.English: "Deploy smart contract of IoTeX blockchain",
+		config.Chinese: "在IoTeX区块链部署智能合约",
+	}
+)
+
+// NewContractDeployCmd represents the contract deploy command
+func NewContractDeployCmd(client ioctl.Client) *cobra.Command {
+	short, _ := client.SelectTranslation(_deployCmdShorts)
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: short,
+	}
+	// cmd.AddCommand(NewcontractDeployBytecodeCmd)
+	// cmd.AddCommand(NewContractDeployBinCmd)
+	// cmd.AddCommand(NewContractDeploySolCmd)
+	// action.RegisterWriteCommand(NewContractDeployBytecodeCmd)
+	// action.RegisterWriteCommand(NewContractDeployBinCmd)
+	// action.RegisterWriteCommand(NewContractDeploySolCmd)
+	return cmd
+}


### PR DESCRIPTION
# Description
Build `contract` and `contractdeploy` command in new `ioctl`, with the following note.

* Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
* Output package is deprecated, replace it with errors package.
* Replace fmt.Println with cmd.Println
* Refactor unit test to cover the modification.

Fixes #3305 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewContractDeployCmd

**Test Configuration**:
- Firmware version: Ubuntu 21.04
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules