### PR TITLE
[evm] Add methods for StatedbAdapter

### DIFF
--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -446,6 +447,17 @@ func (stateDB *StateDBAdapter) HasSuicided(evmAddr common.Address) bool {
 	return ok
 }
 
+// SetTransientState sets transient storage for a given account
+func (stateDB *StateDBAdapter) SetTransientState(addr common.Address, key, value common.Hash) {
+	log.S().Panic("SetTransientState not implemented")
+}
+
+// GetTransientState gets transient storage for a given account.
+func (stateDB *StateDBAdapter) GetTransientState(addr common.Address, key common.Hash) common.Hash {
+	log.S().Panic("GetTransientState not implemented")
+	return common.Hash{}
+}
+
 // Exist checks the existence of an address
 func (stateDB *StateDBAdapter) Exist(evmAddr common.Address) bool {
 	addr, err := address.FromBytes(evmAddr.Bytes())
@@ -464,6 +476,41 @@ func (stateDB *StateDBAdapter) Exist(evmAddr common.Address) bool {
 		return false
 	}
 	return true
+}
+
+// Prepare handles the preparatory steps for executing a state transition with.
+// This method must be invoked before state transition.
+//
+// Berlin fork:
+// - Add sender to access list (2929)
+// - Add destination to access list (2929)
+// - Add precompiles to access list (2929)
+// - Add the contents of the optional tx access list (2930)
+//
+// Potential EIPs:
+// - Reset access list (Berlin)
+// - Add coinbase to access list (EIP-3651)
+// - Reset transient storage (EIP-1153)
+func (stateDB *StateDBAdapter) Prepare(rules params.Rules, sender, coinbase common.Address, dst *common.Address, precompiles []common.Address, list types.AccessList) {
+	if rules.IsBerlin {
+		stateDB.AddAddressToAccessList(sender)
+		if dst != nil {
+			stateDB.AddAddressToAccessList(*dst)
+			// If it's a create-tx, the destination will be added inside evm.create
+		}
+		for _, addr := range precompiles {
+			stateDB.AddAddressToAccessList(addr)
+		}
+		for _, el := range list {
+			stateDB.AddAddressToAccessList(el.Address)
+			for _, key := range el.StorageKeys {
+				stateDB.AddSlotToAccessList(el.Address, key)
+			}
+		}
+		if rules.IsShanghai { // EIP-3651: warm coinbase
+			stateDB.AddAddressToAccessList(coinbase)
+		}
+	}
 }
 
 // PrepareAccessList handles the preparatory steps for executing a state transition with


### PR DESCRIPTION
# Description
In the Shanghai upgrade of EVM, there have been changes to the [StateDB Interface](https://github.com/ethereum/go-ethereum/blob/v1.11.5/core/vm/interface.go#L28), therefore the StatedbAdapter also needs to be modified accordingly.

The modified parts of the new StateDB Interface are as follows:
```
PrepareAccessList(sender common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
```
=>
```
GetTransientState(addr common.Address, key common.Hash) common.Hash
SetTransientState(addr common.Address, key, value common.Hash)

Prepare(rules params.Rules, sender, coinbase common.Address, dest *common.Address, precompiles []common.Address, txAccesses types.AccessList)
```
Among them, `GetTransientState` and `SetTransientState` are prepared for EIP-1153, but this EIP is not activated in Shanghai, so it will not be supported in this PR for now.

The implementation of the `Prepare` method refers to the [implementation in Ethereum](https://github.com/ethereum/go-ethereum/blob/v1.11.5/core/state/statedb.go#L1098).

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
