### PR TITLE
[util] implement block time calculator

### DIFF
--- a/pkg/util/blockutil/block_time_calculator.go
+++ b/pkg/util/blockutil/block_time_calculator.go
@@ -1,0 +1,42 @@
+package blockutil
+
+import "time"
+
+type (
+	// BlockTimeCalculator calculates block time of a given height.
+	BlockTimeCalculator struct {
+		tipHeight        tipHeightFunc
+		historyBlockTime blockTimeFunc
+		blockInterval    time.Duration
+	}
+
+	tipHeightFunc func() uint64
+	blockTimeFunc func(uint64) (time.Time, error)
+)
+
+// NewBlockTimeCalculator creates a new BlockTimeCalculator.
+func NewBlockTimeCalculator(interval time.Duration, tipHeight tipHeightFunc, blockTime blockTimeFunc) *BlockTimeCalculator {
+	return &BlockTimeCalculator{
+		blockInterval:    interval,
+		tipHeight:        tipHeight,
+		historyBlockTime: blockTime,
+	}
+}
+
+// CalculateBlockTime returns the block time of the given height.
+// If the height is in the future, it will predict the block time according to the tip block time and interval.
+// If the height is in the past, it will get the block time from indexer.
+func (btc *BlockTimeCalculator) CalculateBlockTime(height uint64) (time.Time, error) {
+	// get block time from indexer if height is in the past
+	tipHeight := btc.tipHeight()
+	if height <= tipHeight {
+		return btc.historyBlockTime(height)
+	}
+
+	// predict block time according to tip block time and interval
+	tipBlockTime, err := btc.historyBlockTime(tipHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return tipBlockTime.Add(time.Duration(height-tipHeight) * btc.blockInterval), nil
+}

--- a/pkg/util/blockutil/block_time_calculator_test.go
+++ b/pkg/util/blockutil/block_time_calculator_test.go
@@ -1,0 +1,43 @@
+package blockutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockTimeCalculator_CalculateBlockTime(t *testing.T) {
+	r := require.New(t)
+	interval := 5 * time.Second
+	tipHeight := uint64(100)
+	tipHeightF := func() uint64 { return tipHeight }
+	baseTime, err := time.Parse("2006-01-02T15:04:05.000Z", "2022-01-01T00:00:00.000Z")
+	r.NoError(err)
+	historyBlockTimeF := func(height uint64) (time.Time, error) { return baseTime.Add(time.Hour * time.Duration(height)), nil }
+	btc := NewBlockTimeCalculator(interval, tipHeightF, historyBlockTimeF)
+
+	historyWrapper := func(height uint64) time.Time {
+		t, err := historyBlockTimeF(height)
+		r.NoError(err)
+		return t
+	}
+	cases := []struct {
+		name   string
+		height uint64
+		want   time.Time
+	}{
+		{"height is in the past", tipHeight - 1, historyWrapper(tipHeight - 1)},
+		{"height is in the past I", tipHeight, historyWrapper(tipHeight)},
+		{"height is in the future", tipHeight + 1, historyWrapper(tipHeight).Add(interval)},
+		{"height is in the future I", tipHeight + 2, historyWrapper(tipHeight).Add(2 * interval)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := btc.CalculateBlockTime(c.height)
+			r.NoError(err)
+			r.Equal(c.want, got)
+		})
+	}
+}


### PR DESCRIPTION
# Description

A tool has been added to calculate the corresponding time for a given height. It supports accurate querying of historical blocks as well as prediction for future blocks. The prediction for future blocks is calculated based on the latest height and block interval.

This tool will be used in the EVM Shanghai upgrade to set `ShanghaiTime` and to convert block numbers and time for the nft bucket during vote counting.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
