### PR TITLE
[staking] Replace ContainsSelfStakingBucket with isSelfStakeBucket

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -116,6 +116,7 @@ type (
 		ExecutionSizeLimit32KB                  bool
 		UseZeroNonceForFreshAccount             bool
 		SharedGasWithDapp                       bool
+		DisableDelegateEndorsement              bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -257,6 +258,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			ExecutionSizeLimit32KB:                  !g.IsSumatra(height),
 			UseZeroNonceForFreshAccount:             g.IsSumatra(height),
 			SharedGasWithDapp:                       g.IsToBeEnabled(height),
+			DisableDelegateEndorsement:              !g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/staking/bucket_validation.go
+++ b/action/protocol/staking/bucket_validation.go
@@ -56,7 +56,7 @@ func validateBucketCandidate(bucket *VoteBucket, candidate address.Address) Rece
 }
 
 func validateBucketSelfStake(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket, isSelfStaked bool) ReceiptError {
-	selfstake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	selfstake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil {
 		return &handleError{
 			err:           err,

--- a/action/protocol/staking/bucket_validation.go
+++ b/action/protocol/staking/bucket_validation.go
@@ -7,6 +7,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 
+	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/state"
 )
 
@@ -54,8 +55,15 @@ func validateBucketCandidate(bucket *VoteBucket, candidate address.Address) Rece
 	return nil
 }
 
-func validateBucketSelfStake(csm CandidateStateManager, bucket *VoteBucket, isSelfStaked bool) ReceiptError {
-	if csm.ContainsSelfStakingBucket(bucket.Index) != isSelfStaked {
+func validateBucketSelfStake(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket, isSelfStaked bool) ReceiptError {
+	selfstake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	if err != nil {
+		return &handleError{
+			err:           err,
+			failureStatus: iotextypes.ReceiptStatus_ErrUnknown,
+		}
+	}
+	if selfstake != isSelfStaked {
 		err := errors.New("self staking bucket cannot be processed")
 		if isSelfStaked {
 			err = errors.New("bucket is not self staking")

--- a/action/protocol/staking/handler_candidate_endorsement.go
+++ b/action/protocol/staking/handler_candidate_endorsement.go
@@ -45,8 +45,12 @@ func (p *Protocol) handleCandidateEndorsement(ctx context.Context, act *action.C
 		}
 		// expire immediately if the bucket is not self-staked
 		// otherwise, expire after withdraw waiting period
+		selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+		if err != nil {
+			return log, nil, err
+		}
 		expireHeight = protocol.MustGetBlockCtx(ctx).BlockHeight
-		if csm.ContainsSelfStakingBucket(bucket.Index) {
+		if selfStake {
 			expireHeight += p.config.EndorsementWithdrawWaitingBlocks
 		}
 	}
@@ -60,6 +64,7 @@ func (p *Protocol) handleCandidateEndorsement(ctx context.Context, act *action.C
 }
 
 func (p *Protocol) validateEndorsement(ctx context.Context, csm CandidateStateManager, esm *EndorsementStateManager, caller address.Address, bucket *VoteBucket, cand *Candidate) ReceiptError {
+	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	if err := validateBucketOwner(bucket, caller); err != nil {
 		return err
 	}
@@ -72,7 +77,7 @@ func (p *Protocol) validateEndorsement(ctx context.Context, csm CandidateStateMa
 	if err := validateBucketCandidate(bucket, cand.Owner); err != nil {
 		return err
 	}
-	if err := validateBucketSelfStake(csm, bucket, false); err != nil {
+	if err := validateBucketSelfStake(featureCtx, csm, bucket, false); err != nil {
 		return err
 	}
 	return validateBucketEndorsement(esm, bucket, false, protocol.MustGetBlockCtx(ctx).BlockHeight)

--- a/action/protocol/staking/handler_candidate_endorsement.go
+++ b/action/protocol/staking/handler_candidate_endorsement.go
@@ -45,7 +45,7 @@ func (p *Protocol) handleCandidateEndorsement(ctx context.Context, act *action.C
 		}
 		// expire immediately if the bucket is not self-staked
 		// otherwise, expire after withdraw waiting period
-		selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+		selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 		if err != nil {
 			return log, nil, err
 		}

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/test/identityset"
-	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 )
 
 type appendAction struct {
@@ -49,7 +48,7 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 		{identityset.Address(2), identityset.Address(8), identityset.Address(1), "test2"},
 		{identityset.Address(3), identityset.Address(9), identityset.Address(11), "test3"},
 	}
-	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
+	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
 		bucketCfgs := []*bucketConfig{}
 		for _, idx := range bucketCfgIdx {
 			bucketCfgs = append(bucketCfgs, initBucketCfgs[idx])

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 )
 
 type appendAction struct {
@@ -48,7 +49,7 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 		{identityset.Address(2), identityset.Address(8), identityset.Address(1), "test2"},
 		{identityset.Address(3), identityset.Address(9), identityset.Address(11), "test3"},
 	}
-	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
+	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
 		bucketCfgs := []*bucketConfig{}
 		for _, idx := range bucketCfgIdx {
 			bucketCfgs = append(bucketCfgs, initBucketCfgs[idx])

--- a/action/protocol/staking/handler_candidate_selfstake.go
+++ b/action/protocol/staking/handler_candidate_selfstake.go
@@ -71,13 +71,14 @@ func (p *Protocol) handleCandidateActivate(ctx context.Context, act *action.Cand
 
 func (p *Protocol) validateBucketSelfStake(ctx context.Context, csm CandidateStateManager, esm *EndorsementStateManager, bucket *VoteBucket, cand *Candidate) ReceiptError {
 	blkCtx := protocol.MustGetBlockCtx(ctx)
+	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	if err := validateBucketMinAmount(bucket, p.config.RegistrationConsts.MinSelfStake); err != nil {
 		return err
 	}
 	if err := validateBucketStake(bucket, true); err != nil {
 		return err
 	}
-	if err := validateBucketSelfStake(csm, bucket, false); err != nil {
+	if err := validateBucketSelfStake(featureCtx, csm, bucket, false); err != nil {
 		return err
 	}
 	if err := validateBucketCandidate(bucket, cand.Owner); err != nil {

--- a/action/protocol/staking/handler_candidate_selfstake_test.go
+++ b/action/protocol/staking/handler_candidate_selfstake_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/test/identityset"
+	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 	"github.com/iotexproject/iotex-core/testutil/testdb"
 )
 
@@ -58,9 +59,14 @@ type (
 	}
 )
 
-func initTestState(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
+func initTestState(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
+	return initTestStateWithHeight(t, ctrl, bucketCfgs, candidateCfgs, 0)
+}
+
+func initTestStateWithHeight(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig, height uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
 	require := require.New(t)
-	sm := testdb.NewMockStateManager(ctrl)
+	sm := testdb.NewMockStateManagerWithoutHeightFunc(ctrl)
+	sm.EXPECT().Height().Return(height, nil).AnyTimes()
 	csm := newCandidateStateManager(sm)
 	esm := NewEndorsementStateManager(sm)
 	_, err := sm.PutState(
@@ -172,7 +178,7 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 		{identityset.Address(1), identityset.Address(7), identityset.Address(1), "test1"},
 		{identityset.Address(2), identityset.Address(8), identityset.Address(1), "test2"},
 	}
-	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
+	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
 		bucketCfgs := []*bucketConfig{}
 		for _, idx := range bucketCfgIdx {
 			bucketCfgs = append(bucketCfgs, initBucketCfgs[idx])

--- a/action/protocol/staking/handler_candidate_selfstake_test.go
+++ b/action/protocol/staking/handler_candidate_selfstake_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/pkg/unit"
 	"github.com/iotexproject/iotex-core/test/identityset"
-	"github.com/iotexproject/iotex-core/test/mock/mock_chainmanager"
 	"github.com/iotexproject/iotex-core/testutil/testdb"
 )
 
@@ -59,11 +58,11 @@ type (
 	}
 )
 
-func initTestState(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
+func initTestState(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
 	return initTestStateWithHeight(t, ctrl, bucketCfgs, candidateCfgs, 0)
 }
 
-func initTestStateWithHeight(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig, height uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
+func initTestStateWithHeight(t *testing.T, ctrl *gomock.Controller, bucketCfgs []*bucketConfig, candidateCfgs []*candidateConfig, height uint64) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
 	require := require.New(t)
 	sm := testdb.NewMockStateManagerWithoutHeightFunc(ctrl)
 	sm.EXPECT().Height().Return(height, nil).AnyTimes()
@@ -178,7 +177,7 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 		{identityset.Address(1), identityset.Address(7), identityset.Address(1), "test1"},
 		{identityset.Address(2), identityset.Address(8), identityset.Address(1), "test2"},
 	}
-	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (*mock_chainmanager.MockStateManager, *Protocol, []*VoteBucket, []*Candidate) {
+	initTestStateFromIds := func(bucketCfgIdx, candCfgIds []uint64) (protocol.StateManager, *Protocol, []*VoteBucket, []*Candidate) {
 		bucketCfgs := []*bucketConfig{}
 		for _, idx := range bucketCfgIdx {
 			bucketCfgs = append(bucketCfgs, initBucketCfgs[idx])

--- a/action/protocol/staking/handler_candidate_selfstake_test.go
+++ b/action/protocol/staking/handler_candidate_selfstake_test.go
@@ -164,7 +164,7 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 		{identityset.Address(1), identityset.Address(1), "1", 1, true, false, nil, 0},
 		{identityset.Address(1), identityset.Address(1), "1200000000000000000000000", 30, true, false, nil, 0},
 		{identityset.Address(1), identityset.Address(1), "1200000000000000000000000", 30, true, false, &timeBeforeBlockII, 0},
-		{identityset.Address(2), identityset.Address(1), "1200000000000000000000000", 30, true, true, nil, 0},
+		{identityset.Address(2), identityset.Address(2), "1200000000000000000000000", 30, true, true, nil, 0},
 		{identityset.Address(1), identityset.Address(2), "1200000000000000000000000", 30, true, false, nil, 0},
 		{identityset.Address(2), identityset.Address(1), "1200000000000000000000000", 30, true, false, nil, 0},
 		{identityset.Address(2), identityset.Address(2), "1200000000000000000000000", 30, true, true, nil, 0},

--- a/action/protocol/staking/handler_candidate_selfstake_test.go
+++ b/action/protocol/staking/handler_candidate_selfstake_test.go
@@ -166,6 +166,7 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 		{identityset.Address(1), identityset.Address(2), "1200000000000000000000000", 91, true, false, nil, endorsementNotExpireHeight},
 		{identityset.Address(1), identityset.Address(2), "1200000000000000000000000", 91, true, false, nil, 1},
 		{identityset.Address(2), identityset.Address(2), "1200000000000000000000000", 91, true, false, nil, 0},
+		{identityset.Address(1), identityset.Address(1), "1200000000000000000000000", 30, true, true, nil, 0},
 	}
 	initCandidateCfgs := []*candidateConfig{
 		{identityset.Address(1), identityset.Address(7), identityset.Address(1), "test1"},
@@ -258,7 +259,7 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 		},
 		{
 			"bucket is already selfstaked",
-			[]uint64{0, 3},
+			[]uint64{0, 10},
 			[]uint64{0, 1},
 			1300000,
 			identityset.Address(1),

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -141,9 +141,12 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 		return log, fetchErr
 	}
 
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), true, true)
-	if fetchErr != nil {
-		return log, fetchErr
+	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())
+	if rErr != nil {
+		return log, rErr
+	}
+	if rErr = validateBucketOwner(bucket, actionCtx.Caller); rErr != nil {
+		return log, rErr
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes())
 
@@ -178,8 +181,14 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 	if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
 		return log, errors.Wrapf(err, "failed to update bucket for voter %s", bucket.Owner.String())
 	}
-
-	weightedVote := p.calculateVoteWeight(bucket, csm.ContainsSelfStakingBucket(act.BucketIndex()))
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	if err != nil {
+		return log, &handleError{
+			err:           err,
+			failureStatus: iotextypes.ReceiptStatus_ErrUnknown,
+		}
+	}
+	weightedVote := p.calculateVoteWeight(bucket, selfStake)
 	if err := candidate.SubVote(weightedVote); err != nil {
 		return log, &handleError{
 			err:           errors.Wrapf(err, "failed to subtract vote for candidate %s", bucket.Candidate.String()),
@@ -187,7 +196,7 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 		}
 	}
 	// clear candidate's self stake if the bucket is self staking
-	if csm.ContainsSelfStakingBucket(act.BucketIndex()) {
+	if selfStake {
 		candidate.SelfStake = big.NewInt(0)
 	}
 	if err := csm.Upsert(candidate); err != nil {
@@ -210,9 +219,12 @@ func (p *Protocol) handleWithdrawStake(ctx context.Context, act *action.Withdraw
 		return log, nil, fetchErr
 	}
 
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), true, true)
-	if fetchErr != nil {
-		return log, nil, fetchErr
+	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())
+	if rErr != nil {
+		return log, nil, rErr
+	}
+	if rErr = validateBucketOwner(bucket, actionCtx.Caller); rErr != nil {
+		return log, nil, rErr
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes())
 
@@ -292,9 +304,15 @@ func (p *Protocol) handleChangeCandidate(ctx context.Context, act *action.Change
 		return log, errCandNotExist
 	}
 
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), true, false)
-	if fetchErr != nil {
-		return log, fetchErr
+	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())
+	if rErr != nil {
+		return log, rErr
+	}
+	if rErr = validateBucketOwner(bucket, actionCtx.Caller); rErr != nil {
+		return log, rErr
+	}
+	if rErr = validateBucketSelfStake(featureCtx, csm, bucket, false); rErr != nil {
+		return log, rErr
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes(), candidate.Owner.Bytes())
 
@@ -371,7 +389,11 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 	}
 
 	newOwner := act.VoterAddress()
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), true, false)
+	bucket, fetchErr := p.fetchBucket(csm, act.BucketIndex())
+	if fetchErr != nil {
+		return log, fetchErr
+	}
+	fetchErr = p.validateTransferStakeBucket(featureCtx, csm, bucket, actionCtx.Caller)
 	if fetchErr != nil {
 		if featureCtx.ReturnFetchError ||
 			fetchErr.ReceiptStatus() != uint64(iotextypes.ReceiptStatus_ErrUnauthorizedOperator) {
@@ -379,7 +401,7 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 		}
 
 		// check whether the payload contains a valid consignment transfer
-		if consignment, ok := p.handleConsignmentTransfer(csm, actionCtx, act, bucket); ok {
+		if consignment, ok := p.handleConsignmentTransfer(csm, ctx, act, bucket); ok {
 			newOwner = consignment.Transferee()
 		} else {
 			return log, fetchErr
@@ -413,9 +435,16 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 	return log, nil
 }
 
+func (p *Protocol) validateTransferStakeBucket(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket, caller address.Address) ReceiptError {
+	if rErr := validateBucketOwner(bucket, caller); rErr != nil {
+		return rErr
+	}
+	return validateBucketSelfStake(featureCtx, csm, bucket, false)
+}
+
 func (p *Protocol) handleConsignmentTransfer(
 	csm CandidateStateManager,
-	actCtx protocol.ActionCtx,
+	ctx context.Context,
 	act *action.TransferStake,
 	bucket *VoteBucket) (action.Consignment, bool) {
 	if len(act.Payload()) == 0 {
@@ -423,7 +452,10 @@ func (p *Protocol) handleConsignmentTransfer(
 	}
 
 	// self-stake cannot be transferred
-	if csm.ContainsSelfStakingBucket(bucket.Index) {
+	actCtx := protocol.MustGetActionCtx(ctx)
+	featureCtx := protocol.MustGetFeatureCtx(ctx)
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	if err != nil || selfStake {
 		return nil, false
 	}
 
@@ -454,9 +486,9 @@ func (p *Protocol) handleDepositToStake(ctx context.Context, act *action.Deposit
 		return log, nil, fetchErr
 	}
 
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), false, true)
-	if fetchErr != nil {
-		return log, nil, fetchErr
+	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())
+	if rErr != nil {
+		return log, nil, rErr
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Owner.Bytes(), bucket.Candidate.Bytes())
 	if !bucket.AutoStake {
@@ -476,8 +508,14 @@ func (p *Protocol) handleDepositToStake(ctx context.Context, act *action.Deposit
 			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 		}
 	}
-
-	prevWeightedVotes := p.calculateVoteWeight(bucket, csm.ContainsSelfStakingBucket(act.BucketIndex()))
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, act.BucketIndex())
+	if err != nil {
+		return log, nil, &handleError{
+			err:           err,
+			failureStatus: iotextypes.ReceiptStatus_ErrUnknown,
+		}
+	}
+	prevWeightedVotes := p.calculateVoteWeight(bucket, selfStake)
 	// update bucket
 	bucket.StakedAmount.Add(bucket.StakedAmount, act.Amount())
 	if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
@@ -491,14 +529,14 @@ func (p *Protocol) handleDepositToStake(ctx context.Context, act *action.Deposit
 			failureStatus: iotextypes.ReceiptStatus_ErrNotEnoughBalance,
 		}
 	}
-	weightedVotes := p.calculateVoteWeight(bucket, csm.ContainsSelfStakingBucket(act.BucketIndex()))
+	weightedVotes := p.calculateVoteWeight(bucket, selfStake)
 	if err := candidate.AddVote(weightedVotes); err != nil {
 		return log, nil, &handleError{
 			err:           errors.Wrapf(err, "failed to add vote for candidate %s", candidate.Owner.String()),
 			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketAmount,
 		}
 	}
-	if csm.ContainsSelfStakingBucket(act.BucketIndex()) {
+	if selfStake {
 		if err := candidate.AddSelfStake(act.Amount()); err != nil {
 			return log, nil, &handleError{
 				err:           errors.Wrapf(err, "failed to add self stake for candidate %s", candidate.Owner.String()),
@@ -553,9 +591,12 @@ func (p *Protocol) handleRestake(ctx context.Context, act *action.Restake, csm C
 		return log, fetchErr
 	}
 
-	bucket, fetchErr := p.fetchBucketAndValidate(csm, actionCtx.Caller, act.BucketIndex(), true, true)
-	if fetchErr != nil {
-		return log, fetchErr
+	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())
+	if rErr != nil {
+		return log, rErr
+	}
+	if rErr = validateBucketOwner(bucket, actionCtx.Caller); rErr != nil {
+		return log, rErr
 	}
 	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes())
 
@@ -570,8 +611,14 @@ func (p *Protocol) handleRestake(ctx context.Context, act *action.Restake, csm C
 			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 		}
 	}
-
-	prevWeightedVotes := p.calculateVoteWeight(bucket, csm.ContainsSelfStakingBucket(act.BucketIndex()))
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, act.BucketIndex())
+	if err != nil {
+		return log, &handleError{
+			err:           err,
+			failureStatus: iotextypes.ReceiptStatus_ErrUnknown,
+		}
+	}
+	prevWeightedVotes := p.calculateVoteWeight(bucket, selfStake)
 	// update bucket
 	actDuration := time.Duration(act.Duration()) * 24 * time.Hour
 	if bucket.StakedDuration.Hours() > actDuration.Hours() {
@@ -604,7 +651,7 @@ func (p *Protocol) handleRestake(ctx context.Context, act *action.Restake, csm C
 			failureStatus: iotextypes.ReceiptStatus_ErrNotEnoughBalance,
 		}
 	}
-	weightedVotes := p.calculateVoteWeight(bucket, csm.ContainsSelfStakingBucket(act.BucketIndex()))
+	weightedVotes := p.calculateVoteWeight(bucket, selfStake)
 	if err := candidate.AddVote(weightedVotes); err != nil {
 		return log, &handleError{
 			err:           errors.Wrapf(err, "failed to add vote for candidate %s", candidate.Owner.String()),
@@ -786,36 +833,6 @@ func (p *Protocol) fetchBucket(csm CandidateStateManager, index uint64) (*VoteBu
 			fetchErr.failureStatus = iotextypes.ReceiptStatus_ErrInvalidBucketIndex
 		}
 		return nil, fetchErr
-	}
-	return bucket, nil
-}
-
-func (p *Protocol) fetchBucketAndValidate(
-	csm CandidateStateManager,
-	caller address.Address,
-	index uint64,
-	checkOwner bool,
-	allowSelfStaking bool,
-) (*VoteBucket, ReceiptError) {
-	bucket, err := p.fetchBucket(csm, index)
-	if err != nil {
-		return nil, err
-	}
-
-	// ReceiptStatus_ErrUnauthorizedOperator indicates action caller is not bucket owner
-	// upon return, the action will be subject to check whether it contains a valid consignment transfer
-	// do NOT return this value in case changes are added in the future
-	if checkOwner && !address.Equal(bucket.Owner, caller) {
-		return bucket, &handleError{
-			err:           errors.New("bucket owner does not match action caller"),
-			failureStatus: iotextypes.ReceiptStatus_ErrUnauthorizedOperator,
-		}
-	}
-	if !allowSelfStaking && csm.ContainsSelfStakingBucket(index) {
-		return bucket, &handleError{
-			err:           errors.New("self staking bucket cannot be processed"),
-			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
-		}
 	}
 	return bucket, nil
 }

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -419,13 +419,6 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 	return log, nil
 }
 
-func (p *Protocol) validateTransferStakeBucket(featureCtx protocol.FeatureCtx, csm CandidateStateManager, bucket *VoteBucket, caller address.Address) ReceiptError {
-	if rErr := validateBucketOwner(bucket, caller); rErr != nil {
-		return rErr
-	}
-	return validateBucketSelfStake(featureCtx, csm, bucket, false)
-}
-
 func (p *Protocol) handleConsignmentTransfer(
 	csm CandidateStateManager,
 	ctx context.Context,

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -178,7 +178,7 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 	if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
 		return log, errors.Wrapf(err, "failed to update bucket for voter %s", bucket.Owner.String())
 	}
-	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil {
 		return log, &handleError{
 			err:           err,
@@ -438,7 +438,7 @@ func (p *Protocol) handleConsignmentTransfer(
 	// self-stake cannot be transferred
 	actCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket.Index)
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil || selfStake {
 		return nil, false
 	}
@@ -492,7 +492,7 @@ func (p *Protocol) handleDepositToStake(ctx context.Context, act *action.Deposit
 			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 		}
 	}
-	selfStake, err := isSelfStakeBucket(featureCtx, csm, act.BucketIndex())
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil {
 		return log, nil, &handleError{
 			err:           err,
@@ -592,7 +592,7 @@ func (p *Protocol) handleRestake(ctx context.Context, act *action.Restake, csm C
 			failureStatus: iotextypes.ReceiptStatus_ErrInvalidBucketType,
 		}
 	}
-	selfStake, err := isSelfStakeBucket(featureCtx, csm, act.BucketIndex())
+	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil {
 		return log, &handleError{
 			err:           err,
@@ -841,7 +841,7 @@ func (p *Protocol) fetchBucketAndValidate(
 		}
 	}
 	if !allowSelfStaking {
-		selfStaking, serr := isSelfStakeBucket(featureCtx, csm, index)
+		selfStaking, serr := isSelfStakeBucket(featureCtx, csm, bucket)
 		if err != nil {
 			return bucket, &handleError{
 				err:           serr,

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -684,3 +684,37 @@ func writeCandCenterStateToStateDB(sm protocol.StateManager, name, op, owners Ca
 	_, err := sm.PutState(owners, protocol.NamespaceOption(CandsMapNS), protocol.KeyOption(_ownerKey))
 	return err
 }
+
+// isSelfStakeBucket returns true if the bucket is self-stake bucket and not expired
+func isSelfStakeBucket(featureCtx protocol.FeatureCtx, csm CandidateStateManager, index uint64) (bool, error) {
+	// bucket index should be settled in one of candidates
+	selfStake := csm.ContainsSelfStakingBucket(index)
+	if featureCtx.DisableDelegateEndorsement || !selfStake {
+		return selfStake, nil
+	}
+
+	bucket, err := csm.getBucket(index)
+	switch {
+	case err == nil:
+	case errors.Is(err, ErrWithdrawnBucket):
+		// the bucket is withdrawn
+		return false, nil
+	default:
+		return false, err
+	}
+	// bucket should not be unstaked if it is self-owned
+	if address.Equal(bucket.Owner, bucket.Candidate) {
+		return !bucket.isUnstaked(), nil
+	}
+	// otherwise bucket should be an endorse bucket which is not expired
+	esm := NewEndorsementStateManager(csm.SM())
+	height, err := esm.Height()
+	if err != nil {
+		return false, err
+	}
+	endorse, err := esm.Get(index)
+	if err != nil {
+		return false, err
+	}
+	return endorse.Status(height) != EndorseExpired, nil
+}


### PR DESCRIPTION
# Description
Due to the introduction of endorsement, the `SelfStakeBucketIndex` field of the Candidate will not be reset between expiration and the next bucket action. Therefore, the `ContainsSelfStakingBucket` function returns true no longer to indicate whether the bucket is a valid self-stake bucket. As a result, this PR introduces a new private function `isSelfStakeBucket` to achieve this functionality.

## Type of change
Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
