### PR TITLE
[contractstaking]fix vote bug when change delegate

### DIFF
--- a/action/protocol/staking/contractstake_bucket_type.go
+++ b/action/protocol/staking/contractstake_bucket_type.go
@@ -38,6 +38,15 @@ func (bt *ContractStakingBucketType) Deserialize(b []byte) error {
 	return bt.loadProto(&m)
 }
 
+// Clone clones the bucket type
+func (bt *ContractStakingBucketType) Clone() *ContractStakingBucketType {
+	return &ContractStakingBucketType{
+		Amount:      big.NewInt(0).Set(bt.Amount),
+		Duration:    bt.Duration,
+		ActivatedAt: bt.ActivatedAt,
+	}
+}
+
 func (bt *ContractStakingBucketType) toProto() *stakingpb.BucketType {
 	return &stakingpb.BucketType{
 		Amount:      bt.Amount.String(),

--- a/blockindex/contractstaking/bucket_info.go
+++ b/blockindex/contractstaking/bucket_info.go
@@ -41,13 +41,21 @@ func (bi *bucketInfo) Deserialize(b []byte) error {
 
 // clone clones the bucket info
 func (bi *bucketInfo) clone() *bucketInfo {
+	delegate := bi.Delegate
+	if delegate != nil {
+		delegate, _ = address.FromBytes(delegate.Bytes())
+	}
+	owner := bi.Owner
+	if owner != nil {
+		owner, _ = address.FromBytes(owner.Bytes())
+	}
 	return &bucketInfo{
 		TypeIndex:  bi.TypeIndex,
 		CreatedAt:  bi.CreatedAt,
 		UnlockedAt: bi.UnlockedAt,
 		UnstakedAt: bi.UnstakedAt,
-		Delegate:   bi.Delegate,
-		Owner:      bi.Owner,
+		Delegate:   delegate,
+		Owner:      owner,
 	}
 }
 

--- a/blockindex/contractstaking/bucket_info.go
+++ b/blockindex/contractstaking/bucket_info.go
@@ -39,8 +39,8 @@ func (bi *bucketInfo) Deserialize(b []byte) error {
 	return bi.loadProto(&m)
 }
 
-// Clone clones the bucket info
-func (bi *bucketInfo) Clone() *bucketInfo {
+// clone clones the bucket info
+func (bi *bucketInfo) clone() *bucketInfo {
 	return &bucketInfo{
 		TypeIndex:  bi.TypeIndex,
 		CreatedAt:  bi.CreatedAt,

--- a/blockindex/contractstaking/bucket_info.go
+++ b/blockindex/contractstaking/bucket_info.go
@@ -39,6 +39,18 @@ func (bi *bucketInfo) Deserialize(b []byte) error {
 	return bi.loadProto(&m)
 }
 
+// Clone clones the bucket info
+func (bi *bucketInfo) Clone() *bucketInfo {
+	return &bucketInfo{
+		TypeIndex:  bi.TypeIndex,
+		CreatedAt:  bi.CreatedAt,
+		UnlockedAt: bi.UnlockedAt,
+		UnstakedAt: bi.UnstakedAt,
+		Delegate:   bi.Delegate,
+		Owner:      bi.Owner,
+	}
+}
+
 func (bi *bucketInfo) toProto() *contractstakingpb.BucketInfo {
 	pb := &contractstakingpb.BucketInfo{
 		TypeIndex:  bi.TypeIndex,

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -372,11 +372,15 @@ func (s *contractStakingCache) putBucketType(id uint64, bt *BucketType) {
 }
 
 func (s *contractStakingCache) putBucketInfo(id uint64, bi *bucketInfo) {
+	oldBi := s.bucketInfoMap[id]
 	s.bucketInfoMap[id] = bi
 	if _, ok := s.candidateBucketMap[bi.Delegate.String()]; !ok {
 		s.candidateBucketMap[bi.Delegate.String()] = make(map[uint64]bool)
 	}
 	s.candidateBucketMap[bi.Delegate.String()][id] = true
+	if oldBi != nil && oldBi.Delegate.String() != bi.Delegate.String() {
+		delete(s.candidateBucketMap[oldBi.Delegate.String()], id)
+	}
 }
 
 func (s *contractStakingCache) deleteBucketInfo(id uint64) {

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -233,7 +233,6 @@ func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	delta := newContractStakingDelta()
 	// load height
 	var height uint64
 	h, err := kvstore.Get(_StakingNS, _stakingHeightKey)
@@ -246,7 +245,7 @@ func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
 		height = byteutil.BytesToUint64BigEndian(h)
 
 	}
-	delta.PutHeight(height)
+	s.putHeight(height)
 
 	// load total bucket count
 	var totalBucketCount uint64
@@ -258,7 +257,7 @@ func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
 	} else {
 		totalBucketCount = byteutil.BytesToUint64BigEndian(tbc)
 	}
-	delta.PutTotalBucketCount(totalBucketCount)
+	s.putTotalBucketCount(totalBucketCount)
 
 	// load bucket info
 	ks, vs, err := kvstore.Filter(_StakingBucketInfoNS, func(k, v []byte) bool { return true }, nil, nil)
@@ -270,7 +269,7 @@ func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
 		if err := b.Deserialize(vs[i]); err != nil {
 			return err
 		}
-		delta.AddBucketInfo(byteutil.BytesToUint64BigEndian(ks[i]), &b)
+		s.putBucketInfo(byteutil.BytesToUint64BigEndian(ks[i]), &b)
 	}
 
 	// load bucket type
@@ -283,9 +282,9 @@ func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
 		if err := b.Deserialize(vs[i]); err != nil {
 			return err
 		}
-		delta.AddBucketType(byteutil.BytesToUint64BigEndian(ks[i]), &b)
+		s.putBucketType(byteutil.BytesToUint64BigEndian(ks[i]), &b)
 	}
-	return s.merge(delta)
+	return nil
 }
 
 func (s *contractStakingCache) getBucketTypeIndex(amount *big.Int, duration uint64) (uint64, bool) {

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -379,12 +379,18 @@ func (s *contractStakingCache) putBucketType(id uint64, bt *BucketType) {
 func (s *contractStakingCache) putBucketInfo(id uint64, bi *bucketInfo) {
 	oldBi := s.bucketInfoMap[id]
 	s.bucketInfoMap[id] = bi
-	if _, ok := s.candidateBucketMap[bi.Delegate.String()]; !ok {
-		s.candidateBucketMap[bi.Delegate.String()] = make(map[uint64]bool)
+	// update candidate bucket map
+	newDelegate := bi.Delegate.String()
+	if _, ok := s.candidateBucketMap[newDelegate]; !ok {
+		s.candidateBucketMap[newDelegate] = make(map[uint64]bool)
 	}
-	s.candidateBucketMap[bi.Delegate.String()][id] = true
-	if oldBi != nil && oldBi.Delegate.String() != bi.Delegate.String() {
-		delete(s.candidateBucketMap[oldBi.Delegate.String()], id)
+	s.candidateBucketMap[newDelegate][id] = true
+	// delete old candidate bucket map
+	if oldBi != nil {
+		oldDelegate := oldBi.Delegate.String()
+		if oldDelegate != newDelegate {
+			delete(s.candidateBucketMap[oldDelegate], id)
+		}
 	}
 }
 

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -146,7 +146,7 @@ func (s *contractStakingCache) TotalBucketCount() uint64 {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.getTotalBucketCount()
+	return s.totalBucketCount
 }
 
 func (s *contractStakingCache) ActiveBucketTypes() map[uint64]*BucketType {
@@ -313,10 +313,6 @@ func (s *contractStakingCache) getBucket(id uint64) (*Bucket, bool) {
 	}
 	bt := s.mustGetBucketType(bi.TypeIndex)
 	return assembleBucket(id, bi, bt, s.contractAddress), true
-}
-
-func (s *contractStakingCache) getTotalBucketCount() uint64 {
-	return s.totalBucketCount
 }
 
 func (s *contractStakingCache) putBucketType(id uint64, bt *BucketType) {

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -427,7 +427,5 @@ func (s *contractStakingCache) merge(delta *contractStakingDelta) error {
 			}
 		}
 	}
-	s.putHeight(delta.GetHeight())
-	s.putTotalBucketCount(s.getTotalBucketCount() + delta.AddedBucketCnt())
 	return nil
 }

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -187,7 +187,11 @@ func (s *contractStakingCache) Merge(delta *contractStakingDelta) error {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	return s.merge(delta)
+	if err := s.merge(delta); err != nil {
+		return err
+	}
+	s.putTotalBucketCount(s.totalBucketCount + delta.AddedBucketCnt())
+	return nil
 }
 
 func (s *contractStakingCache) PutTotalBucketCount(count uint64) {

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -79,9 +79,9 @@ func (s *contractStakingCache) Buckets() []*Bucket {
 	defer s.mutex.RUnlock()
 
 	vbs := []*Bucket{}
-	for id, bi := range s.getAllBucketInfo() {
+	for id, bi := range s.bucketInfoMap {
 		bt := s.mustGetBucketType(bi.TypeIndex)
-		vb := assembleBucket(id, bi, bt, s.contractAddress)
+		vb := assembleBucket(id, bi.clone(), bt, s.contractAddress)
 		vbs = append(vbs, vb)
 	}
 	return vbs
@@ -126,7 +126,7 @@ func (s *contractStakingCache) BucketsByCandidate(candidate address.Address) []*
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	bucketMap := s.getBucketInfoByCandidate(candidate)
+	bucketMap := s.candidateBucketMap[candidate.String()]
 	vbs := make([]*Bucket, 0, len(bucketMap))
 	for id := range bucketMap {
 		vb := s.mustGetBucket(id)
@@ -341,24 +341,6 @@ func (s *contractStakingCache) getBucket(id uint64) (*Bucket, bool) {
 	}
 	bt := s.mustGetBucketType(bi.TypeIndex)
 	return assembleBucket(id, bi, bt, s.contractAddress), true
-}
-
-func (s *contractStakingCache) getAllBucketInfo() map[uint64]*bucketInfo {
-	m := make(map[uint64]*bucketInfo)
-	for k, v := range s.bucketInfoMap {
-		m[k] = v.clone()
-	}
-	return m
-}
-
-func (s *contractStakingCache) getBucketInfoByCandidate(candidate address.Address) map[uint64]*bucketInfo {
-	m := make(map[uint64]*bucketInfo)
-	for k, v := range s.candidateBucketMap[candidate.String()] {
-		if v {
-			m[k] = s.bucketInfoMap[k].clone()
-		}
-	}
-	return m
 }
 
 func (s *contractStakingCache) getTotalBucketCount() uint64 {

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -309,7 +309,7 @@ func (s *contractStakingCache) mustGetBucketType(id uint64) *BucketType {
 	if !ok {
 		panic("bucket type not found")
 	}
-	return bt.Clone()
+	return bt
 }
 
 func (s *contractStakingCache) getBucketInfo(id uint64) (*bucketInfo, bool) {
@@ -317,7 +317,7 @@ func (s *contractStakingCache) getBucketInfo(id uint64) (*bucketInfo, bool) {
 	if !ok {
 		return nil, false
 	}
-	return bi.Clone(), ok
+	return bi.clone(), ok
 }
 
 func (s *contractStakingCache) mustGetBucketInfo(id uint64) *bucketInfo {
@@ -325,7 +325,7 @@ func (s *contractStakingCache) mustGetBucketInfo(id uint64) *bucketInfo {
 	if !ok {
 		panic("bucket info not found")
 	}
-	return bt.Clone()
+	return bt
 }
 
 func (s *contractStakingCache) mustGetBucket(id uint64) *Bucket {
@@ -346,7 +346,7 @@ func (s *contractStakingCache) getBucket(id uint64) (*Bucket, bool) {
 func (s *contractStakingCache) getAllBucketInfo() map[uint64]*bucketInfo {
 	m := make(map[uint64]*bucketInfo)
 	for k, v := range s.bucketInfoMap {
-		m[k] = v.Clone()
+		m[k] = v.clone()
 	}
 	return m
 }
@@ -355,7 +355,7 @@ func (s *contractStakingCache) getBucketInfoByCandidate(candidate address.Addres
 	m := make(map[uint64]*bucketInfo)
 	for k, v := range s.candidateBucketMap[candidate.String()] {
 		if v {
-			m[k] = s.bucketInfoMap[k].Clone()
+			m[k] = s.bucketInfoMap[k].clone()
 		}
 	}
 	return m

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -163,7 +163,7 @@ func (s *contractStakingCache) ActiveBucketTypes() map[uint64]*BucketType {
 	m := make(map[uint64]*BucketType)
 	for k, v := range s.bucketTypeMap {
 		if v.ActivatedAt != maxBlockNumber {
-			m[k] = v
+			m[k] = v.Clone()
 		}
 	}
 	return m
@@ -299,7 +299,10 @@ func (s *contractStakingCache) getBucketTypeIndex(amount *big.Int, duration uint
 
 func (s *contractStakingCache) getBucketType(id uint64) (*BucketType, bool) {
 	bt, ok := s.bucketTypeMap[id]
-	return bt, ok
+	if !ok {
+		return nil, false
+	}
+	return bt.Clone(), ok
 }
 
 func (s *contractStakingCache) mustGetBucketType(id uint64) *BucketType {
@@ -307,12 +310,15 @@ func (s *contractStakingCache) mustGetBucketType(id uint64) *BucketType {
 	if !ok {
 		panic("bucket type not found")
 	}
-	return bt
+	return bt.Clone()
 }
 
 func (s *contractStakingCache) getBucketInfo(id uint64) (*bucketInfo, bool) {
 	bi, ok := s.bucketInfoMap[id]
-	return bi, ok
+	if !ok {
+		return nil, false
+	}
+	return bi.Clone(), ok
 }
 
 func (s *contractStakingCache) mustGetBucketInfo(id uint64) *bucketInfo {
@@ -320,7 +326,7 @@ func (s *contractStakingCache) mustGetBucketInfo(id uint64) *bucketInfo {
 	if !ok {
 		panic("bucket info not found")
 	}
-	return bt
+	return bt.Clone()
 }
 
 func (s *contractStakingCache) mustGetBucket(id uint64) *Bucket {
@@ -341,7 +347,7 @@ func (s *contractStakingCache) getBucket(id uint64) (*Bucket, bool) {
 func (s *contractStakingCache) getAllBucketInfo() map[uint64]*bucketInfo {
 	m := make(map[uint64]*bucketInfo)
 	for k, v := range s.bucketInfoMap {
-		m[k] = v
+		m[k] = v.Clone()
 	}
 	return m
 }
@@ -350,7 +356,7 @@ func (s *contractStakingCache) getBucketInfoByCandidate(candidate address.Addres
 	m := make(map[uint64]*bucketInfo)
 	for k, v := range s.candidateBucketMap[candidate.String()] {
 		if v {
-			m[k] = s.bucketInfoMap[k]
+			m[k] = s.bucketInfoMap[k].Clone()
 		}
 	}
 	return m

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -1,0 +1,496 @@
+package contractstaking
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/testutil"
+)
+
+func TestContractStakingCache_Height(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	cache.PutHeight(12345)
+	require.Equal(uint64(12345), cache.Height())
+
+	cache.PutHeight(54321)
+	require.Equal(uint64(54321), cache.Height())
+}
+
+func TestContractStakingCache_CandidateVotes(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// no bucket
+	require.EqualValues(0, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// one bucket
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(100, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// two buckets
+	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(200, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// add one bucket with different delegate
+	cache.PutBucketInfo(3, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
+	require.EqualValues(200, cache.CandidateVotes(identityset.Address(1)).Int64())
+	require.EqualValues(100, cache.CandidateVotes(identityset.Address(3)).Int64())
+
+	// add one bucket with different owner
+	cache.PutBucketInfo(4, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(4)})
+	require.EqualValues(300, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// add one bucket with different amount
+	cache.PutBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+	cache.PutBucketInfo(5, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(500, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// add one bucket with different duration
+	cache.PutBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 200, ActivatedAt: 1})
+	cache.PutBucketInfo(6, &bucketInfo{TypeIndex: 3, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(800, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// add one bucket that is unstaked
+	cache.PutBucketInfo(7, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: 1, UnstakedAt: 1, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(800, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// add one bucket that is unlocked and staked
+	cache.PutBucketInfo(8, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: 100, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.EqualValues(900, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// change delegate of bucket 1
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
+	require.EqualValues(800, cache.CandidateVotes(identityset.Address(1)).Int64())
+	require.EqualValues(200, cache.CandidateVotes(identityset.Address(3)).Int64())
+
+	// change owner of bucket 1
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	require.EqualValues(800, cache.CandidateVotes(identityset.Address(1)).Int64())
+	require.EqualValues(200, cache.CandidateVotes(identityset.Address(3)).Int64())
+
+	// change amount of bucket 1
+	cache.putBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	require.EqualValues(800, cache.CandidateVotes(identityset.Address(1)).Int64())
+	require.EqualValues(300, cache.CandidateVotes(identityset.Address(3)).Int64())
+}
+
+func TestContractStakingCache_Buckets(t *testing.T) {
+	require := require.New(t)
+	contractAddr := identityset.Address(27).String()
+	cache := newContractStakingCache(contractAddr)
+
+	// no bucket
+	require.Empty(cache.Buckets())
+
+	// add one bucket
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	buckets := cache.Buckets()
+	require.Len(buckets, 1)
+	checkVoteBucket(require, buckets[0], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	bucket, ok := cache.Bucket(1)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// add one bucket with different index
+	cache.PutBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 1})
+	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	bucketMaps := bucketsToMap(cache.Buckets())
+	require.Len(bucketMaps, 2)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(3).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+	bucket, ok = cache.Bucket(1)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	bucket, ok = cache.Bucket(2)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 2, identityset.Address(3).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// update delegate of bucket 2
+	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(5), Owner: identityset.Address(4)})
+	bucketMaps = bucketsToMap(cache.Buckets())
+	require.Len(bucketMaps, 2)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(5).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+	bucket, ok = cache.Bucket(1)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	bucket, ok = cache.Bucket(2)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 2, identityset.Address(5).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// delete bucket 1
+	cache.DeleteBucketInfo(1)
+	bucketMaps = bucketsToMap(cache.Buckets())
+	require.Len(bucketMaps, 1)
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(5).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+	_, ok = cache.Bucket(1)
+	require.False(ok)
+	bucket, ok = cache.Bucket(2)
+	require.True(ok)
+	checkVoteBucket(require, bucket, 2, identityset.Address(5).String(), identityset.Address(4).String(), 200, 200, 1, 1, maxBlockNumber, true, contractAddr)
+}
+
+func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
+	require := require.New(t)
+	contractAddr := identityset.Address(27).String()
+	cache := newContractStakingCache(contractAddr)
+
+	// no bucket
+	buckets := cache.BucketsByCandidate(identityset.Address(1))
+	require.Len(buckets, 0)
+
+	// one bucket
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	bucketMaps := bucketsToMap(cache.BucketsByCandidate(identityset.Address(1)))
+	require.Len(bucketMaps, 1)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// two buckets
+	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(1)))
+	require.Len(bucketMaps, 2)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// add one bucket with different delegate
+	cache.PutBucketInfo(3, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(1)))
+	require.Len(bucketMaps, 2)
+	require.Nil(bucketMaps[3])
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(3)))
+	require.Len(bucketMaps, 1)
+	checkVoteBucket(require, bucketMaps[3], 3, identityset.Address(3).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// change delegate of bucket 1
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(1)))
+	require.Len(bucketMaps, 1)
+	require.Nil(bucketMaps[1])
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(3)))
+	require.Len(bucketMaps, 2)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(3).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[3], 3, identityset.Address(3).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// delete bucket 2
+	cache.DeleteBucketInfo(2)
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(1)))
+	require.Len(bucketMaps, 0)
+	bucketMaps = bucketsToMap(cache.BucketsByCandidate(identityset.Address(3)))
+	require.Len(bucketMaps, 2)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(3).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[3], 3, identityset.Address(3).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+}
+
+func TestContractStakingCache_BucketsByIndices(t *testing.T) {
+	require := require.New(t)
+	contractAddr := identityset.Address(27).String()
+	cache := newContractStakingCache(contractAddr)
+
+	// no bucket
+	buckets, err := cache.BucketsByIndices([]uint64{1})
+	require.NoError(err)
+	require.Len(buckets, 0)
+
+	// one bucket
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	buckets, err = cache.BucketsByIndices([]uint64{1})
+	require.NoError(err)
+	require.Len(buckets, 1)
+	bucketMaps := bucketsToMap(buckets)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// two buckets
+	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	buckets, err = cache.BucketsByIndices([]uint64{1, 2})
+	require.NoError(err)
+	require.Len(buckets, 2)
+	bucketMaps = bucketsToMap(buckets)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+	checkVoteBucket(require, bucketMaps[2], 2, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// one bucket not found
+	buckets, err = cache.BucketsByIndices([]uint64{3})
+	require.NoError(err)
+	require.Len(buckets, 0)
+
+	// one bucket found, one not found
+	buckets, err = cache.BucketsByIndices([]uint64{1, 3})
+	require.NoError(err)
+	require.Len(buckets, 1)
+	bucketMaps = bucketsToMap(buckets)
+	checkVoteBucket(require, bucketMaps[1], 1, identityset.Address(1).String(), identityset.Address(2).String(), 100, 100, 1, 1, maxBlockNumber, true, contractAddr)
+
+	// delete bucket 1
+	cache.DeleteBucketInfo(1)
+	buckets, err = cache.BucketsByIndices([]uint64{1})
+	require.NoError(err)
+	require.Len(buckets, 0)
+}
+
+func TestContractStakingCache_TotalBucketCount(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// no bucket
+	require.EqualValues(0, cache.TotalBucketCount())
+
+	// one bucket
+	cache.PutTotalBucketCount(1)
+	require.EqualValues(1, cache.TotalBucketCount())
+
+	// two buckets
+	cache.PutTotalBucketCount(2)
+	require.EqualValues(2, cache.TotalBucketCount())
+
+	// delete bucket 1
+	cache.DeleteBucketInfo(1)
+	require.EqualValues(2, cache.TotalBucketCount())
+}
+
+func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// no bucket type
+	require.Empty(cache.ActiveBucketTypes())
+
+	// one bucket type
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	activeBucketTypes := cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 1)
+	require.EqualValues(100, activeBucketTypes[1].Amount.Int64())
+	require.EqualValues(100, activeBucketTypes[1].Duration)
+	require.EqualValues(1, activeBucketTypes[1].ActivatedAt)
+
+	// two bucket types
+	cache.PutBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	activeBucketTypes = cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 2)
+	require.EqualValues(100, activeBucketTypes[1].Amount.Int64())
+	require.EqualValues(100, activeBucketTypes[1].Duration)
+	require.EqualValues(1, activeBucketTypes[1].ActivatedAt)
+	require.EqualValues(200, activeBucketTypes[2].Amount.Int64())
+	require.EqualValues(200, activeBucketTypes[2].Duration)
+	require.EqualValues(2, activeBucketTypes[2].ActivatedAt)
+
+	// add one inactive bucket type
+	cache.PutBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 300, ActivatedAt: maxBlockNumber})
+	activeBucketTypes = cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 2)
+	require.EqualValues(100, activeBucketTypes[1].Amount.Int64())
+	require.EqualValues(100, activeBucketTypes[1].Duration)
+	require.EqualValues(1, activeBucketTypes[1].ActivatedAt)
+	require.EqualValues(200, activeBucketTypes[2].Amount.Int64())
+	require.EqualValues(200, activeBucketTypes[2].Duration)
+	require.EqualValues(2, activeBucketTypes[2].ActivatedAt)
+
+	// deactivate bucket type 1
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: maxBlockNumber})
+	activeBucketTypes = cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 1)
+	require.EqualValues(200, activeBucketTypes[2].Amount.Int64())
+	require.EqualValues(200, activeBucketTypes[2].Duration)
+	require.EqualValues(2, activeBucketTypes[2].ActivatedAt)
+
+	// reactivate bucket type 1
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	activeBucketTypes = cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 2)
+	require.EqualValues(100, activeBucketTypes[1].Amount.Int64())
+	require.EqualValues(100, activeBucketTypes[1].Duration)
+	require.EqualValues(1, activeBucketTypes[1].ActivatedAt)
+	require.EqualValues(200, activeBucketTypes[2].Amount.Int64())
+	require.EqualValues(200, activeBucketTypes[2].Duration)
+	require.EqualValues(2, activeBucketTypes[2].ActivatedAt)
+}
+
+func TestContractStakingCache_Merge(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// create delta with one bucket type
+	delta := newContractStakingDelta()
+	delta.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	// merge delta into cache
+	err := cache.Merge(delta)
+	require.NoError(err)
+	// check that bucket type was added to cache
+	activeBucketTypes := cache.ActiveBucketTypes()
+	require.Len(activeBucketTypes, 1)
+	require.EqualValues(100, activeBucketTypes[1].Amount.Int64())
+	require.EqualValues(100, activeBucketTypes[1].Duration)
+	require.EqualValues(1, activeBucketTypes[1].ActivatedAt)
+
+	// create delta with one bucket
+	delta = newContractStakingDelta()
+	delta.AddBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	// merge delta into cache
+	err = cache.Merge(delta)
+	require.NoError(err)
+	// check that bucket was added to cache and vote count is correct
+	require.EqualValues(100, cache.CandidateVotes(identityset.Address(1)).Int64())
+
+	// create delta with updated bucket delegate
+	delta = newContractStakingDelta()
+	delta.UpdateBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
+	// merge delta into cache
+	err = cache.Merge(delta)
+	require.NoError(err)
+	// check that bucket delegate was updated and vote count is correct
+	require.EqualValues(0, cache.CandidateVotes(identityset.Address(1)).Int64())
+	require.EqualValues(100, cache.CandidateVotes(identityset.Address(3)).Int64())
+
+	// create delta with deleted bucket
+	delta = newContractStakingDelta()
+	delta.DeleteBucketInfo(1)
+	// merge delta into cache
+	err = cache.Merge(delta)
+	require.NoError(err)
+	// check that bucket was deleted from cache and vote count is 0
+	require.EqualValues(0, cache.CandidateVotes(identityset.Address(3)).Int64())
+}
+
+func TestContractStakingCache_MatchBucketType(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// no bucket types
+	_, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
+	require.False(ok)
+	require.Nil(bucketType)
+
+	// one bucket type
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	// match exact bucket type
+	id, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
+	require.True(ok)
+	require.EqualValues(1, id)
+	require.EqualValues(100, bucketType.Amount.Int64())
+	require.EqualValues(100, bucketType.Duration)
+	require.EqualValues(1, bucketType.ActivatedAt)
+
+	// match bucket type with different amount
+	_, bucketType, ok = cache.MatchBucketType(big.NewInt(200), 100)
+	require.False(ok)
+	require.Nil(bucketType)
+
+	// match bucket type with different duration
+	_, bucketType, ok = cache.MatchBucketType(big.NewInt(100), 200)
+	require.False(ok)
+	require.Nil(bucketType)
+
+	// no match
+	_, bucketType, ok = cache.MatchBucketType(big.NewInt(200), 200)
+	require.False(ok)
+	require.Nil(bucketType)
+}
+
+func TestContractStakingCache_BucketTypeCount(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// no bucket type
+	require.EqualValues(0, cache.BucketTypeCount())
+
+	// one bucket type
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	require.EqualValues(1, cache.BucketTypeCount())
+
+	// two bucket types
+	cache.PutBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	require.EqualValues(2, cache.BucketTypeCount())
+
+	// deactivate bucket type 1
+	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: maxBlockNumber})
+	require.EqualValues(2, cache.BucketTypeCount())
+}
+
+func TestContractStakingCache_LoadFromDB(t *testing.T) {
+	require := require.New(t)
+	cache := newContractStakingCache("")
+
+	// load from empty db
+	path, err := testutil.PathOfTempFile("staking.db")
+	require.NoError(err)
+	defer testutil.CleanupPath(path)
+	cfg := config.Default.DB
+	cfg.DbPath = path
+	kvstore := db.NewBoltDB(cfg)
+	require.NoError(kvstore.Start(context.Background()))
+	defer kvstore.Stop(context.Background())
+
+	err = cache.LoadFromDB(kvstore)
+	require.NoError(err)
+	require.Equal(uint64(0), cache.Height())
+	require.Equal(uint64(0), cache.TotalBucketCount())
+	require.Equal(0, len(cache.Buckets()))
+	require.EqualValues(0, cache.BucketTypeCount())
+
+	// load from db with height and total bucket count
+	kvstore.Put(_StakingNS, _stakingHeightKey, byteutil.Uint64ToBytesBigEndian(12345))
+	kvstore.Put(_StakingNS, _stakingTotalBucketCountKey, byteutil.Uint64ToBytesBigEndian(10))
+	err = cache.LoadFromDB(kvstore)
+	require.NoError(err)
+	require.Equal(uint64(12345), cache.Height())
+	require.Equal(uint64(10), cache.TotalBucketCount())
+	require.Equal(0, len(cache.Buckets()))
+	require.EqualValues(0, cache.BucketTypeCount())
+
+	// load from db with bucket
+	bucketInfo := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	kvstore.Put(_StakingBucketInfoNS, byteutil.Uint64ToBytesBigEndian(1), bucketInfo.Serialize())
+	bucketType := &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}
+	kvstore.Put(_StakingBucketTypeNS, byteutil.Uint64ToBytesBigEndian(1), bucketType.Serialize())
+	err = cache.LoadFromDB(kvstore)
+	require.NoError(err)
+	require.Equal(uint64(12345), cache.Height())
+	require.Equal(uint64(10), cache.TotalBucketCount())
+	bi, ok := cache.BucketInfo(1)
+	require.True(ok)
+	require.Equal(1, len(cache.Buckets()))
+	require.Equal(bucketInfo, bi)
+	require.EqualValues(1, cache.BucketTypeCount())
+	id, bt, ok := cache.MatchBucketType(big.NewInt(100), 100)
+	require.True(ok)
+	require.EqualValues(1, id)
+	require.EqualValues(100, bt.Amount.Int64())
+	require.EqualValues(100, bt.Duration)
+	require.EqualValues(1, bt.ActivatedAt)
+}
+
+func bucketsToMap(buckets []*staking.VoteBucket) map[uint64]*staking.VoteBucket {
+	m := make(map[uint64]*staking.VoteBucket)
+	for _, bucket := range buckets {
+		m[bucket.Index] = bucket
+	}
+	return m
+}
+
+func checkVoteBucket(r *require.Assertions, bucket *staking.VoteBucket, index uint64, candidate, owner string, amount, duration, createHeight, startHeight, unstakeHeight uint64, autoStake bool, contractAddr string) {
+	r.EqualValues(index, bucket.Index)
+	r.EqualValues(candidate, bucket.Candidate.String())
+	r.EqualValues(owner, bucket.Owner.String())
+	r.EqualValues(amount, bucket.StakedAmount.Int64())
+	r.EqualValues(duration, bucket.StakedDurationBlockNumber)
+	r.EqualValues(createHeight, bucket.CreateBlockHeight)
+	r.EqualValues(startHeight, bucket.StakeStartBlockHeight)
+	r.EqualValues(unstakeHeight, bucket.UnstakeStartBlockHeight)
+	r.EqualValues(autoStake, bucket.AutoStake)
+	r.EqualValues(contractAddr, bucket.ContractAddress)
+}

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -15,17 +15,6 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
-func TestContractStakingCache_Height(t *testing.T) {
-	require := require.New(t)
-	cache := newContractStakingCache("")
-
-	cache.PutHeight(12345)
-	require.Equal(uint64(12345), cache.Height())
-
-	cache.PutHeight(54321)
-	require.Equal(uint64(54321), cache.Height())
-}
-
 func TestContractStakingCache_CandidateVotes(t *testing.T) {
 	require := require.New(t)
 	cache := newContractStakingCache("")
@@ -437,7 +426,6 @@ func TestContractStakingCache_LoadFromDB(t *testing.T) {
 
 	err = cache.LoadFromDB(kvstore)
 	require.NoError(err)
-	require.Equal(uint64(0), cache.Height())
 	require.Equal(uint64(0), cache.TotalBucketCount())
 	require.Equal(0, len(cache.Buckets()))
 	require.EqualValues(0, cache.BucketTypeCount())
@@ -447,7 +435,6 @@ func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	kvstore.Put(_StakingNS, _stakingTotalBucketCountKey, byteutil.Uint64ToBytesBigEndian(10))
 	err = cache.LoadFromDB(kvstore)
 	require.NoError(err)
-	require.Equal(uint64(12345), cache.Height())
 	require.Equal(uint64(10), cache.TotalBucketCount())
 	require.Equal(0, len(cache.Buckets()))
 	require.EqualValues(0, cache.BucketTypeCount())
@@ -459,7 +446,6 @@ func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	kvstore.Put(_StakingBucketTypeNS, byteutil.Uint64ToBytesBigEndian(1), bucketType.Serialize())
 	err = cache.LoadFromDB(kvstore)
 	require.NoError(err)
-	require.Equal(uint64(12345), cache.Height())
 	require.Equal(uint64(10), cache.TotalBucketCount())
 	bi, ok := cache.BucketInfo(1)
 	require.True(ok)

--- a/blockindex/contractstaking/delta_cache.go
+++ b/blockindex/contractstaking/delta_cache.go
@@ -68,27 +68,23 @@ func (s *contractStakingDelta) MatchBucketType(amount *big.Int, duration uint64)
 }
 
 func (s *contractStakingDelta) GetBucketInfo(id uint64) (*bucketInfo, deltaState) {
-	if state, ok := s.bucketInfoDeltaState[id]; ok {
-		switch state {
-		case deltaStateAdded, deltaStateModified:
-			return s.cache.MustGetBucketInfo(id), state
-		default:
-			return nil, state
-		}
+	state := s.bucketInfoDeltaState[id]
+	switch state {
+	case deltaStateAdded, deltaStateModified:
+		return s.cache.MustGetBucketInfo(id), state
+	default: // deltaStateRemoved, deltaStateUnchanged
+		return nil, state
 	}
-	return nil, deltaStateReverted
 }
 
 func (s *contractStakingDelta) GetBucketType(id uint64) (*BucketType, deltaState) {
-	if state, ok := s.bucketTypeDeltaState[id]; ok {
-		switch state {
-		case deltaStateAdded, deltaStateModified:
-			return s.cache.MustGetBucketType(id), state
-		default:
-			return nil, state
-		}
+	state := s.bucketTypeDeltaState[id]
+	switch state {
+	case deltaStateAdded, deltaStateModified:
+		return s.cache.MustGetBucketType(id), state
+	default: // deltaStateUnchanged
+		return nil, state
 	}
-	return nil, deltaStateReverted
 }
 
 func (s *contractStakingDelta) AddBucketInfo(id uint64, bi *bucketInfo) error {
@@ -96,56 +92,41 @@ func (s *contractStakingDelta) AddBucketInfo(id uint64, bi *bucketInfo) error {
 }
 
 func (s *contractStakingDelta) AddBucketType(id uint64, bt *BucketType) error {
-	if _, ok := s.bucketTypeDeltaState[id]; !ok {
-		s.bucketTypeDeltaState[id] = deltaStateAdded
-	} else {
-		var err error
-		s.bucketTypeDeltaState[id], err = s.bucketTypeDeltaState[id].Transfer(deltaActionAdd)
-		if err != nil {
-			return err
-		}
+	var err error
+	s.bucketTypeDeltaState[id], err = s.bucketTypeDeltaState[id].Transfer(deltaActionAdd)
+	if err != nil {
+		return err
 	}
+
 	s.cache.PutBucketType(id, bt)
 	return nil
 }
 
 func (s *contractStakingDelta) UpdateBucketType(id uint64, bt *BucketType) error {
-	if _, ok := s.bucketTypeDeltaState[id]; !ok {
-		s.bucketTypeDeltaState[id] = deltaStateModified
-	} else {
-		var err error
-		s.bucketTypeDeltaState[id], err = s.bucketTypeDeltaState[id].Transfer(deltaActionModify)
-		if err != nil {
-			return err
-		}
+	var err error
+	s.bucketTypeDeltaState[id], err = s.bucketTypeDeltaState[id].Transfer(deltaActionModify)
+	if err != nil {
+		return err
 	}
 	s.cache.PutBucketType(id, bt)
 	return nil
 }
 
 func (s *contractStakingDelta) UpdateBucketInfo(id uint64, bi *bucketInfo) error {
-	if _, ok := s.bucketInfoDeltaState[id]; !ok {
-		s.bucketInfoDeltaState[id] = deltaStateModified
-	} else {
-		var err error
-		s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionModify)
-		if err != nil {
-			return err
-		}
+	var err error
+	s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionModify)
+	if err != nil {
+		return err
 	}
 	s.cache.PutBucketInfo(id, bi)
 	return nil
 }
 
 func (s *contractStakingDelta) DeleteBucketInfo(id uint64) error {
-	if _, ok := s.bucketInfoDeltaState[id]; !ok {
-		s.bucketInfoDeltaState[id] = deltaStateRemoved
-	} else {
-		var err error
-		s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionRemove)
-		if err != nil {
-			return err
-		}
+	var err error
+	s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionRemove)
+	if err != nil {
+		return err
 	}
 	s.cache.DeleteBucketInfo(id)
 	return nil
@@ -172,21 +153,14 @@ func (s *contractStakingDelta) AddedBucketTypeCnt() uint64 {
 }
 
 func (s *contractStakingDelta) isBucketDeleted(id uint64) bool {
-	if _, ok := s.bucketInfoDeltaState[id]; ok {
-		return s.bucketInfoDeltaState[id] == deltaStateRemoved
-	}
-	return false
+	return s.bucketInfoDeltaState[id] == deltaStateRemoved
 }
 
 func (s *contractStakingDelta) addBucketInfo(id uint64, bi *bucketInfo) error {
 	var err error
-	if _, ok := s.bucketInfoDeltaState[id]; !ok {
-		s.bucketInfoDeltaState[id] = deltaStateAdded
-	} else {
-		s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionAdd)
-		if err != nil {
-			return err
-		}
+	s.bucketInfoDeltaState[id], err = s.bucketInfoDeltaState[id].Transfer(deltaActionAdd)
+	if err != nil {
+		return err
 	}
 	s.cache.PutBucketInfo(id, bi)
 	return nil

--- a/blockindex/contractstaking/delta_cache.go
+++ b/blockindex/contractstaking/delta_cache.go
@@ -24,18 +24,6 @@ func newContractStakingDelta() *contractStakingDelta {
 	}
 }
 
-func (s *contractStakingDelta) PutHeight(height uint64) {
-	s.cache.PutHeight(height)
-}
-
-func (s *contractStakingDelta) GetHeight() uint64 {
-	return s.cache.Height()
-}
-
-func (s *contractStakingDelta) PutTotalBucketCount(count uint64) {
-	s.cache.PutTotalBucketCount(count)
-}
-
 func (s *contractStakingDelta) BucketInfoDelta() map[deltaState]map[uint64]*bucketInfo {
 	delta := map[deltaState]map[uint64]*bucketInfo{
 		deltaStateAdded:    make(map[uint64]*bucketInfo),

--- a/blockindex/contractstaking/delta_cache_test.go
+++ b/blockindex/contractstaking/delta_cache_test.go
@@ -1,0 +1,297 @@
+package contractstaking
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/test/identityset"
+)
+
+func TestContractStakingDelta_GetHeight(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// test with height 0
+	height := cache.GetHeight()
+	require.EqualValues(0, height)
+
+	// test with height 12345
+	cache.PutHeight(12345)
+	height = cache.GetHeight()
+	require.EqualValues(12345, height)
+}
+
+func TestContractStakingDelta_BucketInfoDelta(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// add bucket info
+	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	cache.AddBucketInfo(1, bi)
+
+	// modify bucket info
+	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}
+	cache.UpdateBucketInfo(2, bi)
+
+	// remove bucket info
+	cache.DeleteBucketInfo(3)
+
+	// add and remove bucket info
+	bi = &bucketInfo{TypeIndex: 4, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(5), Owner: identityset.Address(6)}
+	cache.AddBucketInfo(4, bi)
+	cache.DeleteBucketInfo(4)
+
+	// get bucket info delta
+	delta := cache.BucketInfoDelta()
+
+	// check added bucket info
+	require.Len(delta[deltaStateAdded], 1)
+	added, ok := delta[deltaStateAdded][1]
+	require.True(ok)
+	require.NotNil(added)
+	require.EqualValues(1, added.TypeIndex)
+	require.EqualValues(1, added.CreatedAt)
+	require.EqualValues(maxBlockNumber, added.UnlockedAt)
+	require.EqualValues(maxBlockNumber, added.UnstakedAt)
+	require.EqualValues(identityset.Address(1), added.Delegate)
+	require.EqualValues(identityset.Address(2), added.Owner)
+
+	// check modified bucket info
+	require.Len(delta[deltaStateModified], 1)
+	modified, ok := delta[deltaStateModified][2]
+	require.True(ok)
+	require.NotNil(modified)
+	require.EqualValues(2, modified.TypeIndex)
+	require.EqualValues(2, modified.CreatedAt)
+	require.EqualValues(maxBlockNumber, modified.UnlockedAt)
+	require.EqualValues(maxBlockNumber, modified.UnstakedAt)
+	require.EqualValues(identityset.Address(3), modified.Delegate)
+	require.EqualValues(identityset.Address(4), modified.Owner)
+
+	// check removed bucket info
+	require.Len(delta[deltaStateRemoved], 1)
+	removed, ok := delta[deltaStateRemoved][3]
+	require.True(ok)
+	require.Nil(removed)
+
+}
+
+func TestContractStakingDelta_BucketTypeDelta(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// add bucket type
+	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+
+	// modify bucket type 1 & 3
+	cache.UpdateBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 3})
+	cache.UpdateBucketType(3, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 4})
+
+	delta := cache.BucketTypeDelta()
+	// check added bucket type
+	require.Len(delta[deltaStateAdded], 2)
+	added, ok := delta[deltaStateAdded][1]
+	require.True(ok)
+	require.NotNil(added)
+	require.EqualValues(100, added.Amount.Int64())
+	require.EqualValues(100, added.Duration)
+	require.EqualValues(3, added.ActivatedAt)
+	// check modified bucket type
+	modified, ok := delta[deltaStateModified][3]
+	require.True(ok)
+	require.NotNil(modified)
+	require.EqualValues(100, modified.Amount.Int64())
+	require.EqualValues(100, modified.Duration)
+	require.EqualValues(4, modified.ActivatedAt)
+
+}
+
+func TestContractStakingDelta_MatchBucketType(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// test with empty bucket type
+	index, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
+	require.False(ok)
+	require.EqualValues(0, index)
+	require.Nil(bucketType)
+
+	// add bucket types
+	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+
+	// test with amount and duration that match bucket type 1
+	amount := big.NewInt(100)
+	duration := uint64(100)
+	index, bucketType, ok = cache.MatchBucketType(amount, duration)
+	require.True(ok)
+	require.EqualValues(1, index)
+	require.NotNil(bucketType)
+	require.EqualValues(big.NewInt(100), bucketType.Amount)
+	require.EqualValues(uint64(100), bucketType.Duration)
+	require.EqualValues(uint64(1), bucketType.ActivatedAt)
+
+	// test with amount and duration that match bucket type 2
+	amount = big.NewInt(200)
+	duration = uint64(100)
+	index, bucketType, ok = cache.MatchBucketType(amount, duration)
+	require.True(ok)
+	require.EqualValues(2, index)
+	require.NotNil(bucketType)
+	require.EqualValues(big.NewInt(200), bucketType.Amount)
+	require.EqualValues(uint64(100), bucketType.Duration)
+	require.EqualValues(uint64(1), bucketType.ActivatedAt)
+
+	// test with amount and duration that do not match any bucket type
+	amount = big.NewInt(300)
+	duration = uint64(100)
+	index, bucketType, ok = cache.MatchBucketType(amount, duration)
+	require.False(ok)
+	require.EqualValues(0, index)
+	require.Nil(bucketType)
+}
+
+func TestContractStakingDelta_GetBucketInfo(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// add bucket info
+	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	cache.AddBucketInfo(1, bi)
+
+	// get added bucket info
+	info, state := cache.GetBucketInfo(1)
+	require.NotNil(info)
+	require.EqualValues(1, info.TypeIndex)
+	require.EqualValues(1, info.CreatedAt)
+	require.EqualValues(maxBlockNumber, info.UnlockedAt)
+	require.EqualValues(maxBlockNumber, info.UnstakedAt)
+	require.EqualValues(identityset.Address(1), info.Delegate)
+	require.EqualValues(identityset.Address(2), info.Owner)
+	require.EqualValues(deltaStateAdded, state)
+
+	// revert bucket info 1
+	cache.DeleteBucketInfo(1)
+	// get bucket info
+	info, state = cache.GetBucketInfo(1)
+	require.Nil(info)
+	require.EqualValues(deltaStateReverted, state)
+
+	// modify bucket info 2
+	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}
+	cache.UpdateBucketInfo(2, bi)
+	// get modified bucket info
+	info, state = cache.GetBucketInfo(2)
+	require.NotNil(info)
+	require.EqualValues(2, info.TypeIndex)
+	require.EqualValues(2, info.CreatedAt)
+	require.EqualValues(maxBlockNumber, info.UnlockedAt)
+	require.EqualValues(maxBlockNumber, info.UnstakedAt)
+	require.EqualValues(identityset.Address(3), info.Delegate)
+	require.EqualValues(identityset.Address(4), info.Owner)
+	require.EqualValues(deltaStateModified, state)
+
+	// remove bucket info 2
+	cache.DeleteBucketInfo(2)
+	// get removed bucket info
+	info, state = cache.GetBucketInfo(2)
+	require.Nil(info)
+	require.EqualValues(deltaStateRemoved, state)
+}
+
+func TestContractStakingDelta_GetBucketType(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// add bucket type
+	bt := &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}
+	cache.AddBucketType(1, bt)
+
+	// get added bucket type
+	bucketType, state := cache.GetBucketType(1)
+	require.NotNil(bucketType)
+	require.EqualValues(big.NewInt(100), bucketType.Amount)
+	require.EqualValues(100, bucketType.Duration)
+	require.EqualValues(1, bucketType.ActivatedAt)
+	require.EqualValues(deltaStateAdded, state)
+
+	// modify bucket type
+	bt = &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}
+	cache.UpdateBucketType(2, bt)
+	// get modified bucket type
+	bucketType, state = cache.GetBucketType(2)
+	require.NotNil(bucketType)
+	require.EqualValues(big.NewInt(200), bucketType.Amount)
+	require.EqualValues(200, bucketType.Duration)
+	require.EqualValues(2, bucketType.ActivatedAt)
+	require.EqualValues(deltaStateModified, state)
+
+}
+
+func TestContractStakingDelta_AddedBucketCnt(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// test with no added bucket info
+	addedBucketCnt := cache.AddedBucketCnt()
+	require.EqualValues(0, addedBucketCnt)
+
+	// add bucket types
+	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+
+	// add bucket info
+	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	cache.AddBucketInfo(1, bi)
+	// add bucket info
+	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	cache.AddBucketInfo(2, bi)
+
+	// test with added bucket info
+	addedBucketCnt = cache.AddedBucketCnt()
+	require.EqualValues(2, addedBucketCnt)
+
+	// remove bucket info
+	cache.DeleteBucketInfo(2)
+
+	// test with removed bucket info
+	addedBucketCnt = cache.AddedBucketCnt()
+	require.EqualValues(1, addedBucketCnt)
+}
+
+func TestContractStakingDelta_AddedBucketTypeCnt(t *testing.T) {
+	require := require.New(t)
+
+	// create a new delta cache
+	cache := newContractStakingDelta()
+
+	// test with no added bucket types
+	addedBucketTypeCnt := cache.AddedBucketTypeCnt()
+	require.EqualValues(0, addedBucketTypeCnt)
+
+	// add bucket types
+	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+	cache.AddBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 100, ActivatedAt: 1})
+
+	// test with added bucket type
+	addedBucketTypeCnt = cache.AddedBucketTypeCnt()
+	require.EqualValues(3, addedBucketTypeCnt)
+}

--- a/blockindex/contractstaking/delta_cache_test.go
+++ b/blockindex/contractstaking/delta_cache_test.go
@@ -9,22 +9,6 @@ import (
 	"github.com/iotexproject/iotex-core/test/identityset"
 )
 
-func TestContractStakingDelta_GetHeight(t *testing.T) {
-	require := require.New(t)
-
-	// create a new delta cache
-	cache := newContractStakingDelta()
-
-	// test with height 0
-	height := cache.GetHeight()
-	require.EqualValues(0, height)
-
-	// test with height 12345
-	cache.PutHeight(12345)
-	height = cache.GetHeight()
-	require.EqualValues(12345, height)
-}
-
 func TestContractStakingDelta_BucketInfoDelta(t *testing.T) {
 	require := require.New(t)
 

--- a/blockindex/contractstaking/delta_cache_test.go
+++ b/blockindex/contractstaking/delta_cache_test.go
@@ -172,7 +172,7 @@ func TestContractStakingDelta_GetBucketInfo(t *testing.T) {
 	// get bucket info
 	info, state = cache.GetBucketInfo(1)
 	require.Nil(info)
-	require.EqualValues(deltaStateReverted, state)
+	require.EqualValues(deltaStateUnchanged, state)
 
 	// modify bucket info 2
 	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}

--- a/blockindex/contractstaking/delta_cache_test.go
+++ b/blockindex/contractstaking/delta_cache_test.go
@@ -17,19 +17,14 @@ func TestContractStakingDelta_BucketInfoDelta(t *testing.T) {
 
 	// add bucket info
 	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
-	cache.AddBucketInfo(1, bi)
+	require.NoError(cache.AddBucketInfo(1, bi))
 
 	// modify bucket info
 	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}
-	cache.UpdateBucketInfo(2, bi)
+	require.NoError(cache.UpdateBucketInfo(2, bi))
 
 	// remove bucket info
-	cache.DeleteBucketInfo(3)
-
-	// add and remove bucket info
-	bi = &bucketInfo{TypeIndex: 4, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(5), Owner: identityset.Address(6)}
-	cache.AddBucketInfo(4, bi)
-	cache.DeleteBucketInfo(4)
+	require.NoError(cache.DeleteBucketInfo(3))
 
 	// get bucket info delta
 	delta := cache.BucketInfoDelta()
@@ -73,12 +68,12 @@ func TestContractStakingDelta_BucketTypeDelta(t *testing.T) {
 	cache := newContractStakingDelta()
 
 	// add bucket type
-	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
-	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+	require.NoError(cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}))
+	require.NoError(cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1}))
 
 	// modify bucket type 1 & 3
-	cache.UpdateBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 3})
-	cache.UpdateBucketType(3, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 4})
+	require.NoError(cache.UpdateBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 3}))
+	require.NoError(cache.UpdateBucketType(3, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 4}))
 
 	delta := cache.BucketTypeDelta()
 	// check added bucket type
