### PR TITLE
[staking] ActiveCandidate Exclude Candidate with Expired Endorsement

### DIFF
--- a/action/protocol/poll/nativestakingV2.go
+++ b/action/protocol/poll/nativestakingV2.go
@@ -7,11 +7,12 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-election/util"
+
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/staking"
 	"github.com/iotexproject/iotex-core/state"
-	"github.com/iotexproject/iotex-election/util"
 )
 
 type nativeStakingV2 struct {
@@ -83,6 +84,7 @@ func (ns *nativeStakingV2) CalculateCandidatesByHeight(ctx context.Context, sr p
 		return cands, err
 	}
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	// TODO: put candidates which will expired during current or next epoch behind the active candidates
 	return ns.filterAndSortCandidatesByVoteScore(cands, bcCtx.Tip.Timestamp), nil
 }
 

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -58,6 +58,13 @@ type (
 		DebitBucketPool(*big.Int, bool) error
 		Commit(context.Context) error
 		SM() protocol.StateManager
+		SR() protocol.StateReader
+	}
+
+	// CandidiateStateCommon is the common interface for candidate state manager and reader
+	CandidiateStateCommon interface {
+		ContainsSelfStakingBucket(uint64) bool
+		SR() protocol.StateReader
 	}
 
 	candSM struct {
@@ -103,6 +110,10 @@ func newCandidateStateManager(sm protocol.StateManager) CandidateStateManager {
 }
 
 func (csm *candSM) SM() protocol.StateManager {
+	return csm.StateManager
+}
+
+func (csm *candSM) SR() protocol.StateReader {
 	return csm.StateManager
 }
 

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -65,6 +65,7 @@ type (
 		AllCandidates() CandidateList
 		TotalStakedAmount() *big.Int
 		ActiveBucketsCount() uint64
+		ContainsSelfStakingBucket(index uint64) bool
 	}
 
 	candSR struct {
@@ -108,6 +109,10 @@ func (c *candSR) GetCandidateByOwner(owner address.Address) *Candidate {
 
 func (c *candSR) AllCandidates() CandidateList {
 	return c.view.candCenter.All()
+}
+
+func (c *candSR) ContainsSelfStakingBucket(index uint64) bool {
+	return c.view.candCenter.ContainsSelfStakingBucket(index)
 }
 
 func (c *candSR) TotalStakedAmount() *big.Int {

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -66,6 +66,7 @@ type (
 		TotalStakedAmount() *big.Int
 		ActiveBucketsCount() uint64
 		ContainsSelfStakingBucket(index uint64) bool
+		IsActiveCandidateAt(cand *Candidate, height uint64) (bool, error)
 	}
 
 	candSR struct {
@@ -109,6 +110,37 @@ func (c *candSR) GetCandidateByOwner(owner address.Address) *Candidate {
 
 func (c *candSR) AllCandidates() CandidateList {
 	return c.view.candCenter.All()
+}
+
+func (c *candSR) IsActiveCandidateAt(cand *Candidate, height uint64) (bool, error) {
+	// self-stake bucket should be either self-owned or endorsed
+	vb, err := c.getBucket(cand.SelfStakeBucketIdx)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get bucket %d", cand.SelfStakeBucketIdx)
+	}
+	// self-owned bucket should not be unstaked
+	if address.Equal(vb.Owner, cand.Owner) {
+		return !vb.isUnstaked(), nil
+	}
+	// endorsed bucket should not be expired
+	if !address.Equal(vb.Candidate, cand.Owner) {
+		return false, nil
+	}
+	esr := NewEndorsementStateReader(c.SR())
+	endorse, err := esr.Get(cand.SelfStakeBucketIdx)
+	switch {
+	case err == nil:
+		// endorsement should not be expired
+		if endorse.Status(height) == EndorseExpired {
+			return false, nil
+		}
+		return true, nil
+	case errors.Is(err, state.ErrStateNotExist):
+		// impossible to happen
+		return false, errors.Wrapf(ErrEndorsementNotExist, "bucket index %d", cand.SelfStakeBucketIdx)
+	default:
+		return false, err
+	}
 }
 
 func (c *candSR) ContainsSelfStakingBucket(index uint64) bool {

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -2810,7 +2810,7 @@ func TestProtocol_FetchBucketAndValidate(t *testing.T) {
 		})
 		isSelfStake := true
 		isSelfStakeErr := error(nil)
-		patches.ApplyFunc(isSelfStakeBucket, func(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket) (bool, error) {
+		patches.ApplyFunc(isSelfStakeBucket, func(featureCtx protocol.FeatureCtx, csm CandidiateStateCommon, bucket *VoteBucket) (bool, error) {
 			return isSelfStake, isSelfStakeErr
 		})
 		_, err = p.fetchBucketAndValidate(protocol.FeatureCtx{}, csm, identityset.Address(1), 1, false, false)
@@ -2831,7 +2831,7 @@ func TestProtocol_FetchBucketAndValidate(t *testing.T) {
 				Owner: identityset.Address(1),
 			}, nil
 		})
-		patches.ApplyFunc(isSelfStakeBucket, func(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket) (bool, error) {
+		patches.ApplyFunc(isSelfStakeBucket, func(featureCtx protocol.FeatureCtx, csm CandidiateStateCommon, bucket *VoteBucket) (bool, error) {
 			return false, nil
 		})
 		defer patches.Reset()

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -498,10 +498,6 @@ func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidateStateRead
 	if address.Equal(vb.Owner, cand.Owner) {
 		return true, nil
 	}
-	// bucket is not endorsed to the candidate
-	if !address.Equal(vb.Candidate, cand.Owner) {
-		return false, nil
-	}
 	esr := NewEndorsementStateReader(csr.SR())
 	endorse, err := esr.Get(cand.SelfStakeBucketIdx)
 	switch {
@@ -517,6 +513,7 @@ func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidateStateRead
 		return false, err
 	default:
 		// endorsement does not exist
+		return false, errors.New("endorsement does not exist")
 	}
 	return true, nil
 }

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -56,8 +56,9 @@ const (
 
 // Errors
 var (
-	ErrWithdrawnBucket = errors.New("the bucket is already withdrawn")
-	TotalBucketKey     = append([]byte{_const}, []byte("totalBucket")...)
+	ErrWithdrawnBucket     = errors.New("the bucket is already withdrawn")
+	ErrEndorsementNotExist = errors.New("the endorsement does not exist")
+	TotalBucketKey         = append([]byte{_const}, []byte("totalBucket")...)
 )
 
 var (
@@ -489,10 +490,7 @@ func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidateStateRead
 	}
 	vb, err := csr.getBucket(cand.SelfStakeBucketIdx)
 	if err != nil {
-		if errors.Is(err, state.ErrStateNotExist) {
-			return false, nil
-		}
-		return false, err
+		return false, errors.Wrapf(err, "failed to get bucket %d", cand.SelfStakeBucketIdx)
 	}
 	// bucket is self-owned
 	if address.Equal(vb.Owner, cand.Owner) {
@@ -513,7 +511,7 @@ func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidateStateRead
 		return false, err
 	default:
 		// endorsement does not exist
-		return false, errors.New("endorsement does not exist")
+		return false, errors.Wrapf(ErrEndorsementNotExist, "bucket index %d", cand.SelfStakeBucketIdx)
 	}
 	return true, nil
 }


### PR DESCRIPTION
# Description
Since the `SelfStake` field of a `Candidate` is not cleared when an endorsement expires, the current `ActiveCandidate` function does not remove expired candidates. This PR is aimed at fixing this issue.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
