### PR TITLE
[blockindex] restrict height for contract_staking_indexer during read operation

### DIFF
--- a/action/protocol/staking/contractstake_indexer.go
+++ b/action/protocol/staking/contractstake_indexer.go
@@ -28,7 +28,5 @@ type (
 		TotalBucketCount(height uint64) (uint64, error)
 		// BucketTypes returns the active bucket types
 		BucketTypes(height uint64) ([]*ContractStakingBucketType, error)
-		// Height returns the indexer height
-		Height() (uint64, error)
 	}
 )

--- a/action/protocol/staking/contractstake_indexer.go
+++ b/action/protocol/staking/contractstake_indexer.go
@@ -17,16 +17,18 @@ type (
 	ContractStakingIndexer interface {
 		// CandidateVotes returns the total staked votes of a candidate
 		// candidate identified by owner address
-		CandidateVotes(ownerAddr address.Address) *big.Int
+		CandidateVotes(ownerAddr address.Address, height uint64) (*big.Int, error)
 		// Buckets returns active buckets
-		Buckets() ([]*VoteBucket, error)
+		Buckets(height uint64) ([]*VoteBucket, error)
 		// BucketsByIndices returns active buckets by indices
-		BucketsByIndices([]uint64) ([]*VoteBucket, error)
+		BucketsByIndices([]uint64, uint64) ([]*VoteBucket, error)
 		// BucketsByCandidate returns active buckets by candidate
-		BucketsByCandidate(ownerAddr address.Address) ([]*VoteBucket, error)
+		BucketsByCandidate(ownerAddr address.Address, height uint64) ([]*VoteBucket, error)
 		// TotalBucketCount returns the total number of buckets including burned buckets
-		TotalBucketCount() uint64
+		TotalBucketCount(height uint64) (uint64, error)
 		// BucketTypes returns the active bucket types
-		BucketTypes() ([]*ContractStakingBucketType, error)
+		BucketTypes(height uint64) ([]*ContractStakingBucketType, error)
+		// Height returns the indexer height
+		Height() (uint64, error)
 	}
 )

--- a/action/protocol/staking/contractstake_indexer_mock.go
+++ b/action/protocol/staking/contractstake_indexer_mock.go
@@ -36,89 +36,106 @@ func (m *MockContractStakingIndexer) EXPECT() *MockContractStakingIndexerMockRec
 }
 
 // BucketTypes mocks base method.
-func (m *MockContractStakingIndexer) BucketTypes() ([]*ContractStakingBucketType, error) {
+func (m *MockContractStakingIndexer) BucketTypes(height uint64) ([]*ContractStakingBucketType, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BucketTypes")
+	ret := m.ctrl.Call(m, "BucketTypes", height)
 	ret0, _ := ret[0].([]*ContractStakingBucketType)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BucketTypes indicates an expected call of BucketTypes.
-func (mr *MockContractStakingIndexerMockRecorder) BucketTypes() *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) BucketTypes(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketTypes", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketTypes))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketTypes", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketTypes), height)
 }
 
 // Buckets mocks base method.
-func (m *MockContractStakingIndexer) Buckets() ([]*VoteBucket, error) {
+func (m *MockContractStakingIndexer) Buckets(height uint64) ([]*VoteBucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Buckets")
+	ret := m.ctrl.Call(m, "Buckets", height)
 	ret0, _ := ret[0].([]*VoteBucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Buckets indicates an expected call of Buckets.
-func (mr *MockContractStakingIndexerMockRecorder) Buckets() *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) Buckets(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Buckets", reflect.TypeOf((*MockContractStakingIndexer)(nil).Buckets))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Buckets", reflect.TypeOf((*MockContractStakingIndexer)(nil).Buckets), height)
 }
 
 // BucketsByCandidate mocks base method.
-func (m *MockContractStakingIndexer) BucketsByCandidate(ownerAddr address.Address) ([]*VoteBucket, error) {
+func (m *MockContractStakingIndexer) BucketsByCandidate(ownerAddr address.Address, height uint64) ([]*VoteBucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BucketsByCandidate", ownerAddr)
+	ret := m.ctrl.Call(m, "BucketsByCandidate", ownerAddr, height)
 	ret0, _ := ret[0].([]*VoteBucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BucketsByCandidate indicates an expected call of BucketsByCandidate.
-func (mr *MockContractStakingIndexerMockRecorder) BucketsByCandidate(ownerAddr interface{}) *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) BucketsByCandidate(ownerAddr, height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByCandidate", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketsByCandidate), ownerAddr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByCandidate", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketsByCandidate), ownerAddr, height)
 }
 
 // BucketsByIndices mocks base method.
-func (m *MockContractStakingIndexer) BucketsByIndices(arg0 []uint64) ([]*VoteBucket, error) {
+func (m *MockContractStakingIndexer) BucketsByIndices(arg0 []uint64, arg1 uint64) ([]*VoteBucket, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BucketsByIndices", arg0)
+	ret := m.ctrl.Call(m, "BucketsByIndices", arg0, arg1)
 	ret0, _ := ret[0].([]*VoteBucket)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BucketsByIndices indicates an expected call of BucketsByIndices.
-func (mr *MockContractStakingIndexerMockRecorder) BucketsByIndices(arg0 interface{}) *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) BucketsByIndices(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByIndices", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketsByIndices), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByIndices", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketsByIndices), arg0, arg1)
 }
 
 // CandidateVotes mocks base method.
-func (m *MockContractStakingIndexer) CandidateVotes(ownerAddr address.Address) *big.Int {
+func (m *MockContractStakingIndexer) CandidateVotes(ownerAddr address.Address, height uint64) (*big.Int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidateVotes", ownerAddr)
+	ret := m.ctrl.Call(m, "CandidateVotes", ownerAddr, height)
 	ret0, _ := ret[0].(*big.Int)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CandidateVotes indicates an expected call of CandidateVotes.
-func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ownerAddr interface{}) *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ownerAddr, height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ownerAddr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ownerAddr, height)
+}
+
+// Height mocks base method.
+func (m *MockContractStakingIndexer) Height() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Height")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Height indicates an expected call of Height.
+func (mr *MockContractStakingIndexerMockRecorder) Height() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContractStakingIndexer)(nil).Height))
 }
 
 // TotalBucketCount mocks base method.