@@ -112,8 +107,8 @@ func TestContractStakingDelta_MatchBucketType(t *testing.T) {
 	require.Nil(bucketType)
 
 	// add bucket types
-	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
-	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+	require.NoError(cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}))
+	require.NoError(cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1}))
 
 	// test with amount and duration that match bucket type 1
 	amount := big.NewInt(100)
@@ -154,7 +149,7 @@ func TestContractStakingDelta_GetBucketInfo(t *testing.T) {
 
 	// add bucket info
 	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
-	cache.AddBucketInfo(1, bi)
+	require.NoError(cache.AddBucketInfo(1, bi))
 
 	// get added bucket info
 	info, state := cache.GetBucketInfo(1)
@@ -167,16 +162,9 @@ func TestContractStakingDelta_GetBucketInfo(t *testing.T) {
 	require.EqualValues(identityset.Address(2), info.Owner)
 	require.EqualValues(deltaStateAdded, state)
 
-	// revert bucket info 1
-	cache.DeleteBucketInfo(1)
-	// get bucket info
-	info, state = cache.GetBucketInfo(1)
-	require.Nil(info)
-	require.EqualValues(deltaStateUnchanged, state)
-
 	// modify bucket info 2
 	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}
-	cache.UpdateBucketInfo(2, bi)
+	require.NoError(cache.UpdateBucketInfo(2, bi))
 	// get modified bucket info
 	info, state = cache.GetBucketInfo(2)
 	require.NotNil(info)
@@ -189,7 +177,7 @@ func TestContractStakingDelta_GetBucketInfo(t *testing.T) {
 	require.EqualValues(deltaStateModified, state)
 
 	// remove bucket info 2
-	cache.DeleteBucketInfo(2)
+	require.NoError(cache.DeleteBucketInfo(2))
 	// get removed bucket info
 	info, state = cache.GetBucketInfo(2)
 	require.Nil(info)
@@ -204,7 +192,7 @@ func TestContractStakingDelta_GetBucketType(t *testing.T) {
 
 	// add bucket type
 	bt := &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}
-	cache.AddBucketType(1, bt)
+	require.NoError(cache.AddBucketType(1, bt))
 
 	// get added bucket type
 	bucketType, state := cache.GetBucketType(1)
@@ -216,7 +204,7 @@ func TestContractStakingDelta_GetBucketType(t *testing.T) {
 
 	// modify bucket type
 	bt = &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}
-	cache.UpdateBucketType(2, bt)
+	require.NoError(cache.UpdateBucketType(2, bt))
 	// get modified bucket type
 	bucketType, state = cache.GetBucketType(2)
 	require.NotNil(bucketType)
@@ -238,26 +226,26 @@ func TestContractStakingDelta_AddedBucketCnt(t *testing.T) {
 	require.EqualValues(0, addedBucketCnt)
 
 	// add bucket types
-	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
-	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
+	require.NoError(cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}))
+	require.NoError(cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1}))
 
 	// add bucket info
 	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
