### PR TITLE
[staking] CandidateCenter Support for Missing and Changes of Self-Stake Bucket

### DIFF
--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -94,6 +94,11 @@ func (d *Candidate) Validate() error {
 	return nil
 }
 
+// selfStaked checks if the candidate is self staked
+func (d *Candidate) selfStaked() bool {
+	return d.SelfStakeBucketIdx != candidateNoSelfStakeBucketIndex && d.SelfStake.Sign() > 0
+}
+
 // Collision checks collsion of 2 candidates
 func (d *Candidate) Collision(c *Candidate) error {
 	if address.Equal(d.Owner, c.Owner) {
@@ -105,7 +110,7 @@ func (d *Candidate) Collision(c *Candidate) error {
 	if address.Equal(c.Operator, d.Operator) {
 		return ErrInvalidOperator
 	}
-	if c.SelfStakeBucketIdx == d.SelfStakeBucketIdx {
+	if c.SelfStakeBucketIdx == d.SelfStakeBucketIdx && c.selfStaked() {
 		return ErrInvalidSelfStkIndex
 	}
 	return nil

--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -94,9 +94,9 @@ func (d *Candidate) Validate() error {
 	return nil
 }
 
-// selfStaked checks if the candidate is self staked
-func (d *Candidate) selfStaked() bool {
-	return d.SelfStakeBucketIdx != candidateNoSelfStakeBucketIndex && d.SelfStake.Sign() > 0
+// isSelfStakeBucketSettled checks if self stake bucket is settled
+func (d *Candidate) isSelfStakeBucketSettled() bool {
+	return d.SelfStakeBucketIdx != candidateNoSelfStakeBucketIndex
 }
 
 // Collision checks collsion of 2 candidates
@@ -110,7 +110,7 @@ func (d *Candidate) Collision(c *Candidate) error {
 	if address.Equal(c.Operator, d.Operator) {
 		return ErrInvalidOperator
 	}
-	if c.SelfStakeBucketIdx == d.SelfStakeBucketIdx && c.selfStaked() {
+	if c.SelfStakeBucketIdx == d.SelfStakeBucketIdx && c.isSelfStakeBucketSettled() {
 		return ErrInvalidSelfStkIndex
 	}
 	return nil

--- a/action/protocol/staking/candidate_center.go
+++ b/action/protocol/staking/candidate_center.go
@@ -369,7 +369,7 @@ func (cc *candChange) containsOperator(operator address.Address) bool {
 
 func (cc *candChange) containsSelfStakingBucket(index uint64) bool {
 	for _, d := range cc.dirty {
-		if d.selfStaked() && index == d.SelfStakeBucketIdx {
+		if d.isSelfStakeBucketSettled() && index == d.SelfStakeBucketIdx {
 			return true
 		}
 	}
@@ -398,7 +398,7 @@ func (cc *candChange) getByOwner(owner address.Address) *Candidate {
 
 func (cc *candChange) getBySelfStakingIndex(index uint64) *Candidate {
 	for _, d := range cc.dirty {
-		if d.selfStaked() && index == d.SelfStakeBucketIdx {
+		if d.isSelfStakeBucketSettled() && index == d.SelfStakeBucketIdx {
 			return d.Clone()
 		}
 	}
@@ -484,7 +484,7 @@ func (cb *candBase) commit(change *candChange, keepAliasBug bool) (int, error) {
 			cb.ownerMap[d.Owner.String()] = d
 			cb.nameMap[d.Name] = d
 			cb.operatorMap[d.Operator.String()] = d
-			if d.selfStaked() {
+			if d.isSelfStakeBucketSettled() {
 				cb.selfStkBucketMap[d.SelfStakeBucketIdx] = d
 			}
 		}

--- a/action/protocol/staking/candidate_center.go
+++ b/action/protocol/staking/candidate_center.go
@@ -369,7 +369,7 @@ func (cc *candChange) containsOperator(operator address.Address) bool {
 
 func (cc *candChange) containsSelfStakingBucket(index uint64) bool {
 	for _, d := range cc.dirty {
-		if index == d.SelfStakeBucketIdx {
+		if d.selfStaked() && index == d.SelfStakeBucketIdx {
 			return true
 		}
 	}
@@ -398,7 +398,7 @@ func (cc *candChange) getByOwner(owner address.Address) *Candidate {
 
 func (cc *candChange) getBySelfStakingIndex(index uint64) *Candidate {
 	for _, d := range cc.dirty {
-		if index == d.SelfStakeBucketIdx {
+		if d.selfStaked() && index == d.SelfStakeBucketIdx {
 			return d.Clone()
 		}
 	}
@@ -479,11 +479,14 @@ func (cb *candBase) commit(change *candChange, keepAliasBug bool) (int, error) {
 			if curr, ok := cb.ownerMap[d.Owner.String()]; ok {
 				delete(cb.nameMap, curr.Name)
 				delete(cb.operatorMap, curr.Operator.String())
+				delete(cb.selfStkBucketMap, curr.SelfStakeBucketIdx)
 			}
 			cb.ownerMap[d.Owner.String()] = d
 			cb.nameMap[d.Name] = d
 			cb.operatorMap[d.Operator.String()] = d
-			cb.selfStkBucketMap[d.SelfStakeBucketIdx] = d
+			if d.selfStaked() {
+				cb.selfStkBucketMap[d.SelfStakeBucketIdx] = d
+			}
 		}
 	}
 	return len(cb.ownerMap), nil

--- a/action/protocol/staking/candidate_center_test.go
+++ b/action/protocol/staking/candidate_center_test.go
@@ -33,7 +33,7 @@ func testEqual(m *CandidateCenter, l CandidateList) bool {
 		}
 
 		d = m.GetBySelfStakingIndex(v.SelfStakeBucketIdx)
-		if d == nil && v.selfStaked() {
+		if d == nil && v.isSelfStakeBucketSettled() {
 			return false
 		}
 		if d != nil && !v.Equal(d) {


### PR DESCRIPTION
# Description
Due to the introduction of CandidateRegister without staking, there will occur candidate which lack staking and updates in self-staking bucket. However, the current `CandidateCenter` does not support these operations. This PR aims to resolve these issues.

## Type of change
Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
