### PR TITLE
[ioctl] build contract test function command line into new ioctl

### DIFF
--- a/ioctl/newcmd/contract/contract.go
+++ b/ioctl/newcmd/contract/contract.go
@@ -7,7 +7,6 @@ package contract
 
 import (
 	"encoding/hex"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -18,7 +17,6 @@ import (
 
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
-	"github.com/iotexproject/iotex-core/ioctl/output"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 )
 
@@ -54,6 +52,7 @@ func NewContractCmd(client ioctl.Client) *cobra.Command {
 	cmd.AddCommand(NewContractCompileCmd(client))
 	client.SetEndpointWithFlag(cmd.PersistentFlags().StringVar)
 	client.SetInsecureWithFlag(cmd.PersistentFlags().BoolVar)
+
 	return cmd
 }
 
@@ -124,19 +123,19 @@ func packArguments(targetAbi *abi.ABI, targetMethod string, rowInput string) ([]
 
 		rowArg, ok := rowArguments[param.Name]
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("failed to parse argument \"%s\"", param.Name))
+			return nil, errors.Errorf("failed to parse argument \"%s\"", param.Name)
 		}
 
 		arg, err := parseInputArgument(&param.Type, rowArg)
 		if err != nil {
-			return nil, output.NewError(output.InputError, fmt.Sprintf("failed to parse argument \"%s\"", param.Name), err)
+			return nil, errors.Wrapf(err, "failed to parse argument \"%s\"", param.Name)
 		}
 		arguments = append(arguments, arg)
 	}
 	return targetAbi.Pack(targetMethod, arguments...)
 }
 
-func translate(client ioctl.Client, trls map[config.Language]string) string {
+func selectTranslate(client ioctl.Client, trls map[config.Language]string) string {
 	trans, _ := client.SelectTranslation(trls)
 	return trans
 }

--- a/ioctl/newcmd/contract/contract.go
+++ b/ioctl/newcmd/contract/contract.go
@@ -134,8 +134,3 @@ func packArguments(targetAbi *abi.ABI, targetMethod string, rowInput string) ([]
 	}
 	return targetAbi.Pack(targetMethod, arguments...)
 }
-
-func selectTranslate(client ioctl.Client, trls map[config.Language]string) string {
-	trans, _ := client.SelectTranslation(trls)
-	return trans
-}

