### PR TITLE
[IIP-13] contract indexer ignore blocks lower than height of contract deployment

### DIFF
--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -83,8 +83,9 @@ func defaultConfig() Genesis {
 			ProbationEpochPeriod:             6,
 			ProbationIntensityRate:           90,
 			UnproductiveDelegateMaxCacheSize: 20,
-			// TODO (iip-13): replace the following with the address on mainnet
-			LiquidStakingContractAddress: "io1uw3gvmhrjz5mwxpd966wxxt6fn5uuvwfpynrwj",
+			// TODO (iip-13): replace the following with the address and height on mainnet
+			SystemStakingContractAddress: "io1uw3gvmhrjz5mwxpd966wxxt6fn5uuvwfpynrwj",
+			SystemStakingContractHeight:  20386536,
 		},
 		Rewarding: Rewarding{
 			InitBalanceStr:                 unit.ConvertIotxToRau(200000000).String(),
@@ -283,8 +284,10 @@ type (
 		ProbationIntensityRate uint32 `yaml:"probationIntensityRate"`
 		// UnproductiveDelegateMaxCacheSize is a max cache size of upd which is stored into state DB (probationEpochPeriod <= UnproductiveDelegateMaxCacheSize)
 		UnproductiveDelegateMaxCacheSize uint64 `yaml:unproductiveDelegateMaxCacheSize`
-		// LiquidStakingContractAddress is the address of liquid staking contract
-		LiquidStakingContractAddress string `yaml:"liquidStakingContractAddress"`
+		// SystemStakingContractAddress is the address of system staking contract
+		SystemStakingContractAddress string `yaml:"systemStakingContractAddress"`
+		// SystemStakingContractHeight is the height of system staking contract
+		SystemStakingContractHeight uint64 `yaml:"systemStakingContractHeight"`
 	}
 	// Delegate defines a delegate with address and votes
 	Delegate struct {

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -48,19 +48,20 @@ type (
 	// 		1. handle contract staking contract events when new block comes to generate index data
 	// 		2. provide query interface for contract staking index data
 	Indexer struct {
-		kvstore         db.KVStore            // persistent storage, used to initialize index cache at startup
-		cache           *contractStakingCache // in-memory index for clean data, used to query index data
-		contractAddress string                // stake contract address
-		contractHeight  uint64                // height of the contract deployment
+		kvstore              db.KVStore            // persistent storage, used to initialize index cache at startup
+		cache                *contractStakingCache // in-memory index for clean data, used to query index data
+		contractAddress      string                // stake contract address
+		contractDeployHeight uint64                // height of the contract deployment
 	}
 )
 
 // NewContractStakingIndexer creates a new contract staking indexer
-func NewContractStakingIndexer(kvStore db.KVStore, contractAddr string, contractHeight uint64) *Indexer {
+func NewContractStakingIndexer(kvStore db.KVStore, contractAddr string, contractDeployHeight uint64) *Indexer {
 	return &Indexer{
-		kvstore:         kvStore,
-		cache:           newContractStakingCache(contractAddr),
-		contractAddress: contractAddr,
+		kvstore:              kvStore,
+		cache:                newContractStakingCache(contractAddr),
+		contractAddress:      contractAddr,
+		contractDeployHeight: contractDeployHeight,
 	}
 }
 
@@ -88,7 +89,7 @@ func (s *Indexer) Height() (uint64, error) {
 
 // StartHeight returns the start height of the indexer
 func (s *Indexer) StartHeight() uint64 {
-	return s.contractHeight
+	return s.contractDeployHeight
 }
 
 // CandidateVotes returns the candidate votes
@@ -133,7 +134,7 @@ func (s *Indexer) BucketTypes() ([]*BucketType, error) {
 
 // PutBlock puts a block into indexer
 func (s *Indexer) PutBlock(ctx context.Context, blk *block.Block) error {
-	if blk.Height() < s.contractHeight {
+	if blk.Height() < s.contractDeployHeight {
 		return nil
 	}
 	// new event handler for this block

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -12,11 +12,11 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
-	"github.com/iotexproject/iotex-address/address"
-
+	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
@@ -34,7 +34,7 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress)
+	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0)
 	r.NoError(indexer.Start(context.Background()))
 
 	// create a stake
@@ -51,7 +51,7 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	r.NoError(indexer.Stop(context.Background()))
 
 	// load cache from db
-	newIndexer := NewContractStakingIndexer(db.NewBoltDB(cfg), _testStakingContractAddress)
+	newIndexer := NewContractStakingIndexer(db.NewBoltDB(cfg), _testStakingContractAddress, 0)
 	r.NoError(newIndexer.Start(context.Background()))
 
 	// check cache
@@ -76,7 +76,7 @@ func TestContractStakingIndexerDirty(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress)
+	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0)
 	r.NoError(indexer.Start(context.Background()))
 
 	// before commit dirty, the cache should be empty
@@ -103,7 +103,7 @@ func TestContractStakingIndexerThreadSafe(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress)
+	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0)
 	r.NoError(indexer.Start(context.Background()))
 
 	wait := sync.WaitGroup{}
@@ -156,7 +156,7 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress)
+	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0)
 	r.NoError(indexer.Start(context.Background()))
 
 	// activate
@@ -238,7 +238,7 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress)
+	indexer := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0)
 	r.NoError(indexer.Start(context.Background()))
 
 	// init bucket type
@@ -349,6 +349,23 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	r.False(ok)
 	r.EqualValues(0, indexer.CandidateVotes(delegate).Uint64())
 	r.EqualValues(1, indexer.TotalBucketCount())
+}
+
+func BenchmarkIndexer_PutBlockBeforeContractHeight(b *testing.B) {
+	// Create a new Indexer with a contract height of 100
+	indexer := &Indexer{contractHeight: 100}
+
+	// Create a mock block with a height of 50
+	blk := &block.Block{}
+
+	// Run the benchmark
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		err := indexer.PutBlock(context.Background(), blk)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
 }
 
 func activateBucketType(r *require.Assertions, handler *contractStakingEventHandler, amount, duration int64, height uint64) {

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -353,7 +353,7 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 
 func BenchmarkIndexer_PutBlockBeforeContractHeight(b *testing.B) {
 	// Create a new Indexer with a contract height of 100
-	indexer := &Indexer{contractHeight: 100}
+	indexer := &Indexer{contractDeployHeight: 100}
 
 	// Create a mock block with a height of 50
 	blk := &block.Block{}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -294,7 +294,7 @@ func (builder *Builder) buildContractStakingIndexer(forTest bool) error {
 	} else {
 		dbConfig := builder.cfg.DB
 		dbConfig.DbPath = builder.cfg.Chain.ContractStakingIndexDBPath
-		builder.cs.contractStakingIndexer = contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.LiquidStakingContractAddress)
+		builder.cs.contractStakingIndexer = contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight)
 	}
 	return nil
 }

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -1706,7 +1706,7 @@ func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r 
 	r.NoError(err)
 	cc := cfg.DB
 	cc.DbPath = testContractStakeIndexerPath
-	contractStakeIndexer := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress)
+	contractStakeIndexer := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0)
 	// create BlockDAO
 	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer, contractStakeIndexer})
 	r.NotNil(dao)


### PR DESCRIPTION
# Description
To optimize the startup check of the contract indexer, the main changes are as follows:
- implement the `StartHeight()` method to prepare to join the `BlockIndexerWithStartGroup` introduced in #3869 
- ignore blocks with a height lower than the deployment height of the contract when processing PutBlock.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
