### PR TITLE
use config.GasStation instead of config.API

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -230,7 +230,7 @@ func newCoreService(
 		cfg:           cfg,
 		registry:      registry,
 		chainListener: NewChainListener(500),
-		gs:            gasstation.NewGasStation(chain, dao, cfg),
+		gs:            gasstation.NewGasStation(chain, dao, cfg.GasStation),
 		readCache:     NewReadCache(),
 	}
 

--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -33,11 +33,11 @@ type SimulateFunc func(context.Context, address.Address, *action.Execution, evm.
 type GasStation struct {
 	bc  blockchain.Blockchain
 	dao BlockDAO
-	cfg config.API
+	cfg config.GasStation
 }
 
 // NewGasStation creates a new gas station
-func NewGasStation(bc blockchain.Blockchain, dao BlockDAO, cfg config.API) *GasStation {
+func NewGasStation(bc blockchain.Blockchain, dao BlockDAO, cfg config.GasStation) *GasStation {
 	return &GasStation{
 		bc:  bc,
 		dao: dao,
@@ -51,14 +51,14 @@ func (gs *GasStation) SuggestGasPrice() (uint64, error) {
 	tip := gs.bc.TipHeight()
 
 	endBlockHeight := uint64(0)
-	if tip > uint64(gs.cfg.GasStation.SuggestBlockWindow) {
-		endBlockHeight = tip - uint64(gs.cfg.GasStation.SuggestBlockWindow)
+	if tip > uint64(gs.cfg.SuggestBlockWindow) {
+		endBlockHeight = tip - uint64(gs.cfg.SuggestBlockWindow)
 	}
 
 	for height := tip; height > endBlockHeight; height-- {
 		blk, err := gs.dao.GetBlockByHeight(height)
 		if err != nil {
-			return gs.cfg.GasStation.DefaultGas, err
+			return gs.cfg.DefaultGas, err
 		}
 		if len(blk.Actions) == 0 {
 			continue
@@ -80,12 +80,12 @@ func (gs *GasStation) SuggestGasPrice() (uint64, error) {
 
 	if len(smallestPrices) == 0 {
 		// return default price
-		return gs.cfg.GasStation.DefaultGas, nil
+		return gs.cfg.DefaultGas, nil
 	}
 	sort.Sort(bigIntArray(smallestPrices))
-	gasPrice := smallestPrices[(len(smallestPrices)-1)*gs.cfg.GasStation.Percentile/100].Uint64()
-	if gasPrice < gs.cfg.GasStation.DefaultGas {
-		gasPrice = gs.cfg.GasStation.DefaultGas
+	gasPrice := smallestPrices[(len(smallestPrices)-1)*gs.cfg.Percentile/100].Uint64()
+	if gasPrice < gs.cfg.DefaultGas {
+		gasPrice = gs.cfg.DefaultGas
 	}
 	return gasPrice, nil
 }

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestNewGasStation(t *testing.T) {
 	require := require.New(t)
-	require.NotNil(NewGasStation(nil, nil, config.Default.API))
+	require.NotNil(NewGasStation(nil, nil, config.Default.API.GasStation))
 }
 func TestSuggestGasPriceForUserAction(t *testing.T) {
 	ctx := context.Background()
@@ -105,7 +105,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, blkMemDao, cfg.API)
+	gs := NewGasStation(bc, blkMemDao, cfg.API.GasStation)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -164,12 +164,12 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, blkMemDao, cfg.API)
+	gs := NewGasStation(bc, blkMemDao, cfg.API.GasStation)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
 	fmt.Println(gp)
 	require.NoError(t, err)
 	// i from 10 to 29,gasprice for 20 to 39,60%*20+20=31
-	require.Equal(t, gs.cfg.GasStation.DefaultGas, gp)
+	require.Equal(t, gs.cfg.DefaultGas, gp)
 }

--- a/ioctl/cmd/action/stake2add.go
+++ b/ioctl/cmd/action/stake2add.go
@@ -1,5 +1,5 @@
 // Copyright (c) 2022 IoTeX Foundation
-// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability 
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
 // or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is didslaimed.
 // This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
 


### PR DESCRIPTION
# Description

Change `cfg` field type in `GasStation` from `config.API` to `config.GasStation`.

Fixes #3718

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test

**Test Configuration**:
- Firmware version: macOS Monterey 12.5.1
- Hardware: Apple M1 Pro
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