--- a/ioctl/newcmd/contract/contract_test.go
+++ b/ioctl/newcmd/contract/contract_test.go
@@ -35,21 +35,21 @@ func TestNewContractCmd(t *testing.T) {
 }
 
 func TestReadAbiFile(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 	testAbiFile := "test.abi"
 	abi, err := readAbiFile(testAbiFile)
-	r.NoError(err)
-	r.Equal("", abi.Constructor.Name)
-	r.Equal(10, len(abi.Methods))
-	r.Equal("recipients", abi.Methods["multiSend"].Inputs[0].Name)
+	require.NoError(err)
+	require.Equal("", abi.Constructor.Name)
+	require.Len(abi.Methods, 10)
+	require.Equal("recipients", abi.Methods["multiSend"].Inputs[0].Name)
 }
 
 func TestParseInput(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 
 	testAbiFile := "test.abi"
 	testAbi, err := readAbiFile(testAbiFile)
-	r.NoError(err)
+	require.NoError(err)
 
 	tests := []struct {
 		expectCode string
@@ -82,21 +82,21 @@ func TestParseInput(t *testing.T) {
 
 	for _, test := range tests {
 		expect, err := decodeBytecode(test.expectCode)
-		r.NoError(err)
+		require.NoError(err)
 
 		bytecode, err := packArguments(testAbi, test.method, test.inputs)
-		r.NoError(err)
+		require.NoError(err)
 
-		r.True(bytes.Equal(expect, bytecode))
+		require.True(bytes.Equal(expect, bytecode))
 	}
 }
 
 func TestParseOutput(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 
 	testAbiFile := "test.abi"
 	testAbi, err := readAbiFile(testAbiFile)
-	r.NoError(err)
+	require.NoError(err)
 
 	tests := []struct {
 		expectResult string
@@ -127,7 +127,7 @@ func TestParseOutput(t *testing.T) {
 
 	for _, test := range tests {
 		v, err := parseOutput(testAbi, test.method, test.outputs)
-		r.NoError(err)
-		r.Equal(test.expectResult, fmt.Sprint(v))
+		require.NoError(err)
+		require.Equal(test.expectResult, fmt.Sprint(v))
 	}
 }

--- a/ioctl/newcmd/contract/contracttestfunction.go
+++ b/ioctl/newcmd/contract/contracttestfunction.go
@@ -9,13 +9,14 @@ import (
 	"math/big"
 
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
 	"github.com/iotexproject/iotex-core/ioctl"
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/flag"
 	"github.com/iotexproject/iotex-core/ioctl/newcmd/action"
 	"github.com/iotexproject/iotex-core/ioctl/util"
-	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
 )
 
 // Multi-language support
@@ -33,9 +34,12 @@ var (
 
 // NewContractTestFunctionCmd represents the contract test function cmd
 func NewContractTestFunctionCmd(client ioctl.Client) *cobra.Command {
+	use, _ := client.SelectTranslation(_testFunctionCmdUses)
+	short, _ := client.SelectTranslation(_testFunctionCmdShorts)
+
 	cmd := &cobra.Command{
-		Use:   selectTranslate(client, _testFunctionCmdUses),
-		Short: selectTranslate(client, _testFunctionCmdShorts),
+		Use:   use,
+		Short: short,
 		Args:  cobra.RangeArgs(3, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cmd.SilenceUsage = true
@@ -90,6 +94,7 @@ func contractTestFunction(client ioctl.Client, cmd *cobra.Command, args []string
 
 	result, err := parseOutput(abi, methodName, rowResult)
 	if err != nil {
+		cmd.PrintErrln("parseOutput failed", err)
 		result = rowResult
 	}
 

--- a/ioctl/newcmd/contract/contracttestfunction.go
+++ b/ioctl/newcmd/contract/contracttestfunction.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/flag"
+	"github.com/iotexproject/iotex-core/ioctl/newcmd/action"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// Multi-language support
+var (
+	_testFunctionCmdUses = map[config.Language]string{
+		config.English: "function (CONTRACT_ADDRESS|ALIAS) ABI_PATH FUNCTION_NAME [AMOUNT_IOTX] " +
+			"[--with-arguments INVOKE_INPUT]",
+		config.Chinese: "function (合约地址|别名) ABI文件路径 函数名 [IOTX数量] [--with-arguments 调用输入]",
+	}
+	_testFunctionCmdShorts = map[config.Language]string{
+		config.English: "test smart contract on IoTeX blockchain with function name",
+		config.Chinese: "调用函数测试IoTeX区块链上的智能合约",
+	}
+	_failToGetAddress = map[config.Language]string{
+		config.English: "failed to get contract address",
+		config.Chinese: "获取合约地址失败",
+	}
+	_failToConvertStringIntoAddress = map[config.Language]string{
+		config.English: "failed to convert string into address",
+		config.Chinese: "转换字符串到地址失败",
+	}
+	_failToReadABIFile = map[config.Language]string{
+		config.English: "failed to read abi file",
+		config.Chinese: "读取 ABI 文件失败",
+	}
+	_InvalidAmount = map[config.Language]string{
+		config.English: "invalid amount",
+		config.Chinese: "无效的数字",
+	}
+)
+
+// NewContractTestFunctionCmd represents the contract test function cmd
+func NewContractTestFunctionCmd(client ioctl.Client) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   translate(client, _testFunctionCmdUses),
+		Short: translate(client, _testFunctionCmdShorts),
+		Args:  cobra.RangeArgs(3, 4),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmd.SilenceUsage = true
+			return contractTestFunction(client, cmd, args)
+		},
+	}
+	return cmd
+}
+
+func contractTestFunction(client ioctl.Client, cmd *cobra.Command, args []string) error {
+	addr, err := client.Address(args[0])
+	if err != nil {
+		return errors.WithMessage(err, translate(client, _failToGetAddress))
+	}
+
+	contract, err := address.FromString(addr)
+	if err != nil {
+		return errors.WithMessage(err, translate(client, _failToConvertStringIntoAddress))
+	}
+
+	abi, err := readAbiFile(args[1])
+	if err != nil {
+		return errors.WithMessage(err, translate(client, _failToReadABIFile)+" "+args[1])
+	}
+
+	methodName := args[2]
+
+	amount := big.NewInt(0)
+	if len(args) == 4 {
+		amount, err = util.StringToRau(args[3], util.IotxDecimalNum)
+		if err != nil {
+			return errors.WithMessage(err, translate(client, _InvalidAmount))
+		}
+	}
+
+	bytecode, err := packArguments(abi, methodName, flag.WithArgumentsFlag.Value().(string))
+	if err != nil {
+		return errors.WithMessage(err, "failed to pack given arguments")
+	}
+
+	_, signer, _, _, gasLimit, _, err := action.GetWriteCommandFlag(cmd)
+	if err != nil {
+		return errors.WithMessage(err, "failed to get command flag")
+	}
+
+	rowResult, err := action.Read(client, contract, amount.String(), bytecode, signer, gasLimit)
+	if err != nil {
+		return err
+	}
+
+	result, err := parseOutput(abi, methodName, rowResult)
+	if err != nil {
+		result = rowResult
+	}
+
+	fmt.Println("return: " + result)
+	return nil
+}

--- a/ioctl/newcmd/contract/contracttestfunction.go
+++ b/ioctl/newcmd/contract/contracttestfunction.go
@@ -94,7 +94,6 @@ func contractTestFunction(client ioctl.Client, cmd *cobra.Command, args []string
 
 	result, err := parseOutput(abi, methodName, rowResult)
 	if err != nil {
-		cmd.PrintErrln("parseOutput failed", err)
 		result = rowResult
 	}
 

--- a/ioctl/newcmd/contract/contracttestfunction_test.go
+++ b/ioctl/newcmd/contract/contracttestfunction_test.go
@@ -10,62 +10,113 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/iotex-core/ioctl/config"
 	"github.com/iotexproject/iotex-core/ioctl/util"
 	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi"
-	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNewContractTestFunctionCmd(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
-	client := mock_ioctlclient.NewMockClient(ctrl)
-	apiClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
-
-	client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).AnyTimes()
-	client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
-		_, err := address.FromString(addr)
-		return addr, err
-	}).AnyTimes()
-	client.EXPECT().APIServiceClient().Return(apiClient, nil).AnyTimes()
-	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", nil).AnyTimes()
-	apiClient.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iotexapi.ReadContractResponse{}, nil).AnyTimes()
 
 	t.Run("test_pass", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		apiClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
+		client.EXPECT().APIServiceClient().Return(apiClient, nil).Times(1)
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", nil).Times(1)
+		apiClient.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iotexapi.ReadContractResponse{}, nil).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		result, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "3.4")
 		require.NoError(err)
 		require.Contains(result, "return")
 	})
 
+	t.Run("test_output", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		apiClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
+		client.EXPECT().APIServiceClient().Return(apiClient, nil).Times(1)
+		client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", nil).Times(1)
+		apiClient.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iotexapi.ReadContractResponse{
+			Data:    "0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b48656c6c6f20576f726c64000000000000000000000000000000000000000000",
+			Receipt: &iotextypes.Receipt{},
+		}, nil).Times(1)
+		cmd := NewContractTestFunctionCmd(client)
+		result, err := util.ExecuteCmd(cmd, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "getMessage")
+		require.NoError(err)
+		require.Contains(result, "Hello World")
+	})
+
 	t.Run("invalid_address", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "123", "test.abi", "multiSend")
 		require.Contains(err.Error(), "invalid address")
 	})
 
 	t.Run("abifile_not_exist", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "not_exist.abi", "multiSend")
 		require.Contains(err.Error(), "no such file")
 	})
 
 	t.Run("invalid_method", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend1")
 		require.Contains(err.Error(), "invalid method name")
 	})
 
 	t.Run("invalid_amount", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "amount")
 		require.Contains(err.Error(), "invalid amount")
 	})
 
 	t.Run("invalid_argument", func(t *testing.T) {
+		client := mock_ioctlclient.NewMockClient(ctrl)
+		client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).MinTimes(2)
+		client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+			_, err := address.FromString(addr)
+			return addr, err
+		}).Times(1)
 		cmd := NewContractTestFunctionCmd(client)
 		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":"asd"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "3.4")
 		require.Contains(err.Error(), "invalid argument")

