### PR TITLE
[api] fix revert custom errors and returns the correct revert message…

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -85,6 +85,7 @@ type (
 		SystemWideActionGasLimit                bool
 		NotFixTopicCopyBug                      bool
 		SetRevertMessageToReceipt               bool
+		FixCustomErrorRevertMessage             bool
 		FixGetHashFnHeight                      bool
 		FixSortCacheContractsAndUsePendingNonce bool
 		AsyncContractTrie                       bool
@@ -224,6 +225,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			SystemWideActionGasLimit:                !g.IsAleutian(height),
 			NotFixTopicCopyBug:                      !g.IsAleutian(height),
 			SetRevertMessageToReceipt:               g.IsHawaii(height),
+			FixCustomErrorRevertMessage:             g.IsCustomErrorEnabled(height),
 			FixGetHashFnHeight:                      g.IsHawaii(height),
 			FixSortCacheContractsAndUsePendingNonce: g.IsHawaii(height),
 			AsyncContractTrie:                       g.IsGreenland(height),

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -225,7 +225,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			SystemWideActionGasLimit:                !g.IsAleutian(height),
 			NotFixTopicCopyBug:                      !g.IsAleutian(height),
 			SetRevertMessageToReceipt:               g.IsHawaii(height),
-			FixCustomErrorRevertMessage:             g.IsCustomErrorEnabled(height),
+			FixCustomErrorRevertMessage:             g.IsToBeEnabled(height),
 			FixGetHashFnHeight:                      g.IsHawaii(height),
 			FixSortCacheContractsAndUsePendingNonce: g.IsHawaii(height),
 			AsyncContractTrie:                       g.IsGreenland(height),

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1430,19 +1430,19 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 	sc.SetGasPrice(big.NewInt(0))
 	blockGasLimit := core.bc.Genesis().BlockGasLimit
 	sc.SetGasLimit(blockGasLimit)
-	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc)
+	enough, ret, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc)
 	if err != nil {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
 	if !enough {
-		if receipt.ExecutionRevertMsg() != "" {
-			return 0, status.Errorf(codes.Internal, fmt.Sprintf("execution simulation is reverted due to the reason: %s", receipt.ExecutionRevertMsg()))
+		if receipt != nil && len(receipt.ExecutionRevertMsg()) > 0 {
+			return 0, newRevertError(ret)
 		}
 		return 0, status.Error(codes.Internal, fmt.Sprintf("execution simulation failed: status = %d", receipt.Status))
 	}
 	estimatedGas := receipt.GasConsumed
 	sc.SetGasLimit(estimatedGas)
-	enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
+	enough, _, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
 	if err != nil && err != action.ErrInsufficientFunds {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
@@ -1452,7 +1452,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		for low <= high {
 			mid := (low + high) / 2
 			sc.SetGasLimit(mid)
-			enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
+			enough, _, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
 			if err != nil && err != action.ErrInsufficientFunds {
 				return 0, status.Error(codes.Internal, err.Error())
 			}
@@ -1472,18 +1472,18 @@ func (core *coreService) isGasLimitEnough(
 	ctx context.Context,
 	caller address.Address,
 	sc *action.Execution,
-) (bool, *action.Receipt, error) {
+) (bool, []byte, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "Server.isGasLimitEnough")
 	defer span.End()
 	ctx, err := core.bc.Context(ctx)
 	if err != nil {
-		return false, nil, err
+		return false, nil, nil, err
 	}
-	_, receipt, err := core.sf.SimulateExecution(ctx, caller, sc, core.dao.GetBlockHash)
+	ret, receipt, err := core.sf.SimulateExecution(ctx, caller, sc, core.dao.GetBlockHash)
 	if err != nil {
-		return false, nil, err
+		return false, nil, nil, err
 	}
-	return receipt.Status == uint64(iotextypes.ReceiptStatus_Success), receipt, nil
+	return receipt.Status == uint64(iotextypes.ReceiptStatus_Success), ret, receipt, nil
 }
 
 func (core *coreService) getProductivityByEpoch(

--- a/api/json.go
+++ b/api/json.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	vsn              = "2.0"
+	defaultErrorCode = -32000
+)
+
+var null = json.RawMessage("null")
+
+// error response. Which one it is depends on the fields.
+type jsonrpcMessage struct {
+	Version string          `json:"jsonrpc,omitempty"`
+	ID      int64           `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Error   *jsonError      `json:"error,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+}
+
+func (obj *jsonrpcMessage) MarshalJSON() ([]byte, error) {
+	return json.Marshal(*obj)
+}
+
+func successMessage(result interface{}) *jsonrpcMessage {
+	msg := &jsonrpcMessage{Version: vsn, Result: null}
+	if result != nil {
+		msg.Result, _ = json.Marshal(result)
+	}
+	return msg
+}
+
+func errorMessage(err error) *jsonrpcMessage {
+	msg := &jsonrpcMessage{Version: vsn, Error: &jsonError{
+		Code:    defaultErrorCode,
+		Message: err.Error(),
+	}}
+	de, ok := err.(rpc.DataError)
+	if ok {
+		msg.Error.Data = de.ErrorData()
+	}
+	ec, ok := err.(rpc.Error)
+	if ok {
+		msg.Error.Code = ec.ErrorCode()
+		return msg
+	}
+	if s, ok := status.FromError(err); ok {
+		msg.Error.Code, msg.Error.Message = int(s.Code()), s.Message()
+	} else {
+		msg.Error.Code, msg.Error.Message = -32603, err.Error()
+	}
+	return msg
+}
+
+type jsonError struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+func (err *jsonError) Error() string {
+	if err.Message == "" {
+		return fmt.Sprintf("json-rpc error %d", err.Code)
+	}
+	return err.Message
+}
+
+func (err *jsonError) ErrorCode() int {
+	return err.Code
+}
+
+func (err *jsonError) ErrorData() interface{} {
+	return err.Data
+}
+
+func newRevertError(revertReason []byte) *revertError {
+	reason, errUnpack := abi.UnpackRevert(revertReason)
+	err := errors.New("execution reverted")
+	if errUnpack == nil {
+		err = fmt.Errorf("execution reverted: %v", reason)
+	}
+	return &revertError{
+		error:  err,
+		reason: hexutil.Encode(revertReason),
+	}
+}
+
+// revertError is an API error that encompasses an EVM revert with JSON error
+// code and a binary data blob.
+type revertError struct {
+	error
+	reason string // revert reason hex encoded
+}
+
+// ErrorCode returns the JSON error code for a revert.
+// See: https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal
+func (e *revertError) ErrorCode() int {
+	return 3
+}
+
+// ErrorData returns the hex encoded revert reason.
+func (e *revertError) ErrorData() interface{} {
+	return e.reason
+}

--- a/api/web3server_marshal.go
+++ b/api/web3server_marshal.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/iotexproject/go-pkgs/crypto"
@@ -22,18 +21,6 @@ const (
 )
 
 type (
-	web3Response struct {
-		id     int
-		result interface{}
-		err    error
-	}
-
-	errMessage struct {
-		Code    int         `json:"code"`
-		Message string      `json:"message"`
-		Data    interface{} `json:"data,omitempty"`
-	}
-
 	streamResponse struct {
 		id     string
 		result interface{}
@@ -90,45 +77,6 @@ type (
 var (
 	errInvalidObject = errors.New("invalid object")
 )
-
-func (obj *web3Response) MarshalJSON() ([]byte, error) {
-	if obj.err == nil {
-		return json.Marshal(&struct {
-			Jsonrpc string      `json:"jsonrpc"`
-			ID      int         `json:"id"`
-			Result  interface{} `json:"result"`
-		}{
-			Jsonrpc: "2.0",
-			ID:      obj.id,
-			Result:  obj.result,
-		})
-	}
-
-	var (
-		errCode int
-		errMsg  string
-	)
-	// error code: https://eth.wiki/json-rpc/json-rpc-error-codes-improvement-proposal
-	if s, ok := status.FromError(obj.err); ok {
-		errCode, errMsg = int(s.Code()), s.Message()
-	} else {
-		errCode, errMsg = -32603, obj.err.Error()
-	}
-
-	return json.Marshal(&struct {
-		Jsonrpc string     `json:"jsonrpc"`
-		ID      int        `json:"id"`
-		Error   errMessage `json:"error"`
-	}{
-		Jsonrpc: "2.0",
-		ID:      obj.id,
-		Error: errMessage{
-			Code:    errCode,
-			Message: errMsg,
-			Data:    obj.result,
-		},
-	})
-}
 
 func getLogsBloomHex(logsbloom string) string {
 	if len(logsbloom) == 0 {

--- a/api/web3server_marshal_test.go
+++ b/api/web3server_marshal_test.go
@@ -36,11 +36,9 @@ func TestWeb3ResponseMarshal(t *testing.T) {
 	require := require.New(t)
 
 	t.Run("Result", func(t *testing.T) {
-		res, err := json.Marshal(&web3Response{
-			id:     1,
-			result: false,
-			err:    nil,
-		})
+		js := successMessage(false)
+		js.ID = 1
+		res, err := json.Marshal(js)
 		require.NoError(err)
 		require.JSONEq(`
 		{
@@ -52,11 +50,9 @@ func TestWeb3ResponseMarshal(t *testing.T) {
 	})
 
 	t.Run("Error", func(t *testing.T) {
-		res, err := json.Marshal(&web3Response{
-			id:     1,
-			result: nil,
-			err:    errInvalidBlock,
-		})
+		js := errorMessage(errInvalidBlock)
+		js.ID = 1
+		res, err := json.Marshal(js)
 		require.NoError(err)
 		require.JSONEq(`
 		{

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -71,7 +71,9 @@ func defaultConfig() Genesis {
 			OkhotskBlockHeight:      21542761,
 			PalauBlockHeight:        22991401,
 			QuebecBlockHeight:       24838201,
-			ToBeEnabledBlockHeight:  math.MaxUint64,
+			//todo: update the block height
+			FixCustomErrorBlockHeight: math.MaxUint64,
+			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{
 			InitBalanceMap: make(map[string]string),
@@ -241,6 +243,8 @@ type (
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
+		// FixCustomErrorBlockHeight is the start height to fix contract's custom error in evm
+		FixCustomErrorBlockHeight uint64 `yaml:"fixCustomErrorHeight"`
 	}
 	// Account contains the configs for account protocol
 	Account struct {
@@ -574,6 +578,11 @@ func (g *Blockchain) IsQuebec(height uint64) bool {
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height
 func (g *Blockchain) IsToBeEnabled(height uint64) bool {
 	return g.isPost(g.ToBeEnabledBlockHeight, height)
+}
+
+// IsCustomErrorEnabled checks whether height is equal to or larger than custom error height
+func (g *Blockchain) IsCustomErrorEnabled(height uint64) bool {
+	return g.isPost(g.FixCustomErrorBlockHeight, height)
 }
 
 // InitBalances returns the address that have initial balances and the corresponding amounts. The i-th amount is the

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -71,9 +71,7 @@ func defaultConfig() Genesis {
 			OkhotskBlockHeight:      21542761,
 			PalauBlockHeight:        22991401,
 			QuebecBlockHeight:       24838201,
-			//todo: update the block height
-			FixCustomErrorBlockHeight: math.MaxUint64,
-			ToBeEnabledBlockHeight:    math.MaxUint64,
+			ToBeEnabledBlockHeight:  math.MaxUint64,
 		},
 		Account: Account{
 			InitBalanceMap: make(map[string]string),
@@ -243,8 +241,6 @@ type (
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
-		// FixCustomErrorBlockHeight is the start height to fix contract's custom error in evm
-		FixCustomErrorBlockHeight uint64 `yaml:"fixCustomErrorHeight"`
 	}
 	// Account contains the configs for account protocol
 	Account struct {
@@ -578,11 +574,6 @@ func (g *Blockchain) IsQuebec(height uint64) bool {
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height
 func (g *Blockchain) IsToBeEnabled(height uint64) bool {
 	return g.isPost(g.ToBeEnabledBlockHeight, height)
-}
-
-// IsCustomErrorEnabled checks whether height is equal to or larger than custom error height
-func (g *Blockchain) IsCustomErrorEnabled(height uint64) bool {
-	return g.isPost(g.FixCustomErrorBlockHeight, height)
 }
 
 // InitBalances returns the address that have initial balances and the corresponding amounts. The i-th amount is the


### PR DESCRIPTION
# Description
Returns the correct json when the contract call contains a custom revert error

The PR needs to add a new HF height config in genesis.yaml , pls confirm it when deploying.

fix before
```bash
$ curl -X POST http://127.0.0.1:15014/ -H "Content-Type:application/json" \
            --data "{\"id\":2248897981,\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x4f2f741648699c1dc0ad8352e937057cd7e66bd7\",\"to\":\"0x3f5f75147437c8354d1ff31ece231ba29be90f65\",\"data\":\"0xa6b206bf0000000000000000000000000000000000000000000000000000000000000000\",\"value\":\"0x0\",\"type\":\"0x1\"}]}"

{"jsonrpc":"2.0","id":2248897981,"error":{"code":13,"message":"execution simulation failed: status = 106"}}


$ curl -X POST http://127.0.0.1:15014/ -H "Content-Type:application/json" \
            --data '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0xa6b206bf0000000000000000000000000000000000000000000000000000000000000000","to":"0x3F5f75147437C8354d1fF31EcE231BA29bE90f65","gas":"0x2faf080"},"latest"]}'
{"jsonrpc":"2.0","id":1,"result":"0x1bd9aa400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000001456616c75652063616e6e6f74206265207a65726f000000000000000000000000"}
```
after fix
```bash
$ curl -X POST http://127.0.0.1:15014/ -H "Content-Type:application/json" \
            --data "{\"id\":2248897981,\"jsonrpc\":\"2.0\",\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x4f2f741648699c1dc0ad8352e937057cd7e66bd7\",\"to\":\"0x3f5f75147437c8354d1ff31ece231ba29be90f65\",\"data\":\"0xa6b206bf0000000000000000000000000000000000000000000000000000000000000000\",\"value\":\"0x0\",\"type\":\"0x1\"}]}"

{"jsonrpc":"2.0","id":2248897981,"error":{"code":3,"message":"execution reverted","data":"0x1bd9aa400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000001456616c75652063616e6e6f74206265207a65726f000000000000000000000000"}}

$ curl -X POST http://127.0.0.1:15014/ -H "Content-Type:application/json" \
            --data '{"jsonrpc":"2.0","id":1,"method":"eth_call","params":[{"data":"0xa6b206bf0000000000000000000000000000000000000000000000000000000000000000","to":"0x3F5f75147437C8354d1fF31EcE231BA29bE90f65","gas":"0x2faf080"},"latest"]}'

{"jsonrpc":"2.0","id":1,"error":{"code":3,"message":"execution reverted","data":"0x1bd9aa400000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000007b000000000000000000000000000000000000000000000000000000000000001456616c75652063616e6e6f74206265207a65726f000000000000000000000000"}}
```

The fixed API response is the same as geth

Fixes #3919

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
