### PR TITLE
[staking] fix weighted votes of contract staking bucket

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -114,6 +114,7 @@ type (
 		AllowCorrectChainIDOnly                 bool
 		AddContractStakingVotes                 bool
 		SharedGasWithDapp                       bool
+		FixContractStakingWeightedVotes         bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -253,6 +254,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AllowCorrectChainIDOnly:                 g.IsQuebec(height),
 			AddContractStakingVotes:                 g.IsQuebec(height),
 			SharedGasWithDapp:                       g.IsToBeEnabled(height),
+			FixContractStakingWeightedVotes:         g.IsRedsea(height),
 		},
 	)
 }

--- a/action/protocol/staking/contractstake_indexer.go
+++ b/action/protocol/staking/contractstake_indexer.go
@@ -6,6 +6,7 @@
 package staking
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/iotexproject/iotex-address/address"
@@ -17,7 +18,7 @@ type (
 	ContractStakingIndexer interface {
 		// CandidateVotes returns the total staked votes of a candidate
 		// candidate identified by owner address
-		CandidateVotes(ownerAddr address.Address, height uint64) (*big.Int, error)
+		CandidateVotes(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error)
 		// Buckets returns active buckets
 		Buckets(height uint64) ([]*VoteBucket, error)
 		// BucketsByIndices returns active buckets by indices

--- a/action/protocol/staking/contractstake_indexer_mock.go
+++ b/action/protocol/staking/contractstake_indexer_mock.go
@@ -5,6 +5,7 @@
 package staking
 
 import (
+	context "context"
 	big "math/big"
 	reflect "reflect"
 
@@ -96,18 +97,18 @@ func (mr *MockContractStakingIndexerMockRecorder) BucketsByIndices(arg0, arg1 in
 }
 
 // CandidateVotes mocks base method.
-func (m *MockContractStakingIndexer) CandidateVotes(ownerAddr address.Address, height uint64) (*big.Int, error) {
+func (m *MockContractStakingIndexer) CandidateVotes(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidateVotes", ownerAddr, height)
+	ret := m.ctrl.Call(m, "CandidateVotes", ctx, ownerAddr, height)
 	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CandidateVotes indicates an expected call of CandidateVotes.
-func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ownerAddr, height interface{}) *gomock.Call {
+func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ctx, ownerAddr, height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ownerAddr, height)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ctx, ownerAddr, height)
 }
 
 // TotalBucketCount mocks base method.

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -483,7 +483,7 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 			// specifying the height param instead of query latest from indexer directly, aims to cause error when indexer falls behind
 			// currently there are two possible sr (i.e. factory or workingSet), it means the height could be chain height or current block height
 			// using height-1 will cover the two scenario while detect whether the indexer is lagging behind
-			contractVotes, err := p.contractStakingIndexer.CandidateVotes(list[i].Owner, srHeight-1)
+			contractVotes, err := p.contractStakingIndexer.CandidateVotes(ctx, list[i].Owner, srHeight-1)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to get CandidateVotes from contractStakingIndexer")
 			}
@@ -598,7 +598,7 @@ func (p *Protocol) Name() string {
 }
 
 func (p *Protocol) calculateVoteWeight(v *VoteBucket, selfStake bool) *big.Int {
-	return calculateVoteWeight(p.config.VoteWeightCalConsts, v, selfStake)
+	return CalculateVoteWeight(p.config.VoteWeightCalConsts, v, selfStake)
 }
 
 // settleAccount deposits gas fee and updates caller's nonce

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -436,7 +436,7 @@ func TestProtocol_ActiveCandidates(t *testing.T) {
 	require.NoError(err)
 
 	var csIndexerHeight, csVotes uint64
-	csIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
+	csIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
 		if height != csIndexerHeight {
 			return nil, errors.Errorf("invalid height")
 		}

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -224,7 +224,7 @@ func (c *compositeStakingStateReader) readStateCandidates(ctx context.Context, r
 		return candidates, height, nil
 	}
 	for _, candidate := range candidates.Candidates {
-		if err = addContractStakingVotes(candidate, c.contractIndexer, height); err != nil {
+		if err = addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
 			return nil, 0, err
 		}
 	}
@@ -242,7 +242,7 @@ func (c *compositeStakingStateReader) readStateCandidateByName(ctx context.Conte
 	if !protocol.MustGetFeatureCtx(ctx).AddContractStakingVotes {
 		return candidate, height, nil
 	}
-	if err := addContractStakingVotes(candidate, c.contractIndexer, height); err != nil {
+	if err := addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
 		return nil, 0, err
 	}
 	return candidate, height, nil
@@ -259,7 +259,7 @@ func (c *compositeStakingStateReader) readStateCandidateByAddress(ctx context.Co
 	if !protocol.MustGetFeatureCtx(ctx).AddContractStakingVotes {
 		return candidate, height, nil
 	}
-	if err := addContractStakingVotes(candidate, c.contractIndexer, height); err != nil {
+	if err := addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
 		return nil, 0, err
 	}
 	return candidate, height, nil
@@ -314,7 +314,7 @@ func (c *compositeStakingStateReader) isContractStakingEnabled() bool {
 	return c.contractIndexer != nil
 }
 
-func addContractStakingVotes(candidate *iotextypes.CandidateV2, contractStakingSR ContractStakingIndexer, height uint64) error {
+func addContractStakingVotes(ctx context.Context, candidate *iotextypes.CandidateV2, contractStakingSR ContractStakingIndexer, height uint64) error {
 	votes, ok := big.NewInt(0).SetString(candidate.TotalWeightedVotes, 10)
 	if !ok {
 		return errors.Errorf("invalid total weighted votes %s", candidate.TotalWeightedVotes)
@@ -323,7 +323,7 @@ func addContractStakingVotes(candidate *iotextypes.CandidateV2, contractStakingS
 	if err != nil {
 		return err
 	}
-	contractVotes, err := contractStakingSR.CandidateVotes(addr, height)
+	contractVotes, err := contractStakingSR.CandidateVotes(ctx, addr, height)
 	if err != nil {
 		return err
 	}

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -314,6 +314,7 @@ func (c *compositeStakingStateReader) isContractStakingEnabled() bool {
 	return c.contractIndexer != nil
 }
 
+// TODO: move into compositeStakingStateReader
 func addContractStakingVotes(ctx context.Context, candidate *iotextypes.CandidateV2, contractStakingSR ContractStakingIndexer, height uint64) error {
 	votes, ok := big.NewInt(0).SetString(candidate.TotalWeightedVotes, 10)
 	if !ok {

--- a/action/protocol/staking/staking_statereader_test.go
+++ b/action/protocol/staking/staking_statereader_test.go
@@ -332,7 +332,7 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidates", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
 					return b.StakedAmount, nil
@@ -362,7 +362,7 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidateByName", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
 					return b.StakedAmount, nil
@@ -385,7 +385,7 @@ func TestStakingStateReader(t *testing.T) {
 	})
 	t.Run("readStateCandidateByAddress", func(t *testing.T) {
 		_, contractIndexer, stakeSR, ctx, r := prepare(t)
-		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any()).DoAndReturn(func(ownerAddr address.Address, height uint64) (*big.Int, error) {
+		contractIndexer.EXPECT().CandidateVotes(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
 			for _, b := range testContractBuckets {
 				if b.Owner.String() == ownerAddr.String() {
 					return b.StakedAmount, nil

--- a/action/protocol/staking/vote_bucket.go
+++ b/action/protocol/staking/vote_bucket.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	maxBlockNumber = math.MaxUint64
+	maxBlockNumber       = math.MaxUint64
+	blockProduceInterval = 5 // produce one block per 5 seconds
 )
 
 type (
@@ -221,8 +222,8 @@ func bucketKey(index uint64) []byte {
 func CalculateVoteWeight(c genesis.VoteWeightCalConsts, v *VoteBucket, selfStake bool) *big.Int {
 	remainingTime := v.StakedDuration.Seconds()
 	if !v.isNative() {
-		// according to produce one block per 5 seconds
-		remainingTime = float64(v.StakedDurationBlockNumber) * 5
+		// for contract staking, use block number to calculate remaining time
+		remainingTime = float64(v.StakedDurationBlockNumber) * blockProduceInterval
 	}
 	weight := float64(1)
 	var m float64

--- a/action/protocol/staking/vote_bucket.go
+++ b/action/protocol/staking/vote_bucket.go
@@ -23,8 +23,7 @@ import (
 )
 
 const (
-	maxBlockNumber       = math.MaxUint64
-	blockProduceInterval = 5 // produce one block per 5 seconds
+	maxBlockNumber = math.MaxUint64
 )
 
 type (
@@ -221,10 +220,6 @@ func bucketKey(index uint64) []byte {
 // CalculateVoteWeight calculates the vote weight
 func CalculateVoteWeight(c genesis.VoteWeightCalConsts, v *VoteBucket, selfStake bool) *big.Int {
 	remainingTime := v.StakedDuration.Seconds()
-	if !v.isNative() {
-		// for contract staking, use block number to calculate remaining time
-		remainingTime = float64(v.StakedDurationBlockNumber) * blockProduceInterval
-	}
 	weight := float64(1)
 	var m float64
 	if v.AutoStake {

--- a/action/protocol/staking/vote_bucket.go
+++ b/action/protocol/staking/vote_bucket.go
@@ -228,7 +228,7 @@ func CalculateVoteWeight(c genesis.VoteWeightCalConsts, v *VoteBucket, selfStake
 	if remainingTime > 0 {
 		weight += math.Log(math.Ceil(remainingTime/86400)*(1+m)) / math.Log(c.DurationLg) / 100
 	}
-	if v.isNative() && selfStake && v.AutoStake && v.StakedDuration >= time.Duration(91)*24*time.Hour {
+	if selfStake && v.AutoStake && v.StakedDuration >= time.Duration(91)*24*time.Hour {
 		// self-stake extra bonus requires enable auto-stake for at least 3 months
 		weight *= c.SelfStake
 	}

--- a/action/protocol/staking/vote_bucket_test.go
+++ b/action/protocol/staking/vote_bucket_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/state"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil/testdb"
@@ -106,6 +107,7 @@ func TestGetPutStaking(t *testing.T) {
 
 func TestCalculateVoteWeight(t *testing.T) {
 	// Define test cases
+	blockInterval := consensusfsm.DefaultDardanellesUpgradeConfig.BlockInterval
 	consts := genesis.Default.VoteWeightCalConsts
 	tests := []struct {
 		name       string
@@ -162,7 +164,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake enabled, self-stake enabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 24 * time.Hour,
+				StakedDuration:            30 * 17280 * blockInterval,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 true,
 				StakedAmount:              big.NewInt(10000),
@@ -175,7 +177,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake enabled, self-stake disabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 24 * time.Hour,
+				StakedDuration:            30 * 17280 * blockInterval,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 true,
 				StakedAmount:              big.NewInt(10000),
@@ -188,7 +190,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake disabled, self-stake enabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 24 * time.Hour,
+				StakedDuration:            30 * 17280 * blockInterval,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 false,
 				StakedAmount:              big.NewInt(10000),
@@ -201,7 +203,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake disabled, self-stake disabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 24 * time.Hour,
+				StakedDuration:            30 * 17280 * blockInterval,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 false,
 				StakedAmount:              big.NewInt(10000),

--- a/action/protocol/staking/vote_bucket_test.go
+++ b/action/protocol/staking/vote_bucket_test.go
@@ -162,6 +162,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake enabled, self-stake enabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
+				StakedDuration:            30 * 24 * time.Hour,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 true,
 				StakedAmount:              big.NewInt(10000),
@@ -174,6 +175,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake enabled, self-stake disabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
+				StakedDuration:            30 * 24 * time.Hour,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 true,
 				StakedAmount:              big.NewInt(10000),
@@ -186,6 +188,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake disabled, self-stake enabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
+				StakedDuration:            30 * 24 * time.Hour,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 false,
 				StakedAmount:              big.NewInt(10000),
@@ -198,6 +201,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			name:   "NFT, auto-stake disabled, self-stake disabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
+				StakedDuration:            30 * 24 * time.Hour,
 				StakedDurationBlockNumber: 30 * 17280,
 				AutoStake:                 false,
 				StakedAmount:              big.NewInt(10000),

--- a/action/protocol/staking/vote_bucket_test.go
+++ b/action/protocol/staking/vote_bucket_test.go
@@ -161,20 +161,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			expected:  big.NewInt(125),
 		},
 		{
-			name:   "NFT, auto-stake enabled, self-stake enabled",
-			consts: consts,
-			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 17280 * blockInterval,
-				StakedDurationBlockNumber: 30 * 17280,
-				AutoStake:                 true,
-				StakedAmount:              big.NewInt(10000),
-				ContractAddress:           identityset.Address(1).String(),
-			},
-			selfStake: true,
-			expected:  big.NewInt(12245),
-		},
-		{
-			name:   "NFT, auto-stake enabled, self-stake disabled",
+			name:   "NFT, auto-stake enabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
 				StakedDuration:            30 * 17280 * blockInterval,
@@ -187,20 +174,7 @@ func TestCalculateVoteWeight(t *testing.T) {
 			expected:  big.NewInt(12245),
 		},
 		{
-			name:   "NFT, auto-stake disabled, self-stake enabled",
-			consts: consts,
-			voteBucket: &VoteBucket{
-				StakedDuration:            30 * 17280 * blockInterval,
-				StakedDurationBlockNumber: 30 * 17280,
-				AutoStake:                 false,
-				StakedAmount:              big.NewInt(10000),
-				ContractAddress:           identityset.Address(1).String(),
-			},
-			selfStake: true,
-			expected:  big.NewInt(11865),
-		},
-		{
-			name:   "NFT, auto-stake disabled, self-stake disabled",
+			name:   "NFT, auto-stake disabled",
 			consts: consts,
 			voteBucket: &VoteBucket{
 				StakedDuration:            30 * 17280 * blockInterval,
@@ -211,6 +185,84 @@ func TestCalculateVoteWeight(t *testing.T) {
 			},
 			selfStake: false,
 			expected:  big.NewInt(11865),
+		},
+		{
+			name:   "NFT-I, auto-stake enabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            91 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 91 * 17280,
+				AutoStake:                 true,
+				StakedAmount:              big.NewInt(10000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: false,
+			expected:  big.NewInt(12854),
+		},
+		{
+			name:   "NFT-I, auto-stake disabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            91 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 91 * 17280,
+				AutoStake:                 false,
+				StakedAmount:              big.NewInt(10000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: true,
+			expected:  big.NewInt(12474),
+		},
+		{
+			name:   "NFT-II, auto-stake enabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            91 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 91 * 17280,
+				AutoStake:                 true,
+				StakedAmount:              big.NewInt(100000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: false,
+			expected:  big.NewInt(128543),
+		},
+		{
+			name:   "NFT-II, auto-stake disabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            91 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 91 * 17280,
+				AutoStake:                 false,
+				StakedAmount:              big.NewInt(100000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: true,
+			expected:  big.NewInt(124741),
+		},
+		{
+			name:   "NFT-III, auto-stake enabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            2 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 2 * 17280,
+				AutoStake:                 true,
+				StakedAmount:              big.NewInt(1000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: false,
+			expected:  big.NewInt(1076),
+		},
+		{
+			name:   "NFT-III, auto-stake disabled",
+			consts: consts,
+			voteBucket: &VoteBucket{
+				StakedDuration:            2 * 17280 * blockInterval,
+				StakedDurationBlockNumber: 2 * 17280,
+				AutoStake:                 false,
+				StakedAmount:              big.NewInt(1000),
+				ContractAddress:           identityset.Address(1).String(),
+			},
+			selfStake: true,
+			expected:  big.NewInt(1038),
 		},
 	}
 

--- a/action/protocol/staking/vote_reviser.go
+++ b/action/protocol/staking/vote_reviser.go
@@ -137,7 +137,7 @@ func (vr *VoteReviser) calculateVoteWeight(csm CandidateStateManager) (Candidate
 		}
 
 		if cand.SelfStakeBucketIdx == bucket.Index {
-			if err = cand.AddVote(calculateVoteWeight(vr.c, bucket, true)); err != nil {
+			if err = cand.AddVote(CalculateVoteWeight(vr.c, bucket, true)); err != nil {
 				log.L().Error("failed to add vote for candidate",
 					zap.Uint64("bucket index", bucket.Index),
 					zap.String("candidate", bucket.Candidate.String()),
@@ -146,7 +146,7 @@ func (vr *VoteReviser) calculateVoteWeight(csm CandidateStateManager) (Candidate
 			}
 			cand.SelfStake = bucket.StakedAmount
 		} else {
-			_ = cand.AddVote(calculateVoteWeight(vr.c, bucket, false))
+			_ = cand.AddVote(CalculateVoteWeight(vr.c, bucket, false))
 		}
 	}
 

--- a/action/protocol/staking/vote_reviser_test.go
+++ b/action/protocol/staking/vote_reviser_test.go
@@ -198,10 +198,10 @@ func TestVoteReviser(t *testing.T) {
 			if address.Equal(v.cand, c.Owner) && v.index != c.SelfStakeBucketIdx {
 				bucket, err := csr.getBucket(v.index)
 				r.NoError(err)
-				total := calculateVoteWeight(cv, bucket, false)
+				total := CalculateVoteWeight(cv, bucket, false)
 				bucket, err = csr.getBucket(c.SelfStakeBucketIdx)
 				r.NoError(err)
-				total.Add(total, calculateVoteWeight(cv, bucket, true))
+				total.Add(total, CalculateVoteWeight(cv, bucket, true))
 				r.Equal(0, total.Cmp(c.Votes))
 				break
 			}

--- a/blockindex/contractstaking/bucket.go
+++ b/blockindex/contractstaking/bucket.go
@@ -6,16 +6,19 @@
 package contractstaking
 
 import (
+	"time"
+
 	"github.com/iotexproject/iotex-core/action/protocol/staking"
 )
 
 // Bucket defines the bucket struct for contract staking
 type Bucket = staking.VoteBucket
 
-func assembleBucket(token uint64, bi *bucketInfo, bt *BucketType, contractAddr string) *Bucket {
+func assembleBucket(token uint64, bi *bucketInfo, bt *BucketType, contractAddr string, blockInterval time.Duration) *Bucket {
 	vb := Bucket{
 		Index:                     token,
 		StakedAmount:              bt.Amount,
+		StakedDuration:            time.Duration(bt.Duration) * blockInterval,
 		StakedDurationBlockNumber: bt.Duration,
 		CreateBlockHeight:         bi.CreatedAt,
 		StakeStartBlockHeight:     bi.CreatedAt,

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -78,6 +78,9 @@ func (s *contractStakingCache) CandidateVotes(ctx context.Context, candidate add
 		}
 		bt := s.mustGetBucketType(bi.TypeIndex)
 		if featureCtx.FixContractStakingWeightedVotes {
+			if s.config.CalculateVoteWeight == nil {
+				return nil, errors.New("calculate vote weight function is not set")
+			}
 			votes.Add(votes, s.config.CalculateVoteWeight(assembleBucket(id, bi, bt, s.config.ContractAddress, s.config.BlockInterval)))
 		} else {
 			votes.Add(votes, bt.Amount)

--- a/blockindex/contractstaking/cache.go
+++ b/blockindex/contractstaking/cache.go
@@ -78,9 +78,6 @@ func (s *contractStakingCache) CandidateVotes(ctx context.Context, candidate add
 		}
 		bt := s.mustGetBucketType(bi.TypeIndex)
 		if featureCtx.FixContractStakingWeightedVotes {
-			if s.config.CalculateVoteWeight == nil {
-				return nil, errors.New("calculate vote weight function is not set")
-			}
 			votes.Add(votes, s.config.CalculateVoteWeight(assembleBucket(id, bi, bt, s.config.ContractAddress, s.config.BlockInterval)))
 		} else {
 			votes.Add(votes, bt.Amount)

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -302,7 +302,7 @@ func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 
 func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket
@@ -331,7 +331,7 @@ func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 
 func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket type
@@ -396,7 +396,7 @@ func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 
 func TestContractStakingCache_Merge(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 	height := uint64(1)
 	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: height}))
 
@@ -454,7 +454,7 @@ func TestContractStakingCache_Merge(t *testing.T) {
 
 func TestContractStakingCache_MatchBucketType(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 
 	// no bucket types
 	_, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
@@ -489,7 +489,7 @@ func TestContractStakingCache_MatchBucketType(t *testing.T) {
 
 func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket type
@@ -518,7 +518,7 @@ func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 
 func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
 
 	// load from empty db
 	path, err := testutil.PathOfTempFile("staking.db")

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -26,8 +26,8 @@ func _checkCacheCandidateVotes(ctx context.Context, r *require.Assertions, cache
 }
 
 func calculateVoteWeightGen(c genesis.VoteWeightCalConsts) calculateVoteWeightFunc {
-	return func(v *Bucket, selfStake bool) *big.Int {
-		return staking.CalculateVoteWeight(c, v, selfStake)
+	return func(v *Bucket) *big.Int {
+		return staking.CalculateVoteWeight(c, v, false)
 	}
 }
 
@@ -38,7 +38,7 @@ func TestContractStakingCache_CandidateVotes(t *testing.T) {
 		}
 	}
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(1).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(1).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 	checkCacheCandidateVotes := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1})))
 	checkCacheCandidateVotesAfterRedsea := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: genesis.Default.RedseaBlockHeight})))
 	// no bucket
@@ -115,7 +115,7 @@ func TestContractStakingCache_CandidateVotes(t *testing.T) {
 func TestContractStakingCache_Buckets(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: contractAddr, CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket
@@ -189,7 +189,7 @@ func TestContractStakingCache_Buckets(t *testing.T) {
 func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: contractAddr, CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket
@@ -261,7 +261,7 @@ func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: contractAddr, CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket
@@ -308,7 +308,7 @@ func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 
 func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket
@@ -337,7 +337,7 @@ func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 
 func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket type
@@ -402,7 +402,7 @@ func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 
 func TestContractStakingCache_Merge(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 	height := uint64(1)
 	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: height}))
 
@@ -460,7 +460,7 @@ func TestContractStakingCache_Merge(t *testing.T) {
 
 func TestContractStakingCache_MatchBucketType(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	// no bucket types
 	_, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
@@ -495,7 +495,7 @@ func TestContractStakingCache_MatchBucketType(t *testing.T) {
 
 func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	height := uint64(0)
 	// no bucket type
@@ -524,7 +524,7 @@ func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 
 func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	cache := newContractStakingCache(Config{ContractAddress: identityset.Address(27).String(), CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts), BlockInterval: _blockInterval})
 
 	// load from empty db
 	path, err := testutil.PathOfTempFile("staking.db")

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -9,7 +9,9 @@ import (
 
 	"github.com/iotexproject/iotex-address/address"
 
+	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
@@ -17,75 +19,97 @@ import (
 	"github.com/iotexproject/iotex-core/testutil"
 )
 
-func checkCacheCandidateVotes(r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
-	votes, err := cache.CandidateVotes(addr, height)
+func _checkCacheCandidateVotes(ctx context.Context, r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
+	votes, err := cache.CandidateVotes(ctx, addr, height)
 	r.NoError(err)
 	r.EqualValues(expectVotes, votes.Int64())
 }
 
 func TestContractStakingCache_CandidateVotes(t *testing.T) {
+	checkCacheCandidateVotesGen := func(ctx context.Context) func(r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
+		return func(r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
+			_checkCacheCandidateVotes(ctx, r, cache, height, addr, expectVotes)
+		}
+	}
 	require := require.New(t)
-	cache := newContractStakingCache("")
-
+	cache := newContractStakingCache(identityset.Address(1).String(), genesis.Default.VoteWeightCalConsts)
+	checkCacheCandidateVotes := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1})))
+	checkCacheCandidateVotesAfterRedsea := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: genesis.Default.RedseaBlockHeight})))
 	// no bucket
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 0)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 0)
 
 	// one bucket
 	cache.PutBucketType(1, &BucketType{Amount: big.NewInt(100), Duration: 100, ActivatedAt: 1})
 	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 100)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 103)
 
 	// two buckets
 	cache.PutBucketInfo(2, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 200)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 206)
 
 	// add one bucket with different delegate
 	cache.PutBucketInfo(3, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 200)
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(3), 100)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 206)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(3), 103)
 
 	// add one bucket with different owner
 	cache.PutBucketInfo(4, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(4)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 300)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 309)
 
 	// add one bucket with different amount
 	cache.PutBucketType(2, &BucketType{Amount: big.NewInt(200), Duration: 100, ActivatedAt: 1})
 	cache.PutBucketInfo(5, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 500)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 516)
 
 	// add one bucket with different duration
 	cache.PutBucketType(3, &BucketType{Amount: big.NewInt(300), Duration: 200, ActivatedAt: 1})
 	cache.PutBucketInfo(6, &bucketInfo{TypeIndex: 3, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 800)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 827)
 
 	// add one bucket that is unstaked
 	cache.PutBucketInfo(7, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: 1, UnstakedAt: 1, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 800)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 827)
 
 	// add one bucket that is unlocked and staked
 	cache.PutBucketInfo(8, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: 100, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(1), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 900)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 927)
 
 	// change delegate of bucket 1
 	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(2)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 800)
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(3), 200)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 824)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(3), 206)
 
 	// change owner of bucket 1
 	cache.PutBucketInfo(1, &bucketInfo{TypeIndex: 1, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 800)
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(3), 200)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 824)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(3), 206)
 
 	// change amount of bucket 1
 	cache.putBucketInfo(1, &bucketInfo{TypeIndex: 2, CreatedAt: 1, UnlockedAt: maxBlockNumber, UnstakedAt: maxBlockNumber, Delegate: identityset.Address(3), Owner: identityset.Address(4)})
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(1), 800)
 	checkCacheCandidateVotes(require, cache, 0, identityset.Address(3), 300)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(1), 824)
+	checkCacheCandidateVotesAfterRedsea(require, cache, 0, identityset.Address(3), 310)
 }
 
 func TestContractStakingCache_Buckets(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr)
+	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket
@@ -159,7 +183,7 @@ func TestContractStakingCache_Buckets(t *testing.T) {
 func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr)
+	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket
@@ -231,7 +255,7 @@ func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr)
+	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket
@@ -278,7 +302,7 @@ func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 
 func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket
@@ -307,7 +331,7 @@ func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 
 func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket type
@@ -372,8 +396,9 @@ func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 
 func TestContractStakingCache_Merge(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	height := uint64(1)
+	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: height}))
 
 	// create delta with one bucket type
 	delta := newContractStakingDelta()
@@ -397,7 +422,7 @@ func TestContractStakingCache_Merge(t *testing.T) {
 	err = cache.Merge(delta, height)
 	require.NoError(err)
 	// check that bucket was added to cache and vote count is correct
-	votes, err := cache.CandidateVotes(identityset.Address(1), height)
+	votes, err := cache.CandidateVotes(ctx, identityset.Address(1), height)
 	require.NoError(err)
 	require.EqualValues(100, votes.Int64())
 
@@ -408,10 +433,10 @@ func TestContractStakingCache_Merge(t *testing.T) {
 	err = cache.Merge(delta, height)
 	require.NoError(err)
 	// check that bucket delegate was updated and vote count is correct
-	votes, err = cache.CandidateVotes(identityset.Address(1), height)
+	votes, err = cache.CandidateVotes(ctx, identityset.Address(1), height)
 	require.NoError(err)
 	require.EqualValues(0, votes.Int64())
-	votes, err = cache.CandidateVotes(identityset.Address(3), height)
+	votes, err = cache.CandidateVotes(ctx, identityset.Address(3), height)
 	require.NoError(err)
 	require.EqualValues(100, votes.Int64())
 
@@ -422,14 +447,14 @@ func TestContractStakingCache_Merge(t *testing.T) {
 	err = cache.Merge(delta, height)
 	require.NoError(err)
 	// check that bucket was deleted from cache and vote count is 0
-	votes, err = cache.CandidateVotes(identityset.Address(3), height)
+	votes, err = cache.CandidateVotes(ctx, identityset.Address(3), height)
 	require.NoError(err)
 	require.EqualValues(0, votes.Int64())
 }
 
 func TestContractStakingCache_MatchBucketType(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 
 	// no bucket types
 	_, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
@@ -464,7 +489,7 @@ func TestContractStakingCache_MatchBucketType(t *testing.T) {
 
 func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 
 	height := uint64(0)
 	// no bucket type
@@ -493,7 +518,7 @@ func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 
 func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache("")
+	cache := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 
 	// load from empty db
 	path, err := testutil.PathOfTempFile("staking.db")

--- a/blockindex/contractstaking/cache_test.go
+++ b/blockindex/contractstaking/cache_test.go
@@ -25,6 +25,12 @@ func _checkCacheCandidateVotes(ctx context.Context, r *require.Assertions, cache
 	r.EqualValues(expectVotes, votes.Int64())
 }
 
+func calculateVoteWeightGen(c genesis.VoteWeightCalConsts) calculateVoteWeightFunc {
+	return func(v *Bucket, selfStake bool) *big.Int {
+		return staking.CalculateVoteWeight(c, v, selfStake)
+	}
+}
+
 func TestContractStakingCache_CandidateVotes(t *testing.T) {
 	checkCacheCandidateVotesGen := func(ctx context.Context) func(r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
 		return func(r *require.Assertions, cache *contractStakingCache, height uint64, addr address.Address, expectVotes int64) {
@@ -32,7 +38,7 @@ func TestContractStakingCache_CandidateVotes(t *testing.T) {
 		}
 	}
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(1).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(1).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	checkCacheCandidateVotes := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1})))
 	checkCacheCandidateVotesAfterRedsea := checkCacheCandidateVotesGen(protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: genesis.Default.RedseaBlockHeight})))
 	// no bucket
@@ -109,7 +115,7 @@ func TestContractStakingCache_CandidateVotes(t *testing.T) {
 func TestContractStakingCache_Buckets(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket
@@ -183,7 +189,7 @@ func TestContractStakingCache_Buckets(t *testing.T) {
 func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket
@@ -255,7 +261,7 @@ func TestContractStakingCache_BucketsByCandidate(t *testing.T) {
 func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 	require := require.New(t)
 	contractAddr := identityset.Address(27).String()
-	cache := newContractStakingCache(contractAddr, genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(contractAddr, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket
@@ -302,7 +308,7 @@ func TestContractStakingCache_BucketsByIndices(t *testing.T) {
 
 func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket
@@ -331,7 +337,7 @@ func TestContractStakingCache_TotalBucketCount(t *testing.T) {
 
 func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket type
@@ -396,7 +402,7 @@ func TestContractStakingCache_ActiveBucketTypes(t *testing.T) {
 
 func TestContractStakingCache_Merge(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	height := uint64(1)
 	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: height}))
 
@@ -454,7 +460,7 @@ func TestContractStakingCache_Merge(t *testing.T) {
 
 func TestContractStakingCache_MatchBucketType(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	// no bucket types
 	_, bucketType, ok := cache.MatchBucketType(big.NewInt(100), 100)
@@ -489,7 +495,7 @@ func TestContractStakingCache_MatchBucketType(t *testing.T) {
 
 func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	height := uint64(0)
 	// no bucket type
@@ -518,7 +524,7 @@ func TestContractStakingCache_BucketTypeCount(t *testing.T) {
 
 func TestContractStakingCache_LoadFromDB(t *testing.T) {
 	require := require.New(t)
-	cache := newContractStakingCache(identityset.Address(27).String(), genesis.Default.VoteWeightCalConsts)
+	cache := newContractStakingCache(identityset.Address(27).String(), calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 
 	// load from empty db
 	path, err := testutil.PathOfTempFile("staking.db")

--- a/blockindex/contractstaking/delta_cache.go
+++ b/blockindex/contractstaking/delta_cache.go
@@ -20,7 +20,7 @@ type (
 
 func newContractStakingDelta() *contractStakingDelta {
 	return &contractStakingDelta{
-		cache:                newContractStakingCache("", nil),
+		cache:                newContractStakingCache(Config{}),
 		bucketTypeDeltaState: make(map[uint64]deltaState),
 		bucketInfoDeltaState: make(map[uint64]deltaState),
 	}

--- a/blockindex/contractstaking/delta_cache.go
+++ b/blockindex/contractstaking/delta_cache.go
@@ -5,7 +5,11 @@
 
 package contractstaking
 
-import "math/big"
+import (
+	"math/big"
+
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
+)
 
 type (
 	contractStakingDelta struct {
@@ -18,7 +22,7 @@ type (
 
 func newContractStakingDelta() *contractStakingDelta {
 	return &contractStakingDelta{
-		cache:                newContractStakingCache(""),
+		cache:                newContractStakingCache("", genesis.VoteWeightCalConsts{}),
 		bucketTypeDeltaState: make(map[uint64]deltaState),
 		bucketInfoDeltaState: make(map[uint64]deltaState),
 	}

--- a/blockindex/contractstaking/delta_cache.go
+++ b/blockindex/contractstaking/delta_cache.go
@@ -7,8 +7,6 @@ package contractstaking
 
 import (
 	"math/big"
-
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 )
 
 type (
@@ -22,7 +20,7 @@ type (
 
 func newContractStakingDelta() *contractStakingDelta {
 	return &contractStakingDelta{
-		cache:                newContractStakingCache("", genesis.VoteWeightCalConsts{}),
+		cache:                newContractStakingCache("", nil),
 		bucketTypeDeltaState: make(map[uint64]deltaState),
 		bucketInfoDeltaState: make(map[uint64]deltaState),
 	}

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestContractStakingDirty_getBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -41,7 +41,7 @@ func TestContractStakingDirty_getBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket info
@@ -93,7 +93,7 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 
 func TestContractStakingDirty_matchBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -123,7 +123,7 @@ func TestContractStakingDirty_matchBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -143,7 +143,7 @@ func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 
 func TestContractStakingDirty_finalize(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// no dirty data
@@ -205,7 +205,7 @@ func TestContractStakingDirty_finalize(t *testing.T) {
 
 func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
+	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	dirty := newContractStakingDirty(clean)
 
 	// add bucket type to dirty cache

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/db/batch"
 	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/test/identityset"
@@ -13,7 +14,7 @@ import (
 
 func TestContractStakingDirty_getBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -40,7 +41,7 @@ func TestContractStakingDirty_getBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket info
@@ -92,7 +93,7 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 
 func TestContractStakingDirty_matchBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -122,7 +123,7 @@ func TestContractStakingDirty_matchBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -142,7 +143,7 @@ func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 
 func TestContractStakingDirty_finalize(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// no dirty data
@@ -204,7 +205,7 @@ func TestContractStakingDirty_finalize(t *testing.T) {
 
 func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("")
+	clean := newContractStakingCache("", genesis.Default.VoteWeightCalConsts)
 	dirty := newContractStakingDirty(clean)
 
 	// add bucket type to dirty cache

--- a/blockindex/contractstaking/dirty_cache_test.go
+++ b/blockindex/contractstaking/dirty_cache_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestContractStakingDirty_getBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -41,7 +41,7 @@ func TestContractStakingDirty_getBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket info
@@ -93,7 +93,7 @@ func TestContractStakingDirty_getBucketInfo(t *testing.T) {
 
 func TestContractStakingDirty_matchBucketType(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -123,7 +123,7 @@ func TestContractStakingDirty_matchBucketType(t *testing.T) {
 
 func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// no bucket type
@@ -143,7 +143,7 @@ func TestContractStakingDirty_getBucketTypeCount(t *testing.T) {
 
 func TestContractStakingDirty_finalize(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// no dirty data
@@ -205,7 +205,7 @@ func TestContractStakingDirty_finalize(t *testing.T) {
 
 func TestContractStakingDirty_noSideEffectOnClean(t *testing.T) {
 	require := require.New(t)
-	clean := newContractStakingCache("", calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	clean := newContractStakingCache(Config{CalculateVoteWeight: calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts)})
 	dirty := newContractStakingDirty(clean)
 
 	// add bucket type to dirty cache

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -55,6 +55,9 @@ func NewContractStakingIndexer(kvStore db.KVStore, config Config) (*Indexer, err
 	if _, err := address.FromString(config.ContractAddress); err != nil {
 		return nil, errors.Wrapf(err, "invalid contract address %s", config.ContractAddress)
 	}
+	if config.CalculateVoteWeight == nil {
+		return nil, errors.New("calculate vote weight function is nil")
+	}
 	return &Indexer{
 		kvstore: kvStore,
 		cache:   newContractStakingCache(config),

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -37,10 +37,11 @@ type (
 
 	// Config is the config for contract staking indexer
 	Config struct {
-		ContractAddress      string                  // stake contract ContractAddress
-		ContractDeployHeight uint64                  // height of the contract deployment
-		CalculateVoteWeight  calculateVoteWeightFunc // calculate vote weight function
-		BlockInterval        time.Duration           // block produce interval
+		ContractAddress      string // stake contract ContractAddress
+		ContractDeployHeight uint64 // height of the contract deployment
+		// TODO: move calculateVoteWeightFunc out of config
+		CalculateVoteWeight calculateVoteWeightFunc // calculate vote weight function
+		BlockInterval       time.Duration           // block produce interval
 	}
 
 	calculateVoteWeightFunc func(v *Bucket) *big.Int

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -30,20 +30,31 @@ import (
 
 const (
 	_testStakingContractAddress = "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd"
+	_blockInterval              = 5 * time.Second
 )
 
 func TestNewContractStakingIndexer(t *testing.T) {
 	r := require.New(t)
 
 	t.Run("kvStore is nil", func(t *testing.T) {
-		_, err := NewContractStakingIndexer(nil, "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd", 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+		_, err := NewContractStakingIndexer(nil, Config{
+			ContractAddress:      "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd",
+			ContractDeployHeight: 0,
+			CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+			BlockInterval:        _blockInterval,
+		})
 		r.Error(err)
 		r.Contains(err.Error(), "kv store is nil")
 	})
 
 	t.Run("invalid contract address", func(t *testing.T) {
 		kvStore := db.NewMemKVStore()
-		_, err := NewContractStakingIndexer(kvStore, "invalid address", 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+		_, err := NewContractStakingIndexer(kvStore, Config{
+			ContractAddress:      "invalid address",
+			ContractDeployHeight: 0,
+			CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+			BlockInterval:        _blockInterval,
+		})
 		r.Error(err)
 		r.Contains(err.Error(), "invalid contract address")
 	})
@@ -51,7 +62,12 @@ func TestNewContractStakingIndexer(t *testing.T) {
 	t.Run("valid input", func(t *testing.T) {
 		contractAddr, err := address.FromString("io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd")
 		r.NoError(err)
-		indexer, err := NewContractStakingIndexer(db.NewMemKVStore(), contractAddr.String(), 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+		indexer, err := NewContractStakingIndexer(db.NewMemKVStore(), Config{
+			ContractAddress:      contractAddr.String(),
+			ContractDeployHeight: 0,
+			CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+			BlockInterval:        _blockInterval,
+		})
 		r.NoError(err)
 		r.NotNil(indexer)
 	})
@@ -65,7 +81,12 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -92,7 +113,12 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	r.NoError(indexer.Stop(context.Background()))
 
 	// load cache from db
-	newIndexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), _testStakingContractAddress, startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	newIndexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: startHeight,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(newIndexer.Start(context.Background()))
 
@@ -121,7 +147,12 @@ func TestContractStakingIndexerDirty(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -149,7 +180,12 @@ func TestContractStakingIndexerThreadSafe(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -204,7 +240,12 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -287,7 +328,12 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -447,7 +493,12 @@ func TestContractStakingIndexerChangeBucketType(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -496,7 +547,12 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -596,7 +652,12 @@ func TestContractStakingIndexerCacheClean(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -658,7 +719,12 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+	indexer, err := NewContractStakingIndexer(kvStore, Config{
+		ContractAddress:      _testStakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+		BlockInterval:        _blockInterval,
+	})
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1}))
@@ -840,6 +906,12 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 		r.EqualValues(4, bts[3].Index)
 		r.EqualValues(5, bts[4].Index)
 		r.EqualValues(8, bts[5].Index)
+		r.EqualValues(10*_blockInterval, bts[0].StakedDuration)
+		r.EqualValues(20*_blockInterval, bts[1].StakedDuration)
+		r.EqualValues(20*_blockInterval, bts[2].StakedDuration)
+		r.EqualValues(20*_blockInterval, bts[3].StakedDuration)
+		r.EqualValues(20*_blockInterval, bts[4].StakedDuration)
+		r.EqualValues(20*_blockInterval, bts[5].StakedDuration)
 		r.EqualValues(10, bts[0].StakedDurationBlockNumber)
 		r.EqualValues(20, bts[1].StakedDurationBlockNumber)
 		r.EqualValues(20, bts[2].StakedDurationBlockNumber)
@@ -889,7 +961,6 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 		r.EqualValues(9, bts[4].UnstakeStartBlockHeight)
 		r.EqualValues(maxBlockNumber, bts[5].UnstakeStartBlockHeight)
 		for _, b := range bts {
-			r.EqualValues(0, b.StakedDuration)
 			r.EqualValues(time.Time{}, b.CreateTime)
 			r.EqualValues(time.Time{}, b.StakeStartTime)
 			r.EqualValues(time.Time{}, b.UnstakeStartTime)
@@ -962,7 +1033,12 @@ func TestIndexer_ReadHeightRestriction(t *testing.T) {
 			dbPath, err := testutil.PathOfTempFile("db")
 			r.NoError(err)
 			cfg.DbPath = dbPath
-			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), Config{
+				ContractAddress:      identityset.Address(1).String(),
+				ContractDeployHeight: startHeight,
+				CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+				BlockInterval:        _blockInterval,
+			})
 			r.NoError(err)
 			r.NoError(indexer.Start(context.Background()))
 			defer func() {
@@ -1042,7 +1118,12 @@ func TestIndexer_PutBlock(t *testing.T) {
 			dbPath, err := testutil.PathOfTempFile("db")
 			r.NoError(err)
 			cfg.DbPath = dbPath
-			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
+			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), Config{
+				ContractAddress:      identityset.Address(1).String(),
+				ContractDeployHeight: startHeight,
+				CalculateVoteWeight:  calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts),
+				BlockInterval:        _blockInterval,
+			})
 			r.NoError(err)
 			r.NoError(indexer.Start(context.Background()))
 			defer func() {
@@ -1071,7 +1152,7 @@ func TestIndexer_PutBlock(t *testing.T) {
 
 func BenchmarkIndexer_PutBlockBeforeContractHeight(b *testing.B) {
 	// Create a new Indexer with a contract height of 100
-	indexer := &Indexer{contractDeployHeight: 100}
+	indexer := &Indexer{config: Config{ContractDeployHeight: 100}}
 
 	// Create a mock block with a height of 50
 	blk := &block.Block{}

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -36,14 +36,14 @@ func TestNewContractStakingIndexer(t *testing.T) {
 	r := require.New(t)
 
 	t.Run("kvStore is nil", func(t *testing.T) {
-		_, err := NewContractStakingIndexer(nil, "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd", 0, genesis.Default.VoteWeightCalConsts)
+		_, err := NewContractStakingIndexer(nil, "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd", 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 		r.Error(err)
 		r.Contains(err.Error(), "kv store is nil")
 	})
 
 	t.Run("invalid contract address", func(t *testing.T) {
 		kvStore := db.NewMemKVStore()
-		_, err := NewContractStakingIndexer(kvStore, "invalid address", 0, genesis.Default.VoteWeightCalConsts)
+		_, err := NewContractStakingIndexer(kvStore, "invalid address", 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 		r.Error(err)
 		r.Contains(err.Error(), "invalid contract address")
 	})
@@ -51,7 +51,7 @@ func TestNewContractStakingIndexer(t *testing.T) {
 	t.Run("valid input", func(t *testing.T) {
 		contractAddr, err := address.FromString("io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd")
 		r.NoError(err)
-		indexer, err := NewContractStakingIndexer(db.NewMemKVStore(), contractAddr.String(), 0, genesis.Default.VoteWeightCalConsts)
+		indexer, err := NewContractStakingIndexer(db.NewMemKVStore(), contractAddr.String(), 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 		r.NoError(err)
 		r.NotNil(indexer)
 	})
@@ -65,7 +65,7 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -92,7 +92,7 @@ func TestContractStakingIndexerLoadCache(t *testing.T) {
 	r.NoError(indexer.Stop(context.Background()))
 
 	// load cache from db
-	newIndexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), _testStakingContractAddress, startHeight, genesis.Default.VoteWeightCalConsts)
+	newIndexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), _testStakingContractAddress, startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(newIndexer.Start(context.Background()))
 
@@ -121,7 +121,7 @@ func TestContractStakingIndexerDirty(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -149,7 +149,7 @@ func TestContractStakingIndexerThreadSafe(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -204,7 +204,7 @@ func TestContractStakingIndexerBucketType(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -287,7 +287,7 @@ func TestContractStakingIndexerBucketInfo(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -447,7 +447,7 @@ func TestContractStakingIndexerChangeBucketType(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -496,7 +496,7 @@ func TestContractStakingIndexerReadBuckets(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -596,7 +596,7 @@ func TestContractStakingIndexerCacheClean(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 
@@ -658,7 +658,7 @@ func TestContractStakingIndexerVotes(t *testing.T) {
 	cfg := db.DefaultConfig
 	cfg.DbPath = testDBPath
 	kvStore := db.NewBoltDB(cfg)
-	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	indexer, err := NewContractStakingIndexer(kvStore, _testStakingContractAddress, 0, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 	r.NoError(err)
 	r.NoError(indexer.Start(context.Background()))
 	ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1}))
@@ -962,7 +962,7 @@ func TestIndexer_ReadHeightRestriction(t *testing.T) {
 			dbPath, err := testutil.PathOfTempFile("db")
 			r.NoError(err)
 			cfg.DbPath = dbPath
-			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, genesis.Default.VoteWeightCalConsts)
+			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 			r.NoError(err)
 			r.NoError(indexer.Start(context.Background()))
 			defer func() {
@@ -1042,7 +1042,7 @@ func TestIndexer_PutBlock(t *testing.T) {
 			dbPath, err := testutil.PathOfTempFile("db")
 			r.NoError(err)
 			cfg.DbPath = dbPath
-			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, genesis.Default.VoteWeightCalConsts)
+			indexer, err := NewContractStakingIndexer(db.NewBoltDB(cfg), identityset.Address(1).String(), startHeight, calculateVoteWeightGen(genesis.Default.VoteWeightCalConsts))
 			r.NoError(err)
 			r.NoError(indexer.Start(context.Background()))
 			defer func() {

--- a/blockindex/contractstaking/indexer_test.go
+++ b/blockindex/contractstaking/indexer_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/block"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/config"
+	"github.com/iotexproject/iotex-core/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/db"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/testutil"
@@ -30,7 +31,10 @@ import (
 
 const (
 	_testStakingContractAddress = "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd"
-	_blockInterval              = 5 * time.Second
+)
+
+var (
+	_blockInterval = consensusfsm.DefaultDardanellesUpgradeConfig.BlockInterval
 )
 
 func TestNewContractStakingIndexer(t *testing.T) {

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -318,7 +318,7 @@ func (builder *Builder) buildContractStakingIndexer(forTest bool) error {
 	}
 	dbConfig := builder.cfg.DB
 	dbConfig.DbPath = builder.cfg.Chain.ContractStakingIndexDBPath
-	indexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight)
+	indexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight, builder.cfg.Genesis.VoteWeightCalConsts)
 	if err != nil {
 		return err
 	}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -327,7 +327,7 @@ func (builder *Builder) buildContractStakingIndexer(forTest bool) error {
 			CalculateVoteWeight: func(v *staking.VoteBucket) *big.Int {
 				return staking.CalculateVoteWeight(voteCalcConsts, v, false)
 			},
-			BlockInterval: builder.cfg.Genesis.BlockInterval,
+			BlockInterval: builder.cfg.DardanellesUpgrade.BlockInterval,
 		})
 	if err != nil {
 		return err

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -318,7 +318,10 @@ func (builder *Builder) buildContractStakingIndexer(forTest bool) error {
 	}
 	dbConfig := builder.cfg.DB
 	dbConfig.DbPath = builder.cfg.Chain.ContractStakingIndexDBPath
-	indexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight, builder.cfg.Genesis.VoteWeightCalConsts)
+	voteCalcConsts := builder.cfg.Genesis.VoteWeightCalConsts
+	indexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight, func(v *staking.VoteBucket, selfStake bool) *big.Int {
+		return staking.CalculateVoteWeight(voteCalcConsts, v, selfStake)
+	})
 	if err != nil {
 		return err
 	}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -319,9 +319,16 @@ func (builder *Builder) buildContractStakingIndexer(forTest bool) error {
 	dbConfig := builder.cfg.DB
 	dbConfig.DbPath = builder.cfg.Chain.ContractStakingIndexDBPath
 	voteCalcConsts := builder.cfg.Genesis.VoteWeightCalConsts
-	indexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(dbConfig), builder.cfg.Genesis.SystemStakingContractAddress, builder.cfg.Genesis.SystemStakingContractHeight, func(v *staking.VoteBucket, selfStake bool) *big.Int {
-		return staking.CalculateVoteWeight(voteCalcConsts, v, selfStake)
-	})
+	indexer, err := contractstaking.NewContractStakingIndexer(
+		db.NewBoltDB(dbConfig),
+		contractstaking.Config{
+			ContractAddress:      builder.cfg.Genesis.SystemStakingContractAddress,
+			ContractDeployHeight: builder.cfg.Genesis.SystemStakingContractHeight,
+			CalculateVoteWeight: func(v *staking.VoteBucket) *big.Int {
+				return staking.CalculateVoteWeight(voteCalcConsts, v, false)
+			},
+			BlockInterval: builder.cfg.Genesis.BlockInterval,
+		})
 	if err != nil {
 		return err
 	}

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -1957,8 +1958,13 @@ func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r 
 	r.NoError(err)
 	cc := cfg.DB
 	cc.DbPath = testContractStakeIndexerPath
-	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0, func(v *staking.VoteBucket, selfStake bool) *big.Int {
-		return staking.CalculateVoteWeight(genesis.Default.VoteWeightCalConsts, v, selfStake)
+	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), contractstaking.Config{
+		ContractAddress:      _stakingContractAddress,
+		ContractDeployHeight: 0,
+		CalculateVoteWeight: func(v *staking.VoteBucket) *big.Int {
+			return staking.CalculateVoteWeight(genesis.Default.VoteWeightCalConsts, v, false)
+		},
+		BlockInterval: 5 * time.Second,
 	})
 	r.NoError(err)
 	// create BlockDAO

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -1259,6 +1259,7 @@ var (
 		common.BytesToAddress(identityset.Address(4).Bytes()),
 		common.BytesToAddress(identityset.Address(5).Bytes()),
 		common.BytesToAddress(identityset.Address(6).Bytes()),
+		common.BytesToAddress(identityset.Address(7).Bytes()),
 	}
 )
 
@@ -1875,11 +1876,11 @@ func TestContractStaking(t *testing.T) {
 	t.Run("afterRedsea", func(t *testing.T) {
 		jumpBlocks(bc, _testRedseaBlockHeight, r)
 		t.Run("weightedVotes", func(t *testing.T) {
-			simpleStake(_delegates[6], big.NewInt(100), big.NewInt(100))
+			simpleStake(_delegates[7], big.NewInt(100), big.NewInt(100))
 			height, err := indexer.Height()
 			r.NoError(err)
 			ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(ctx, protocol.BlockCtx{BlockHeight: height}))
-			votes, err := indexer.CandidateVotes(ctx, identityset.Address(6), height)
+			votes, err := indexer.CandidateVotes(ctx, identityset.Address(7), height)
 			r.NoError(err)
 			r.EqualValues(103, votes.Int64())
 		})

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -1358,7 +1358,8 @@ func TestContractStaking(t *testing.T) {
 		r.EqualValues(blk.Height(), bt.CreateBlockHeight)
 		r.EqualValues(blk.Height(), bt.StakeStartBlockHeight)
 		r.True(bt.UnstakeStartBlockHeight == math.MaxUint64)
-		votes, err := indexer.CandidateVotes(identityset.Address(delegateIdx), blk.Height())
+		ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1}))
+		votes, err := indexer.CandidateVotes(ctx, identityset.Address(delegateIdx), blk.Height())
 		r.NoError(err)
 		r.EqualValues(10, votes.Int64())
 		tbc, err := indexer.TotalBucketCount(blk.Height())
@@ -1389,7 +1390,8 @@ func TestContractStaking(t *testing.T) {
 			r.NoError(err)
 			r.True(ok)
 			r.EqualValues(blk.Height(), bt.StakeStartBlockHeight)
-			votes, err := indexer.CandidateVotes(identityset.Address(delegateIdx), blk.Height())
+			ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1}))
+			votes, err := indexer.CandidateVotes(ctx, identityset.Address(delegateIdx), blk.Height())
 			r.NoError(err)
 			r.EqualValues(10, votes.Int64())
 			tbc, err := indexer.TotalBucketCount(blk.Height())
@@ -1415,7 +1417,8 @@ func TestContractStaking(t *testing.T) {
 				r.NoError(err)
 				r.True(ok)
 				r.EqualValues(blk.Height(), bt.UnstakeStartBlockHeight)
-				votes, err := indexer.CandidateVotes(identityset.Address(delegateIdx), blk.Height())
+				ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(genesis.WithGenesisContext(context.Background(), genesis.Default), protocol.BlockCtx{BlockHeight: 1}))
+				votes, err := indexer.CandidateVotes(ctx, identityset.Address(delegateIdx), blk.Height())
 				r.NoError(err)
 				r.EqualValues(0, votes.Int64())
 				tbc, err := indexer.TotalBucketCount(blk.Height())
@@ -1938,7 +1941,7 @@ func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r 
 	r.NoError(err)
 	cc := cfg.DB
 	cc.DbPath = testContractStakeIndexerPath
-	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0)
+	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
 	r.NoError(err)
 	// create BlockDAO
 	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer, contractStakeIndexer})

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/action/protocol/execution"
 	"github.com/iotexproject/iotex-core/action/protocol/rewarding"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
+	"github.com/iotexproject/iotex-core/action/protocol/staking"
 	"github.com/iotexproject/iotex-core/actpool"
 	"github.com/iotexproject/iotex-core/blockchain"
 	"github.com/iotexproject/iotex-core/blockchain/block"
@@ -1956,7 +1957,9 @@ func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r 
 	r.NoError(err)
 	cc := cfg.DB
 	cc.DbPath = testContractStakeIndexerPath
-	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0, genesis.Default.VoteWeightCalConsts)
+	contractStakeIndexer, err := contractstaking.NewContractStakingIndexer(db.NewBoltDB(cc), _stakingContractAddress, 0, func(v *staking.VoteBucket, selfStake bool) *big.Int {
+		return staking.CalculateVoteWeight(genesis.Default.VoteWeightCalConsts, v, selfStake)
+	})
 	r.NoError(err)
 	// create BlockDAO
 	dao := blockdao.NewBlockDAOInMemForTest([]blockdao.BlockIndexer{sf, indexer, contractStakeIndexer})

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -1247,6 +1247,7 @@ const (
 	]`
 	_stakingContractAddress = "io19ys8f4uhwms6lq6ulexr5fwht9gsjes8mvuugd"
 	_adminID                = 22
+	_testRedseaBlockHeight  = 100
 )
 
 var (
@@ -1871,6 +1872,18 @@ func TestContractStaking(t *testing.T) {
 		})
 	})
 
+	t.Run("afterRedsea", func(t *testing.T) {
+		jumpBlocks(bc, _testRedseaBlockHeight, r)
+		t.Run("weightedVotes", func(t *testing.T) {
+			simpleStake(_delegates[6], big.NewInt(100), big.NewInt(100))
+			height, err := indexer.Height()
+			r.NoError(err)
+			ctx := protocol.WithFeatureCtx(protocol.WithBlockCtx(ctx, protocol.BlockCtx{BlockHeight: height}))
+			votes, err := indexer.CandidateVotes(ctx, identityset.Address(6), height)
+			r.NoError(err)
+			r.EqualValues(103, votes.Int64())
+		})
+	})
 }
 
 func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r *require.Assertions) (blockchain.Blockchain, factory.Factory, blockdao.BlockDAO, actpool.ActPool, *contractstaking.Indexer) {
@@ -1903,6 +1916,7 @@ func prepareContractStakingBlockchain(ctx context.Context, cfg config.Config, r 
 	cfg.Genesis.FairbankBlockHeight = 0
 	cfg.Genesis.GreenlandBlockHeight = 0
 	cfg.Genesis.IcelandBlockHeight = 0
+	cfg.Genesis.RedseaBlockHeight = _testRedseaBlockHeight
 
 	// London is enabled at okhotsk height
 	cfg.Genesis.Blockchain.JutlandBlockHeight = 0


### PR DESCRIPTION
# Description

Currently, the IIP-13 `contract staking bucket` does not take into account the impact of the `staking duration` and `stake-lock` when **calculating the voting power.** It only considers the amount of IOTX staked. However, it should actually use the similar voting logic as the `native staking bucket`.

It's a hard-fork at `RedseaBlockHeight`.

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
