### PR TITLE
[action] check calldata size instead of total size for 48kB init code limit

### DIFF
--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -89,14 +89,18 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.S
 	if !ok {
 		return nil
 	}
-	sizeLimit := _executionSizeLimit48KB
+	var (
+		sizeLimit = _executionSizeLimit48KB
+		dataSize  = uint32(len(exec.Data()))
+	)
 	fCtx := protocol.MustGetFeatureCtx(ctx)
 	if fCtx.ExecutionSizeLimit32KB {
 		sizeLimit = _executionSizeLimit32KB
+		dataSize = exec.TotalSize()
 	}
 
 	// Reject oversize execution
-	if exec.TotalSize() > sizeLimit {
+	if dataSize > sizeLimit {
 		return action.ErrOversizedData
 	}
 	return nil

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -635,8 +635,8 @@ func TestProtocol_Validate(t *testing.T) {
 	}{
 		{"limit 32KB", 0, 32683, nil},
 		{"exceed 32KB", 0, 32684, action.ErrOversizedData},
-		{"limit 48KB", genesis.Default.SumatraBlockHeight, 49067, nil},
-		{"exceed 48KB", genesis.Default.SumatraBlockHeight, 49068, action.ErrOversizedData},
+		{"limit 48KB", genesis.Default.SumatraBlockHeight, uint64(_executionSizeLimit48KB), nil},
+		{"exceed 48KB", genesis.Default.SumatraBlockHeight, uint64(_executionSizeLimit48KB) + 1, action.ErrOversizedData},
 	}
 
 	for i := range cases {


### PR DESCRIPTION
# Description
follow the same behavior as Ethereum.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
