### PR TITLE
[staking] fix readStateCandidates returning empty

### DIFF
--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -33,11 +33,9 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 	}()
 
 	// nothing in db, return empty list
-	a, height, err := cbi.GetCandidates(1, 0, 1)
+	r, height, err := cbi.GetCandidates(1, 0, 1)
 	require.NoError(err)
 	require.EqualValues(0, height)
-	var r iotextypes.CandidateListV2
-	require.NoError(proto.Unmarshal(a, &r))
 	require.Zero(len(r.Candidates))
 
 	cand := []*iotextypes.CandidateV2{
@@ -83,10 +81,9 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 		require.NoError(cbi.PutCandidates(v.height, v.candidates))
 
 		for _, v2 := range tests2 {
-			a, b, err := cbi.GetCandidates(v.height, v2.offset, v2.limit)
+			r, b, err := cbi.GetCandidates(v.height, v2.offset, v2.limit)
 			require.NoError(err)
 			require.Equal(b, v.height)
-			require.NoError(proto.Unmarshal(a, &r))
 			if tests[v.height].candidates == nil {
 				continue
 			}
@@ -112,10 +109,9 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 
 	// test height > latest height
 	require.EqualValues(6, cbi.latestCandidatesHeight)
-	a, height, err = cbi.GetCandidates(7, 0, 1)
+	r, height, err = cbi.GetCandidates(7, 0, 1)
 	require.NoError(err)
 	require.EqualValues(6, height)
-	require.NoError(proto.Unmarshal(a, &r))
 	require.Equal(1, len(r.Candidates))
 	expect := tests[6].candidates.Candidates[0]
 	actual := r.Candidates[0]
@@ -134,9 +130,11 @@ func TestCandidatesBucketsIndexer_PutGetCandidates(t *testing.T) {
 	}
 	require.NoError(cbi.PutCandidates(height, candMax))
 	lcHash := cbi.latestCandidatesHash
-	a, _, err = cbi.GetCandidates(height, 0, 4)
+	r, _, err = cbi.GetCandidates(height, 0, 4)
 	require.NoError(err)
 	c, err := getFromIndexer(store, StakingCandidatesNamespace, height+1)
+	require.NoError(err)
+	a, err := proto.Marshal(r)
 	require.NoError(err)
 	require.Equal(a, c)
 	require.NoError(cbi.Stop(ctx))

--- a/action/protocol/staking/candidate_buckets_indexer_test.go
+++ b/action/protocol/staking/candidate_buckets_indexer_test.go
@@ -164,11 +164,9 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 	}()
 
 	// nothing in db, return empty list
-	a, height, err := cbi.GetBuckets(1, 0, 1)
+	r, height, err := cbi.GetBuckets(1, 0, 1)
 	require.NoError(err)
 	require.EqualValues(0, height)
-	var r iotextypes.VoteBucketList
-	require.NoError(proto.Unmarshal(a, &r))
 	require.Zero(len(r.Buckets))
 
 	bucket := []*iotextypes.VoteBucket{
@@ -214,10 +212,9 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 		require.NoError(cbi.PutBuckets(v.height, v.buckets))
 
 		for _, v2 := range tests2 {
-			a, b, err := cbi.GetBuckets(v.height, v2.offset, v2.limit)
+			r, b, err := cbi.GetBuckets(v.height, v2.offset, v2.limit)
 			require.NoError(err)
 			require.Equal(b, v.height)
-			require.NoError(proto.Unmarshal(a, &r))
 			if tests[v.height].buckets == nil {
 				continue
 			}
@@ -243,10 +240,9 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 
 	// test height > latest height
 	require.EqualValues(6, cbi.latestBucketsHeight)
-	a, b, err := cbi.GetBuckets(7, 0, 1)
+	r, b, err := cbi.GetBuckets(7, 0, 1)
 	require.NoError(err)
 	require.EqualValues(6, b)
-	require.NoError(proto.Unmarshal(a, &r))
 	require.Equal(1, len(r.Buckets))
 	expect := tests[6].buckets.Buckets[0]
 	actual := r.Buckets[0]
@@ -265,9 +261,11 @@ func TestCandidatesBucketsIndexer_PutGetBuckets(t *testing.T) {
 	}
 	require.NoError(cbi.PutBuckets(height, voteMax))
 	lbHash := cbi.latestBucketsHash
-	a, _, err = cbi.GetBuckets(height, 0, 4)
+	r, _, err = cbi.GetBuckets(height, 0, 4)
 	require.NoError(err)
 	c, err := getFromIndexer(store, StakingBucketsNamespace, height+1)
+	require.NoError(err)
+	a, err := proto.Marshal(r)
 	require.NoError(err)
 	require.Equal(a, c)
 	require.NoError(cbi.Stop(ctx))

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -524,9 +524,10 @@ func (p *Protocol) ReadState(ctx context.Context, sr protocol.StateReader, metho
 	switch m.GetMethod() {
 	case iotexapi.ReadStakingDataMethod_BUCKETS:
 		if epochStartHeight != 0 && p.candBucketsIndexer != nil {
-			return p.candBucketsIndexer.GetBuckets(epochStartHeight, r.GetBuckets().GetPagination().GetOffset(), r.GetBuckets().GetPagination().GetLimit())
+			resp, height, err = p.candBucketsIndexer.GetBuckets(epochStartHeight, r.GetBuckets().GetPagination().GetOffset(), r.GetBuckets().GetPagination().GetLimit())
+		} else {
+			resp, height, err = nativeSR.readStateBuckets(ctx, r.GetBuckets())
 		}
-		resp, height, err = nativeSR.readStateBuckets(ctx, r.GetBuckets())
 	case iotexapi.ReadStakingDataMethod_BUCKETS_BY_VOTER:
 		resp, height, err = nativeSR.readStateBucketsByVoter(ctx, r.GetBucketsByVoter())
 	case iotexapi.ReadStakingDataMethod_BUCKETS_BY_CANDIDATE:

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -182,19 +182,14 @@ func (c *compositeStakingStateReader) readStateCandidates(ctx context.Context, r
 
 	// read native candidates
 	var (
-		candidates      *iotextypes.CandidateListV2
-		height          uint64
-		candidatesBytes []byte
+		candidates *iotextypes.CandidateListV2
+		height     uint64
 	)
 	if epochStartHeight != 0 && c.nativeIndexer != nil {
 		// read candidates from indexer
-		candidatesBytes, height, err = c.nativeIndexer.GetCandidates(epochStartHeight, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
+		candidates, height, err = c.nativeIndexer.GetCandidates(epochStartHeight, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
 		if err != nil {
 			return nil, 0, err
-		}
-		candidates = &iotextypes.CandidateListV2{}
-		if err = proto.Unmarshal(candidatesBytes, candidates); err != nil {
-			return nil, 0, errors.Wrap(err, "failed to unmarshal candidates")
 		}
 	} else {
 		// read candidates from native state

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -13,7 +13,6 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
-	"google.golang.org/protobuf/proto"
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
@@ -51,18 +50,13 @@ func (c *compositeStakingStateReader) readStateBuckets(ctx context.Context, req 
 	epochStartHeight := rp.GetEpochHeight(rp.GetEpochNum(inputHeight))
 
 	var (
-		buckets      *iotextypes.VoteBucketList
-		height       uint64
-		bucketsBytes []byte
+		buckets *iotextypes.VoteBucketList
+		height  uint64
 	)
 	if epochStartHeight != 0 && c.nativeIndexer != nil {
 		// read native buckets from indexer
-		bucketsBytes, height, err = c.nativeIndexer.GetBuckets(epochStartHeight, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
+		buckets, height, err = c.nativeIndexer.GetBuckets(epochStartHeight, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
 		if err != nil {
-			return nil, 0, err
-		}
-		buckets = &iotextypes.VoteBucketList{}
-		if err := proto.Unmarshal(bucketsBytes, buckets); err != nil {
 			return nil, 0, err
 		}
 	} else {

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -204,6 +204,10 @@ func (c *compositeStakingStateReader) readStateCandidates(ctx context.Context, r
 		}
 	}
 
+	if !protocol.MustGetFeatureCtx(ctx).AddContractStakingVotes {
+		return candidates, height, nil
+	}
+
 	for _, candidate := range candidates.Candidates {
 		if err = addContractStakingVotes(candidate, c.contractIndexer); err != nil {
 			return nil, 0, err

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -188,7 +188,7 @@ func (c *compositeStakingStateReader) readStateCandidates(ctx context.Context, r
 	)
 	if epochStartHeight != 0 && c.nativeIndexer != nil {
 		// read candidates from indexer
-		candidatesBytes, height, err = c.nativeIndexer.GetCandidates(height, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
+		candidatesBytes, height, err = c.nativeIndexer.GetCandidates(epochStartHeight, req.GetPagination().GetOffset(), req.GetPagination().GetLimit())
 		if err != nil {
 			return nil, 0, err
 		}


### PR DESCRIPTION
# Description
fix two bugs on `readStateCandidates`:
- return nothing due to zero height
- miss hard-fork for Quebec

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
