### PR TITLE
[staking] Cannot Unstake if Bucket is Endorsed

### DIFF
--- a/action/protocol/staking/bucket_validation.go
+++ b/action/protocol/staking/bucket_validation.go
@@ -83,7 +83,7 @@ func validateBucketEndorsement(esm *EndorsementStateManager, bucket *VoteBucket,
 		status := endorse.Status(height)
 		if isEndorsed && status == EndorseExpired {
 			return &handleError{
-				err:           errors.New("bucket is not an endorse bucket"),
+				err:           errors.New("endorse bucket is expired"),
 				failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 			}
 		}

--- a/action/protocol/staking/bucket_validation.go
+++ b/action/protocol/staking/bucket_validation.go
@@ -83,7 +83,7 @@ func validateBucketEndorsement(esm *EndorsementStateManager, bucket *VoteBucket,
 		status := endorse.Status(height)
 		if isEndorsed && status == EndorseExpired {
 			return &handleError{
-				err:           errors.New("bucket is not endorsed"),
+				err:           errors.New("bucket is not an endorse bucket"),
 				failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 			}
 		}
@@ -96,7 +96,7 @@ func validateBucketEndorsement(esm *EndorsementStateManager, bucket *VoteBucket,
 	case errors.Is(err, state.ErrStateNotExist):
 		if isEndorsed {
 			return &handleError{
-				err:           errors.New("bucket is not endorsed"),
+				err:           errors.New("bucket is not an endorse bucket"),
 				failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 			}
 		}

--- a/action/protocol/staking/bucket_validation_test.go
+++ b/action/protocol/staking/bucket_validation_test.go
@@ -126,6 +126,6 @@ func TestValidateBucket(t *testing.T) {
 		// endorse expired bucket
 		r.NoError(esm.Put(bktIdx, &Endorsement{ExpireHeight: blkHeight}))
 		r.Nil(validateBucketEndorsement(esm, bkt, false, blkHeight))
-		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "bucket is not an endorse bucket")
+		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "endorse bucket is expired")
 	})
 }

--- a/action/protocol/staking/bucket_validation_test.go
+++ b/action/protocol/staking/bucket_validation_test.go
@@ -114,7 +114,7 @@ func TestValidateBucket(t *testing.T) {
 		blkHeight := uint64(10)
 		// not endorsed bucket
 		r.Nil(validateBucketEndorsement(esm, bkt, false, blkHeight))
-		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "bucket is not endorsed")
+		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "bucket is not an endorse bucket")
 		// endorsed bucket
 		r.NoError(esm.Put(bktIdx, &Endorsement{ExpireHeight: endorsementNotExpireHeight}))
 		r.Nil(validateBucketEndorsement(esm, bkt, true, blkHeight))
@@ -126,6 +126,6 @@ func TestValidateBucket(t *testing.T) {
 		// endorse expired bucket
 		r.NoError(esm.Put(bktIdx, &Endorsement{ExpireHeight: blkHeight}))
 		r.Nil(validateBucketEndorsement(esm, bkt, false, blkHeight))
-		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "bucket is not endorsed")
+		r.ErrorContains(validateBucketEndorsement(esm, bkt, true, blkHeight), "bucket is not an endorse bucket")
 	})
 }

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -259,6 +259,33 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 			nil,
 		},
 		{
+			"once endorsed, bucket cannot be unstaked",
+			[]uint64{0, 10},
+			[]uint64{0, 1},
+			1300000,
+			identityset.Address(1),
+			1,
+			uint64(1000000),
+			uint64(1000000),
+			big.NewInt(1000),
+			1,
+			true,
+			true,
+			&appendAction{
+				func() action.Action {
+					act, err := action.NewUnstake(0, 1, []byte{}, uint64(1000000), big.NewInt(1000))
+					require.NoError(err)
+					return act
+				},
+				iotextypes.ReceiptStatus_ErrInvalidBucketType,
+				nil,
+			},
+			nil,
+			iotextypes.ReceiptStatus_Success,
+			[]expectCandidate{},
+			nil,
+		},
+		{
 			"unendorse a valid bucket",
 			[]uint64{0, 9},
 			[]uint64{0, 1},

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -172,6 +172,10 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 			failureStatus: iotextypes.ReceiptStatus_ErrUnstakeBeforeMaturity,
 		}
 	}
+	if rErr := validateBucketEndorsement(NewEndorsementStateManager(csm.SM()), bucket, false, blkCtx.BlockHeight); rErr != nil {
+		return log, rErr
+	}
+	// TODO: cannot unstake if selected as candidates in this or next epoch
 
 	// update bucket
 	bucket.UnstakeStartTime = blkCtx.BlockTimeStamp.UTC()


### PR DESCRIPTION
# Description

After delegate endorsement introduced, we cannot unstake bucket if it's a endorse bucket.

## Type of change
Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
