### PR TITLE
[api] fix estimateGas API error when passing gasPrice parameter

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1441,6 +1441,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		return 0, status.Error(codes.InvalidArgument, err.Error())
 	}
 	sc.SetNonce(state.PendingNonce())
+	//gasprice should be 0, otherwiseit may cause the API to return an error, such as insufficient balance.
 	sc.SetGasPrice(big.NewInt(0))
 	blockGasLimit := core.bc.Genesis().BlockGasLimit
 	sc.SetGasLimit(blockGasLimit)

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1441,7 +1441,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		return 0, status.Error(codes.InvalidArgument, err.Error())
 	}
 	sc.SetNonce(state.PendingNonce())
-	//gasprice should be 0, otherwiseit may cause the API to return an error, such as insufficient balance.
+	//gasprice should be 0, otherwise it may cause the API to return an error, such as insufficient balance.
 	sc.SetGasPrice(big.NewInt(0))
 	blockGasLimit := core.bc.Genesis().BlockGasLimit
 	sc.SetGasLimit(blockGasLimit)

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1441,6 +1441,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		return 0, status.Error(codes.InvalidArgument, err.Error())
 	}
 	sc.SetNonce(state.PendingNonce())
+	sc.SetGasPrice(big.NewInt(0))
 	blockGasLimit := core.bc.Genesis().BlockGasLimit
 	sc.SetGasLimit(blockGasLimit)
 	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc)

--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -204,6 +204,31 @@ func TestEstimateGasForAction(t *testing.T) {
 	require.Contains(err.Error(), action.ErrNilProto.Error())
 }
 
+func TestEstimateExecutionGasConsumption(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	svr, _, _, _, cleanCallback := setupTestCoreService()
+	defer cleanCallback()
+
+	callAddr := identityset.Address(29)
+	sc, err := action.NewExecution("", 0, big.NewInt(0), 0, big.NewInt(0), []byte{})
+	require.NoError(err)
+
+	//gasprice is zero
+	sc.SetGasPrice(big.NewInt(0))
+	estimatedGas, err := svr.EstimateExecutionGasConsumption(context.Background(), sc, callAddr)
+	require.NoError(err)
+	require.Equal(uint64(10000), estimatedGas)
+
+	//gasprice no zero, should return error before fixed
+	sc.SetGasPrice(big.NewInt(100))
+	estimatedGas, err = svr.EstimateExecutionGasConsumption(context.Background(), sc, callAddr)
+	require.NoError(err)
+	require.Equal(uint64(10000), estimatedGas)
+
+}
+
 func TestTraceTransaction(t *testing.T) {
 	require := require.New(t)
 	ctrl := gomock.NewController(t)

--- a/api/grpcserver.go
+++ b/api/grpcserver.go
@@ -401,6 +401,17 @@ func (svr *gRPCHandler) EstimateActionGasConsumption(ctx context.Context, in *io
 		if err := sc.LoadProto(in.GetExecution()); err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
+		var (
+			gasPrice *big.Int = big.NewInt(0)
+			ok       bool
+		)
+		if in.GetGasPrice() != "" {
+			gasPrice, ok = big.NewInt(0).SetString(in.GetGasPrice(), 10)
+			if !ok {
+				return nil, status.Error(codes.InvalidArgument, "invalid gas price")
+			}
+		}
+		sc.SetGasPrice(gasPrice)
 		ret, err := svr.coreService.EstimateExecutionGasConsumption(ctx, sc, callerAddr)
 		if err != nil {
 			return nil, err

--- a/api/grpcserver.go
+++ b/api/grpcserver.go
@@ -401,17 +401,6 @@ func (svr *gRPCHandler) EstimateActionGasConsumption(ctx context.Context, in *io
 		if err := sc.LoadProto(in.GetExecution()); err != nil {
 			return nil, status.Error(codes.InvalidArgument, err.Error())
 		}
-		var (
-			gasPrice *big.Int = big.NewInt(0)
-			ok       bool
-		)
-		if in.GetGasPrice() != "" {
-			gasPrice, ok = big.NewInt(0).SetString(in.GetGasPrice(), 10)
-			if !ok {
-				return nil, status.Error(codes.InvalidArgument, "invalid gas price")
-			}
-		}
-		sc.SetGasPrice(gasPrice)
 		ret, err := svr.coreService.EstimateExecutionGasConsumption(ctx, sc, callerAddr)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
# Description
The gas price passed in actually does not affect the result of estimateGas (which only depends on gasConsumed). However, it may cause the API to return an error, such as insufficient balance. 

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
