### PR TITLE
[util] implement block time calculator

### DIFF
--- a/pkg/util/blockutil/block_time_calculator.go
+++ b/pkg/util/blockutil/block_time_calculator.go
@@ -1,0 +1,43 @@
+package blockutil
+
+import "time"
+
+type (
+	// BlockTimeCalculator calculates block time of a given height.
+	BlockTimeCalculator struct {
+		getBlockInterval    getBlockIntervalFn
+		getTipHeight        getTipHeightFn
+		getHistoryBlockTime getHistoryblockTimeFn
+	}
+
+	getBlockIntervalFn    func(uint64) time.Duration
+	getTipHeightFn        func() uint64
+	getHistoryblockTimeFn func(uint64) (time.Time, error)
+)
+
+// NewBlockTimeCalculator creates a new BlockTimeCalculator.
+func NewBlockTimeCalculator(getBlockInterval getBlockIntervalFn, getTipHeight getTipHeightFn, getHistoryBlockTime getHistoryblockTimeFn) *BlockTimeCalculator {
+	return &BlockTimeCalculator{
+		getBlockInterval:    getBlockInterval,
+		getTipHeight:        getTipHeight,
+		getHistoryBlockTime: getHistoryBlockTime,
+	}
+}
+
+// CalculateBlockTime returns the block time of the given height.
+// If the height is in the future, it will predict the block time according to the tip block time and interval.
+// If the height is in the past, it will get the block time from indexer.
+func (btc *BlockTimeCalculator) CalculateBlockTime(height uint64) (time.Time, error) {
+	// get block time from indexer if height is in the past
+	tipHeight := btc.getTipHeight()
+	if height <= tipHeight {
+		return btc.getHistoryBlockTime(height)
+	}
+
+	// predict block time according to tip block time and interval
+	tipBlockTime, err := btc.getHistoryBlockTime(tipHeight)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return tipBlockTime.Add(time.Duration(height-tipHeight) * btc.getBlockInterval(height)), nil
+}

--- a/pkg/util/blockutil/block_time_calculator.go
+++ b/pkg/util/blockutil/block_time_calculator.go
@@ -1,6 +1,9 @@
 package blockutil
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 type (
 	// BlockTimeCalculator calculates block time of a given height.
@@ -16,12 +19,21 @@ type (
 )
 
 // NewBlockTimeCalculator creates a new BlockTimeCalculator.
-func NewBlockTimeCalculator(getBlockInterval getBlockIntervalFn, getTipHeight getTipHeightFn, getHistoryBlockTime getHistoryblockTimeFn) *BlockTimeCalculator {
+func NewBlockTimeCalculator(getBlockInterval getBlockIntervalFn, getTipHeight getTipHeightFn, getHistoryBlockTime getHistoryblockTimeFn) (*BlockTimeCalculator, error) {
+	if getBlockInterval == nil {
+		return nil, errors.New("nil getBlockInterval")
+	}
+	if getTipHeight == nil {
+		return nil, errors.New("nil getTipHeight")
+	}
+	if getHistoryBlockTime == nil {
+		return nil, errors.New("nil getHistoryBlockTime")
+	}
 	return &BlockTimeCalculator{
 		getBlockInterval:    getBlockInterval,
 		getTipHeight:        getTipHeight,
 		getHistoryBlockTime: getHistoryBlockTime,
-	}
+	}, nil
 }
 
 // CalculateBlockTime returns the block time of the given height.
@@ -39,5 +51,5 @@ func (btc *BlockTimeCalculator) CalculateBlockTime(height uint64) (time.Time, er
 	if err != nil {
 		return time.Time{}, err
 	}
-	return tipBlockTime.Add(time.Duration(height-tipHeight) * btc.getBlockInterval(height)), nil
+	return tipBlockTime.Add(time.Duration(height-tipHeight) * btc.getBlockInterval(tipHeight)), nil
 }

--- a/pkg/util/blockutil/block_time_calculator.go
+++ b/pkg/util/blockutil/block_time_calculator.go
@@ -2,6 +2,7 @@ package blockutil
 
 import (
 	"errors"
+	"math"
 	"time"
 )
 
@@ -47,9 +48,14 @@ func (btc *BlockTimeCalculator) CalculateBlockTime(height uint64) (time.Time, er
 	}
 
 	// predict block time according to tip block time and interval
+	blockInterval := btc.getBlockInterval(tipHeight)
+	blockNumer := time.Duration(height - tipHeight)
+	if blockNumer > math.MaxInt64/blockInterval {
+		return time.Time{}, errors.New("height overflow")
+	}
 	tipBlockTime, err := btc.getHistoryBlockTime(tipHeight)
 	if err != nil {
 		return time.Time{}, err
 	}
-	return tipBlockTime.Add(time.Duration(height-tipHeight) * btc.getBlockInterval(tipHeight)), nil
+	return tipBlockTime.Add(blockNumer * blockInterval), nil
 }