-	cache.AddBucketInfo(1, bi)
+	require.NoError(cache.AddBucketInfo(1, bi))
 	// add bucket info
 	bi = &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
-	cache.AddBucketInfo(2, bi)
+	require.NoError(cache.AddBucketInfo(2, bi))
 
 	// test with added bucket info
 	addedBucketCnt = cache.AddedBucketCnt()
 	require.EqualValues(2, addedBucketCnt)
 
 	// remove bucket info
-	cache.DeleteBucketInfo(2)
+	require.NoError(cache.DeleteBucketInfo(3))
 
 	// test with removed bucket info
 	addedBucketCnt = cache.AddedBucketCnt()
-	require.EqualValues(1, addedBucketCnt)
+	require.EqualValues(2, addedBucketCnt)
 }
 
 func TestContractStakingDelta_AddedBucketTypeCnt(t *testing.T) {
@@ -271,9 +259,9 @@ func TestContractStakingDelta_AddedBucketTypeCnt(t *testing.T) {
 	require.EqualValues(0, addedBucketTypeCnt)
 
 	// add bucket types
-	cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
-	cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
-	cache.AddBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 100, ActivatedAt: 1})
+	require.NoError(cache.AddBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}))
+	require.NoError(cache.AddBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1}))
+	require.NoError(cache.AddBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 100, ActivatedAt: 1}))
 
 	// test with added bucket type
 	addedBucketTypeCnt = cache.AddedBucketTypeCnt()

