### PR TITLE
[evm] remove NotCheckPutStateErrorOption()

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -399,9 +399,6 @@ func prepareStateDB(ctx context.Context, sm protocol.StateManager) (*StateDBAdap
 	if featureCtx.RevertLog {
 		opts = append(opts, RevertLogOption())
 	}
-	if !featureCtx.FixUnproductiveDelegates {
-		opts = append(opts, NotCheckPutStateErrorOption())
-	}
 	if !featureCtx.CorrectGasRefund {
 		opts = append(opts, ManualCorrectGasRefundOption())
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -67,7 +67,6 @@ type (
 		legacyNonceAccount         bool
 		fixSnapshotOrder           bool
 		revertLog                  bool
-		notCheckPutStateError      bool
 		manualCorrectGasRefund     bool
 	}
 )
@@ -127,14 +126,6 @@ func FixSnapshotOrderOption() StateDBAdapterOption {
 func RevertLogOption() StateDBAdapterOption {
 	return func(adapter *StateDBAdapter) error {
 		adapter.revertLog = true
-		return nil
-	}
-}
-
-// NotCheckPutStateErrorOption set notCheckPutStateError as true
-func NotCheckPutStateErrorOption() StateDBAdapterOption {
-	return func(adapter *StateDBAdapter) error {
-		adapter.notCheckPutStateError = true
 		return nil
 	}
 }
@@ -990,8 +981,7 @@ func (stateDB *StateDBAdapter) CommitContracts() error {
 		v := stateDB.preimages[k]
 		h := make([]byte, len(k))
 		copy(h, k[:])
-		_, err = stateDB.sm.PutState(v, protocol.NamespaceOption(PreimageKVNameSpace), protocol.KeyOption(h))
-		if !stateDB.notCheckPutStateError && err != nil {
+		if _, err = stateDB.sm.PutState(v, protocol.NamespaceOption(PreimageKVNameSpace), protocol.KeyOption(h)); err != nil {
 			stateDB.logError(err)
 			return errors.Wrap(err, "failed to update preimage to db")
 		}


### PR DESCRIPTION
# Description
In the EVM forget to check one error. This is protected by a hard-fork flag, now the hard-fork has passed and this flag can be removed

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
