### PR TITLE
[config] move config.API to api package

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package api
+
+import (
+	"github.com/iotexproject/iotex-core/gasstation"
+	"github.com/iotexproject/iotex-core/pkg/tracer"
+)
+
+// Config is the api service config
+type Config struct {
+	UseRDS          bool              `yaml:"useRDS"`
+	GRPCPort        int               `yaml:"port"`
+	HTTPPort        int               `yaml:"web3port"`
+	WebSocketPort   int               `yaml:"webSocketPort"`
+	RedisCacheURL   string            `yaml:"redisCacheURL"`
+	TpsWindow       int               `yaml:"tpsWindow"`
+	GasStation      gasstation.Config `yaml:"gasStation"`
+	RangeQueryLimit uint64            `yaml:"rangeQueryLimit"`
+	Tracer          tracer.Config     `yaml:"tracer"`
+}
+
+// DefaultConfig is the default config
+var DefaultConfig = Config{
+	UseRDS:          false,
+	GRPCPort:        14014,
+	HTTPPort:        15014,
+	WebSocketPort:   16014,
+	TpsWindow:       10,
+	GasStation:      gasstation.DefaultConfig,
+	RangeQueryLimit: 1000,
+}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -47,7 +47,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/blocksync"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/gasstation"
 	"github.com/iotexproject/iotex-core/pkg/log"