-func (m *MockContractStakingIndexer) TotalBucketCount() uint64 {
+func (m *MockContractStakingIndexer) TotalBucketCount(height uint64) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TotalBucketCount")
+	ret := m.ctrl.Call(m, "TotalBucketCount", height)
 	ret0, _ := ret[0].(uint64)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // TotalBucketCount indicates an expected call of TotalBucketCount.
-func (mr *MockContractStakingIndexerMockRecorder) TotalBucketCount() *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) TotalBucketCount(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBucketCount", reflect.TypeOf((*MockContractStakingIndexer)(nil).TotalBucketCount))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBucketCount", reflect.TypeOf((*MockContractStakingIndexer)(nil).TotalBucketCount), height)
 }

--- a/action/protocol/staking/contractstake_indexer_mock.go
+++ b/action/protocol/staking/contractstake_indexer_mock.go
@@ -110,21 +110,6 @@ func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ownerAddr, heig
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ownerAddr, height)
 }
 
-// Height mocks base method.
-func (m *MockContractStakingIndexer) Height() (uint64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Height")
-	ret0, _ := ret[0].(uint64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Height indicates an expected call of Height.
-func (mr *MockContractStakingIndexerMockRecorder) Height() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContractStakingIndexer)(nil).Height))
-}
-
 // TotalBucketCount mocks base method.
 func (m *MockContractStakingIndexer) TotalBucketCount(height uint64) (uint64, error) {
 	m.ctrl.T.Helper()

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -476,7 +476,11 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	for i := range list {
 		if p.contractStakingIndexer != nil && featureCtx.AddContractStakingVotes {
-			list[i].Votes.Add(list[i].Votes, p.contractStakingIndexer.CandidateVotes(list[i].Owner))
+			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, height)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to get CandidateVotes from contractStakingIndexer")
+			}
+			list[i].Votes.Add(list[i].Votes, contractVotes)
 		}
 		if list[i].SelfStake.Cmp(p.config.RegistrationConsts.MinSelfStake) >= 0 {
 			cand = append(cand, list[i])

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -467,6 +467,10 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.
 
 // ActiveCandidates returns all active candidates in candidate center
 func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader, height uint64) (state.CandidateList, error) {
+	height, err := sr.Height()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get StateReader height")
+	}
 	c, err := ConstructBaseView(sr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get ActiveCandidates")
@@ -476,7 +480,10 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	for i := range list {
 		if p.contractStakingIndexer != nil && featureCtx.AddContractStakingVotes {
-			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, height)
+			// specifying the height param instead of query latest from indexer directly, aims to cause error when indexer falls behind
+			// currently there are two possible sr (i.e. factory or workingSet), it means the height could be chain height or current block height
+			// using height-1 will cover the two scenario while detect whether the indexer is lagging behind
+			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, height-1)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get CandidateVotes from contractStakingIndexer")
 			}

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -467,7 +467,7 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.
 
 // ActiveCandidates returns all active candidates in candidate center
 func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader, height uint64) (state.CandidateList, error) {
-	height, err := sr.Height()
+	srHeight, err := sr.Height()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get StateReader height")
 	}
@@ -483,7 +483,7 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 			// specifying the height param instead of query latest from indexer directly, aims to cause error when indexer falls behind
 			// currently there are two possible sr (i.e. factory or workingSet), it means the height could be chain height or current block height
 			// using height-1 will cover the two scenario while detect whether the indexer is lagging behind
-			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, height-1)
+			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, srHeight-1)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get CandidateVotes from contractStakingIndexer")
 			}

--- a/action/protocol/staking/staking_statereader_test.go
+++ b/action/protocol/staking/staking_statereader_test.go
@@ -123,7 +123,7 @@ func TestStakingStateReader(t *testing.T) {
 		sf.EXPECT().ReadView(gomock.Any()).Return(testNativeData, nil).Times(1)
 
 		contractIndexer := NewMockContractStakingIndexer(ctrl)
-		contractIndexer.EXPECT().Buckets().Return(testContractBuckets, nil).AnyTimes()
+		contractIndexer.EXPECT().Buckets(gomock.Any()).Return(testContractBuckets, nil).AnyTimes()
 
 		stakeSR, err := newCompositeStakingStateReader(contractIndexer, nil, sf)
 		r.NoError(err)
@@ -241,7 +241,7 @@ func TestStakingStateReader(t *testing.T) {
 			*arg0R = totalBucketCount{count: 1}
 			return uint64(1), nil
 		}).Times(1)
