### PR TITLE
[grpc] Set MaxConnectionIdle to 5 min

### DIFF
--- a/api/grpcserver.go
+++ b/api/grpcserver.go
@@ -65,8 +65,9 @@ var (
 		PermitWithoutStream: true,            // Allow pings even when there are no active streams
 	}
 	kasp = keepalive.ServerParameters{
-		Time:    60 * time.Second, // Ping the client if it is idle for 60 seconds to ensure the connection is still active
-		Timeout: 10 * time.Second, // Wait 10 seconds for the ping ack before assuming the connection is dead
+		Time:              60 * time.Second, // Ping the client if it is idle for 60 seconds to ensure the connection is still active
+		Timeout:           10 * time.Second, // Wait 10 seconds for the ping ack before assuming the connection is dead
+		MaxConnectionIdle: 5 * time.Minute,  // If a client is idle for 5 minutes, send a GOAWAY
 	}
 )
 


### PR DESCRIPTION
# Description

If a client is idle for 5 minutes, grpc server send a GOAWAY to terminate the connection

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
