### PR TITLE
[db] Reset only if Snapshots exceed size of 10

### DIFF
--- a/db/batch/batch_impl.go
+++ b/db/batch/batch_impl.go
@@ -11,6 +11,11 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	// resetSnapshotIgnoreThreshold is the threshold of snapshot number to ignore reset snapshots
+	resetSnapshotIgnoreThreshold = 10
+)
+
 type (
 	// baseKVStoreBatch is the base implementation of KVStoreBatch
 	baseKVStoreBatch struct {
@@ -359,6 +364,10 @@ func (cb *cachedBatch) ResetSnapshots() {
 	cb.lock.Lock()
 	defer cb.lock.Unlock()
 
+	// ignore reset snapshots if the snapshot number is less than threshold
+	if cb.tag <= resetSnapshotIgnoreThreshold {
+		return
+	}
 	cb.tag = 0
 	cb.batchShots = nil
 	cb.batchShots = make([]int, 0)


### PR DESCRIPTION
# Description

## Backgroud
`ResetSnapshots` occupies almost half of the time of `MintBlock` under high TPS, so we need to optimize it. 

## What to do
Currently, `ResetSnapshot` is called after each action is processed, but in most cases, the number of snapshots is only 1. In this case, performing `ResetSnapshot` is not very meaningful, so we have changed it to only reset when the snapshot count exceeds 10. 

Why choose 10? This threshold will lead to too many calls of `ResetSnapshot` if it's too small, resulting in waste; a threshold that is too large may cause a significant impact on the kv read/write performance due to too many snapshots. When the threshold is set to 10, the time of `ResetSnapshots` decreases from 1s to 100ms, and the MintBlock time decreases from 2.2s to 1.3s, which is acceptable

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