-		contractIndexer.EXPECT().BucketsByCandidate(gomock.Any()).DoAndReturn(func(arg0 address.Address) ([]*VoteBucket, error) {
+		contractIndexer.EXPECT().BucketsByCandidate(gomock.Any(), gomock.Any()).DoAndReturn(func(arg0 address.Address, arg1 uint64) ([]*VoteBucket, error) {
 			buckets := []*VoteBucket{}
 			for i := range testContractBuckets {
 				if testContractBuckets[i].Candidate.String() == arg0.String() {
@@ -285,7 +285,7 @@ func TestStakingStateReader(t *testing.T) {
 			*arg0R = totalBucketCount{count: 1}
 			return uint64(1), nil
 		}).Times(1)
-		contractIndexer.EXPECT().BucketsByIndices(gomock.Any()).DoAndReturn(func(arg0 []uint64) ([]*VoteBucket, error) {
+		contractIndexer.EXPECT().BucketsByIndices(gomock.Any(), gomock.Any()).DoAndReturn(func(arg0 []uint64, arg1 uint64) ([]*VoteBucket, error) {
 			buckets := []*VoteBucket{}
 			for i := range arg0 {
 				buckets = append(buckets, testContractBuckets[arg0[i]])
@@ -318,7 +318,7 @@ func TestStakingStateReader(t *testing.T) {
 			*arg0R = totalBucketCount{count: 1}
 			return uint64(1), nil
 		}).Times(1)
-		contractIndexer.EXPECT().TotalBucketCount().Return(uint64(len(testContractBuckets))).Times(1)
+		contractIndexer.EXPECT().TotalBucketCount(gomock.Any()).Return(uint64(len(testContractBuckets)), nil).Times(1)
 		cfg := genesis.Default
 		cfg.GreenlandBlockHeight = 0
 		ctx = genesis.WithGenesisContext(ctx, cfg)
@@ -332,13 +332,13 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidates", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any()).DoAndReturn(func(ownerAddr address.Address) *big.Int {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
-					return b.StakedAmount
+					return b.StakedAmount, nil
 				}
 			}
-			return big.NewInt(0)
+			return big.NewInt(0), nil
 		}).MinTimes(1)
 		req := &iotexapi.ReadStakingDataRequest_Candidates{
 			Pagination: &iotexapi.PaginationParam{
@@ -362,13 +362,13 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidateByName", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any()).DoAndReturn(func(ownerAddr address.Address) *big.Int {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
-					return b.StakedAmount
+					return b.StakedAmount, nil
 				}
 			}
-			return big.NewInt(0)
+			return big.NewInt(0), nil
 		}).MinTimes(1)
 		req := &iotexapi.ReadStakingDataRequest_CandidateByName{
 			CandName: "cand1",
@@ -385,13 +385,13 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidateByAddress", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any()).DoAndReturn(func(ownerAddr address.Address) *big.Int {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
-					return b.StakedAmount
+					return b.StakedAmount, nil
 				}
 			}
-			return big.NewInt(0)
+			return big.NewInt(0), nil
 		}).MinTimes(1)
 		req := &iotexapi.ReadStakingDataRequest_CandidateByAddress{
 			OwnerAddr: identityset.Address(1).String(),

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -455,8 +455,11 @@ func (s *contractStakingCache) validateHeight(height uint64) error {
 	if height == 0 {
 		return nil
 	}
-	// indexer only store latest height
-	if height != s.height {
+	// Currently, historical block data query is not supported.
+	// However, the latest data is actually returned when querying historical block data, for the following reasons:
+	//	1. to maintain compatibility with the current code's invocation of ActiveCandidate
+	//	2. to cause consensus errors when the indexer is lagging behind
+	if height > s.height {
 		return errors.Wrapf(ErrInvalidHeight, "expected %d, actual %d", s.height, height)
 	}
 	return nil

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -32,6 +32,8 @@ type (
 var (
 	// ErrBucketNotExist is the error when bucket does not exist
 	ErrBucketNotExist = errors.New("bucket does not exist")
+	// ErrInvalidHeight is the error when height is invalid
+	ErrInvalidHeight = errors.New("invalid height")
 )
 
 func newContractStakingCache(contractAddr string) *contractStakingCache {
@@ -50,14 +52,17 @@ func (s *contractStakingCache) Height() uint64 {
 	return s.height
 }
 
-func (s *contractStakingCache) CandidateVotes(candidate address.Address) *big.Int {
+func (s *contractStakingCache) CandidateVotes(candidate address.Address, height uint64) (*big.Int, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	if err := s.validateHeight(height); err != nil {
+		return nil, err
+	}
 	votes := big.NewInt(0)
 	m, ok := s.candidateBucketMap[candidate.String()]
 	if !ok {
-		return votes
+		return votes, nil
 	}
 	for id, existed := range m {
 		if !existed {
@@ -71,12 +76,16 @@ func (s *contractStakingCache) CandidateVotes(candidate address.Address) *big.In
 		bt := s.mustGetBucketType(bi.TypeIndex)
 		votes.Add(votes, bt.Amount)
 	}
-	return votes
+	return votes, nil
 }
 
-func (s *contractStakingCache) Buckets() []*Bucket {
+func (s *contractStakingCache) Buckets(height uint64) ([]*Bucket, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
+
+	if err := s.validateHeight(height); err != nil {
+		return nil, err
+	}
 
 	vbs := []*Bucket{}
 	for id, bi := range s.bucketInfoMap {
@@ -84,14 +93,18 @@ func (s *contractStakingCache) Buckets() []*Bucket {
 		vb := assembleBucket(id, bi.clone(), bt, s.contractAddress)
 		vbs = append(vbs, vb)
 	}
-	return vbs
+	return vbs, nil
 }
 
-func (s *contractStakingCache) Bucket(id uint64) (*Bucket, bool) {
+func (s *contractStakingCache) Bucket(id, height uint64) (*Bucket, bool, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.getBucket(id)
+	if err := s.validateHeight(height); err != nil {
+		return nil, false, err
+	}
+	bt, ok := s.getBucket(id)
+	return bt, ok, nil
 }
 
 func (s *contractStakingCache) BucketInfo(id uint64) (*bucketInfo, bool) {
@@ -122,23 +135,29 @@ func (s *contractStakingCache) BucketType(id uint64) (*BucketType, bool) {
 	return s.getBucketType(id)
 }
 
-func (s *contractStakingCache) BucketsByCandidate(candidate address.Address) []*Bucket {
+func (s *contractStakingCache) BucketsByCandidate(candidate address.Address, height uint64) ([]*Bucket, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	if err := s.validateHeight(height); err != nil {
+		return nil, err
+	}
 	bucketMap := s.candidateBucketMap[candidate.String()]
 	vbs := make([]*Bucket, 0, len(bucketMap))
 	for id := range bucketMap {
 		vb := s.mustGetBucket(id)
 		vbs = append(vbs, vb)
 	}
-	return vbs
+	return vbs, nil
 }
 
-func (s *contractStakingCache) BucketsByIndices(indices []uint64) ([]*Bucket, error) {
+func (s *contractStakingCache) BucketsByIndices(indices []uint64, height uint64) ([]*Bucket, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	if err := s.validateHeight(height); err != nil {
+		return nil, err
+	}
 	vbs := make([]*Bucket, 0, len(indices))
 	for _, id := range indices {
 		vb, ok := s.getBucket(id)
@@ -149,24 +168,30 @@ func (s *contractStakingCache) BucketsByIndices(indices []uint64) ([]*Bucket, er
 	return vbs, nil
 }
 
-func (s *contractStakingCache) TotalBucketCount() uint64 {
+func (s *contractStakingCache) TotalBucketCount(height uint64) (uint64, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return s.totalBucketCount
+	if err := s.validateHeight(height); err != nil {
+		return 0, err
+	}
+	return s.totalBucketCount, nil
 }
 
-func (s *contractStakingCache) ActiveBucketTypes() map[uint64]*BucketType {
+func (s *contractStakingCache) ActiveBucketTypes(height uint64) (map[uint64]*BucketType, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
+	if err := s.validateHeight(height); err != nil {
+		return nil, err
+	}
 	m := make(map[uint64]*BucketType)
 	for k, v := range s.bucketTypeMap {
 		if v.ActivatedAt != maxBlockNumber {
 			m[k] = v.Clone()
 		}
 	}
-	return m
+	return m, nil
 }
 
 func (s *contractStakingCache) PutBucketType(id uint64, bt *BucketType) {
@@ -213,11 +238,14 @@ func (s *contractStakingCache) MatchBucketType(amount *big.Int, duration uint64)
 	return id, s.mustGetBucketType(id), true
 }
 
-func (s *contractStakingCache) BucketTypeCount() uint64 {
+func (s *contractStakingCache) BucketTypeCount(height uint64) (uint64, error) {
 	s.mutex.RLock()
 	defer s.mutex.RUnlock()
 
-	return uint64(len(s.bucketTypeMap))
+	if err := s.validateHeight(height); err != nil {
+		return 0, err
+	}
+	return uint64(len(s.bucketTypeMap)), nil
 }
 
 func (s *contractStakingCache) LoadFromDB(kvstore db.KVStore) error {
@@ -418,6 +446,18 @@ func (s *contractStakingCache) mergeDelta(delta *contractStakingDelta) error {
 				s.deleteBucketInfo(id)
 			}
 		}
+	}
+	return nil
+}
+
+func (s *contractStakingCache) validateHeight(height uint64) error {
+	// means latest height
+	if height == 0 {
+		return nil
+	}
+	// indexer only store latest height
+	if height != s.height {
+		return errors.Wrapf(ErrInvalidHeight, "expected %d, actual %d", s.height, height)
 	}
 	return nil
 }

--- a/blockindex/contractstaking/dirty_cache.go
+++ b/blockindex/contractstaking/dirty_cache.go
@@ -105,7 +105,8 @@ func (dirty *contractStakingDirty) finalize() (batch.KVStoreBatch, *contractStak
 
 func (dirty *contractStakingDirty) finalizeBatch() batch.KVStoreBatch {
 	dirty.once.Do(func() {
-		total := dirty.clean.totalBucketCount + dirty.delta.AddedBucketCnt()
+		tbc, _ := dirty.clean.TotalBucketCount(0)
+		total := tbc + dirty.delta.AddedBucketCnt()
 		dirty.batch.Put(_StakingNS, _stakingTotalBucketCountKey, byteutil.Uint64ToBytesBigEndian(total), "failed to put total bucket count")
 	})
 	return dirty.batch
@@ -125,7 +126,8 @@ func (dirty *contractStakingDirty) matchBucketType(amount *big.Int, duration uin
 }
 
 func (dirty *contractStakingDirty) getBucketTypeCount() uint64 {
-	return uint64(len(dirty.clean.bucketTypeMap)) + dirty.delta.AddedBucketTypeCnt()
+	btc, _ := dirty.clean.BucketTypeCount(0)
+	return uint64(btc) + dirty.delta.AddedBucketTypeCnt()
 }
 
 func (dirty *contractStakingDirty) updateBucketType(id uint64, bt *BucketType) error {

--- a/blockindex/contractstaking/dirty_cache.go
+++ b/blockindex/contractstaking/dirty_cache.go
@@ -105,7 +105,7 @@ func (dirty *contractStakingDirty) finalize() (batch.KVStoreBatch, *contractStak
 
 func (dirty *contractStakingDirty) finalizeBatch() batch.KVStoreBatch {
 	dirty.once.Do(func() {
-		total := dirty.clean.TotalBucketCount() + dirty.delta.AddedBucketCnt()
+		total := dirty.clean.totalBucketCount + dirty.delta.AddedBucketCnt()
 		dirty.batch.Put(_StakingNS, _stakingTotalBucketCountKey, byteutil.Uint64ToBytesBigEndian(total), "failed to put total bucket count")
 	})
 	return dirty.batch
@@ -125,7 +125,7 @@ func (dirty *contractStakingDirty) matchBucketType(amount *big.Int, duration uin
 }
 
 func (dirty *contractStakingDirty) getBucketTypeCount() uint64 {
-	return dirty.clean.BucketTypeCount() + dirty.delta.AddedBucketTypeCnt()
+	return uint64(len(dirty.clean.bucketTypeMap)) + dirty.delta.AddedBucketTypeCnt()
 }
 
 func (dirty *contractStakingDirty) updateBucketType(id uint64, bt *BucketType) error {

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -80,38 +80,41 @@ func (s *Indexer) StartHeight() uint64 {
 }
 
 // CandidateVotes returns the candidate votes
-func (s *Indexer) CandidateVotes(candidate address.Address) *big.Int {
-	return s.cache.CandidateVotes(candidate)
+func (s *Indexer) CandidateVotes(candidate address.Address, height uint64) (*big.Int, error) {
+	return s.cache.CandidateVotes(candidate, height)
 }
 
 // Buckets returns the buckets
-func (s *Indexer) Buckets() ([]*Bucket, error) {
-	return s.cache.Buckets(), nil
+func (s *Indexer) Buckets(height uint64) ([]*Bucket, error) {
+	return s.cache.Buckets(height)
 }
 
 // Bucket returns the bucket
-func (s *Indexer) Bucket(id uint64) (*Bucket, bool) {
-	return s.cache.Bucket(id)
+func (s *Indexer) Bucket(id uint64, height uint64) (*Bucket, bool, error) {
+	return s.cache.Bucket(id, height)
 }
 
 // BucketsByIndices returns the buckets by indices
-func (s *Indexer) BucketsByIndices(indices []uint64) ([]*Bucket, error) {
-	return s.cache.BucketsByIndices(indices)
+func (s *Indexer) BucketsByIndices(indices []uint64, height uint64) ([]*Bucket, error) {
+	return s.cache.BucketsByIndices(indices, height)
 }
 
 // BucketsByCandidate returns the buckets by candidate
-func (s *Indexer) BucketsByCandidate(candidate address.Address) ([]*Bucket, error) {
-	return s.cache.BucketsByCandidate(candidate), nil
+func (s *Indexer) BucketsByCandidate(candidate address.Address, height uint64) ([]*Bucket, error) {
+	return s.cache.BucketsByCandidate(candidate, height)
 }
 
 // TotalBucketCount returns the total bucket count including active and burnt buckets
-func (s *Indexer) TotalBucketCount() uint64 {
-	return s.cache.TotalBucketCount()
+func (s *Indexer) TotalBucketCount(height uint64) (uint64, error) {
+	return s.cache.TotalBucketCount(height)
 }
 
 // BucketTypes returns the active bucket types
-func (s *Indexer) BucketTypes() ([]*BucketType, error) {
-	btMap := s.cache.ActiveBucketTypes()
+func (s *Indexer) BucketTypes(height uint64) ([]*BucketType, error) {
+	btMap, err := s.cache.ActiveBucketTypes(height)
+	if err != nil {
+		return nil, err
+	}
 	bts := make([]*BucketType, 0, len(btMap))
 	for _, bt := range btMap {
 		bts = append(bts, bt)

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -927,31 +927,38 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 			{height, true},
 			{height + 1, false},
 		}
-		noErr := func(args ...interface{}) {
-			r.Nil(args[len(args)-1])
-		}
-		hasErr := func(args ...interface{}) {
-			err := args[len(args)-1].(error)
-			r.ErrorIs(err, ErrInvalidHeight)
-		}
 		for i := range cases {
 			h := cases[i].height
 			if cases[i].valid {
-				noErr(indexer.Buckets(h))
-				noErr(indexer.BucketTypes(h))
-				noErr(indexer.BucketsByCandidate(delegate1, h))
-				noErr(indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8}, h))
-				noErr(indexer.CandidateVotes(delegate1, h))
-				noErr(indexer.Bucket(1, h))
-				noErr(indexer.TotalBucketCount(h))
+				_, err = indexer.Buckets(h)
+				r.NoError(err)
+				_, err = indexer.BucketTypes(h)
+				r.NoError(err)
+				_, err = indexer.BucketsByCandidate(delegate1, h)
+				r.NoError(err)
+				_, err = indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8}, h)
+				r.NoError(err)
+				_, err = indexer.CandidateVotes(delegate1, h)
+				r.NoError(err)
+				_, _, err = indexer.Bucket(1, h)
+				r.NoError(err)
+				_, err = indexer.TotalBucketCount(h)
+				r.NoError(err)
 			} else {
-				hasErr(indexer.Buckets(h))
-				hasErr(indexer.BucketTypes(h))
-				hasErr(indexer.BucketsByCandidate(delegate1, h))
-				hasErr(indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8}, h))
-				hasErr(indexer.CandidateVotes(delegate1, h))
-				hasErr(indexer.Bucket(1, h))
-				hasErr(indexer.TotalBucketCount(h))
+				_, err = indexer.Buckets(h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, err = indexer.BucketTypes(h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, err = indexer.BucketsByCandidate(delegate1, h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, err = indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8}, h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, err = indexer.CandidateVotes(delegate1, h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, _, err = indexer.Bucket(1, h)
+				r.ErrorIs(err, ErrInvalidHeight)
+				_, err = indexer.TotalBucketCount(h)
+				r.ErrorIs(err, ErrInvalidHeight)
 			}
 		}
 	})

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -76,10 +76,12 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	stake(r, handler, owner, delegate, 1, 10, 100, height)
 	err = indexer.commit(handler, height)
 	r.NoError(err)
-	buckets, err := indexer.Buckets()
+	buckets, err := indexer.Buckets(height)
 	r.NoError(err)
 	r.EqualValues(1, len(buckets))
-	r.EqualValues(1, indexer.TotalBucketCount())
+	tbc, err := indexer.TotalBucketCount(height)
+	r.EqualValues(1, tbc)
+	r.NoError(err)
 	h, err := indexer.Height()
 	r.NoError(err)
 	r.EqualValues(height, h)
@@ -92,7 +94,7 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	r.NoError(newIndexer.Start(context.Background()))
 
 	// check cache
-	newBuckets, err := newIndexer.Buckets()
+	newBuckets, err := newIndexer.Buckets(height)
 	r.NoError(err)
 	r.Equal(len(buckets), len(newBuckets))
 	for i := range buckets {
@@ -102,7 +104,9 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	r.NoError(err)
 	r.Equal(height, newHeight)
 	r.Equal(startHeight, newIndexer.StartHeight())
-	r.EqualValues(1, newIndexer.TotalBucketCount())
+	tbc, err = newIndexer.TotalBucketCount(height)
+	r.EqualValues(1, tbc)
+	r.NoError(err)
 	r.NoError(newIndexer.Stop(context.Background()))
 }
 
@@ -155,16 +159,16 @@ func TestContractStakingIndexerThreadSafe(t *testing.T) {
 		go func() {
 			defer wait.Done()
 			for i := 0; i < 1000; i++ {
-				_, err := indexer.Buckets()
+				_, err := indexer.Buckets(0)
 				r.NoError(err)
-				_, err = indexer.BucketTypes()
+				_, err = indexer.BucketTypes(0)
 				r.NoError(err)
-				_, err = indexer.BucketsByCandidate(delegate)
+				_, err = indexer.BucketsByCandidate(delegate, 0)
 				r.NoError(err)
-				indexer.CandidateVotes(delegate)
+				indexer.CandidateVotes(delegate, 0)
 				_, err = indexer.Height()
 				r.NoError(err)
-				indexer.TotalBucketCount()
+				indexer.TotalBucketCount(0)
 			}
 		}()
 	}
@@ -224,7 +228,7 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	}
 	err = indexer.commit(handler, height)
 	r.NoError(err)
-	bucketTypes, err := indexer.BucketTypes()
+	bucketTypes, err := indexer.BucketTypes(height)
 	r.NoError(err)
 	r.Equal(len(bucketTypeData), len(bucketTypes))
 	for _, bt := range bucketTypes {
@@ -240,7 +244,7 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	}
 	err = indexer.commit(handler, height)
 	r.NoError(err)
-	bucketTypes, err = indexer.BucketTypes()
+	bucketTypes, err = indexer.BucketTypes(height)
 	r.NoError(err)
 	r.Equal(len(bucketTypeData)-2, len(bucketTypes))
 	for _, bt := range bucketTypes {
@@ -256,7 +260,7 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	}
 	err = indexer.commit(handler, height)
 	r.NoError(err)
-	bucketTypes, err = indexer.BucketTypes()
+	bucketTypes, err = indexer.BucketTypes(height)
 	r.NoError(err)
 	r.Equal(len(bucketTypeData), len(bucketTypes))
 	for _, bt := range bucketTypes {
@@ -307,7 +311,8 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	stake(r, handler, owner, delegate, 1, 10, 100, height)
 	r.NoError(err)
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok := indexer.Bucket(1)
+	bucket, ok, err := indexer.Bucket(1, height)
+	r.NoError(err)
 	r.True(ok)
 	r.EqualValues(1, bucket.Index)
 	r.EqualValues(owner, bucket.Owner)
@@ -319,8 +324,12 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	r.EqualValues(height, bucket.CreateBlockHeight)
 	r.EqualValues(maxBlockNumber, bucket.UnstakeStartBlockHeight)
 	r.EqualValues(_testStakingContractAddress, bucket.ContractAddress)
-	r.EqualValues(10, indexer.CandidateVotes(delegate).Uint64())
-	r.EqualValues(1, indexer.TotalBucketCount())
+	votes, err := indexer.CandidateVotes(delegate, height)
+	r.NoError(err)
+	r.EqualValues(10, votes.Uint64())
+	tbc, err := indexer.TotalBucketCount(height)
+	r.NoError(err)
+	r.EqualValues(1, tbc)
 
 	// transfer
 	newOwner := identityset.Address(2)
@@ -328,7 +337,8 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	handler = newContractStakingEventHandler(indexer.cache)
 	transfer(r, handler, newOwner, int64(bucket.Index))
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok = indexer.Bucket(bucket.Index)
+	bucket, ok, err = indexer.Bucket(bucket.Index, height)
+	r.NoError(err)
 	r.True(ok)
 	r.EqualValues(newOwner, bucket.Owner)
 
@@ -337,7 +347,8 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	handler = newContractStakingEventHandler(indexer.cache)
 	unlock(r, handler, int64(bucket.Index), height)
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok = indexer.Bucket(bucket.Index)
+	bucket, ok, err = indexer.Bucket(bucket.Index, height)
+	r.NoError(err)
 	r.True(ok)
 	r.EqualValues(1, bucket.Index)
 	r.EqualValues(newOwner, bucket.Owner)
@@ -349,15 +360,20 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	r.EqualValues(createHeight, bucket.CreateBlockHeight)
 	r.EqualValues(maxBlockNumber, bucket.UnstakeStartBlockHeight)
 	r.EqualValues(_testStakingContractAddress, bucket.ContractAddress)
-	r.EqualValues(10, indexer.CandidateVotes(delegate).Uint64())
-	r.EqualValues(1, indexer.TotalBucketCount())
+	votes, err = indexer.CandidateVotes(delegate, height)
+	r.NoError(err)
+	r.EqualValues(10, votes.Uint64())
+	tbc, err = indexer.TotalBucketCount(height)
+	r.NoError(err)
+	r.EqualValues(1, tbc)
 
 	// lock again
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	lock(r, handler, int64(bucket.Index), int64(10))
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok = indexer.Bucket(bucket.Index)
+	bucket, ok, err = indexer.Bucket(bucket.Index, height)
+	r.NoError(err)
 	r.True(ok)
 	r.EqualValues(1, bucket.Index)
 	r.EqualValues(newOwner, bucket.Owner)
@@ -369,8 +385,12 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	r.EqualValues(createHeight, bucket.CreateBlockHeight)
 	r.EqualValues(maxBlockNumber, bucket.UnstakeStartBlockHeight)
 	r.EqualValues(_testStakingContractAddress, bucket.ContractAddress)
-	r.EqualValues(10, indexer.CandidateVotes(delegate).Uint64())
-	r.EqualValues(1, indexer.TotalBucketCount())
+	votes, err = indexer.CandidateVotes(delegate, height)
+	r.NoError(err)
+	r.EqualValues(10, votes.Uint64())
+	tbc, err = indexer.TotalBucketCount(height)
+	r.NoError(err)
+	r.EqualValues(1, tbc)
 
 	// unstake
 	height++
@@ -378,7 +398,8 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	unlock(r, handler, int64(bucket.Index), height)
 	unstake(r, handler, int64(bucket.Index), height)
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok = indexer.Bucket(bucket.Index)
+	bucket, ok, err = indexer.Bucket(bucket.Index, height)
+	r.NoError(err)
 	r.True(ok)
 	r.EqualValues(1, bucket.Index)
 	r.EqualValues(newOwner, bucket.Owner)
@@ -390,18 +411,27 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	r.EqualValues(createHeight, bucket.CreateBlockHeight)
 	r.EqualValues(height, bucket.UnstakeStartBlockHeight)
 	r.EqualValues(_testStakingContractAddress, bucket.ContractAddress)
-	r.EqualValues(0, indexer.CandidateVotes(delegate).Uint64())
-	r.EqualValues(1, indexer.TotalBucketCount())
+	votes, err = indexer.CandidateVotes(delegate, height)
+	r.NoError(err)
+	r.EqualValues(0, votes.Uint64())
+	tbc, err = indexer.TotalBucketCount(height)
+	r.NoError(err)
+	r.EqualValues(1, tbc)
 
 	// withdraw
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	withdraw(r, handler, int64(bucket.Index))
 	r.NoError(indexer.commit(handler, height))
-	bucket, ok = indexer.Bucket(bucket.Index)
+	bucket, ok, err = indexer.Bucket(bucket.Index, height)
+	r.NoError(err)
 	r.False(ok)
-	r.EqualValues(0, indexer.CandidateVotes(delegate).Uint64())
-	r.EqualValues(1, indexer.TotalBucketCount())
+	votes, err = indexer.CandidateVotes(delegate, height)
+	r.NoError(err)
+	r.EqualValues(0, votes.Uint64())
+	tbc, err = indexer.TotalBucketCount(height)
+	r.NoError(err)
+	r.EqualValues(1, tbc)
 }
 
 func TestContractStakingIndexerChangeBucketType(t *testing.T) {
@@ -439,12 +469,14 @@ func TestContractStakingIndexerChangeBucketType(t *testing.T) {
 		stake(r, handler, owner, delegate, 1, 10, 100, height)
 		r.NoError(err)
 		r.NoError(indexer.commit(handler, height))
-		bucket, ok := indexer.Bucket(1)
+		bucket, ok, err := indexer.Bucket(1, height)
+		r.NoError(err)
 		r.True(ok)
 
 		expandBucketType(r, handler, int64(bucket.Index), 20, 100)
 		r.NoError(indexer.commit(handler, height))
-		bucket, ok = indexer.Bucket(bucket.Index)
+		bucket, ok, err = indexer.Bucket(bucket.Index, height)
+		r.NoError(err)
 		r.True(ok)
 		r.EqualValues(20, bucket.StakedAmount.Int64())
 		r.EqualValues(100, bucket.StakedDurationBlockNumber)
@@ -499,7 +531,7 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 	r.NoError(indexer.commit(handler, height))
 
 	t.Run("Buckets", func(t *testing.T) {
-		buckets, err := indexer.Buckets()
+		buckets, err := indexer.Buckets(height)
 		r.NoError(err)
 		r.Len(buckets, len(stakeData))
 	})
@@ -510,7 +542,7 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 			candidateMap[stakeData[i].delegate]++
 		}
 		for cand := range candidateMap {
-			buckets, err := indexer.BucketsByCandidate(identityset.Address(cand))
+			buckets, err := indexer.BucketsByCandidate(identityset.Address(cand), height)
 			r.NoError(err)
 			r.Len(buckets, candidateMap[cand])
 		}
@@ -518,7 +550,7 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 
 	t.Run("BucketsByIndices", func(t *testing.T) {
 		indices := []uint64{0, 1, 2, 3, 4, 5, 6}
-		buckets, err := indexer.BucketsByIndices(indices)
+		buckets, err := indexer.BucketsByIndices(indices, height)
 		r.NoError(err)
 		expectedLen := 0
 		for _, idx := range indices {
@@ -530,7 +562,9 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 	})
 
 	t.Run("TotalBucketCount", func(t *testing.T) {
-		r.EqualValues(len(stakeData), indexer.TotalBucketCount())
+		tbc, err := indexer.TotalBucketCount(height)
+		r.NoError(err)
+		r.EqualValues(len(stakeData), tbc)
 	})
 
 	t.Run("CandidateVotes", func(t *testing.T) {
@@ -541,7 +575,9 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 		candidates := []int{1, 2, 3}
 		for _, cand := range candidates {
 			votes := candidateMap[cand]
-			r.EqualValues(votes, indexer.CandidateVotes(identityset.Address(cand)).Uint64())
+			cvotes, err := indexer.CandidateVotes(identityset.Address(cand), height)
+			r.NoError(err)
+			r.EqualValues(votes, cvotes.Uint64())
 		}
 	})
 }
@@ -571,27 +607,39 @@ func TestContractStakingIndexerCacheClean(t *testing.T) {
 	stake(r, handler, owner, delegate1, 2, 20, 20, height)
 	stake(r, handler, owner, delegate2, 3, 20, 20, height)
 	stake(r, handler, owner, delegate2, 4, 20, 20, height)
-	r.Len(indexer.cache.ActiveBucketTypes(), 0)
-	r.Len(indexer.cache.Buckets(), 0)
+	abt, err := indexer.cache.ActiveBucketTypes(height - 1)
+	r.NoError(err)
+	r.Len(abt, 0)
+	bts, err := indexer.cache.Buckets(height - 1)
+	r.NoError(err)
+	r.Len(bts, 0)
 	r.NoError(indexer.commit(handler, height))
-	r.Len(indexer.cache.ActiveBucketTypes(), 2)
-	r.Len(indexer.cache.Buckets(), 4)
+	abt, err = indexer.cache.ActiveBucketTypes(height)
+	r.NoError(err)
+	r.Len(abt, 2)
+	bts, err = indexer.cache.Buckets(height)
+	r.NoError(err)
+	r.Len(bts, 4)
 
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	changeDelegate(r, handler, delegate1, 3)
 	transfer(r, handler, delegate1, 1)
-	bt, ok := indexer.Bucket(3)
+	bt, ok, err := indexer.Bucket(3, height-1)
+	r.NoError(err)
 	r.True(ok)
 	r.Equal(delegate2.String(), bt.Candidate.String())
-	bt, ok = indexer.Bucket(1)
+	bt, ok, err = indexer.Bucket(1, height-1)
+	r.NoError(err)
 	r.True(ok)
 	r.Equal(owner.String(), bt.Owner.String())
 	r.NoError(indexer.commit(handler, height))
-	bt, ok = indexer.Bucket(3)
+	bt, ok, err = indexer.Bucket(3, height)
+	r.NoError(err)
 	r.True(ok)
 	r.Equal(delegate1.String(), bt.Candidate.String())
-	bt, ok = indexer.Bucket(1)
+	bt, ok, err = indexer.Bucket(1, height)
+	r.NoError(err)
 	r.True(ok)
 	r.Equal(delegate1.String(), bt.Owner.String())
 }
@@ -624,17 +672,26 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	stake(r, handler, owner, delegate2, 3, 20, 20, height)
 	stake(r, handler, owner, delegate2, 4, 20, 20, height)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(30, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(40, indexer.CandidateVotes(delegate2).Uint64())
-	r.EqualValues(0, indexer.CandidateVotes(owner).Uint64())
+	votes, err := indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(30, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(40, votes.Uint64())
+	votes, err = indexer.CandidateVotes(owner, height)
+	r.EqualValues(0, votes.Uint64())
 
 	// change delegate bucket 3 to delegate1
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	changeDelegate(r, handler, delegate1, 3)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// unlock bucket 1 & 4
 	height++
@@ -642,8 +699,12 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	unlock(r, handler, 1, height)
 	unlock(r, handler, 4, height)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// unstake bucket 1 & lock 4
 	height++
@@ -651,24 +712,36 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	unstake(r, handler, 1, height)
 	lock(r, handler, 4, 20)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(40, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(40, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// expand bucket 2
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	expandBucketType(r, handler, 2, 30, 20)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// transfer bucket 4
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	transfer(r, handler, delegate2, 4)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// create bucket 5, 6, 7
 	height++
@@ -677,16 +750,24 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	stake(r, handler, owner, delegate2, 6, 20, 20, height)
 	stake(r, handler, owner, delegate2, 7, 20, 20, height)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(80, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(80, votes.Uint64())
 
 	// merge bucket 5, 6, 7
 	height++
 	handler = newContractStakingEventHandler(indexer.cache)
 	mergeBuckets(r, handler, []int64{5, 6, 7}, 60, 20)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(80, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(80, votes.Uint64())
 
 	// unlock & unstake 5
 	height++
@@ -694,8 +775,12 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	unlock(r, handler, 5, height)
 	unstake(r, handler, 5, height)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(50, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(50, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	// create & merge bucket 8, 9, 10
 	height++
@@ -705,8 +790,12 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	stake(r, handler, owner, delegate2, 10, 20, 20, height)
 	mergeBuckets(r, handler, []int64{8, 9, 10}, 60, 20)
 	r.NoError(indexer.commit(handler, height))
-	r.EqualValues(110, indexer.CandidateVotes(delegate1).Uint64())
-	r.EqualValues(20, indexer.CandidateVotes(delegate2).Uint64())
+	votes, err = indexer.CandidateVotes(delegate1, height)
+	r.NoError(err)
+	r.EqualValues(110, votes.Uint64())
+	votes, err = indexer.CandidateVotes(delegate2, height)
+	r.NoError(err)
+	r.EqualValues(20, votes.Uint64())
 
 	t.Run("Height", func(t *testing.T) {
 		h, err := indexer.Height()
@@ -715,7 +804,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	})
 
 	t.Run("BucketTypes", func(t *testing.T) {
-		bts, err := indexer.BucketTypes()
+		bts, err := indexer.BucketTypes(height)
 		r.NoError(err)
 		r.Len(bts, 4)
 		slices.SortFunc(bts, func(i, j *staking.ContractStakingBucketType) bool {
@@ -732,7 +821,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	})
 
 	t.Run("Buckets", func(t *testing.T) {
-		bts, err := indexer.Buckets()
+		bts, err := indexer.Buckets(height)
 		r.NoError(err)
 		r.Len(bts, 6)
 		slices.SortFunc(bts, func(i, j *staking.VoteBucket) bool {
@@ -802,7 +891,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	})
 
 	t.Run("BucketsByCandidate", func(t *testing.T) {
-		d1Bts, err := indexer.BucketsByCandidate(delegate1)
+		d1Bts, err := indexer.BucketsByCandidate(delegate1, height)
 		r.NoError(err)
 		r.Len(d1Bts, 4)
 		slices.SortFunc(d1Bts, func(i, j *staking.VoteBucket) bool {
@@ -812,7 +901,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 		r.EqualValues(2, d1Bts[1].Index)
 		r.EqualValues(3, d1Bts[2].Index)
 		r.EqualValues(8, d1Bts[3].Index)
-		d2Bts, err := indexer.BucketsByCandidate(delegate2)
+		d2Bts, err := indexer.BucketsByCandidate(delegate2, height)
 		r.NoError(err)
 		r.Len(d2Bts, 2)
 		slices.SortFunc(d2Bts, func(i, j *staking.VoteBucket) bool {
@@ -823,7 +912,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	})
 
 	t.Run("BucketsByIndices", func(t *testing.T) {
-		bts, err := indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8})
+		bts, err := indexer.BucketsByIndices([]uint64{1, 2, 3, 4, 5, 8}, height)
 		r.NoError(err)
 		r.Len(bts, 6)
 	})


### PR DESCRIPTION
# Description
Motivation:
Strictly limiting the blocks during PutBlock can avoid block skipping issues
Specifying the height during queries can help detect errors in the indexer at an earlier stage
Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