--- a/pkg/util/blockutil/block_time_calculator_test.go
+++ b/pkg/util/blockutil/block_time_calculator_test.go
@@ -30,16 +30,23 @@ func TestBlockTimeCalculator_CalculateBlockTime(t *testing.T) {
 		name   string
 		height uint64
 		want   time.Time
+		errMsg string
 	}{
-		{"height is in the past", tipHeight - 1, historyWrapper(tipHeight - 1)},
-		{"height is in the past I", tipHeight, historyWrapper(tipHeight)},
-		{"height is in the future", tipHeight + 1, historyWrapper(tipHeight).Add(interval)},
-		{"height is in the future I", tipHeight + 2, historyWrapper(tipHeight).Add(2 * interval)},
+		{"height is in the past", tipHeight - 1, historyWrapper(tipHeight - 1), ""},
+		{"height is in the past I", tipHeight, historyWrapper(tipHeight), ""},
+		{"height is in the future", tipHeight + 1, historyWrapper(tipHeight).Add(interval), ""},
+		{"height is in the future I", tipHeight + 2, historyWrapper(tipHeight).Add(2 * interval), ""},
+		{"height is not overflow", tipHeight + (1<<63-1)/uint64(interval), historyWrapper(tipHeight).Add((1<<63 - 1) / interval * interval), ""},
+		{"height is overflow", tipHeight + (1<<63-1)/uint64(interval) + 1, time.Time{}, "height overflow"},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got, err := btc.CalculateBlockTime(c.height)
+			if c.errMsg != "" {
+				r.ErrorContains(err, c.errMsg)
+				return
+			}
 			r.NoError(err)
 			r.Equal(c.want, got)
 		})

--- a/pkg/util/blockutil/block_time_calculator_test.go
+++ b/pkg/util/blockutil/block_time_calculator_test.go
@@ -1,0 +1,46 @@
+package blockutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockTimeCalculator_CalculateBlockTime(t *testing.T) {
+	r := require.New(t)
+	interval := 5 * time.Second
+	intervalFn := func(h uint64) time.Duration {
+		return 5 * time.Second
+	}
+	tipHeight := uint64(100)
+	tipHeightF := func() uint64 { return tipHeight }
+	baseTime, err := time.Parse("2006-01-02T15:04:05.000Z", "2022-01-01T00:00:00.000Z")
+	r.NoError(err)
+	historyBlockTimeF := func(height uint64) (time.Time, error) { return baseTime.Add(time.Hour * time.Duration(height)), nil }
+	btc := NewBlockTimeCalculator(intervalFn, tipHeightF, historyBlockTimeF)
+
+	historyWrapper := func(height uint64) time.Time {
+		t, err := historyBlockTimeF(height)
+		r.NoError(err)
+		return t
+	}
+	cases := []struct {
+		name   string
+		height uint64
+		want   time.Time
+	}{
+		{"height is in the past", tipHeight - 1, historyWrapper(tipHeight - 1)},
+		{"height is in the past I", tipHeight, historyWrapper(tipHeight)},
+		{"height is in the future", tipHeight + 1, historyWrapper(tipHeight).Add(interval)},
+		{"height is in the future I", tipHeight + 2, historyWrapper(tipHeight).Add(2 * interval)},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := btc.CalculateBlockTime(c.height)
+			r.NoError(err)
+			r.Equal(c.want, got)
+		})
+	}
+}

--- a/pkg/util/blockutil/block_time_calculator_test.go
+++ b/pkg/util/blockutil/block_time_calculator_test.go
@@ -18,7 +18,8 @@ func TestBlockTimeCalculator_CalculateBlockTime(t *testing.T) {
 	baseTime, err := time.Parse("2006-01-02T15:04:05.000Z", "2022-01-01T00:00:00.000Z")
 	r.NoError(err)
 	historyBlockTimeF := func(height uint64) (time.Time, error) { return baseTime.Add(time.Hour * time.Duration(height)), nil }
-	btc := NewBlockTimeCalculator(intervalFn, tipHeightF, historyBlockTimeF)
+	btc, err := NewBlockTimeCalculator(intervalFn, tipHeightF, historyBlockTimeF)
+	r.NoError(err)
 
 	historyWrapper := func(height uint64) time.Time {
 		t, err := historyBlockTimeF(height)


### PR DESCRIPTION
# Description

There are several reasons for introcuding block time calculator: 
- After the Shanghai upgrade of Ethereum, hard-fork judgment is now based on timestamps. We need to convert specified block heights into timestamps. 
- When calculating the votes for NFT Bucket, we need to convert block numbers into staking times. 
- We need a unified calculation method that takes into account the variation of BlockInterval.

It calculates the corresponding time for a given height. It supports accurate querying of historical blocks as well as prediction for future blocks. The prediction for future blocks is calculated based on the latest height and block interval.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
