### PR TITLE
[action] Increase Execution Size Limit to 48K

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -114,7 +114,7 @@ type (
 		AddContractStakingVotes                 bool
 		FixContractStakingWeightedVotes         bool
 		SharedGasWithDapp                       bool
-		IncreaseExecutionSizeLimitTo48KB        bool
+		ExecutionSizeLimit32KB                  bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -254,7 +254,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AddContractStakingVotes:                 g.IsQuebec(height),
 			FixContractStakingWeightedVotes:         g.IsRedsea(height),
 			SharedGasWithDapp:                       g.IsToBeEnabled(height),
-			IncreaseExecutionSizeLimitTo48KB:        g.IsToBeEnabled(height),
+			ExecutionSizeLimit32KB:                  !g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -114,7 +114,7 @@ type (
 		AddContractStakingVotes                 bool
 		FixContractStakingWeightedVotes         bool
 		SharedGasWithDapp                       bool
-		IncreaseExecutionSizeLimitTo64          bool
+		IncreaseExecutionSizeLimitTo48KB        bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -254,7 +254,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AddContractStakingVotes:                 g.IsQuebec(height),
 			FixContractStakingWeightedVotes:         g.IsRedsea(height),
 			SharedGasWithDapp:                       g.IsToBeEnabled(height),
-			IncreaseExecutionSizeLimitTo64:          g.IsToBeEnabled(height),
+			IncreaseExecutionSizeLimitTo48KB:        g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -114,6 +114,7 @@ type (
 		AddContractStakingVotes                 bool
 		FixContractStakingWeightedVotes         bool
 		SharedGasWithDapp                       bool
+		IncreaseExecutionSizeLimitTo64          bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -253,6 +254,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AddContractStakingVotes:                 g.IsQuebec(height),
 			FixContractStakingWeightedVotes:         g.IsRedsea(height),
 			SharedGasWithDapp:                       g.IsToBeEnabled(height),
+			IncreaseExecutionSizeLimitTo64:          g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -21,8 +21,8 @@ import (
 
 const (
 	// the maximum size of execution allowed
-	_executionSizeLimit48KB = 48 * 1024
-	_executionSizeLimit32KB = 32 * 1024
+	_executionSizeLimit48KB = uint32(48 * 1024)
+	_executionSizeLimit32KB = uint32(32 * 1024)
 	// TODO: it works only for one instance per protocol definition now
 	_protocolID = "smart_contract"
 )
@@ -89,10 +89,10 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.S
 	if !ok {
 		return nil
 	}
-	sizeLimit := uint32(_executionSizeLimit32KB)
+	sizeLimit := _executionSizeLimit48KB
 	fCtx := protocol.MustGetFeatureCtx(ctx)
-	if fCtx.IncreaseExecutionSizeLimitTo48KB {
-		sizeLimit = uint32(_executionSizeLimit48KB)
+	if fCtx.ExecutionSizeLimit32KB {
+		sizeLimit = _executionSizeLimit32KB
 	}
 
 	// Reject oversize execution

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -20,9 +20,9 @@ import (
 )
 
 const (
-	// ExecutionSizeLimit is the maximum size of execution allowed
-	ExecutionSizeLimit    = 64 * 1024
-	_executionSizeLimit32 = 32 * 1024
+	// the maximum size of execution allowed
+	_executionSizeLimit48KB = 48 * 1024
+	_executionSizeLimit32KB = 32 * 1024
 	// TODO: it works only for one instance per protocol definition now
 	_protocolID = "smart_contract"
 )
@@ -89,10 +89,10 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.S
 	if !ok {
 		return nil
 	}
-	sizeLimit := uint32(_executionSizeLimit32)
+	sizeLimit := uint32(_executionSizeLimit32KB)
 	fCtx := protocol.MustGetFeatureCtx(ctx)
-	if fCtx.IncreaseExecutionSizeLimitTo64 {
-		sizeLimit = uint32(ExecutionSizeLimit)
+	if fCtx.IncreaseExecutionSizeLimitTo48KB {
+		sizeLimit = uint32(_executionSizeLimit48KB)
 	}
 
 	// Reject oversize execution

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -623,7 +623,7 @@ func TestProtocol_Validate(t *testing.T) {
 	}{
 		{"limit 32KB", 0, 32684, action.ErrOversizedData},
 		{"limit 48KB I", genesis.Default.ToBeEnabledBlockHeight, 32684, nil},
-		{"limit 48KB II", genesis.Default.ToBeEnabledBlockHeight, 49152, action.ErrOversizedData},
+		{"limit 48KB II", genesis.Default.ToBeEnabledBlockHeight, 49153, action.ErrOversizedData},
 	}
 
 	for i := range cases {

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -615,9 +615,29 @@ func TestProtocol_Validate(t *testing.T) {
 		return time.Time{}, nil
 	})
 
-	ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), make([]byte, 32684))
-	require.NoError(err)
-	require.Equal(action.ErrOversizedData, errors.Cause(p.Validate(context.Background(), ex, nil)))
+	cases := []struct {
+		name      string
+		height    uint64
+		size      uint64
+		expectErr error
+	}{
+		{"limit 32KB", 0, 32684, action.ErrOversizedData},
+		{"limit 48KB I", genesis.Default.ToBeEnabledBlockHeight, 32684, nil},
+		{"limit 48KB II", genesis.Default.ToBeEnabledBlockHeight, 49152, action.ErrOversizedData},
+	}
+
+	for i := range cases {
+		t.Run(cases[i].name, func(t *testing.T) {
+			ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), make([]byte, cases[i].size))
+			require.NoError(err)
+			ctx := genesis.WithGenesisContext(context.Background(), config.Default.Genesis)
+			ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
+				BlockHeight: cases[i].height,
+			})
+			ctx = protocol.WithFeatureCtx(ctx)
+			require.Equal(cases[i].expectErr, errors.Cause(p.Validate(ctx, ex, nil)))
+		})
+	}
 }
 
 func TestProtocol_Handle(t *testing.T) {


### PR DESCRIPTION
# Description

After activating EIP-3860: Limit and meter initcode in the Shanghai upgrade, the limit on the initcode size was increased to 48KB in evm. Currently, we have a limit of 32KB on execution action size. To be compatible with this change in Ethereum, we propose to raise the limit size up to 48KB.

## Type of change
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