--- a/blockindex/contractstaking/delta_state.go
+++ b/blockindex/contractstaking/delta_state.go
@@ -8,10 +8,10 @@ package contractstaking
 import "github.com/pkg/errors"
 
 const (
-	deltaStateAdded deltaState = iota
+	deltaStateUnchanged deltaState = iota
+	deltaStateAdded
 	deltaStateRemoved
 	deltaStateModified
-	deltaStateReverted
 )
 
 type deltaState int
@@ -19,18 +19,16 @@ type deltaState int
 var (
 	deltaStateTransferMap = map[deltaState]map[deltaAction]deltaState{
 		deltaStateAdded: {
-			deltaActionRemove: deltaStateReverted,
 			deltaActionModify: deltaStateAdded,
-		},
-		deltaStateRemoved: {
-			deltaActionAdd: deltaStateModified,
 		},
 		deltaStateModified: {
 			deltaActionModify: deltaStateModified,
 			deltaActionRemove: deltaStateRemoved,
 		},
-		deltaStateReverted: {
-			deltaActionAdd: deltaStateAdded,
+		deltaStateUnchanged: {
+			deltaActionAdd:    deltaStateAdded,
+			deltaActionRemove: deltaStateRemoved,
+			deltaActionModify: deltaStateModified,
 		},
 	}
 )

--- a/blockindex/contractstaking/delta_state.go
+++ b/blockindex/contractstaking/delta_state.go
@@ -8,6 +8,8 @@ package contractstaking
 import "github.com/pkg/errors"
 
 const (
+	// deltaState constants
+	// deltaStateUnchanged is the zero-value of the type deltaState
 	deltaStateUnchanged deltaState = iota
 	deltaStateAdded
 	deltaStateRemoved
@@ -18,17 +20,17 @@ type deltaState int
 
 var (
 	deltaStateTransferMap = map[deltaState]map[deltaAction]deltaState{
+		deltaStateUnchanged: {
+			deltaActionAdd:    deltaStateAdded,
+			deltaActionRemove: deltaStateRemoved,
+			deltaActionModify: deltaStateModified,
+		},
 		deltaStateAdded: {
 			deltaActionModify: deltaStateAdded,
 		},
 		deltaStateModified: {
 			deltaActionModify: deltaStateModified,
 			deltaActionRemove: deltaStateRemoved,
-		},
-		deltaStateUnchanged: {
-			deltaActionAdd:    deltaStateAdded,
-			deltaActionRemove: deltaStateRemoved,
-			deltaActionModify: deltaStateModified,
 		},
 	}
 )

--- a/blockindex/contractstaking/delta_state_test.go
+++ b/blockindex/contractstaking/delta_state_test.go
@@ -1,0 +1,46 @@
+package contractstaking
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeltaState_Transfer(t *testing.T) {
+	require := require.New(t)
+
+	cases := []struct {
+		name     string
+		state    deltaState
+		action   deltaAction
+		expected deltaState
+		isError  bool
+	}{
+		{"unchanged->add", deltaStateUnchanged, deltaActionAdd, deltaStateAdded, false},
+		{"unchanged->remove", deltaStateUnchanged, deltaActionRemove, deltaStateRemoved, false},
+		{"unchanged->modify", deltaStateUnchanged, deltaActionModify, deltaStateModified, false},
+		{"added->add", deltaStateAdded, deltaActionAdd, deltaStateUnchanged, true},
+		{"added->remove", deltaStateAdded, deltaActionRemove, deltaStateUnchanged, true},
+		{"added->modify", deltaStateAdded, deltaActionModify, deltaStateAdded, false},
+		{"removed->add", deltaStateRemoved, deltaActionAdd, deltaStateUnchanged, true},
+		{"removed->remove", deltaStateRemoved, deltaActionRemove, deltaStateUnchanged, true},
+		{"removed->modify", deltaStateRemoved, deltaActionModify, deltaStateUnchanged, true},
+		{"modified->add", deltaStateModified, deltaActionAdd, deltaStateUnchanged, true},
+		{"modified->remove", deltaStateModified, deltaActionRemove, deltaStateRemoved, false},
+		{"modified->modify", deltaStateModified, deltaActionModify, deltaStateModified, false},
+		{"invalid state", deltaState(100), deltaActionAdd, deltaState(100), true},
+		{"invalid action", deltaStateUnchanged, deltaAction(100), deltaStateUnchanged, true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, err := c.state.Transfer(c.action)
+			if c.isError {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+				require.Equal(c.expected, s)
+			}
+		})
+	}
+}

--- a/blockindex/contractstaking/delta_state_test.go
+++ b/blockindex/contractstaking/delta_state_test.go
@@ -14,33 +14,41 @@ func TestDeltaState_Transfer(t *testing.T) {
 		state    deltaState
 		action   deltaAction
 		expected deltaState
-		isError  bool
+		err      string
 	}{
-		{"unchanged->add", deltaStateUnchanged, deltaActionAdd, deltaStateAdded, false},
-		{"unchanged->remove", deltaStateUnchanged, deltaActionRemove, deltaStateRemoved, false},
-		{"unchanged->modify", deltaStateUnchanged, deltaActionModify, deltaStateModified, false},
-		{"added->add", deltaStateAdded, deltaActionAdd, deltaStateUnchanged, true},
-		{"added->remove", deltaStateAdded, deltaActionRemove, deltaStateUnchanged, true},
-		{"added->modify", deltaStateAdded, deltaActionModify, deltaStateAdded, false},
-		{"removed->add", deltaStateRemoved, deltaActionAdd, deltaStateUnchanged, true},
-		{"removed->remove", deltaStateRemoved, deltaActionRemove, deltaStateUnchanged, true},
-		{"removed->modify", deltaStateRemoved, deltaActionModify, deltaStateUnchanged, true},
-		{"modified->add", deltaStateModified, deltaActionAdd, deltaStateUnchanged, true},
-		{"modified->remove", deltaStateModified, deltaActionRemove, deltaStateRemoved, false},
-		{"modified->modify", deltaStateModified, deltaActionModify, deltaStateModified, false},
-		{"invalid state", deltaState(100), deltaActionAdd, deltaState(100), true},
-		{"invalid action", deltaStateUnchanged, deltaAction(100), deltaStateUnchanged, true},
+		{"unchanged->add", deltaStateUnchanged, deltaActionAdd, deltaStateAdded, ""},
+		{"unchanged->remove", deltaStateUnchanged, deltaActionRemove, deltaStateRemoved, ""},
+		{"unchanged->modify", deltaStateUnchanged, deltaActionModify, deltaStateModified, ""},
+		{"added->add", deltaStateAdded, deltaActionAdd, deltaStateUnchanged, "invalid delta action 0 on state 1"},
+		{"added->remove", deltaStateAdded, deltaActionRemove, deltaStateUnchanged, "invalid delta action 1 on state 1"},
+		{"added->modify", deltaStateAdded, deltaActionModify, deltaStateAdded, ""},
+		{"removed->add", deltaStateRemoved, deltaActionAdd, deltaStateUnchanged, "invalid delta state 2"},
+		{"removed->remove", deltaStateRemoved, deltaActionRemove, deltaStateUnchanged, "invalid delta state 2"},
+		{"removed->modify", deltaStateRemoved, deltaActionModify, deltaStateUnchanged, "invalid delta state 2"},
+		{"modified->add", deltaStateModified, deltaActionAdd, deltaStateUnchanged, "invalid delta action 0 on state 3"},
+		{"modified->remove", deltaStateModified, deltaActionRemove, deltaStateRemoved, ""},
+		{"modified->modify", deltaStateModified, deltaActionModify, deltaStateModified, ""},
+		{"invalid state", deltaState(100), deltaActionAdd, deltaState(100), "invalid delta state 100"},
+		{"invalid action", deltaStateUnchanged, deltaAction(100), deltaStateUnchanged, "invalid delta action 100 on state 0"},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			s, err := c.state.Transfer(c.action)
-			if c.isError {
+			if len(c.err) > 0 {
 				require.Error(err)
+				require.Contains(err.Error(), c.err)
 			} else {
 				require.NoError(err)
 				require.Equal(c.expected, s)
 			}
 		})
 	}
