### PR TITLE
[api] ReadStateBucketByIndices return existing buckets

### DIFF
--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -142,10 +142,9 @@ func (s *contractStakingCache) BucketsByIndices(indices []uint64) ([]*Bucket, er
 	vbs := make([]*Bucket, 0, len(indices))
 	for _, id := range indices {
 		vb, ok := s.getBucket(id)
-		if !ok {
-			return nil, errors.Wrapf(ErrBucketNotExist, "id %d", id)
+		if ok {
+			vbs = append(vbs, vb)
 		}
-		vbs = append(vbs, vb)
 	}
 	return vbs, nil
 }


### PR DESCRIPTION
# Description
Currently, in the composite staking code, we make separate calls to `ReadStateBucketByIndices` for native and contract buckets. The desired behavior is to be able to look up a bucket by its ID in either the native or contract buckets. However, the current implementation returns an error if the ID does not exist in either bucket, resulting in an error even if the ID exists in one of them. 

The modification to make is changing the behavior of `ReadStateBucketByIndices` for native and contract buckets. Instead of returning an error when there are non-existing IDs in the parameters, we will modify it to return the existing buckets.

The reasons for choosing this approach are twofold:
- Simple: the modification is relatively simple, which allows for a straightforward implementation without significant code changes.
- Limit impact: since this adjustment is specific to error handling in a read-only interface, the impact of the change is expected to be limited to a specific area of the codebase.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
