### PR TITLE
[action] mark access list tx in Execution

### DIFF
--- a/action/builder.go
+++ b/action/builder.go
@@ -181,7 +181,15 @@ func getRecipientAddr(addr *common.Address) string {
 // BuildExecution loads executino action into envelope
 func (b *EnvelopeBuilder) BuildExecution(tx *types.Transaction) (Envelope, error) {
 	b.setEnvelopeCommonFields(tx)
-	exec, err := NewExecutionWithAccessList(getRecipientAddr(tx.To()), tx.Nonce(), tx.Value(), tx.Gas(), tx.GasPrice(), tx.Data(), tx.AccessList())
+	var (
+		exec *Execution
+		err  error
+	)
+	if tx.Type() == types.AccessListTxType {
+		exec, err = NewExecutionWithAccessList(getRecipientAddr(tx.To()), tx.Nonce(), tx.Value(), tx.Gas(), tx.GasPrice(), tx.Data(), tx.AccessList())
+	} else {
+		exec, err = NewExecution(getRecipientAddr(tx.To()), tx.Nonce(), tx.Value(), tx.Gas(), tx.GasPrice(), tx.Data())
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-core/test/identityset"
 )
 
@@ -25,6 +26,7 @@ func TestExecutionSignVerify(t *testing.T) {
 	data, err := hex.DecodeString("")
 	require.NoError(err)
 	ex, err := NewExecution(contractAddr.String(), 2, big.NewInt(10), uint64(100000), big.NewInt(10), data)
+	require.False(ex.IsAccessList())
 	require.NoError(err)
 	require.EqualValues(21, ex.BasicActionSize())
 	require.EqualValues(87, ex.TotalSize())
@@ -128,11 +130,28 @@ func TestExecutionAccessList(t *testing.T) {
 			v.list,
 		)
 		require.NoError(err)
+		require.True(ex.IsAccessList())
 		require.NoError(ex1.LoadProto(ex.Proto()))
 		ex1.AbstractAction = ex.AbstractAction
 		require.Equal(ex, ex1)
 		gas, err := ex.IntrinsicGas()
 		require.NoError(err)
 		require.Equal(v.gas, gas)
+		tx, err := ex.ToEthTx(222)
+		require.NoError(err)
+		require.EqualValues(222, tx.ChainId().Uint64())
+		require.Equal(ex.Nonce(), tx.Nonce())
+		require.Equal(ex.GasLimit(), tx.Gas())
+		require.Equal(ex.GasPrice(), tx.GasPrice())
+		addr, err := address.FromString(ex.Contract())
+		require.NoError(err)
+		require.Equal(addr.Bytes(), tx.To().Bytes())
+		require.Equal(ex.Amount().String(), tx.Value().String())
+		require.Equal(ex.Data(), tx.Data())
+		if ex.AccessList() == nil {
+			require.Equal(types.AccessList{}, tx.AccessList())
+		} else {
+			require.Equal(ex.AccessList(), tx.AccessList())
+		}
 	}
 }

--- a/action/protocol/execution/testdata-london/CVE-2021-39137-attack-replay.json
+++ b/action/protocol/execution/testdata-london/CVE-2021-39137-attack-replay.json
@@ -30,9 +30,9 @@
         "expectedStatus": 1,
         "comment": "launch attack(https://etherscan.io/tx/0x1cb6fb36633d270edefc04d048145b4298e67b8aa82a9e5ec4aa1435dd770ce4)",
         "expectedBlockInfos" : {
-            "txRootHash" : "977a2c16f9d3da0f22b24eab9d2dbcbdb6ae324407eb979413b51d9b2a643c4c",
+            "txRootHash" : "8bca0683b85e5c41b131678fa65a069868add7efc559054a4b5d9ee2d0dde546",
             "stateRootHash" : "431a30093ca6213a048ac891ee1d5d194641f5eb7736c50df20bbb587f1b4192",
-            "receiptRootHash" : "1c96f5d95669b5d8e63003e0ced6988c3ca6ebc64b19a6b0efc4581f3ba5b0be"
+            "receiptRootHash" : "c032b29a26b36e8ff32e8f8d48f0de129227cb3292f72dd8a00fbf1f35cc144b"
         }
     }]
 }

--- a/action/protocol/execution/testdata-london/datacopy.json
+++ b/action/protocol/execution/testdata-london/datacopy.json
@@ -30,9 +30,9 @@
         "expectedStatus": 1,
         "comment": "the data of return is [0x11, 0x22, 0x33]",
         "expectedBlockInfos" : {
-            "txRootHash" : "3d03a074dee9d9edb3dbd2bc30cf854c768e863ecf053c491fd71b2b1092c202",
+            "txRootHash" : "a8a86307dd5ce3392b6ae9c129ca22aca47b47ca053c0d83e005c44335a7932c",
             "stateRootHash" : "3595fffd9f80f99887e3108d84f3558e2691ab9dc1c73f6279e3da5735d02afa",
-            "receiptRootHash" : "1a9cffd85255f3337744824bee82ec21126445d318bcc5edcd626bcf81e8a931"
+            "receiptRootHash" : "cf6e52aec963960a9d89eb65c96acff2b1c43891d9a7de12a26bafd4429e1b56"
         }
     }]
 }