+}
+
+func TestDeltaState_ZeroValue(t *testing.T) {
+	require := require.New(t)
+
+	var state deltaState
+	require.Equal(deltaStateUnchanged, state)
 }

--- a/blockindex/contractstaking/dirty_cache.go
+++ b/blockindex/contractstaking/dirty_cache.go
@@ -51,10 +51,6 @@ func newContractStakingDirty(clean *contractStakingCache) *contractStakingDirty 
 	}
 }
 
-func (dirty *contractStakingDirty) putHeight(h uint64) {
-	dirty.batch.Put(_StakingNS, _stakingHeightKey, byteutil.Uint64ToBytesBigEndian(h), "failed to put height")
-}
-
 func (dirty *contractStakingDirty) addBucketInfo(id uint64, bi *bucketInfo) error {
 	dirty.batch.Put(_StakingBucketInfoNS, byteutil.Uint64ToBytesBigEndian(id), bi.Serialize(), "failed to put bucket info")
 	return dirty.delta.AddBucketInfo(id, bi)

--- a/blockindex/contractstaking/dirty_cache.go
+++ b/blockindex/contractstaking/dirty_cache.go
@@ -53,7 +53,6 @@ func newContractStakingDirty(clean *contractStakingCache) *contractStakingDirty 
 
 func (dirty *contractStakingDirty) putHeight(h uint64) {
 	dirty.batch.Put(_StakingNS, _stakingHeightKey, byteutil.Uint64ToBytesBigEndian(h), "failed to put height")
-	dirty.delta.PutHeight(h)
 }
 
 func (dirty *contractStakingDirty) addBucketInfo(id uint64, bi *bucketInfo) error {

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -61,8 +61,8 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require.Equal(identityset.Address(2), bi.Owner)
 
 	// added bucket info
-	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
-	dirty.addBucketInfo(2, &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(2), Owner: identityset.Address(3)})
+	require.NoError(dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}))
+	require.NoError(dirty.addBucketInfo(2, &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(2), Owner: identityset.Address(3)}))
 	bi, ok = dirty.getBucketInfo(2)
 	require.True(ok)
 	require.EqualValues(2, bi.TypeIndex)