@@ -154,7 +153,7 @@ type (
 		ap                actpool.ActPool
 		gs                *gasstation.GasStation
 		broadcastHandler  BroadcastOutbound
-		cfg               config.API
+		cfg               Config
 		registry          *protocol.Registry
 		chainListener     apitypes.Listener
 		electionCommittee committee.Committee
@@ -199,7 +198,7 @@ var (
 
 // newcoreService creates a api server that contains major blockchain components
 func newCoreService(
-	cfg config.API,
+	cfg Config,
 	chain blockchain.Blockchain,
 	bs blocksync.BlockSync,
 	sf factory.Factory,
@@ -210,9 +209,9 @@ func newCoreService(
 	registry *protocol.Registry,
 	opts ...Option,
 ) (CoreService, error) {
-	if cfg == (config.API{}) {
+	if cfg == (Config{}) {
 		log.L().Warn("API server is not configured.")
-		cfg = config.Default.API
+		cfg = DefaultConfig
 	}
 
 	if cfg.RangeQueryLimit < uint64(cfg.TpsWindow) {

--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -170,7 +170,7 @@ func setupTestCoreSerivce() (CoreService, blockchain.Blockchain, blockdao.BlockD
 	opts := []Option{WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
 		return nil
 	})}
-	svr, err := newCoreService(cfg.API, bc, nil, sf, dao, indexer, bfIndexer, ap, registry, opts...)
+	svr, err := newCoreService(cfg.api, bc, nil, sf, dao, indexer, bfIndexer, ap, registry, opts...)
 	if err != nil {
 		panic(err)
 	}

--- a/api/grpcserver_integrity_test.go
+++ b/api/grpcserver_integrity_test.go
@@ -820,7 +820,7 @@ var (
 func TestGrpcServer_GetAccountIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, bc, dao, _, _, actPool, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -885,7 +885,7 @@ func TestGrpcServer_GetAccountIntegrity(t *testing.T) {
 func TestGrpcServer_GetActionsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -946,7 +946,7 @@ func TestGrpcServer_GetActionsIntegrity(t *testing.T) {
 func TestGrpcServer_GetActionIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, dao, _, _, _, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1000,7 +1000,7 @@ func TestGrpcServer_GetActionIntegrity(t *testing.T) {
 func TestGrpcServer_GetActionsByAddressIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1052,7 +1052,7 @@ func TestGrpcServer_GetActionsByAddressIntegrity(t *testing.T) {
 func TestGrpcServer_GetUnconfirmedActionsByAddressIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1084,7 +1084,7 @@ func TestGrpcServer_GetUnconfirmedActionsByAddressIntegrity(t *testing.T) {
 func TestGrpcServer_GetActionsByBlockIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1122,9 +1122,9 @@ func TestGrpcServer_GetActionsByBlockIntegrity(t *testing.T) {
 func TestGrpcServer_GetBlockMetasIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
-	genesis.SetGenesisTimestamp(cfg.Genesis.Timestamp)
-	block.LoadGenesisHash(&cfg.Genesis)
+	cfg.api.GRPCPort = testutil.RandomPort()
+	genesis.SetGenesisTimestamp(cfg.genesis.Timestamp)
+	block.LoadGenesisHash(&cfg.genesis)
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1186,7 +1186,7 @@ func TestGrpcServer_GetBlockMetasIntegrity(t *testing.T) {
 func TestGrpcServer_GetBlockMetaIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, bc, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1225,7 +1225,7 @@ func TestGrpcServer_GetChainMetaIntegrity(t *testing.T) {
 	for _, test := range _getChainMetaTests {
 		cfg := newConfig()
 		if test.pollProtocolType == lld {
-			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+			pol = poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 		} else if test.pollProtocolType == "governanceChainCommittee" {
 			committee := mock_committee.NewMockCommittee(ctrl)
 			slasher, _ := poll.NewSlasher(
@@ -1236,25 +1236,25 @@ func TestGrpcServer_GetChainMetaIntegrity(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
-				cfg.Genesis.DardanellesNumSubEpochs,
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.ProbationEpochPeriod,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-				cfg.Genesis.ProbationIntensityRate)
+				cfg.genesis.NumCandidateDelegates,
+				cfg.genesis.NumDelegates,
+				cfg.genesis.DardanellesNumSubEpochs,
+				cfg.genesis.ProductivityThreshold,
+				cfg.genesis.ProbationEpochPeriod,
+				cfg.genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.genesis.ProbationIntensityRate)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
 				nil,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Chain.PollInitialCandidatesInterval,
+				cfg.chain.PollInitialCandidatesInterval,
 				slasher)
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epoch.GravityChainStartHeight, nil)
 		}
 
-		cfg.API.GRPCPort = testutil.RandomPort()
-		cfg.API.TpsWindow = test.tpsWindow
+		cfg.api.GRPCPort = testutil.RandomPort()
+		cfg.api.TpsWindow = test.tpsWindow
 		svr, _, _, _, registry, _, bfIndexFile, err := createServerV2(cfg, false)
 		require.NoError(err)
 		grpcHandler := newGRPCHandler(svr.core)
@@ -1288,8 +1288,8 @@ func TestGrpcServer_GetChainMetaIntegrity(t *testing.T) {
 func TestGrpcServer_SendActionIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
-	cfg.Genesis.MidwayBlockHeight = 10
+	cfg.api.GRPCPort = testutil.RandomPort()
+	cfg.genesis.MidwayBlockHeight = 10
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1339,7 +1339,7 @@ func TestGrpcServer_SendActionIntegrity(t *testing.T) {
 		{
 			func() testConfig {
 				cfg := newConfig()
-				cfg.ActPool.MaxNumActsPerPool = 8
+				cfg.actPoll.MaxNumActsPerPool = 8
 				return cfg
 			},
 			_testTransferPb,
@@ -1371,7 +1371,7 @@ func TestGrpcServer_SendActionIntegrity(t *testing.T) {
 	for _, test := range tests {
 		request := &iotexapi.SendActionRequest{Action: test.action}
 		cfg := test.cfg()
-		cfg.API.GRPCPort = testutil.RandomPort()
+		cfg.api.GRPCPort = testutil.RandomPort()
 		svr, _, _, _, _, _, file, err := createServerV2(cfg, true)
 		require.NoError(err)
 		grpcHandler := newGRPCHandler(svr.core)
@@ -1387,7 +1387,7 @@ func TestGrpcServer_SendActionIntegrity(t *testing.T) {
 func TestGrpcServer_StreamLogsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1402,7 +1402,7 @@ func TestGrpcServer_StreamLogsIntegrity(t *testing.T) {
 func TestGrpcServer_GetReceiptByActionIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1432,7 +1432,7 @@ func TestGrpcServer_GetReceiptByActionIntegrity(t *testing.T) {
 func TestGrpcServer_GetServerMetaIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1452,7 +1452,7 @@ func TestGrpcServer_GetServerMetaIntegrity(t *testing.T) {
 func TestGrpcServer_ReadContractIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, dao, indexer, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1486,9 +1486,9 @@ func TestGrpcServer_ReadContractIntegrity(t *testing.T) {
 func TestGrpcServer_SuggestGasPriceIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	for _, test := range _suggestGasPriceTests {
-		cfg.API.GasStation.DefaultGas = test.defaultGasPrice
+		cfg.api.GasStation.DefaultGas = test.defaultGasPrice
 		svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 		require.NoError(err)
 		grpcHandler := newGRPCHandler(svr.core)
@@ -1504,7 +1504,7 @@ func TestGrpcServer_SuggestGasPriceIntegrity(t *testing.T) {
 func TestGrpcServer_EstimateGasForActionIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, dao, indexer, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1530,7 +1530,7 @@ func TestGrpcServer_EstimateGasForActionIntegrity(t *testing.T) {
 func TestGrpcServer_EstimateActionGasConsumptionIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1709,8 +1709,8 @@ func TestGrpcServer_EstimateActionGasConsumptionIntegrity(t *testing.T) {
 func TestGrpcServer_ReadUnclaimedBalanceIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
-	cfg.Consensus.Scheme = consensus.RollDPoSScheme
+	cfg.api.GRPCPort = testutil.RandomPort()
+	cfg.consensus.Scheme = consensus.RollDPoSScheme
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1738,7 +1738,7 @@ func TestGrpcServer_ReadUnclaimedBalanceIntegrity(t *testing.T) {
 func TestGrpcServer_TotalBalanceIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1760,8 +1760,8 @@ func TestGrpcServer_TotalBalanceIntegrity(t *testing.T) {
 func TestGrpcServer_AvailableBalanceIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.Consensus.Scheme = consensus.RollDPoSScheme
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.consensus.Scheme = consensus.RollDPoSScheme
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -1783,7 +1783,7 @@ func TestGrpcServer_AvailableBalanceIntegrity(t *testing.T) {
 func TestGrpcServer_ReadCandidatesByEpochIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 
 	ctrl := gomock.NewController(t)
 	committee := mock_committee.NewMockCommittee(ctrl)
@@ -1803,8 +1803,8 @@ func TestGrpcServer_ReadCandidatesByEpochIntegrity(t *testing.T) {
 	for _, test := range _readCandidatesByEpochTests {
 		var pol poll.Protocol
 		if test.protocolType == lld {
-			cfg.Genesis.Delegates = _delegates
-			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+			cfg.genesis.Delegates = _delegates
+			pol = poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
@@ -1818,19 +1818,19 @@ func TestGrpcServer_ReadCandidatesByEpochIntegrity(t *testing.T) {
 				nil,
 				nil,
 				indexer,
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
-				cfg.Genesis.DardanellesNumSubEpochs,
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.ProbationEpochPeriod,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-				cfg.Genesis.ProbationIntensityRate)
+				cfg.genesis.NumCandidateDelegates,
+				cfg.genesis.NumDelegates,
+				cfg.genesis.DardanellesNumSubEpochs,
+				cfg.genesis.ProductivityThreshold,
+				cfg.genesis.ProbationEpochPeriod,
+				cfg.genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.genesis.ProbationIntensityRate)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
 				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Chain.PollInitialCandidatesInterval,
+				cfg.chain.PollInitialCandidatesInterval,
 				slasher)
 		}
 		svr, _, _, _, registry, _, bfIndexFile, err := createServerV2(cfg, false)
@@ -1856,7 +1856,7 @@ func TestGrpcServer_ReadCandidatesByEpochIntegrity(t *testing.T) {
 func TestGrpcServer_ReadBlockProducersByEpochIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 
 	ctrl := gomock.NewController(t)
 	committee := mock_committee.NewMockCommittee(ctrl)
@@ -1876,8 +1876,8 @@ func TestGrpcServer_ReadBlockProducersByEpochIntegrity(t *testing.T) {
 	for _, test := range _readBlockProducersByEpochTests {
 		var pol poll.Protocol
 		if test.protocolType == lld {
-			cfg.Genesis.Delegates = _delegates
-			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+			cfg.genesis.Delegates = _delegates
+			pol = poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
@@ -1892,19 +1892,19 @@ func TestGrpcServer_ReadBlockProducersByEpochIntegrity(t *testing.T) {
 				nil,
 				indexer,
 				test.numCandidateDelegates,
-				cfg.Genesis.NumDelegates,
-				cfg.Genesis.DardanellesNumSubEpochs,
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.ProbationEpochPeriod,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-				cfg.Genesis.ProbationIntensityRate)
+				cfg.genesis.NumDelegates,
+				cfg.genesis.DardanellesNumSubEpochs,
+				cfg.genesis.ProductivityThreshold,
+				cfg.genesis.ProbationEpochPeriod,
+				cfg.genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.genesis.ProbationIntensityRate)
 
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
 				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Chain.PollInitialCandidatesInterval,
+				cfg.chain.PollInitialCandidatesInterval,
 				slasher)
 		}
 		svr, _, _, _, registry, _, bfIndexFile, err := createServerV2(cfg, false)
@@ -1929,7 +1929,7 @@ func TestGrpcServer_ReadBlockProducersByEpochIntegrity(t *testing.T) {
 func TestGrpcServer_ReadActiveBlockProducersByEpochIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 
 	ctrl := gomock.NewController(t)
 	committee := mock_committee.NewMockCommittee(ctrl)
@@ -1949,8 +1949,8 @@ func TestGrpcServer_ReadActiveBlockProducersByEpochIntegrity(t *testing.T) {
 	for _, test := range _readActiveBlockProducersByEpochTests {
 		var pol poll.Protocol
 		if test.protocolType == lld {
-			cfg.Genesis.Delegates = _delegates
-			pol = poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+			cfg.genesis.Delegates = _delegates
+			pol = poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 		} else {
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
@@ -1964,19 +1964,19 @@ func TestGrpcServer_ReadActiveBlockProducersByEpochIntegrity(t *testing.T) {
 				nil,
 				nil,
 				indexer,
-				cfg.Genesis.NumCandidateDelegates,
+				cfg.genesis.NumCandidateDelegates,
 				test.numDelegates,
-				cfg.Genesis.DardanellesNumSubEpochs,
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.ProbationEpochPeriod,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-				cfg.Genesis.ProbationIntensityRate)
+				cfg.genesis.DardanellesNumSubEpochs,
+				cfg.genesis.ProductivityThreshold,
+				cfg.genesis.ProbationEpochPeriod,
+				cfg.genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.genesis.ProbationIntensityRate)
 			pol, _ = poll.NewGovernanceChainCommitteeProtocol(
 				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Chain.PollInitialCandidatesInterval,
+				cfg.chain.PollInitialCandidatesInterval,
 				slasher)
 		}
 		svr, _, _, _, registry, _, bfIndexFile, err := createServerV2(cfg, false)
@@ -2002,7 +2002,7 @@ func TestGrpcServer_ReadActiveBlockProducersByEpochIntegrity(t *testing.T) {
 func TestGrpcServer_ReadRollDPoSMetaIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	for _, test := range _readRollDPoSMetaTests {
 		svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 		require.NoError(err)
@@ -2024,7 +2024,7 @@ func TestGrpcServer_ReadRollDPoSMetaIntegrity(t *testing.T) {
 func TestGrpcServer_ReadEpochCtxIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	for _, test := range _readEpochCtxTests {
 		svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 		require.NoError(err)
@@ -2048,7 +2048,7 @@ func TestGrpcServer_GetEpochMetaIntegrity(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, registry, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2057,12 +2057,12 @@ func TestGrpcServer_GetEpochMetaIntegrity(t *testing.T) {
 	}()
 	for _, test := range _getEpochMetaTests {
 		if test.pollProtocolType == lld {
-			pol := poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+			pol := poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 			require.NoError(pol.ForceRegister(registry))
 		} else if test.pollProtocolType == "governanceChainCommittee" {
 			committee := mock_committee.NewMockCommittee(ctrl)
 			mbc := mock_blockchain.NewMockBlockchain(ctrl)
-			mbc.EXPECT().Genesis().Return(cfg.Genesis).Times(10)
+			mbc.EXPECT().Genesis().Return(cfg.genesis).Times(10)
 			indexer, err := poll.NewCandidateIndexer(db.NewMemKVStore())
 			require.NoError(err)
 			slasher, _ := poll.NewSlasher(
@@ -2106,19 +2106,19 @@ func TestGrpcServer_GetEpochMetaIntegrity(t *testing.T) {
 				nil,
 				nil,
 				indexer,
-				cfg.Genesis.NumCandidateDelegates,
-				cfg.Genesis.NumDelegates,
-				cfg.Genesis.DardanellesNumSubEpochs,
-				cfg.Genesis.ProductivityThreshold,
-				cfg.Genesis.ProbationEpochPeriod,
-				cfg.Genesis.UnproductiveDelegateMaxCacheSize,
-				cfg.Genesis.ProbationIntensityRate)
+				cfg.genesis.NumCandidateDelegates,
+				cfg.genesis.NumDelegates,
+				cfg.genesis.DardanellesNumSubEpochs,
+				cfg.genesis.ProductivityThreshold,
+				cfg.genesis.ProbationEpochPeriod,
+				cfg.genesis.UnproductiveDelegateMaxCacheSize,
+				cfg.genesis.ProbationIntensityRate)
 			pol, _ := poll.NewGovernanceChainCommitteeProtocol(
 				indexer,
 				committee,
 				uint64(123456),
 				func(uint64) (time.Time, error) { return time.Now(), nil },
-				cfg.Chain.PollInitialCandidatesInterval,
+				cfg.chain.PollInitialCandidatesInterval,
 				slasher)
 			require.NoError(pol.ForceRegister(registry))
 			committee.EXPECT().HeightByTime(gomock.Any()).Return(test.epochData.GravityChainStartHeight, nil)
@@ -2180,7 +2180,7 @@ func TestGrpcServer_GetEpochMetaIntegrity(t *testing.T) {
 func TestGrpcServer_GetRawBlocksIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2248,7 +2248,7 @@ func TestGrpcServer_GetRawBlocksIntegrity(t *testing.T) {
 func TestGrpcServer_GetLogsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2308,7 +2308,7 @@ func TestGrpcServer_GetLogsIntegrity(t *testing.T) {
 func TestGrpcServer_GetElectionBucketsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2327,7 +2327,7 @@ func TestGrpcServer_GetElectionBucketsIntegrity(t *testing.T) {
 func TestGrpcServer_GetActionByActionHashIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	defer func() {
@@ -2344,7 +2344,7 @@ func TestGrpcServer_GetActionByActionHashIntegrity(t *testing.T) {
 func TestGrpcServer_GetTransactionLogByActionHashIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2380,7 +2380,7 @@ func TestGrpcServer_GetTransactionLogByActionHashIntegrity(t *testing.T) {
 func TestGrpcServer_GetEvmTransfersByBlockHeightIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2414,8 +2414,8 @@ func TestGrpcServer_GetEvmTransfersByBlockHeightIntegrity(t *testing.T) {
 func TestGrpcServer_GetActPoolActionsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
-	ctx := genesis.WithGenesisContext(context.Background(), cfg.Genesis)
+	cfg.api.GRPCPort = testutil.RandomPort()
+	ctx := genesis.WithGenesisContext(context.Background(), cfg.genesis)
 	svr, _, _, _, _, actPool, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2473,7 +2473,7 @@ func TestGrpcServer_GetActPoolActionsIntegrity(t *testing.T) {
 func TestGrpcServer_GetEstimateGasSpecialIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, bc, dao, _, _, actPool, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)
@@ -2585,7 +2585,7 @@ func TestChainlinkErrIntegrity(t *testing.T) {
 			"ExceedsBlockGasLimit",
 			func() testConfig {
 				cfg := newConfig()
-				cfg.ActPool.MaxGasLimitPerPool = 1e5
+				cfg.actPoll.MaxGasLimitPerPool = 1e5
 				return cfg
 			},
 			[]*iotextypes.Action{_testTransferInvalid8Pb},
@@ -2596,7 +2596,7 @@ func TestChainlinkErrIntegrity(t *testing.T) {
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			cfg := test.cfg()
-			cfg.API.GRPCPort = testutil.RandomPort()
+			cfg.api.GRPCPort = testutil.RandomPort()
 			svr, _, _, _, _, _, file, err := createServerV2(cfg, true)
 			require.NoError(err)
 			grpcHandler := newGRPCHandler(svr.core)
@@ -2620,7 +2620,7 @@ func TestChainlinkErrIntegrity(t *testing.T) {
 func TestGrpcServer_TraceTransactionStructLogsIntegrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, bc, _, _, _, actPool, bfIndexFile, err := createServerV2(cfg, true)
 	require.NoError(err)
 	grpcHandler := newGRPCHandler(svr.core)

--- a/api/serverV2.go
+++ b/api/serverV2.go
@@ -19,7 +19,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/blocksync"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/pkg/tracer"
 	"github.com/iotexproject/iotex-core/state/factory"
 )
@@ -35,7 +34,7 @@ type ServerV2 struct {
 
 // NewServerV2 creates a new server with coreService and GRPC Server
 func NewServerV2(
-	cfg config.API,
+	cfg Config,
 	chain blockchain.Blockchain,
 	bs blocksync.BlockSync,
 	sf factory.Factory,

--- a/api/serverV2_integrity_test.go
+++ b/api/serverV2_integrity_test.go
@@ -42,13 +42,13 @@ import (
 )
 
 type testConfig struct {
-	API       Config
-	Genesis   genesis.Genesis
-	ActPool   actpool.Config
-	Chain     blockchain.Config
-	Consensus consensus.Config
-	DB        db.Config
-	Indexer   blockindex.Config
+	api       Config
+	genesis   genesis.Genesis
+	actPoll   actpool.Config
+	chain     blockchain.Config
+	consensus consensus.Config
+	db        db.Config
+	indexer   blockindex.Config
 }
 
 var (
@@ -288,27 +288,27 @@ func addActsToActPool(ctx context.Context, ap actpool.ActPool) error {
 }
 
 func setupChain(cfg testConfig) (blockchain.Blockchain, blockdao.BlockDAO, blockindex.Indexer, blockindex.BloomFilterIndexer, factory.Factory, actpool.ActPool, *protocol.Registry, string, error) {
-	cfg.Chain.ProducerPrivKey = hex.EncodeToString(identityset.PrivateKey(0).Bytes())
+	cfg.chain.ProducerPrivKey = hex.EncodeToString(identityset.PrivateKey(0).Bytes())
 	registry := protocol.NewRegistry()
-	factoryCfg := factory.GenerateConfig(cfg.Chain, cfg.Genesis)
+	factoryCfg := factory.GenerateConfig(cfg.chain, cfg.genesis)
 	sf, err := factory.NewFactory(factoryCfg, db.NewMemKVStore(), factory.RegistryOption(registry))
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, "", err
 	}
-	ap, err := setupActPool(cfg.Genesis, sf, cfg.ActPool)
+	ap, err := setupActPool(cfg.genesis, sf, cfg.actPoll)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, "", err
 	}
-	cfg.Genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
-	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = unit.ConvertIotxToRau(10000000000).String()
+	cfg.genesis.InitBalanceMap[identityset.Address(27).String()] = unit.ConvertIotxToRau(10000000000).String()
+	cfg.genesis.InitBalanceMap[identityset.Address(28).String()] = unit.ConvertIotxToRau(10000000000).String()
 	// create indexer
-	indexer, err := blockindex.NewIndexer(db.NewMemKVStore(), cfg.Genesis.Hash())
+	indexer, err := blockindex.NewIndexer(db.NewMemKVStore(), cfg.genesis.Hash())
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, "", errors.New("failed to create indexer")
 	}
 	testPath, _ := testutil.PathOfTempFile("bloomfilter")
-	cfg.DB.DbPath = testPath
-	bfIndexer, err := blockindex.NewBloomfilterIndexer(db.NewBoltDB(cfg.DB), cfg.Indexer)
+	cfg.db.DbPath = testPath
+	bfIndexer, err := blockindex.NewBloomfilterIndexer(db.NewBoltDB(cfg.db), cfg.indexer)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, "", errors.New("failed to create bloomfilter indexer")
 	}
@@ -319,8 +319,8 @@ func setupChain(cfg testConfig) (blockchain.Blockchain, blockdao.BlockDAO, block
 	}
 	// create chain
 	bc := blockchain.NewBlockchain(
-		cfg.Chain,
-		cfg.Genesis,
+		cfg.chain,
+		cfg.genesis,
 		dao,
 		factory.NewMinter(sf, ap),
 		blockchain.BlockValidatorOption(block.NewValidator(
@@ -337,14 +337,14 @@ func setupChain(cfg testConfig) (blockchain.Blockchain, blockdao.BlockDAO, block
 
 	acc := account.NewProtocol(rewarding.DepositGas)
 	evm := execution.NewProtocol(dao.GetBlockHash, rewarding.DepositGas)
-	p := poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates)
+	p := poll.NewLifeLongDelegatesProtocol(cfg.genesis.Delegates)
 	rolldposProtocol := rolldpos.NewProtocol(
 		genesis.Default.NumCandidateDelegates,
 		genesis.Default.NumDelegates,
 		genesis.Default.NumSubEpochs,
-		rolldpos.EnableDardanellesSubEpoch(cfg.Genesis.DardanellesBlockHeight, cfg.Genesis.DardanellesNumSubEpochs),
+		rolldpos.EnableDardanellesSubEpoch(cfg.genesis.DardanellesBlockHeight, cfg.genesis.DardanellesNumSubEpochs),
 	)
-	r := rewarding.NewProtocol(cfg.Genesis.Rewarding)
+	r := rewarding.NewProtocol(cfg.genesis.Rewarding)
 
 	if err := rolldposProtocol.Register(registry); err != nil {
 		return nil, nil, nil, nil, nil, nil, nil, "", err
@@ -378,13 +378,13 @@ func setupActPool(g genesis.Genesis, sf factory.Factory, cfg actpool.Config) (ac
 
 func newConfig() testConfig {
 	cfg := testConfig{
-		API:       DefaultConfig,
-		Genesis:   genesis.Default,
-		ActPool:   actpool.DefaultConfig,
-		Chain:     blockchain.DefaultConfig,
-		Consensus: consensus.DefaultConfig,
-		DB:        db.DefaultConfig,
-		Indexer:   blockindex.DefaultConfig,
+		api:       DefaultConfig,
+		genesis:   genesis.Default,
+		actPoll:   actpool.DefaultConfig,
+		chain:     blockchain.DefaultConfig,
+		consensus: consensus.DefaultConfig,
+		db:        db.DefaultConfig,
+		indexer:   blockindex.DefaultConfig,
 	}
 
 	testTriePath, err := testutil.PathOfTempFile("trie")
@@ -410,17 +410,17 @@ func newConfig() testConfig {
 		testutil.CleanupPath(testSystemLogPath)
 	}()
 
-	cfg.Chain.TrieDBPath = testTriePath
-	cfg.Chain.ChainDBPath = testDBPath
-	cfg.Chain.IndexDBPath = testIndexPath
-	cfg.Chain.EVMNetworkID = _evmNetworkID
-	cfg.Chain.EnableAsyncIndexWrite = false
-	cfg.Genesis.EnableGravityChainVoting = true
-	cfg.ActPool.MinGasPriceStr = "0"
-	cfg.API.RangeQueryLimit = 100
-	cfg.API.GRPCPort = 0
-	cfg.API.HTTPPort = 0
-	cfg.API.WebSocketPort = 0
+	cfg.chain.TrieDBPath = testTriePath
+	cfg.chain.ChainDBPath = testDBPath
+	cfg.chain.IndexDBPath = testIndexPath
+	cfg.chain.EVMNetworkID = _evmNetworkID
+	cfg.chain.EnableAsyncIndexWrite = false
+	cfg.genesis.EnableGravityChainVoting = true
+	cfg.actPoll.MinGasPriceStr = "0"
+	cfg.api.RangeQueryLimit = 100
+	cfg.api.GRPCPort = 0
+	cfg.api.HTTPPort = 0
+	cfg.api.WebSocketPort = 0
 	return cfg
 }
 
@@ -452,7 +452,7 @@ func createServerV2(cfg testConfig, needActPool bool) (*ServerV2, blockchain.Blo
 	opts := []Option{WithBroadcastOutbound(func(ctx context.Context, chainID uint32, msg proto.Message) error {
 		return nil
 	})}
-	svr, err := NewServerV2(cfg.API, bc, nil, sf, dao, indexer, bfIndexer, ap, registry, opts...)
+	svr, err := NewServerV2(cfg.api, bc, nil, sf, dao, indexer, bfIndexer, ap, registry, opts...)
 	if err != nil {
 		return nil, nil, nil, nil, nil, nil, "", err
 	}
@@ -462,7 +462,7 @@ func createServerV2(cfg testConfig, needActPool bool) (*ServerV2, blockchain.Blo
 func TestServerV2Integrity(t *testing.T) {
 	require := require.New(t)
 	cfg := newConfig()
-	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.api.GRPCPort = testutil.RandomPort()
 	svr, _, _, _, _, _, bfIndexFile, err := createServerV2(cfg, false)
 	require.NoError(err)
 	defer func() {

--- a/api/web3server_integrity_test.go
+++ b/api/web3server_integrity_test.go
@@ -149,8 +149,8 @@ func TestWeb3ServerIntegrity(t *testing.T) {
 
 func setupTestServer() (*ServerV2, blockchain.Blockchain, blockdao.BlockDAO, actpool.ActPool, func()) {
 	cfg := newConfig()
-	cfg.Chain.EVMNetworkID = _evmNetworkID
-	cfg.API.HTTPPort = testutil.RandomPort()
+	cfg.chain.EVMNetworkID = _evmNetworkID
+	cfg.api.HTTPPort = testutil.RandomPort()
 	svr, bc, dao, _, _, actPool, bfIndexFile, _ := createServerV2(cfg, false)
 	return svr, bc, dao, actPool, func() {
 		testutil.CleanupPath(bfIndexFile)

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -30,7 +30,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/blockindex"
 	"github.com/iotexproject/iotex-core/blocksync"
-	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/consensus"
 	"github.com/iotexproject/iotex-core/p2p"
 	"github.com/iotexproject/iotex-core/pkg/lifecycle"
@@ -201,7 +200,7 @@ func (cs *ChainService) BlockSync() blocksync.BlockSync {
 func (cs *ChainService) Registry() *protocol.Registry { return cs.registry }
 
 // NewAPIServer creates a new api server
-func (cs *ChainService) NewAPIServer(cfg config.API, plugins map[int]interface{}) (*api.ServerV2, error) {
+func (cs *ChainService) NewAPIServer(cfg api.Config, plugins map[int]interface{}) (*api.ServerV2, error) {
 	if cfg.GRPCPort == 0 && cfg.HTTPPort == 0 {
 		return nil, nil
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	uconfig "go.uber.org/config"
 
 	"github.com/iotexproject/iotex-core/actpool"
+	"github.com/iotexproject/iotex-core/api"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/blockindex"
@@ -22,10 +23,8 @@ import (
 	"github.com/iotexproject/iotex-core/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/dispatcher"
-	"github.com/iotexproject/iotex-core/gasstation"
 	"github.com/iotexproject/iotex-core/p2p"
 	"github.com/iotexproject/iotex-core/pkg/log"
-	"github.com/iotexproject/iotex-core/pkg/tracer"
 )
 
 // IMPORTANT: to define a config, add a field or a new config type to the existing config types. In addition, provide
@@ -69,15 +68,7 @@ var (
 		DardanellesUpgrade: consensusfsm.DefaultDardanellesUpgradeConfig,
 		BlockSync:          blocksync.DefaultConfig,
 		Dispatcher:         dispatcher.DefaultConfig,
-		API: API{
-			UseRDS:          false,
-			GRPCPort:        14014,
-			HTTPPort:        15014,
-			WebSocketPort:   16014,
-			TpsWindow:       10,
-			GasStation:      gasstation.DefaultConfig,
-			RangeQueryLimit: 1000,
-		},
+		API:                api.DefaultConfig,
 		System: System{
 			Active:                true,
 			HeartbeatInterval:     10 * time.Second,
@@ -107,18 +98,6 @@ var (
 
 // Network is the config struct for network package
 type (
-	// API is the api service config
-	API struct {
-		UseRDS          bool              `yaml:"useRDS"`
-		GRPCPort        int               `yaml:"port"`
-		HTTPPort        int               `yaml:"web3port"`
-		WebSocketPort   int               `yaml:"webSocketPort"`
-		RedisCacheURL   string            `yaml:"redisCacheURL"`
-		TpsWindow       int               `yaml:"tpsWindow"`
-		GasStation      gasstation.Config `yaml:"gasStation"`
-		RangeQueryLimit uint64            `yaml:"rangeQueryLimit"`
-		Tracer          tracer.Config     `yaml:"tracer"`
-	}
 
 	// System is the system config
 	System struct {
@@ -143,7 +122,7 @@ type (
 		DardanellesUpgrade consensusfsm.DardanellesUpgrade `yaml:"dardanellesUpgrade"`
 		BlockSync          blocksync.Config                `yaml:"blockSync"`
 		Dispatcher         dispatcher.Config               `yaml:"dispatcher"`
-		API                API                             `yaml:"api"`
+		API                api.Config                      `yaml:"api"`
 		System             System                          `yaml:"system"`
 		DB                 db.Config                       `yaml:"db"`
 		Indexer            blockindex.Config               `yaml:"indexer"`

--- a/config/config.go
+++ b/config/config.go
@@ -22,10 +22,10 @@ import (
 	"github.com/iotexproject/iotex-core/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/dispatcher"
+	"github.com/iotexproject/iotex-core/gasstation"
 	"github.com/iotexproject/iotex-core/p2p"
 	"github.com/iotexproject/iotex-core/pkg/log"
 	"github.com/iotexproject/iotex-core/pkg/tracer"
-	"github.com/iotexproject/iotex-core/pkg/unit"
 )
 
 // IMPORTANT: to define a config, add a field or a new config type to the existing config types. In addition, provide
@@ -70,16 +70,12 @@ var (
 		BlockSync:          blocksync.DefaultConfig,
 		Dispatcher:         dispatcher.DefaultConfig,
 		API: API{
-			UseRDS:        false,
-			GRPCPort:      14014,
-			HTTPPort:      15014,
-			WebSocketPort: 16014,
-			TpsWindow:     10,
-			GasStation: GasStation{
-				SuggestBlockWindow: 20,
-				DefaultGas:         uint64(unit.Qev),
-				Percentile:         60,
-			},
+			UseRDS:          false,
+			GRPCPort:        14014,
+			HTTPPort:        15014,
+			WebSocketPort:   16014,
+			TpsWindow:       10,
+			GasStation:      gasstation.DefaultConfig,
 			RangeQueryLimit: 1000,
 		},
 		System: System{
@@ -113,22 +109,15 @@ var (
 type (
 	// API is the api service config
 	API struct {
-		UseRDS          bool          `yaml:"useRDS"`
-		GRPCPort        int           `yaml:"port"`
-		HTTPPort        int           `yaml:"web3port"`
-		WebSocketPort   int           `yaml:"webSocketPort"`
-		RedisCacheURL   string        `yaml:"redisCacheURL"`
-		TpsWindow       int           `yaml:"tpsWindow"`
-		GasStation      GasStation    `yaml:"gasStation"`
-		RangeQueryLimit uint64        `yaml:"rangeQueryLimit"`
-		Tracer          tracer.Config `yaml:"tracer"`
-	}
-
-	// GasStation is the gas station config
-	GasStation struct {
-		SuggestBlockWindow int    `yaml:"suggestBlockWindow"`
-		DefaultGas         uint64 `yaml:"defaultGas"`
-		Percentile         int    `yaml:"Percentile"`
+		UseRDS          bool              `yaml:"useRDS"`
+		GRPCPort        int               `yaml:"port"`
+		HTTPPort        int               `yaml:"web3port"`
+		WebSocketPort   int               `yaml:"webSocketPort"`
+		RedisCacheURL   string            `yaml:"redisCacheURL"`
+		TpsWindow       int               `yaml:"tpsWindow"`
+		GasStation      gasstation.Config `yaml:"gasStation"`
+		RangeQueryLimit uint64            `yaml:"rangeQueryLimit"`
+		Tracer          tracer.Config     `yaml:"tracer"`
 	}
 
 	// System is the system config

--- a/gasstation/config.go
+++ b/gasstation/config.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2019 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package gasstation
+
+import "github.com/iotexproject/iotex-core/pkg/unit"
+
+// Config is the gas station config
+type Config struct {
+	SuggestBlockWindow int    `yaml:"suggestBlockWindow"`
+	DefaultGas         uint64 `yaml:"defaultGas"`
+	Percentile         int    `yaml:"Percentile"`
+}
+
+// DefaultConfig is the default config
+var DefaultConfig = Config{
+	SuggestBlockWindow: 20,
+	DefaultGas:         uint64(unit.Qev),
+	Percentile:         60,
+}

--- a/gasstation/gasstattion.go
+++ b/gasstation/gasstattion.go
@@ -17,7 +17,6 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/execution/evm"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/config"
 )
 
 // BlockDAO represents the block data access object
@@ -33,11 +32,11 @@ type SimulateFunc func(context.Context, address.Address, *action.Execution, evm.
 type GasStation struct {
 	bc  blockchain.Blockchain
 	dao BlockDAO
-	cfg config.GasStation
+	cfg Config
 }
 
 // NewGasStation creates a new gas station
-func NewGasStation(bc blockchain.Blockchain, dao BlockDAO, cfg config.GasStation) *GasStation {
+func NewGasStation(bc blockchain.Blockchain, dao BlockDAO, cfg Config) *GasStation {
 	return &GasStation{
 		bc:  bc,
 		dao: dao,

--- a/gasstation/gasstattion_test.go
+++ b/gasstation/gasstattion_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
-	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/state/factory"
@@ -32,15 +32,34 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
+type testConfig struct {
+	Genesis    genesis.Genesis
+	Chain      blockchain.Config
+	ActPool    actpool.Config
+	GasStation Config
+}
+
 func TestNewGasStation(t *testing.T) {
 	require := require.New(t)
-	require.NotNil(NewGasStation(nil, nil, config.Default.API.GasStation))
+	require.NotNil(NewGasStation(nil, nil, DefaultConfig))
 }
-func TestSuggestGasPriceForUserAction(t *testing.T) {
-	ctx := context.Background()
-	cfg := config.Default
+
+func newTestConfig() testConfig {
+	cfg := testConfig{
+		Genesis:    genesis.Default,
+		Chain:      blockchain.DefaultConfig,
+		ActPool:    actpool.DefaultConfig,
+		GasStation: DefaultConfig,
+	}
 	cfg.Genesis.BlockGasLimit = uint64(100000)
 	cfg.Genesis.EnableGravityChainVoting = false
+
+	return cfg
+}
+
+func TestSuggestGasPriceForUserAction(t *testing.T) {
+	ctx := context.Background()
+	cfg := newTestConfig()
 	registry := protocol.NewRegistry()
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, acc.Register(registry))
@@ -105,7 +124,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, blkMemDao, cfg.API.GasStation)
+	gs := NewGasStation(bc, blkMemDao, cfg.GasStation)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()
@@ -116,9 +135,7 @@ func TestSuggestGasPriceForUserAction(t *testing.T) {
 
 func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	ctx := context.Background()
-	cfg := config.Default
-	cfg.Genesis.BlockGasLimit = uint64(100000)
-	cfg.Genesis.EnableGravityChainVoting = false
+	cfg := newTestConfig()
 	registry := protocol.NewRegistry()
 	acc := account.NewProtocol(rewarding.DepositGas)
 	require.NoError(t, acc.Register(registry))
@@ -164,7 +181,7 @@ func TestSuggestGasPriceForSystemAction(t *testing.T) {
 	height := bc.TipHeight()
 	fmt.Printf("Open blockchain pass, height = %d\n", height)
 
-	gs := NewGasStation(bc, blkMemDao, cfg.API.GasStation)
+	gs := NewGasStation(bc, blkMemDao, cfg.GasStation)
 	require.NotNil(t, gs)
 
 	gp, err := gs.SuggestGasPrice()


### PR DESCRIPTION
# Description

In order to refactor config.API, the main modifications are:
- move config.GasStation to gasstation package
- move config.API to api package
- refactor unit test of api and gasstation package to remove dependencies on config package

Fixes #3722

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test

**Test Configuration**:
- Firmware version: macOS Monterey 12.5.1
- Hardware: Apple M1 Pro
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
