### PR TITLE
update docker build command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,11 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-
+ARG PACKAGE_VERSION
+ARG PACKAGE_COMMIT_ID
+ARG GIT_STATUS
 RUN mkdir -p $GOPATH/pkg/linux_amd64/github.com/iotexproject/ && \
-    make clean build-all
+    PACKAGE_VERSION=$PACKAGE_VERSION PACKAGE_COMMIT_ID=$PACKAGE_COMMIT_ID GIT_STATUS=$GIT_STATUS make clean build-all
 
 FROM alpine
 

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,19 @@ ROOT_PKG := "github.com/iotexproject/iotex-core"
 DOCKERCMD=docker
 
 # Package Info
+ifndef PACKAGE_VERSION
 PACKAGE_VERSION := $(shell git describe --tags)
+endif
+ifndef PACKAGE_COMMIT_ID
 PACKAGE_COMMIT_ID := $(shell git rev-parse HEAD)
+endif
+ifndef GIT_STATUS
 GIT_STATUS := $(shell git status --porcelain)
 ifdef GIT_STATUS
-	GIT_STATUS := "dirty"
+    GIT_STATUS := "dirty"
 else
-	GIT_STATUS := "clean"
+    GIT_STATUS := "clean"
+endif
 endif
 GO_VERSION := $(shell go version)
 BUILD_TIME=$(shell date +%F-%Z/%T)

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker build  --build-arg PACKAGE_COMMIT_ID=$SOURCE_COMMIT --build-arg PACKAGE_VERSION=$DOCKER_TAG --build-arg GIT_STATUS=clean -f $DOCKERFILE_PATH -t $IMAGE_NAME .


### PR DESCRIPTION
# Description
A long term solution to solve getting version info failed when building docker image on DockerHub:
- `PACKAGE_VERSION`, `PACKAGE_COMMIT_ID`, `GIT_STATUS` are supported by env variable in Makefile
- add `PACKAGE_VERSION`, `PACKAGE_COMMIT_ID`, `GIT_STATUS` three args in Dockerfile
- add hooks to replace default docker build command  on DockerHub

Fixes #3746

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] trigger docker build on DockerHub 

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