@@ -73,7 +73,7 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require.Equal(identityset.Address(3), bi.Owner)
 
 	// modified bucket info
-	dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	require.NoError(dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}))
 	bi, ok = dirty.getBucketInfo(1)
 	require.True(ok)
 	require.EqualValues(2, bi.TypeIndex)
@@ -84,7 +84,7 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require.Equal(identityset.Address(4), bi.Owner)
 
 	// removed bucket info
-	dirty.deleteBucketInfo(1)
+	require.NoError(dirty.deleteBucketInfo(1))
 	bi, ok = dirty.getBucketInfo(1)
 	require.False(ok)
 	require.Nil(bi)
@@ -111,7 +111,7 @@ func TestContractStakingDirty_matchBucketType(t *testing.T) {
 	require.EqualValues(1, id)
 
 	// added bucket type
-	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	require.NoError(dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}))
 	id, bt, ok = dirty.matchBucketType(big.NewInt(200), 200)
 	require.True(ok)
 	require.EqualValues(200, bt.Amount.Int64())
@@ -135,7 +135,7 @@ func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 	require.EqualValues(1, count)
 
 	// added bucket type
-	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	require.NoError(dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}))
 	count = dirty.getBucketTypeCount()
 	require.EqualValues(2, count)
 }
@@ -163,7 +163,7 @@ func TestContractStakingDirty_finalize(t *testing.T) {
 
 	// added bucket type
 	bt := &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}