--- a/action/protocol/execution/testdata-shanghai/CVE-2021-39137-attack-replay.json
+++ b/action/protocol/execution/testdata-shanghai/CVE-2021-39137-attack-replay.json
@@ -31,9 +31,9 @@
         "expectedStatus": 1,
         "comment": "launch attack(https://etherscan.io/tx/0x1cb6fb36633d270edefc04d048145b4298e67b8aa82a9e5ec4aa1435dd770ce4)",
         "expectedBlockInfos" : {
-            "txRootHash" : "2fe919aaaf4bd8cb41c30b6c076c3f63401b8f4e97d10c094cd5d780c1b9bd8a",
+            "txRootHash" : "e22b1d5ef605278873a83dfdddedbd2da7876165ddb958a21e89a0591de2fe85",
             "stateRootHash" : "431a30093ca6213a048ac891ee1d5d194641f5eb7736c50df20bbb587f1b4192",
-            "receiptRootHash" : "a957881177b1e3c04bd4cbda648e06eb628497dd0fc55ab118b307875ba8bde3"
+            "receiptRootHash" : "8528d6f6b8106f60bd2eb64b5285145aec6fffd94cca52abadb7fa0be7922320"
         }
     }]
 }

--- a/action/protocol/execution/testdata-shanghai/datacopy.json
+++ b/action/protocol/execution/testdata-shanghai/datacopy.json
@@ -31,9 +31,9 @@
         "expectedStatus": 1,
         "comment": "the data of return is [0x11, 0x22, 0x33]",
         "expectedBlockInfos" : {
-            "txRootHash" : "fab7f74147ea465df0a94408bf0c8958fed1e1b685ceca3cee0aab3f38179783",
+            "txRootHash" : "5b1c33f593972eddfd4ac4a19ec4239f8dcd79568d98c6f20a78800705ea072f",
             "stateRootHash" : "3595fffd9f80f99887e3108d84f3558e2691ab9dc1c73f6279e3da5735d02afa",
-            "receiptRootHash" : "03e0b2e733fecc2273e8e547a1896243a46e5bed2591facfd274d186a0773d7e"
+            "receiptRootHash" : "fcb2cdf5db304db69a9b6dc4279eafc47632ad7032d637ba9e465e639e1b7d60"
         }
     }]
 }

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -167,6 +167,9 @@ func (svr *web3Handler) ethTxToEnvelope(tx *types.Transaction) (action.Envelope,
 	if to == address.RewardingProtocol {
 		return elpBuilder.BuildRewardingAction(tx)
 	}
+	if tx.Type() == types.AccessListTxType {
+		return elpBuilder.BuildExecution(tx)
+	}
 	isContract, err := svr.checkContractAddr(to)
 	if err != nil {
 		return nil, err

--- a/e2etest/contract_staking_test.go
+++ b/e2etest/contract_staking_test.go
@@ -2009,7 +2009,7 @@ func deployContracts(
 	amount := param.amount
 	gasLimit := param.gasLimit
 	gasPrice := param.gasPrice
-	exec, err := action.NewExecutionWithAccessList(action.EmptyAddress, nonce, amount, gasLimit, gasPrice, bytecode, nil)
+	exec, err := action.NewExecution(action.EmptyAddress, nonce, amount, gasLimit, gasPrice, bytecode)
 	r.NoError(err)
 	builder := &action.EnvelopeBuilder{}
 	elp := builder.SetAction(exec).
@@ -2073,7 +2073,7 @@ func writeContract(bc blockchain.Blockchain,
 		gasPrice := param.gasPrice
 		bytecode, err := hex.DecodeString(param.bytecode)
 		r.NoError(err)
-		exec, err := action.NewExecutionWithAccessList(param.contractAddr, nonce, amount, gasLimit, gasPrice, bytecode, nil)
+		exec, err := action.NewExecution(param.contractAddr, nonce, amount, gasLimit, gasPrice, bytecode)
 		r.NoError(err)
 		builder := &action.EnvelopeBuilder{}
 		elp := builder.SetAction(exec).

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde
+	github.com/iotexproject/iotex-proto v0.5.15-0.20240201032550-0c32112e9a52
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.5.1/go.mod h1:8pDZcM45M0gY6jm3PoM
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d h1:/j1xCAC9YiG/8UKqYvycS/v3ddVsb1G7AMyLXOjeYI0=
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.mod h1:GRWevxtqQ4gPMrd7Qxhr29/7aTgvjiTp+rFI9KMMZEo=
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
-github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde h1:rs5eACTonHCALTwT9rhqMUEVYMQgbnNYMZQ85jJUlBY=
-github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.5.15-0.20240201032550-0c32112e9a52 h1:hpqnVFlO9cndrL1b0yyqfNIK7uO0P5j4c8NmayWTyeU=
+github.com/iotexproject/iotex-proto v0.5.15-0.20240201032550-0c32112e9a52/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
# Description
User could send an access list tx with empty access list, so we need to use the type of the Ethereum tx `tx.Type()`, but not `len(tx.accessList)` to determine if a tx is access list tx or not

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
