### PR TITLE
[ioctl] add bc delegate command

### DIFF
--- a/ioctl/cmd/bc/bc.go
+++ b/ioctl/cmd/bc/bc.go
@@ -50,6 +50,7 @@ func init() {
 	BCCmd.AddCommand(_bcInfoCmd)
 	BCCmd.AddCommand(_bcBucketListCmd)
 	BCCmd.AddCommand(_bcBucketCmd)
+	BCCmd.AddCommand(_bcDelegateCmd)
 	BCCmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint",
 		config.ReadConfig.Endpoint, config.TranslateInLang(_flagEndpointUsages, config.UILanguage))
 	BCCmd.PersistentFlags().BoolVar(&config.Insecure, "insecure", config.Insecure,

--- a/ioctl/cmd/bc/bcdelegate.go
+++ b/ioctl/cmd/bc/bcdelegate.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2022 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package bc
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/spf13/cobra"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/ioctl/config"
+	"github.com/iotexproject/iotex-core/ioctl/output"
+	"github.com/iotexproject/iotex-core/ioctl/util"
+)
+
+// Multi-language support
+var (
+	_bcDelegateCmdShorts = map[config.Language]string{
+		config.English: "Get delegate information on IoTeX blockchain",
+		config.Chinese: "在IoTeX区块链上读取代表信息",
+	}
+	_bcDelegateUses = map[config.Language]string{
+		config.English: "delegate [name]",
+		config.Chinese: "delegate [名字]",
+	}
+)
+
+// _bcBucketCmd represents the bc Bucket command
+var _bcDelegateCmd = &cobra.Command{
+	Use:     config.TranslateInLang(_bcDelegateUses, config.UILanguage),
+	Short:   config.TranslateInLang(_bcDelegateCmdShorts, config.UILanguage),
+	Args:    cobra.ExactArgs(1),
+	Example: `ioctl bc delegate name, to read delegate information by name`,
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		cmd.SilenceUsage = true
+		err = getDelegate(args[0])
+		return output.PrintError(err)
+	},
+}
+
+type delegateMessage struct {
+	Delegate *iotextypes.CandidateV2 `json:"delegate"`
+}
+
+func (m *delegateMessage) delegateString() string {
+	var (
+		d        = m.Delegate
+		vote, _  = new(big.Int).SetString(d.TotalWeightedVotes, 10)
+		token, _ = new(big.Int).SetString(d.SelfStakingTokens, 10)
+		lines    []string
+	)
+	lines = append(lines, "{")
+	lines = append(lines, fmt.Sprintf("	name: %s", d.Name))
+	lines = append(lines, fmt.Sprintf("	ownerAddress: %s", d.OwnerAddress))
+	lines = append(lines, fmt.Sprintf("	operatorAddress: %s", d.OperatorAddress))
+	lines = append(lines, fmt.Sprintf("	rewardAddress: %s", d.RewardAddress))
+	lines = append(lines, fmt.Sprintf("	totalWeightedVotes: %s", util.RauToString(vote, util.IotxDecimalNum)))
+	lines = append(lines, fmt.Sprintf("	selfStakeBucketIdx: %d", d.SelfStakeBucketIdx))
+	lines = append(lines, fmt.Sprintf("	selfStakingTokens: %s IOTX", util.RauToString(token, util.IotxDecimalNum)))
+	lines = append(lines, "}")
+	return strings.Join(lines, "\n")
+}
+
+func (m *delegateMessage) String() string {
+	if output.Format == "" {
+		return m.delegateString()
+	}
+	return output.FormatString(output.Result, m)
+}
+
+func getDelegate(arg string) error {
+	d, err := getDelegateByName(arg)
+	if err != nil {
+		return err
+	}
+	message := delegateMessage{
+		Delegate: d,
+	}
+	fmt.Println(message.String())
+	return nil
+}
+
+func getDelegateByName(name string) (*iotextypes.CandidateV2, error) {
+	conn, err := util.ConnectToEndpoint(config.ReadConfig.SecureConnect && !config.Insecure)
+	if err != nil {
+		return nil, output.NewError(output.NetworkError, "failed to connect to endpoint", err)
+	}
+	defer conn.Close()
+	cli := iotexapi.NewAPIServiceClient(conn)
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME,
+	}
+	methodData, err := proto.Marshal(method)
+	if err != nil {
+		return nil, output.NewError(output.SerializationError, "failed to marshal read staking data method", err)
+	}
+	readStakingdataRequest := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_CandidateByName_{
+			CandidateByName: &iotexapi.ReadStakingDataRequest_CandidateByName{
+				CandName: name,
+			},
+		},
+	}
+	requestData, err := proto.Marshal(readStakingdataRequest)
+	if err != nil {
+		return nil, output.NewError(output.SerializationError, "failed to marshal read staking data request", err)
+	}
+
+	request := &iotexapi.ReadStateRequest{
+		ProtocolID: []byte("staking"),
+		MethodName: methodData,
+		Arguments:  [][]byte{requestData},
+	}
+
+	ctx := context.Background()
+	jwtMD, err := util.JwtAuth()
+	if err == nil {
+		ctx = metautils.NiceMD(jwtMD).ToOutgoing(ctx)
+	}
+
+	response, err := cli.ReadState(ctx, request)
+	if err != nil {
+		sta, ok := status.FromError(err)
+		if ok {
+			return nil, output.NewError(output.APIError, sta.Message(), nil)
+		}
+		return nil, output.NewError(output.NetworkError, "failed to invoke ReadState api", err)
+	}
+	delegate := iotextypes.CandidateV2{}
+	if err := proto.Unmarshal(response.Data, &delegate); err != nil {
+		return nil, output.NewError(output.SerializationError, "failed to unmarshal response", err)
+	}
+	return &delegate, nil
+}

--- a/ioctl/cmd/node/nodedelegate.go
+++ b/ioctl/cmd/node/nodedelegate.go
@@ -46,7 +46,7 @@ var (
 	}
 	_delegateCmdShorts = map[config.Language]string{
 		config.English: "Print consensus delegates information in certain epoch",
-		config.Chinese: "打印在特定epoch内的公认代表的信息",
+		config.Chinese: "打印在特定epoch内的共识代表的信息",
 	}
 	_flagEpochNumUsages = map[config.Language]string{
 		config.English: "specify specific epoch",


### PR DESCRIPTION
# Description
`ioctl node delegate` gives the delegates list of a certain epoch, but not every delegate's detailed info.

add a `ioctl bc delegate` command, like below:
```
./bin/ioctl bc delegate cpc --endpoint=api.iotex.one:443
{
	name: cpc
	ownerAddress: io1smh0a4ms9fc5p8v9h9l7ffgkekv032hzsdkr9a
	operatorAddress: io16fknjsnhj6m5x2fawu5tqfrk6pr9r9xyz489vk
	rewardAddress: io12mgttmfa2ffn9uqvn0yn37f4nz43d248l2ga85
	totalWeightedVotes: 68963450.120222472655746524
	selfStakeBucketIdx: 12
	selfStakingTokens: 2975349.881825114451272576 IOTX
}
```

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