-	dirty.addBucketType(1, bt)
+	require.NoError(dirty.addBucketType(1, bt))
 	batcher, delta = dirty.finalize()
 	require.EqualValues(2, batcher.Size())
 	info, err = batcher.Entry(1)
@@ -181,7 +181,7 @@ func TestContractStakingDirty_finalize(t *testing.T) {
 
 	// add bucket info
 	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 2, UnlockedAt: 3, UnstakedAt: 4, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
-	dirty.addBucketInfo(1, bi)
+	require.NoError(dirty.addBucketInfo(1, bi))
 	batcher, delta = dirty.finalize()
 	require.EqualValues(3, batcher.Size())
 	info, err = batcher.Entry(2)
@@ -208,35 +208,28 @@ func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	dirty := newContractStakingDirty(clean)
 
 	// add bucket type to dirty cache
-	dirty.addBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	require.NoError(dirty.addBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}))
 	// check that clean cache is not affected
 	bt, ok := clean.getBucketType(1)
 	require.False(ok)
 	require.Nil(bt)
 
 	// add bucket info to dirty cache
-	dirty.addBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	require.NoError(dirty.addBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)}))
 	// check that clean cache is not affected
 	bi, ok := clean.getBucketInfo(1)
 	require.False(ok)
 	require.Nil(bi)
 
 	// update bucket type in dirty cache
-	dirty.updateBucketType(1, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	require.NoError(dirty.updateBucketType(1, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2}))
 	// check that clean cache is not affected
 	bt, ok = clean.getBucketType(1)
 	require.False(ok)
 	require.Nil(bt)
 
 	// update bucket info in dirty cache
-	dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
-	// check that clean cache is not affected
-	bi, ok = clean.getBucketInfo(1)
-	require.False(ok)
-	require.Nil(bi)
-
-	// remove bucket info from dirty cache
-	dirty.deleteBucketInfo(1)
+	require.NoError(dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}))
 	// check that clean cache is not affected
 	bi, ok = clean.getBucketInfo(1)
 	require.False(ok)
@@ -245,7 +238,7 @@ func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	// update bucket info existed in clean cache
 	clean.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	// update bucket info in dirty cache
-	dirty.updateBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	require.NoError(dirty.updateBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)}))
 	// check that clean cache is not affected
 	bi, ok = clean.getBucketInfo(2)
 	require.True(ok)
@@ -259,7 +252,7 @@ func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	// remove bucket info existed in clean cache
 	clean.PutBucketInfo(3, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	// remove bucket info from dirty cache
-	dirty.deleteBucketInfo(3)
+	require.NoError(dirty.deleteBucketInfo(3))
 	// check that clean cache is not affected
 	bi, ok = clean.getBucketInfo(3)
 	require.True(ok)

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -1,0 +1,277 @@
+package contractstaking
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/db/batch"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+	"github.com/iotexproject/iotex-core/test/identityset"
+)
+
+func TestContractStakingDirty_getBucketType(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// no bucket type
+	bt, ok := dirty.getBucketType(1)
+	require.False(ok)
+	require.Nil(bt)
+
+	// bucket type in clean cache
+	clean.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	bt, ok = dirty.getBucketType(1)
+	require.True(ok)
+	require.EqualValues(100, bt.Amount.Int64())
+	require.EqualValues(100, bt.Duration)
+	require.EqualValues(1, bt.ActivatedAt)
+
+	// added bucket type
+	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	bt, ok = dirty.getBucketType(2)
+	require.True(ok)
+	require.EqualValues(200, bt.Amount.Int64())
+	require.EqualValues(200, bt.Duration)
+	require.EqualValues(2, bt.ActivatedAt)
+}
+
+func TestContractStakingDirty_getBucketInfo(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// no bucket info
+	bi, ok := dirty.getBucketInfo(1)
+	require.False(ok)
+	require.Nil(bi)
+
+	// bucket info in clean cache
+	clean.putBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	clean.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	bi, ok = dirty.getBucketInfo(1)
+	require.True(ok)
+	require.EqualValues(1, bi.TypeIndex)
+	require.EqualValues(1, bi.CreatedAt)
+	require.EqualValues(maxBlockNumber, bi.UnlockedAt)
+	require.EqualValues(maxBlockNumber, bi.UnstakedAt)
+	require.Equal(identityset.Address(1), bi.Delegate)
+	require.Equal(identityset.Address(2), bi.Owner)
+
+	// added bucket info
+	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	dirty.addBucketInfo(2, &bucketInfo{TypeIndex: 2, CreatedAt: 2, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(2), Owner: identityset.Address(3)})
+	bi, ok = dirty.getBucketInfo(2)
+	require.True(ok)
+	require.EqualValues(2, bi.TypeIndex)
+	require.EqualValues(2, bi.CreatedAt)
+	require.EqualValues(maxBlockNumber, bi.UnlockedAt)
+	require.EqualValues(maxBlockNumber, bi.UnstakedAt)
+	require.Equal(identityset.Address(2), bi.Delegate)
+	require.Equal(identityset.Address(3), bi.Owner)
+
+	// modified bucket info
+	dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	bi, ok = dirty.getBucketInfo(1)
+	require.True(ok)
+	require.EqualValues(2, bi.TypeIndex)
+	require.EqualValues(3, bi.CreatedAt)
+	require.EqualValues(maxBlockNumber, bi.UnlockedAt)
+	require.EqualValues(maxBlockNumber, bi.UnstakedAt)
+	require.Equal(identityset.Address(3), bi.Delegate)
+	require.Equal(identityset.Address(4), bi.Owner)
+
+	// removed bucket info
+	dirty.deleteBucketInfo(1)
+	bi, ok = dirty.getBucketInfo(1)
+	require.False(ok)
+	require.Nil(bi)
+}
+
+func TestContractStakingDirty_matchBucketType(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// no bucket type
+	id, bt, ok := dirty.matchBucketType(big.NewInt(100), 100)
+	require.False(ok)
+	require.Nil(bt)
+	require.EqualValues(0, id)
+
+	// bucket type in clean cache
+	clean.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	id, bt, ok = dirty.matchBucketType(big.NewInt(100), 100)
+	require.True(ok)
+	require.EqualValues(100, bt.Amount.Int64())
+	require.EqualValues(100, bt.Duration)
+	require.EqualValues(1, bt.ActivatedAt)
+	require.EqualValues(1, id)
+
+	// added bucket type
+	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	id, bt, ok = dirty.matchBucketType(big.NewInt(200), 200)
+	require.True(ok)
+	require.EqualValues(200, bt.Amount.Int64())
+	require.EqualValues(200, bt.Duration)
+	require.EqualValues(2, bt.ActivatedAt)
+	require.EqualValues(2, id)
+}
+
+func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// no bucket type
+	count := dirty.getBucketTypeCount()
+	require.EqualValues(0, count)
+
+	// bucket type in clean cache
+	clean.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	count = dirty.getBucketTypeCount()
+	require.EqualValues(1, count)
+
+	// added bucket type
+	dirty.addBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	count = dirty.getBucketTypeCount()
+	require.EqualValues(2, count)
+}
+
+func TestContractStakingDirty_finalize(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// no dirty data
+	batcher, delta := dirty.finalize()
+	require.EqualValues(1, batcher.Size())
+	info, err := batcher.Entry(0)
+	require.NoError(err)
+	require.EqualValues(_StakingNS, info.Namespace())
+	require.EqualValues(batch.Put, info.WriteType())
+	require.EqualValues(_stakingTotalBucketCountKey, info.Key())
+	require.EqualValues(byteutil.Uint64ToBytesBigEndian(0), info.Value())
+	for _, d := range delta.BucketTypeDelta() {
+		require.Len(d, 0)
+	}
+	for _, d := range delta.BucketTypeDelta() {
+		require.Len(d, 0)
+	}
+
+	// added bucket type
+	bt := &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1}
+	dirty.addBucketType(1, bt)
+	batcher, delta = dirty.finalize()
+	require.EqualValues(2, batcher.Size())
+	info, err = batcher.Entry(1)
+	require.NoError(err)
+	require.EqualValues(_StakingBucketTypeNS, info.Namespace())
+	require.EqualValues(batch.Put, info.WriteType())
+	require.EqualValues(byteutil.Uint64ToBytesBigEndian(1), info.Key())
+	require.EqualValues(bt.Serialize(), info.Value())
+	btDelta := delta.BucketTypeDelta()
+	require.NotNil(btDelta[deltaStateAdded])
+	require.Len(btDelta[deltaStateAdded], 1)
+	require.EqualValues(100, btDelta[deltaStateAdded][1].Amount.Int64())
+	require.EqualValues(100, btDelta[deltaStateAdded][1].Duration)
+	require.EqualValues(1, btDelta[deltaStateAdded][1].ActivatedAt)
+
+	// add bucket info
+	bi := &bucketInfo{TypeIndex: 1, CreatedAt: 2, UnlockedAt: 3, UnstakedAt: 4, Delegate: identityset.Address(1), Owner: identityset.Address(2)}
+	dirty.addBucketInfo(1, bi)
+	batcher, delta = dirty.finalize()
+	require.EqualValues(3, batcher.Size())
+	info, err = batcher.Entry(2)
+	require.NoError(err)
+	require.EqualValues(_StakingBucketInfoNS, info.Namespace())
+	require.EqualValues(batch.Put, info.WriteType())
+	require.EqualValues(byteutil.Uint64ToBytesBigEndian(1), info.Key())
+	require.EqualValues(bi.Serialize(), info.Value())
+	biDelta := delta.BucketInfoDelta()
+	require.NotNil(biDelta[deltaStateAdded])
+	require.Len(biDelta[deltaStateAdded], 1)
+	require.EqualValues(1, biDelta[deltaStateAdded][1].TypeIndex)
+	require.EqualValues(2, biDelta[deltaStateAdded][1].CreatedAt)
+	require.EqualValues(3, biDelta[deltaStateAdded][1].UnlockedAt)
+	require.EqualValues(4, biDelta[deltaStateAdded][1].UnstakedAt)
+	require.EqualValues(identityset.Address(1).String(), biDelta[deltaStateAdded][1].Delegate.String())
+	require.EqualValues(identityset.Address(2).String(), biDelta[deltaStateAdded][1].Owner.String())
+
+}
+
+func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
+	require := require.New(t)
+	clean := newContractStakingCache("")
+	dirty := newContractStakingDirty(clean)
+
+	// add bucket type to dirty cache
+	dirty.addBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
+	// check that clean cache is not affected
+	bt, ok := clean.getBucketType(1)
+	require.False(ok)
+	require.Nil(bt)
+
+	// add bucket info to dirty cache
+	dirty.addBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	// check that clean cache is not affected
+	bi, ok := clean.getBucketInfo(1)
+	require.False(ok)
+	require.Nil(bi)
+
+	// update bucket type in dirty cache
+	dirty.updateBucketType(1, &BucketType{Amount: big.NewInt(200), Duration: 200, ActivatedAt: 2})
+	// check that clean cache is not affected
+	bt, ok = clean.getBucketType(1)
+	require.False(ok)
+	require.Nil(bt)
+
+	// update bucket info in dirty cache
+	dirty.updateBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	// check that clean cache is not affected
+	bi, ok = clean.getBucketInfo(1)
+	require.False(ok)
+	require.Nil(bi)
+
+	// remove bucket info from dirty cache
+	dirty.deleteBucketInfo(1)
+	// check that clean cache is not affected
+	bi, ok = clean.getBucketInfo(1)
+	require.False(ok)
+	require.Nil(bi)
+
+	// update bucket info existed in clean cache
+	clean.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	// update bucket info in dirty cache
+	dirty.updateBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 3, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
+	// check that clean cache is not affected
+	bi, ok = clean.getBucketInfo(2)
+	require.True(ok)
+	require.EqualValues(1, bi.TypeIndex)
+	require.EqualValues(1, bi.CreatedAt)
+	require.EqualValues(maxBlockNumber, bi.UnlockedAt)
+	require.EqualValues(maxBlockNumber, bi.UnstakedAt)
+	require.EqualValues(identityset.Address(1).String(), bi.Delegate.String())
+	require.EqualValues(identityset.Address(2).String(), bi.Owner.String())
+
+	// remove bucket info existed in clean cache
+	clean.PutBucketInfo(3, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
+	// remove bucket info from dirty cache
+	dirty.deleteBucketInfo(3)
+	// check that clean cache is not affected
+	bi, ok = clean.getBucketInfo(3)
+	require.True(ok)
+	require.EqualValues(1, bi.TypeIndex)
+	require.EqualValues(1, bi.CreatedAt)
+	require.EqualValues(maxBlockNumber, bi.UnlockedAt)
+	require.EqualValues(maxBlockNumber, bi.UnstakedAt)
+	require.EqualValues(identityset.Address(1).String(), bi.Delegate.String())
+	require.EqualValues(identityset.Address(2).String(), bi.Owner.String())
+
+	// put height in dirty cache
+	dirty.putHeight(1)
+	// check that clean cache is not affected
+	require.EqualValues(0, clean.Height())
+}

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -263,8 +263,4 @@ func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	require.EqualValues(identityset.Address(1).String(), bi.Delegate.String())
 	require.EqualValues(identityset.Address(2).String(), bi.Owner.String())
 
