### PR TITLE
[blockindex] restrict height for sgdindexer during write and read operation

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -55,7 +55,7 @@ type (
 
 	// SGDRegistry is the interface for handling Sharing of Gas-fee with DApps
 	SGDRegistry interface {
-		CheckContract(context.Context, string) (address.Address, uint64, bool, error)
+		CheckContract(context.Context, string, uint64) (address.Address, uint64, bool, error)
 	}
 )
 
@@ -303,8 +303,11 @@ func processSGD(ctx context.Context, sm protocol.StateManager, execution *action
 	if execution.Contract() == action.EmptyAddress {
 		return nil, 0, nil
 	}
-
-	receiver, percentage, ok, err := sgd.CheckContract(ctx, execution.Contract())
+	height, err := sm.Height()
+	if err != nil {
+		return nil, 0, err
+	}
+	receiver, percentage, ok, err := sgd.CheckContract(ctx, execution.Contract(), height)
 	if err != nil || !ok {
 		return nil, 0, err
 	}

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -307,7 +307,7 @@ func processSGD(ctx context.Context, sm protocol.StateManager, execution *action
 	if err != nil {
 		return nil, 0, err
 	}
-	receiver, percentage, ok, err := sgd.CheckContract(ctx, execution.Contract(), height)
+	receiver, percentage, ok, err := sgd.CheckContract(ctx, execution.Contract(), height-1)
 	if err != nil || !ok {
 		return nil, 0, err
 	}

--- a/blockindex/sgd_indexer.go
+++ b/blockindex/sgd_indexer.go
@@ -193,9 +193,9 @@ type (
 	SGDRegistry interface {
 		blockdao.BlockIndexerWithStart
 		// CheckContract returns the contract's eligibility for SGD and percentage
-		CheckContract(context.Context, string) (address.Address, uint64, bool, error)
+		CheckContract(context.Context, string, uint64) (address.Address, uint64, bool, error)
 		// FetchContracts returns all contracts that are eligible for SGD
-		FetchContracts(context.Context) ([]*SGDIndex, error)
+		FetchContracts(context.Context, uint64) ([]*SGDIndex, error)
 	}
 
 	sgdRegistry struct {
@@ -285,9 +285,12 @@ func (sgd *sgdRegistry) StartHeight() uint64 {
 
 // PutBlock puts a block into SGDIndexer
 func (sgd *sgdRegistry) PutBlock(ctx context.Context, blk *block.Block) error {
-	if blk.Height() < sgd.startHeight {
+	if ignore, err := sgd.validateBlock(blk); err != nil {
+		return err
+	} else if ignore {
 		return nil
 	}
+
 	var (
 		r  *action.Receipt
 		ok bool
@@ -430,7 +433,10 @@ func (sgd *sgdRegistry) DeleteTipBlock(context.Context, *block.Block) error {
 }
 
 // CheckContract checks if the contract is a SGD contract
-func (sgd *sgdRegistry) CheckContract(ctx context.Context, contract string) (address.Address, uint64, bool, error) {
+func (sgd *sgdRegistry) CheckContract(ctx context.Context, contract string, height uint64) (address.Address, uint64, bool, error) {
+	if err := sgd.validateQueryHeight(height); err != nil {
+		return nil, 0, false, err
+	}
 	addr, err := address.FromString(contract)
 	if err != nil {
 		return nil, 0, false, err
@@ -458,7 +464,10 @@ func (sgd *sgdRegistry) getSGDIndex(contract []byte) (*indexpb.SGDIndex, error) 
 }
 
 // FetchContracts returns all contracts that are eligible for SGD
-func (sgd *sgdRegistry) FetchContracts(ctx context.Context) ([]*SGDIndex, error) {
+func (sgd *sgdRegistry) FetchContracts(ctx context.Context, height uint64) ([]*SGDIndex, error) {
+	if err := sgd.validateQueryHeight(height); err != nil {
+		return nil, err
+	}
 	_, values, err := sgd.kvStore.Filter(_sgdBucket, func(k, v []byte) bool { return true }, nil, nil)
 	if err != nil {
 		if errors.Cause(err) == db.ErrNotExist || errors.Cause(err) == db.ErrBucketNotExist {
@@ -479,6 +488,39 @@ func (sgd *sgdRegistry) FetchContracts(ctx context.Context) ([]*SGDIndex, error)
 		sgdIndexes = append(sgdIndexes, sgdIndex)
 	}
 	return sgdIndexes, nil
+}
+
+func (sgd *sgdRegistry) validateBlock(blk *block.Block) (ignore bool, err error) {
+	tipHeight, err := sgd.Height()
+	if err != nil {
+		return false, err
+	}
+	expectHeight := tipHeight + 1
+	if expectHeight < sgd.startHeight {
+		expectHeight = sgd.startHeight
+	}
+	if blk.Height() < expectHeight {
+		return true, nil
+	}
+	if blk.Height() > expectHeight {
+		return false, errors.Errorf("invalid block height %d, expect %d", blk.Height(), expectHeight)
+	}
+	return false, nil
+}
+
+func (sgd *sgdRegistry) validateQueryHeight(height uint64) error {
+	// 0 means latest height
+	if height == 0 {
+		return nil
+	}
+	tipHeight, err := sgd.Height()
+	if err != nil {
+		return err
+	}
+	if height != tipHeight {
+		return errors.Errorf("invalid height %d, expect %d", height, tipHeight)
+	}
+	return nil
 }
 
 func getReceiptsFromBlock(blk *block.Block) map[hash.Hash256]*action.Receipt {

--- a/blockindex/sgd_indexer_test.go
+++ b/blockindex/sgd_indexer_test.go
@@ -109,6 +109,31 @@ func TestNewSGDRegistry(t *testing.T) {
 			r.Equal(receiverAddress, receiver)
 			r.True(isApproved)
 			r.Equal(_sgdPercentage, percentage)
+
+			t.Run("heightRestriction", func(t *testing.T) {
+				cases := []struct {
+					height uint64
+					isErr  bool
+				}{
+					{0, false},
+					{1, true},
+					{2, false},
+					{3, true},
+				}
+				for i := range cases {
+					if cases[i].isErr {
+						_, err = sgdRegistry.FetchContracts(ctx, cases[i].height)
+						r.ErrorContains(err, "invalid height")
+						_, _, _, err = sgdRegistry.CheckContract(ctx, registerAddress.String(), cases[i].height)
+						r.ErrorContains(err, "invalid height")
+					} else {
+						_, err = sgdRegistry.FetchContracts(ctx, cases[i].height)
+						r.Nil(err)
+						_, _, _, err = sgdRegistry.CheckContract(ctx, registerAddress.String(), cases[i].height)
+						r.Nil(err)
+					}
+				}
+			})
 		})
 		t.Run("disapproveContract", func(t *testing.T) {
 			builder := block.NewTestingBuilder()

--- a/blockindex/sgd_indexer_test.go
+++ b/blockindex/sgd_indexer_test.go
@@ -77,13 +77,13 @@ func TestNewSGDRegistry(t *testing.T) {
 			}
 			blk := createTestingBlock(builder, 1, h, exec, logs)
 			r.NoError(sgdRegistry.PutBlock(ctx, blk))
-			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String())
+			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String(), 1)
 			r.NoError(err)
 			r.Equal(_sgdPercentage, percentage)
 			r.Equal(receiverAddress, receiver)
 			r.False(isApproved)
 
-			lists, err := sgdRegistry.FetchContracts(ctx)
+			lists, err := sgdRegistry.FetchContracts(ctx, 1)
 			r.NoError(err)
 			r.Equal(1, len(lists))
 			r.Equal(registerAddress.Bytes(), lists[0].Contract.Bytes())
@@ -102,9 +102,9 @@ func TestNewSGDRegistry(t *testing.T) {
 				Topics:  []hash.Hash256{hash.Hash256(event.ID)},
 				Data:    data,
 			}
-			blk := createTestingBlock(builder, 1, h, exec, logs)
+			blk := createTestingBlock(builder, 2, h, exec, logs)
 			r.NoError(sgdRegistry.PutBlock(ctx, blk))
-			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String())
+			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String(), 2)
 			r.NoError(err)
 			r.Equal(receiverAddress, receiver)
 			r.True(isApproved)
@@ -122,9 +122,9 @@ func TestNewSGDRegistry(t *testing.T) {
 				Topics:  []hash.Hash256{hash.Hash256(event.ID)},
 				Data:    data,
 			}
-			blk := createTestingBlock(builder, 1, h, exec, logs)
+			blk := createTestingBlock(builder, 3, h, exec, logs)
 			r.NoError(sgdRegistry.PutBlock(ctx, blk))
-			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String())
+			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String(), 3)
 			r.NoError(err)
 			r.Equal(receiverAddress, receiver)
 			r.False(isApproved)
@@ -142,9 +142,9 @@ func TestNewSGDRegistry(t *testing.T) {
 				Topics:  []hash.Hash256{hash.Hash256(event.ID)},
 				Data:    data,
 			}
-			blk := createTestingBlock(builder, 2, h, exec, logs)
+			blk := createTestingBlock(builder, 4, h, exec, logs)
 			r.NoError(sgdRegistry.PutBlock(ctx, blk))
-			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String())
+			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, registerAddress.String(), 4)
 			r.ErrorContains(err, "not exist in DB")
 			r.Nil(receiver)
 			r.False(isApproved)
@@ -153,7 +153,7 @@ func TestNewSGDRegistry(t *testing.T) {
 			r.Equal(blk.Height(), hh)
 			r.Equal(uint64(0), percentage)
 
-			_, err = sgdRegistry.FetchContracts(ctx)
+			_, err = sgdRegistry.FetchContracts(ctx, blk.Height())
 			r.ErrorIs(err, state.ErrStateNotExist)
 		})
 	})

--- a/e2etest/sgd_registry_test.go
+++ b/e2etest/sgd_registry_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/stretchr/testify/require"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/account"
@@ -27,7 +29,6 @@ import (
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/state/factory"
 	"github.com/iotexproject/iotex-core/testutil"
-	"github.com/stretchr/testify/require"
 )
 
 type checkContractExpectation struct {
@@ -109,7 +110,7 @@ func TestSGDRegistry(t *testing.T) {
 	r.NoError(err)
 	kvstore, err := db.CreateKVStore(db.DefaultConfig, indexSGDDBPath)
 	r.NoError(err)
-	sgdRegistry := blockindex.NewSGDRegistry(contractAddress, 0, kvstore)
+	sgdRegistry := blockindex.NewSGDRegistry(contractAddress, 2, kvstore)
 	r.NoError(sgdRegistry.Start(ctx))
 	defer func() {
 		r.NoError(sgdRegistry.Stop(ctx))
@@ -256,7 +257,7 @@ func TestSGDRegistry(t *testing.T) {
 				)
 				r.NoError(sgdRegistry.PutBlock(ctx, blk))
 			}
-			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, tt.checkContractExpect.contractAddress)
+			receiver, percentage, isApproved, err := sgdRegistry.CheckContract(ctx, tt.checkContractExpect.contractAddress, height)
 			if tt.checkContractExpect.errorContains != "" {
 				r.ErrorContains(err, tt.checkContractExpect.errorContains)
 			} else {


### PR DESCRIPTION
# Description
Motivation:
- Strictly limiting the blocks during PutBlock can avoid block skipping issues
-  Specifying the height during queries can help detect errors in the indexer at an earlier stage

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