--- a/ioctl/newcmd/contract/contracttestfunction_test.go
+++ b/ioctl/newcmd/contract/contracttestfunction_test.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"testing"
+
+	"github.com/iotexproject/iotex-core/ioctl"
+	"github.com/spf13/cobra"
+)
+
+func Test_contractTestFunction(t *testing.T) {
+	type args struct {
+		client ioctl.Client
+		cmd    *cobra.Command
+		args   []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := contractTestFunction(tt.args.client, tt.args.cmd, tt.args.args); (err != nil) != tt.wantErr {
+				t.Errorf("contractTestFunction() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/ioctl/newcmd/contract/contracttestfunction_test.go
+++ b/ioctl/newcmd/contract/contracttestfunction_test.go
@@ -8,28 +8,66 @@ package contract
 import (
 	"testing"
 
-	"github.com/iotexproject/iotex-core/ioctl"
-	"github.com/spf13/cobra"
+	"github.com/golang/mock/gomock"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+	"github.com/iotexproject/iotex-core/test/mock/mock_ioctlclient"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi/mock_iotexapi"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_contractTestFunction(t *testing.T) {
-	type args struct {
-		client ioctl.Client
-		cmd    *cobra.Command
-		args   []string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := contractTestFunction(tt.args.client, tt.args.cmd, tt.args.args); (err != nil) != tt.wantErr {
-				t.Errorf("contractTestFunction() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
+func TestNewContractTestFunctionCmd(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	client := mock_ioctlclient.NewMockClient(ctrl)
+	apiClient := mock_iotexapi.NewMockAPIServiceClient(ctrl)
+
+	client.EXPECT().SelectTranslation(gomock.Any()).Return("test", config.English).AnyTimes()
+	client.EXPECT().Address(gomock.Any()).DoAndReturn(func(addr string) (string, error) {
+		_, err := address.FromString(addr)
+		return addr, err
+	}).AnyTimes()
+	client.EXPECT().APIServiceClient().Return(apiClient, nil).AnyTimes()
+	client.EXPECT().AddressWithDefaultIfNotExist(gomock.Any()).Return("", nil).AnyTimes()
+	apiClient.EXPECT().ReadContract(gomock.Any(), gomock.Any(), gomock.Any()).Return(&iotexapi.ReadContractResponse{}, nil).AnyTimes()
+
+	t.Run("test_pass", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		result, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "3.4")
+		require.NoError(err)
+		require.Contains(result, "return")
+	})
+
+	t.Run("invalid_address", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "123", "test.abi", "multiSend")
+		require.Contains(err.Error(), "invalid address")
+	})
+
+	t.Run("abifile_not_exist", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "not_exist.abi", "multiSend")
+		require.Contains(err.Error(), "no such file")
+	})
+
+	t.Run("invalid_method", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend1")
+		require.Contains(err.Error(), "invalid method name")
+	})
+
+	t.Run("invalid_amount", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":["io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr","io14fmlh7zedcx7tn3k9k744v54nxnv8zky86tjhj"],"amounts":["3123132","123"],"payload":"PLEASE!!!"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "amount")
+		require.Contains(err.Error(), "invalid amount")
+	})
+
+	t.Run("invalid_argument", func(t *testing.T) {
+		cmd := NewContractTestFunctionCmd(client)
+		_, err := util.ExecuteCmd(cmd, "--with-arguments", `{"recipients":"asd"}`, "io1h8zxmdacge966wp6t90a02ncghaa6eptnftfqr", "test.abi", "multiSend", "3.4")
+		require.Contains(err.Error(), "invalid argument")
+	})
 }

--- a/ioctl/newcmd/contract/parse.go
+++ b/ioctl/newcmd/contract/parse.go
@@ -17,8 +17,9 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-core/pkg/util/addrutil"
 	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/pkg/util/addrutil"
 )
 
 // ErrInvalidArg indicates argument is invalid