-	// put height in dirty cache
-	dirty.putHeight(1)
-	// check that clean cache is not affected
-	require.EqualValues(0, clean.Height())
 }

--- a/blockindex/contractstaking/event_handler.go
+++ b/blockindex/contractstaking/event_handler.go
@@ -420,8 +420,7 @@ func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, blk *blo
 }
 
 func (eh *contractStakingEventHandler) Result() (batch.KVStoreBatch, *contractStakingDelta) {
-	batch, delta := eh.dirty.finalize()
-	return batch, delta
+	return eh.dirty.finalize()
 }
 
 func (eh *contractStakingEventHandler) handleTransferEvent(event eventParam) error {

--- a/blockindex/contractstaking/event_handler.go
+++ b/blockindex/contractstaking/event_handler.go
@@ -352,6 +352,7 @@ const (
 type contractStakingEventHandler struct {
 	dirty      *contractStakingDirty
 	tokenOwner map[uint64]address.Address
+	height     uint64
 }
 
 var (
@@ -372,6 +373,7 @@ func newContractStakingEventHandler(cache *contractStakingCache, height uint64) 
 	return &contractStakingEventHandler{
 		dirty:      dirty,
 		tokenOwner: make(map[uint64]address.Address),
+		height:     height,
 	}
 }
 
@@ -420,8 +422,9 @@ func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, blk *blo
 	}
 }
 
-func (eh *contractStakingEventHandler) Result() (batch.KVStoreBatch, *contractStakingDelta) {
-	return eh.dirty.finalize()
+func (eh *contractStakingEventHandler) Result() (batch.KVStoreBatch, *contractStakingDelta, uint64) {
+	batch, delta := eh.dirty.finalize()
+	return batch, delta, eh.height
 }
 
 func (eh *contractStakingEventHandler) handleTransferEvent(event eventParam) error {

--- a/blockindex/contractstaking/event_handler.go
+++ b/blockindex/contractstaking/event_handler.go
@@ -352,7 +352,6 @@ const (
 type contractStakingEventHandler struct {
 	dirty      *contractStakingDirty
 	tokenOwner map[uint64]address.Address
-	height     uint64
 }
 
 var (
@@ -367,13 +366,11 @@ func init() {
 	}
 }
 
-func newContractStakingEventHandler(cache *contractStakingCache, height uint64) *contractStakingEventHandler {
+func newContractStakingEventHandler(cache *contractStakingCache) *contractStakingEventHandler {
 	dirty := newContractStakingDirty(cache)
-	dirty.putHeight(height)
 	return &contractStakingEventHandler{
 		dirty:      dirty,
 		tokenOwner: make(map[uint64]address.Address),
-		height:     height,
 	}
 }
 
@@ -422,9 +419,9 @@ func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, blk *blo
 	}
 }
 
-func (eh *contractStakingEventHandler) Result() (batch.KVStoreBatch, *contractStakingDelta, uint64) {
+func (eh *contractStakingEventHandler) Result() (batch.KVStoreBatch, *contractStakingDelta) {
 	batch, delta := eh.dirty.finalize()
-	return batch, delta, eh.height
+	return batch, delta
 }
 
 func (eh *contractStakingEventHandler) handleTransferEvent(event eventParam) error {

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -171,11 +171,13 @@ func (s *Indexer) DeleteTipBlock(context.Context, *block.Block) error {
 }
 
 func (s *Indexer) commit(handler *contractStakingEventHandler) error {
-	batch, delta := handler.Result()
+	batch, delta, height := handler.Result()
 	if err := s.cache.Merge(delta); err != nil {
 		s.reloadCache()
 		return err
 	}
+	s.cache.PutHeight(height)
+	s.cache.PutTotalBucketCount(s.cache.TotalBucketCount() + delta.AddedBucketCnt())
 	if err := s.kvstore.WriteBatch(batch); err != nil {
 		s.reloadCache()
 		return err

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -8,6 +8,7 @@ package contractstaking
 import (
 	"context"
 	"math/big"
+	"sync/atomic"
 
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/iotexproject/iotex-address/address"
@@ -17,6 +18,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/blockdao"
 	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 )
 
 const (
@@ -52,6 +54,7 @@ type (
 		cache                *contractStakingCache // in-memory index for clean data, used to query index data
 		contractAddress      string                // stake contract address
 		contractDeployHeight uint64                // height of the contract deployment
+		height               atomic.Value          // uint64, current block height
 	}
 )
 
@@ -76,7 +79,7 @@ func (s *Indexer) Start(ctx context.Context) error {
 	if err := s.kvstore.Start(ctx); err != nil {
 		return err
 	}
-	return s.cache.LoadFromDB(s.kvstore)
+	return s.loadFromDB(s.kvstore)
 }
 
 // Stop stops the indexer
@@ -90,7 +93,7 @@ func (s *Indexer) Stop(ctx context.Context) error {
 
 // Height returns the tip block height
 func (s *Indexer) Height() (uint64, error) {
-	return s.cache.Height(), nil
+	return s.height.Load().(uint64), nil
 }
 
 // StartHeight returns the start height of the indexer
@@ -144,7 +147,7 @@ func (s *Indexer) PutBlock(ctx context.Context, blk *block.Block) error {
 		return nil
 	}
 	// new event handler for this block
-	handler := newContractStakingEventHandler(s.cache, blk.Height())
+	handler := newContractStakingEventHandler(s.cache)
 
 	// handle events of block
 	for _, receipt := range blk.Receipts {
@@ -162,7 +165,7 @@ func (s *Indexer) PutBlock(ctx context.Context, blk *block.Block) error {
 	}
 
 	// commit the result
-	return s.commit(handler)
+	return s.commit(handler, blk.Height())
 }
 
 // DeleteTipBlock deletes the tip block from indexer
@@ -170,14 +173,18 @@ func (s *Indexer) DeleteTipBlock(context.Context, *block.Block) error {
 	return errors.New("not implemented")
 }
 
-func (s *Indexer) commit(handler *contractStakingEventHandler) error {
-	batch, delta, height := handler.Result()
+func (s *Indexer) commit(handler *contractStakingEventHandler, height uint64) error {
+	batch, delta := handler.Result()
+	// update cache
 	if err := s.cache.Merge(delta); err != nil {
 		s.reloadCache()
 		return err
 	}
-	s.cache.PutHeight(height)
 	s.cache.PutTotalBucketCount(s.cache.TotalBucketCount() + delta.AddedBucketCnt())
+	// update indexer height cache
+	s.height.Store(height)
+	// update db
+	batch.Put(_StakingNS, _stakingHeightKey, byteutil.Uint64ToBytesBigEndian(height), "failed to put height")
 	if err := s.kvstore.WriteBatch(batch); err != nil {
 		s.reloadCache()
 		return err
@@ -187,5 +194,23 @@ func (s *Indexer) commit(handler *contractStakingEventHandler) error {
 
 func (s *Indexer) reloadCache() error {
 	s.cache = newContractStakingCache(s.contractAddress)
-	return s.cache.LoadFromDB(s.kvstore)
+	return s.loadFromDB(s.kvstore)
+}
+
+func (s *Indexer) loadFromDB(kvstore db.KVStore) error {
+	// load height
+	var height uint64
+	h, err := kvstore.Get(_StakingNS, _stakingHeightKey)
+	if err != nil {
+		if !errors.Is(err, db.ErrNotExist) {
+			return err
+		}
+		height = 0
+	} else {
+		height = byteutil.BytesToUint64BigEndian(h)
+
+	}
+	s.height.Store(height)
+	// load cache
+	return s.cache.LoadFromDB(kvstore)
 }


### PR DESCRIPTION
# Description
The issue is that when `changeDelegate` is called on a bucket, the votes of the old delegate are not reduced.

The issue is caused by two factors: 
1. not remove the bucket of the old candidate from the `candidateBucketMap`
2. the `cache` read operations return a pointer, which means that the clean cache may have already been updated before the `merge`.

pre-required: #3887 

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