@@ -73,9 +74,6 @@ func parseOutput(targetAbi *abi.ABI, targetMethod string, result string) (string
 // parseInputArgument parses input's argument as golang variable
 func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 	switch t.T {
-	default:
-		return nil, ErrInvalidArg
-
 	case abi.BoolTy:
 		if reflect.TypeOf(arg).Kind() != reflect.Bool {
 			return nil, ErrInvalidArg
@@ -152,15 +150,6 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 
 		var value int64
 		switch t.Size {
-		default:
-			if k == reflect.String {
-				arg, ok = new(big.Int).SetString(arg.(string), 10)
-				if !ok {
-					return nil, ErrInvalidArg
-				}
-			} else {
-				arg = big.NewInt(int64(arg.(float64)))
-			}
 		case 8:
 			if k == reflect.String {
 				value, err = strconv.ParseInt(arg.(string), 10, 8)
@@ -188,6 +177,15 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 			} else {
 				arg = int64(arg.(float64))
 			}
+		default:
+			if k == reflect.String {
+				arg, ok = new(big.Int).SetString(arg.(string), 10)
+				if !ok {
+					return nil, ErrInvalidArg
+				}
+			} else {
+				arg = big.NewInt(int64(arg.(float64)))
+			}
 		}
 
 		if err != nil {
@@ -206,19 +204,6 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 
 		var value uint64
 		switch t.Size {
-		default:
-			if k == reflect.String {
-				arg, ok = new(big.Int).SetString(arg.(string), 10)
-				if !ok {
-					return nil, ErrInvalidArg
-				}
-			} else {
-				arg = big.NewInt(int64(arg.(float64)))
-			}
-
-			if arg.(*big.Int).Cmp(big.NewInt(0)) < 0 {
-				return nil, ErrInvalidArg
-			}
 		case 8:
 			if k == reflect.String {
 				value, err = strconv.ParseUint(arg.(string), 10, 8)
@@ -245,6 +230,19 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 				arg, err = strconv.ParseUint(arg.(string), 10, 64)
 			} else {
 				arg = uint64(arg.(float64))
+			}
+		default:
+			if k == reflect.String {
+				arg, ok = new(big.Int).SetString(arg.(string), 10)
+				if !ok {
+					return nil, ErrInvalidArg
+				}
+			} else {
+				arg = big.NewInt(int64(arg.(float64)))
+			}
+
+			if arg.(*big.Int).Cmp(big.NewInt(0)) < 0 {
+				return nil, ErrInvalidArg
 			}
 		}
 
@@ -293,6 +291,8 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 
 		arg = bytes.Interface()
 
+	default:
+		return nil, ErrInvalidArg
 	}
 	return arg, nil
 }

--- a/ioctl/newcmd/contract/parse.go
+++ b/ioctl/newcmd/contract/parse.go
@@ -23,7 +23,7 @@ import (
 
 // ErrInvalidArg indicates argument is invalid
 var (
-	ErrInvalidArg = errors.New("invalid argument")
+	ErrInvalidArg = fmt.Errorf("invalid argument")
 )
 
 func parseAbi(abiBytes []byte) (*abi.ABI, error) {

--- a/ioctl/newcmd/contract/parse.go
+++ b/ioctl/newcmd/contract/parse.go
@@ -1,0 +1,384 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/pkg/util/addrutil"
+	"github.com/pkg/errors"
+)
+
+// ErrInvalidArg indicates argument is invalid
+var (
+	ErrInvalidArg = errors.New("invalid argument")
+)
+
+func parseAbi(abiBytes []byte) (*abi.ABI, error) {
+	parsedAbi, err := abi.JSON(strings.NewReader(string(abiBytes)))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal abi")
+	}
+	return &parsedAbi, nil
+}
+
+func parseInput(rowInput string) (map[string]interface{}, error) {
+	var input map[string]interface{}
+	if err := json.Unmarshal([]byte(rowInput), &input); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal arguments")
+	}
+	return input, nil
+}
+
+func parseOutput(targetAbi *abi.ABI, targetMethod string, result string) (string, error) {
+	resultBytes, err := hex.DecodeString(result)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode result")
+	}
+
+	var (
+		outputArgs = targetAbi.Methods[targetMethod].Outputs
+		tupleStr   = make([]string, 0, len(outputArgs))
+	)
+
+	v, err := targetAbi.Unpack(targetMethod, resultBytes)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse output")
+	}
+
+	if len(outputArgs) == 1 {
+		elemStr, _ := parseOutputArgument(v[0], &outputArgs[0].Type)
+		return elemStr, nil
+	}
+
+	for i, field := range v {
+		elemStr, _ := parseOutputArgument(field, &outputArgs[i].Type)
+		tupleStr = append(tupleStr, outputArgs[i].Name+":"+elemStr)
+	}
+	return "{" + strings.Join(tupleStr, " ") + "}", nil
+}
+
+// parseInputArgument parses input's argument as golang variable
+func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
+	switch t.T {
+	default:
+		return nil, ErrInvalidArg
+
+	case abi.BoolTy:
+		if reflect.TypeOf(arg).Kind() != reflect.Bool {
+			return nil, ErrInvalidArg
+		}
+
+	case abi.StringTy:
+		if reflect.TypeOf(arg).Kind() != reflect.String {
+			return nil, ErrInvalidArg
+		}
+
+	case abi.SliceTy:
+		if reflect.TypeOf(arg).Kind() != reflect.Slice {
+			return nil, ErrInvalidArg
+		}
+
+		slice := reflect.MakeSlice(t.GetType(), 0, t.Size)
+
+		s := reflect.ValueOf(arg)
+		for i := 0; i < s.Len(); i++ {
+			ele, err := parseInputArgument(t.Elem, s.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			slice = reflect.Append(slice, reflect.ValueOf(ele))
+		}
+
+		arg = slice.Interface()
+
+	case abi.ArrayTy:
+		if reflect.TypeOf(arg).Kind() != reflect.Slice {
+			return nil, ErrInvalidArg
+		}
+
+		arrayType := reflect.ArrayOf(t.Size, t.Elem.GetType())
+		array := reflect.New(arrayType).Elem()
+
+		s := reflect.ValueOf(arg)
+		for i := 0; i < s.Len(); i++ {
+			ele, err := parseInputArgument(t.Elem, s.Index(i).Interface())
+			if err != nil {
+				return nil, err
+			}
+			array.Index(i).Set(reflect.ValueOf(ele))
+		}
+
+		arg = array.Interface()
+
+	// support both of Ether address & IoTeX address input
+	case abi.AddressTy:
+		var err error
+		addrString, ok := arg.(string)
+		if !ok {
+			return nil, ErrInvalidArg
+		}
+
+		if common.IsHexAddress(addrString) {
+			arg = common.HexToAddress(addrString)
+		} else {
+			arg, err = addrutil.IoAddrToEvmAddr(addrString)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+	// support both number & string input
+	case abi.IntTy:
+		var ok bool
+		var err error
+
+		k := reflect.TypeOf(arg).Kind()
+		if k != reflect.String && k != reflect.Float64 {
+			return nil, ErrInvalidArg
+		}
+
+		var value int64
+		switch t.Size {
+		default:
+			if k == reflect.String {
+				arg, ok = new(big.Int).SetString(arg.(string), 10)
+				if !ok {
+					return nil, ErrInvalidArg
+				}
+			} else {
+				arg = big.NewInt(int64(arg.(float64)))
+			}
+		case 8:
+			if k == reflect.String {
+				value, err = strconv.ParseInt(arg.(string), 10, 8)
+				arg = int8(value)
+			} else {
+				arg = int8(arg.(float64))
+			}
+		case 16:
+			if k == reflect.String {
+				value, err = strconv.ParseInt(arg.(string), 10, 16)
+				arg = int16(value)
+			} else {
+				arg = int16(arg.(float64))
+			}
+		case 32:
+			if k == reflect.String {
+				value, err = strconv.ParseInt(arg.(string), 10, 32)
+				arg = int32(value)
+			} else {
+				arg = int32(arg.(float64))
+			}
+		case 64:
+			if k == reflect.String {
+				arg, err = strconv.ParseInt(arg.(string), 10, 64)
+			} else {
+				arg = int64(arg.(float64))
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+	// support both number & string input
+	case abi.UintTy:
+		var ok bool
+		var err error
+
+		k := reflect.TypeOf(arg).Kind()
+		if k != reflect.String && k != reflect.Float64 {
+			return nil, ErrInvalidArg
+		}
+
+		var value uint64
+		switch t.Size {
+		default:
+			if k == reflect.String {
+				arg, ok = new(big.Int).SetString(arg.(string), 10)
+				if !ok {
+					return nil, ErrInvalidArg
+				}
+			} else {
+				arg = big.NewInt(int64(arg.(float64)))
+			}
+
+			if arg.(*big.Int).Cmp(big.NewInt(0)) < 0 {
+				return nil, ErrInvalidArg
+			}
+		case 8:
+			if k == reflect.String {
+				value, err = strconv.ParseUint(arg.(string), 10, 8)
+				arg = uint8(value)
+			} else {
+				arg = uint8(arg.(float64))
+			}
+		case 16:
+			if k == reflect.String {
+				value, err = strconv.ParseUint(arg.(string), 10, 16)
+				arg = uint16(value)
+			} else {
+				arg = uint16(arg.(float64))
+			}
+		case 32:
+			if k == reflect.String {
+				value, err = strconv.ParseUint(arg.(string), 10, 32)
+				arg = uint32(value)
+			} else {
+				arg = uint32(arg.(float64))
+			}
+		case 64:
+			if k == reflect.String {
+				arg, err = strconv.ParseUint(arg.(string), 10, 64)
+			} else {
+				arg = uint64(arg.(float64))
+			}
+		}
+
+		if err != nil {
+			return nil, err
+		}
+
+	case abi.BytesTy:
+		if reflect.TypeOf(arg).Kind() != reflect.String {
+			return nil, ErrInvalidArg
+		}
+
+		bytecode, err := decodeBytecode(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		bytes := reflect.MakeSlice(t.GetType(), 0, len(bytecode))
+
+		for _, oneByte := range bytecode {
+			bytes = reflect.Append(bytes, reflect.ValueOf(oneByte))
+		}
+
+		arg = bytes.Interface()
+
+	case abi.FixedBytesTy, abi.FunctionTy:
+		if reflect.TypeOf(arg).Kind() != reflect.String {
+			return nil, ErrInvalidArg
+		}
+
+		bytecode, err := decodeBytecode(arg.(string))
+		if err != nil {
+			return nil, err
+		}
+
+		if t.Size != len(bytecode) {
+			return nil, ErrInvalidArg
+		}
+
+		bytesType := reflect.ArrayOf(t.Size, reflect.TypeOf(uint8(0)))
+		bytes := reflect.New(bytesType).Elem()
+
+		for i, oneByte := range bytecode {
+			bytes.Index(i).Set(reflect.ValueOf(oneByte))
+		}
+
+		arg = bytes.Interface()
+
+	}
+	return arg, nil
+}
+
+// parseOutputArgument parses output's argument as human-readable string
+func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
+	str := fmt.Sprint(v)
+	ok := false
+
+	switch t.T {
+	case abi.StringTy, abi.BoolTy:
+		// case abi.StringTy & abi.BoolTy can be handled by fmt.Sprint()
+		ok = true
+
+	case abi.TupleTy:
+		if reflect.TypeOf(v).Kind() == reflect.Struct {
+			ok = true
+
+			tupleStr := make([]string, 0, len(t.TupleElems))
+			for i, elem := range t.TupleElems {
+				elemStr, elemOk := parseOutputArgument(reflect.ValueOf(v).Field(i).Interface(), elem)
+				tupleStr = append(tupleStr, t.TupleRawNames[i]+":"+elemStr)
+				ok = ok && elemOk
+			}
+
+			str = "{" + strings.Join(tupleStr, " ") + "}"
+		}
+
+	case abi.SliceTy, abi.ArrayTy:
+		if reflect.TypeOf(v).Kind() == reflect.Slice || reflect.TypeOf(v).Kind() == reflect.Array {
+			ok = true
+
+			value := reflect.ValueOf(v)
+			sliceStr := make([]string, 0, value.Len())
+			for i := 0; i < value.Len(); i++ {
+				elemStr, elemOk := parseOutputArgument(value.Index(i).Interface(), t.Elem)
+				sliceStr = append(sliceStr, elemStr)
+				ok = ok && elemOk
+			}
+
+			str = "[" + strings.Join(sliceStr, " ") + "]"
+		}
+
+	case abi.IntTy, abi.UintTy:
+		if reflect.TypeOf(v) == reflect.TypeOf(big.NewInt(0)) {
+			var bigInt *big.Int
+			bigInt, ok = v.(*big.Int)
+			if ok {
+				str = bigInt.String()
+			}
+		} else if 2 <= reflect.TypeOf(v).Kind() && reflect.TypeOf(v).Kind() <= 11 {
+			// other integer types (int8,uint16,...) can be handled by fmt.Sprint(v)
+			ok = true
+		}
+
+	case abi.AddressTy:
+		if reflect.TypeOf(v) == reflect.TypeOf(common.Address{}) {
+			var ethAddr common.Address
+			ethAddr, ok = v.(common.Address)
+			if ok {
+				ioAddress, err := address.FromBytes(ethAddr.Bytes())
+				if err == nil {
+					str = ioAddress.String()
+				}
+			}
+		}
+
+	case abi.BytesTy:
+		if reflect.TypeOf(v) == reflect.TypeOf([]byte{}) {
+			var bytes []byte
+			bytes, ok = v.([]byte)
+			if ok {
+				str = "0x" + hex.EncodeToString(bytes)
+			}
+		}
+
+	case abi.FixedBytesTy, abi.FunctionTy:
+		if reflect.TypeOf(v).Kind() == reflect.Array && reflect.TypeOf(v).Elem() == reflect.TypeOf(byte(0)) {
+			bytesValue := reflect.ValueOf(v)
+			byteSlice := reflect.MakeSlice(reflect.TypeOf([]byte{}), bytesValue.Len(), bytesValue.Len())
+			reflect.Copy(byteSlice, bytesValue)
+
+			str = "0x" + hex.EncodeToString(byteSlice.Bytes())
+			ok = true
+		}
+	}
+
+	return str, ok
+}

--- a/ioctl/newcmd/contract/parse_test.go
+++ b/ioctl/newcmd/contract/parse_test.go
@@ -130,21 +130,21 @@ func Test_parseAbi(t *testing.T) {
 	abi, err := parseAbi(abiBytes)
 	r.NoError(err)
 
-	r.True(len(abi.Methods) == 1)
+	r.Len(abi.Methods, 1)
 	method, ok := abi.Methods["multiSend"]
 	r.True(ok)
-	r.True(!method.IsConstant())
+	r.False(method.IsConstant())
 	r.True(method.IsPayable())
-	r.True(method.StateMutability == "payable")
-	r.True(len(method.Inputs) == 3)
-	r.True(method.Inputs[0].Name == "recipients")
-	r.True(method.Inputs[1].Name == "amounts")
-	r.True(method.Inputs[2].Name == "payload")
-	r.True(len(method.Outputs) == 0)
-
+	r.Equal(method.StateMutability, "payable")
+	r.Len(method.Inputs, 3)
+	r.Equal(method.Inputs[0].Name, "recipients")
+	r.Equal(method.Inputs[1].Name, "amounts")
+	r.Equal(method.Inputs[2].Name, "payload")
+	r.Len(method.Outputs, 0)
 }
 
 func Test_parseInput(t *testing.T) {
+	require := require.New(t)
 
 	tests := []struct {
 		rowInput string
@@ -176,19 +176,19 @@ func Test_parseInput(t *testing.T) {
 	for _, tt := range tests {
 		got, err := parseInput(tt.rowInput)
 		if (err != nil) != tt.wantErr {
-			t.Fatalf("parseInput() error = %v, wantErr %v", err, tt.wantErr)
+			require.FailNow("parseInput() error = %v, wantErr %v", err, tt.wantErr)
 		}
 		if !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("parseInput() = %#v, want %#v", got, tt.want)
+			require.FailNow("parseInput() = %#v, want %#v", got, tt.want)
 		}
 	}
 }
 
 func Test_parseInputArgument(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 
 	abiType, err := abi.NewType("string[]", "", nil)
-	r.NoError(err)
+	require.NoError(err)
 
 	tests := []struct {
 		t       *abi.Type
@@ -206,10 +206,10 @@ func Test_parseInputArgument(t *testing.T) {
 	for _, tt := range tests {
 		got, err := parseInputArgument(tt.t, tt.arg)
 		if (err != nil) != tt.wantErr {
-			t.Fatalf("parseInputArgument() error = %v, wantErr %v", err, tt.wantErr)
+			require.FailNow("parseInputArgument() error = %v, wantErr %v", err, tt.wantErr)
 		}
 		if !reflect.DeepEqual(got, tt.want) {
-			t.Fatalf("parseInputArgument() = %#v, want %#v", got, tt.want)
+			require.FailNow("parseInputArgument() = %#v, want %#v", got, tt.want)
 		}
 	}
 }

--- a/ioctl/newcmd/contract/parse_test.go
+++ b/ioctl/newcmd/contract/parse_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func Test_parseOutputArgument(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 
 	bigInt, _ := new(big.Int).SetString("2346783498523230921101011", 10)
 	var bytes31 [31]byte
@@ -92,15 +92,15 @@ func Test_parseOutputArgument(t *testing.T) {
 
 	for _, test := range tests {
 		t, err := abi.NewType(test.t, "", test.components)
-		r.NoError(err)
+		require.NoError(err)
 		result, ok := parseOutputArgument(test.v, &t)
-		r.True(ok)
-		r.Equal(test.expect, result)
+		require.True(ok)
+		require.Equal(test.expect, result)
 	}
 }
 
 func Test_parseAbi(t *testing.T) {
-	r := require.New(t)
+	require := require.New(t)
 
 	abiBytes := []byte(`[
 {
@@ -128,19 +128,19 @@ func Test_parseAbi(t *testing.T) {
 ]`)
 
 	abi, err := parseAbi(abiBytes)
-	r.NoError(err)
+	require.NoError(err)
 
-	r.Len(abi.Methods, 1)
+	require.Len(abi.Methods, 1)
 	method, ok := abi.Methods["multiSend"]
-	r.True(ok)
-	r.False(method.IsConstant())
-	r.True(method.IsPayable())
-	r.Equal(method.StateMutability, "payable")
-	r.Len(method.Inputs, 3)
-	r.Equal(method.Inputs[0].Name, "recipients")
-	r.Equal(method.Inputs[1].Name, "amounts")
-	r.Equal(method.Inputs[2].Name, "payload")
-	r.Len(method.Outputs, 0)
+	require.True(ok)
+	require.False(method.IsConstant())
+	require.True(method.IsPayable())
+	require.Equal("payable", method.StateMutability)
+	require.Len(method.Inputs, 3)
+	require.Equal("recipients", method.Inputs[0].Name)
+	require.Equal("amounts", method.Inputs[1].Name)
+	require.Equal("payload", method.Inputs[2].Name)
+	require.Len(method.Outputs, 0)
 }
 
 func Test_parseInput(t *testing.T) {
@@ -173,7 +173,7 @@ func Test_parseInput(t *testing.T) {
 		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
 			got, err := parseInput(tt.rowInput)
 			require.NoError(err)
-			require.Equal(got, tt.want)
+			require.Equal(tt.want, got)
 		})
 	}
 }
@@ -199,7 +199,7 @@ func Test_parseInputArgument(t *testing.T) {
 		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
 			got, err := parseInputArgument(tt.t, tt.arg)
 			require.NoError(err)
-			require.Equal(got, tt.want)
+			require.Equal(tt.want, got)
 		})
 	}
 }

--- a/ioctl/newcmd/contract/parse_test.go
+++ b/ioctl/newcmd/contract/parse_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package contract
+
+import (
+	"fmt"
+	"math/big"
+	"reflect"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parseOutput(t *testing.T) {
+	r := require.New(t)
+
+	testAbiFile := "test.abi"
+	testAbi, err := readAbiFile(testAbiFile)
+	r.NoError(err)
+
+	tests := []struct {
+		expectResult string
+		method       string
+		outputs      string
+	}{
+		{
+			"0",
+			"minTips",
+			"0000000000000000000000000000000000000000000000000000000000000000",
+		},
+		{
+			"io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng",
+			"owner",
+			"000000000000000000000000c7f43fab2ca353d29ce0da04851ab74f45b09593",
+		},
+		{
+			"Hello World",
+			"getMessage",
+			"0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b48656c6c6f20576f726c64000000000000000000000000000000000000000000",
+		},
+		{
+			"{i:17 abc:[io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7 io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng]}",
+			"testTuple",
+			"00000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c7f43fab2ca353d29ce0da04851ab74f45b09593",
+		},
+	}
+
+	for _, test := range tests {
+		v, err := parseOutput(testAbi, test.method, test.outputs)
+		r.NoError(err)
+		r.Equal(test.expectResult, fmt.Sprint(v))
+	}
+}
+
+func Test_parseOutputArgument(t *testing.T) {
+	r := require.New(t)
+
+	bigInt, _ := new(big.Int).SetString("2346783498523230921101011", 10)
+	var bytes31 [31]byte
+	var bytes24 [24]byte
+	copy(bytes31[:], "test byte31313131313131313131")
+	copy(bytes24[:], "test function (=24-byte)")
+
+	tests := []struct {
+		v          interface{}
+		t          string
+		components []abi.ArgumentMarshaling
+		expect     string
+	}{
+		{
+			int16(-3),
+			"int16",
+			nil,
+			"-3",
+		},
+		{
+			uint64(98237478346),
+			"uint64",
+			nil,
+			"98237478346",
+		},
+		{
+			bigInt,
+			"uint233",
+			nil,
+			"2346783498523230921101011",
+		},
+		{
+			common.HexToAddress("c7F43FaB2ca353d29cE0DA04851aB74f45B09593"),
+			"address",
+			nil,
+			"io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng",
+		},
+		{
+			[]byte("test bytes"),
+			"bytes",
+			nil,
+			"0x74657374206279746573",
+		},
+		{
+			bytes31,
+			"bytes31",
+			nil,
+			"0x74657374206279746533313331333133313331333133313331333133310000",
+		},
+		{
+			[5]string{"IoTeX blockchain", "Raullen", "MenloPark", "2020/06/13", "Frank-is-testing!"},
+			"string[5]",
+			nil,
+			"[IoTeX blockchain Raullen MenloPark 2020/06/13 Frank-is-testing!]",
+		},
+		{
+			[][31]byte{bytes31, bytes31},
+			"bytes31[]",
+			nil,
+			"[0x74657374206279746533313331333133313331333133313331333133310000 0x74657374206279746533313331333133313331333133313331333133310000]",
+		},
+		{
+			struct {
+				A string
+				B [24]byte
+				C []*big.Int
+			}{"tuple test!", bytes24, []*big.Int{big.NewInt(-123), bigInt, big.NewInt(0)}},
+			"tuple",
+			[]abi.ArgumentMarshaling{{Name: "a", Type: "string"}, {Name: "b", Type: "bytes24"}, {Name: "c", Type: "int256[]"}},
+			"{a:tuple test! b:0x746573742066756e6374696f6e20283d32342d6279746529 c:[-123 2346783498523230921101011 0]}",
+		},
+	}
+
+	for _, test := range tests {
+		t, err := abi.NewType(test.t, "", test.components)
+		r.NoError(err)
+		result, ok := parseOutputArgument(test.v, &t)
+		r.True(ok)
+		r.Equal(test.expect, result)
+	}
+}
+
+func Test_parseAbi(t *testing.T) {
+	r := require.New(t)
+
+	abiBytes := []byte(`[
+{
+	"constant": false,
+    "inputs": [
+      {
+        "name": "recipients",
+        "type": "address[]"
+      },
+      {
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "name": "payload",
+        "type": "string"
+      }
+    ],
+    "name": "multiSend",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+}
+]`)
+
+	abi, err := parseAbi(abiBytes)
+	r.NoError(err)
+
+	r.True(len(abi.Methods) == 1)
+	method, ok := abi.Methods["multiSend"]
+	r.True(ok)
+	r.True(!method.IsConstant())
+	r.True(method.IsPayable())
+	r.True(method.StateMutability == "payable")
+	r.True(len(method.Inputs) == 3)
+	r.True(method.Inputs[0].Name == "recipients")
+	r.True(method.Inputs[1].Name == "amounts")
+	r.True(method.Inputs[2].Name == "payload")
+	r.True(len(method.Outputs) == 0)
+
+}
+
+func Test_parseInput(t *testing.T) {
+
+	tests := []struct {
+		rowInput string
+		want     map[string]interface{}
+		wantErr  bool
+	}{
+		{
+			`{"name": "Marry"}`,
+			map[string]interface{}{
+				"name": "Marry",
+			},
+			true,
+		},
+		{
+			`{"age": 12}`,
+			map[string]interface{}{
+				"age": float64(12),
+			},
+			false,
+		},
+		{
+			`{"names": ["marry", "alice"]}`,
+			map[string]interface{}{
+				"names": []interface{}{"marry", "alice"},
+			},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		got, err := parseInput(tt.rowInput)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("parseInput() error = %v, wantErr %v", err, tt.wantErr)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("parseInput() = %#v, want %#v", got, tt.want)
+		}
+	}
+}
+
+func Test_parseInputArgument(t *testing.T) {
+	r := require.New(t)
+
+	abiType, err := abi.NewType("string[]", "", nil)
+	r.NoError(err)
+
+	tests := []struct {
+		t       *abi.Type
+		arg     interface{}
+		want    interface{}
+		wantErr bool
+	}{
+		{
+			&abiType,
+			[]interface{}{"hello world", "happy holidays"},
+			[]string{"hello world", "happy holidays"},
+			false,
+		},
+	}
+	for _, tt := range tests {
+		got, err := parseInputArgument(tt.t, tt.arg)
+		if (err != nil) != tt.wantErr {
+			t.Fatalf("parseInputArgument() error = %v, wantErr %v", err, tt.wantErr)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Fatalf("parseInputArgument() = %#v, want %#v", got, tt.want)
+		}
+	}
+}

--- a/ioctl/newcmd/contract/parse_test.go
+++ b/ioctl/newcmd/contract/parse_test.go
@@ -7,7 +7,7 @@ package contract
 
 import (
 	"math/big"
-	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -149,38 +149,32 @@ func Test_parseInput(t *testing.T) {
 	tests := []struct {
 		rowInput string
 		want     map[string]interface{}
-		wantErr  bool
 	}{
 		{
 			`{"name": "Marry"}`,
 			map[string]interface{}{
 				"name": "Marry",
 			},
-			false,
 		},
 		{
 			`{"age": 12}`,
 			map[string]interface{}{
 				"age": float64(12),
 			},
-			false,
 		},
 		{
 			`{"names": ["marry", "alice"]}`,
 			map[string]interface{}{
 				"names": []interface{}{"marry", "alice"},
 			},
-			false,
 		},
 	}
-	for _, tt := range tests {
-		got, err := parseInput(tt.rowInput)
-		if (err != nil) != tt.wantErr {
-			require.FailNow("parseInput() error = %v, wantErr %v", err, tt.wantErr)
-		}
-		if !reflect.DeepEqual(got, tt.want) {
-			require.FailNow("parseInput() = %#v, want %#v", got, tt.want)
-		}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			got, err := parseInput(tt.rowInput)
+			require.NoError(err)
+			require.Equal(got, tt.want)
+		})
 	}
 }
 
@@ -191,25 +185,21 @@ func Test_parseInputArgument(t *testing.T) {
 	require.NoError(err)
 
 	tests := []struct {
-		t       *abi.Type
-		arg     interface{}
-		want    interface{}
-		wantErr bool
+		t    *abi.Type
+		arg  interface{}
+		want interface{}
 	}{
 		{
 			&abiType,
 			[]interface{}{"hello world", "happy holidays"},
 			[]string{"hello world", "happy holidays"},
-			false,
 		},
 	}
-	for _, tt := range tests {
-		got, err := parseInputArgument(tt.t, tt.arg)
-		if (err != nil) != tt.wantErr {
-			require.FailNow("parseInputArgument() error = %v, wantErr %v", err, tt.wantErr)
-		}
-		if !reflect.DeepEqual(got, tt.want) {
-			require.FailNow("parseInputArgument() = %#v, want %#v", got, tt.want)
-		}
+	for i, tt := range tests {
+		t.Run(strconv.FormatInt(int64(i), 10), func(t *testing.T) {
+			got, err := parseInputArgument(tt.t, tt.arg)
+			require.NoError(err)
+			require.Equal(got, tt.want)
+		})
 	}
 }

--- a/ioctl/newcmd/contract/parse_test.go
+++ b/ioctl/newcmd/contract/parse_test.go
@@ -6,7 +6,6 @@
 package contract
 
 import (
-	"fmt"
 	"math/big"
 	"reflect"
 	"testing"
@@ -15,47 +14,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 )
-
-func Test_parseOutput(t *testing.T) {
-	r := require.New(t)
-
-	testAbiFile := "test.abi"
-	testAbi, err := readAbiFile(testAbiFile)
-	r.NoError(err)
-
-	tests := []struct {
-		expectResult string
-		method       string
-		outputs      string
-	}{
-		{
-			"0",
-			"minTips",
-			"0000000000000000000000000000000000000000000000000000000000000000",
-		},
-		{
-			"io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng",
-			"owner",
-			"000000000000000000000000c7f43fab2ca353d29ce0da04851ab74f45b09593",
-		},
-		{
-			"Hello World",
-			"getMessage",
-			"0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000b48656c6c6f20576f726c64000000000000000000000000000000000000000000",
-		},
-		{
-			"{i:17 abc:[io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqd39ym7 io1cl6rl2ev5dfa988qmgzg2x4hfazmp9vn2g66ng]}",
-			"testTuple",
-			"00000000000000000000000000000000000000000000000000000000000000110000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c7f43fab2ca353d29ce0da04851ab74f45b09593",
-		},
-	}
-
-	for _, test := range tests {
-		v, err := parseOutput(testAbi, test.method, test.outputs)
-		r.NoError(err)
-		r.Equal(test.expectResult, fmt.Sprint(v))
-	}
-}
 
 func Test_parseOutputArgument(t *testing.T) {
 	r := require.New(t)
@@ -198,7 +156,7 @@ func Test_parseInput(t *testing.T) {
 			map[string]interface{}{
 				"name": "Marry",
 			},
-			true,
+			false,
 		},
 		{
 			`{"age": 12}`,

--- a/ioctl/newcmd/contract/test.abi
+++ b/ioctl/newcmd/contract/test.abi
@@ -1,0 +1,169 @@
+[
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "recipients",
+        "type": "address[]"
+      },
+      {
+        "name": "amounts",
+        "type": "uint256[]"
+      },
+      {
+        "name": "payload",
+        "type": "string"
+      }
+    ],
+    "name": "multiSend",
+    "outputs": [],
+    "payable": true,
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "a",
+        "type": "int248[5]"
+      },
+      {
+        "name": "b",
+        "type": "uint8[3]"
+      }
+    ],
+    "name": "testArray",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "t",
+        "type": "bytes"
+      }
+    ],
+    "name": "testBytes",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "t",
+        "type": "bytes3"
+      }
+    ],
+    "name": "testFixedBytes",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "minTips",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "limit",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "a",
+        "type": "bool"
+      },
+      {
+        "name": "s",
+        "type": "string"
+      }
+    ],
+    "name": "testBoolAndString",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getMessage",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "int256",
+        "name": "a",
+        "type": "int256"
+      }
+    ],
+    "name": "testTuple",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "i",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address[2]",
+        "name": "abc",
+        "type": "address[2]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]


### PR DESCRIPTION
# Description
Build contracttestfunction command in new ioctl, with the following note.

- Use [client interface](https://github.com/iotexproject/iotex-core/blob/master/ioctl/client.go) to construct the Cobra command.
- Output package is deprecated, replace it with errors package.
- Replace fmt.Println with cmd.Println
- Refactor unit test to cover the modification.

Fixes #3315 

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] TestNewContractTestFunctionCmd

**Test Configuration**:
- Firmware version: macOS Monterey
- Hardware: Apple M1 Pro
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
