### PR TITLE
fix bug in worker.Reset()

### DIFF
--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -182,7 +182,7 @@ func (q *actQueue) cleanTimeout() []*action.SealedEnvelope {
 	)
 	for i := 0; i < size; {
 		nonce := q.ascQueue[i].nonce
-		if timeNow.After(q.ascQueue[i].deadline) && nonce > q.pendingNonce {
+		if timeNow.After(q.ascQueue[i].deadline) && nonce != q.pendingNonce {
 			removedFromQueue = append(removedFromQueue, q.items[nonce])
 			delete(q.items, nonce)
 			delete(q.pendingBalance, nonce)

--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -182,7 +182,7 @@ func (q *actQueue) cleanTimeout() []*action.SealedEnvelope {
 	)
 	for i := 0; i < size; {
 		nonce := q.ascQueue[i].nonce
-		if timeNow.After(q.ascQueue[i].deadline) && nonce != q.pendingNonce {
+		if timeNow.After(q.ascQueue[i].deadline) && nonce > q.pendingNonce {
 			removedFromQueue = append(removedFromQueue, q.items[nonce])
 			delete(q.items, nonce)
 			delete(q.pendingBalance, nonce)

--- a/actpool/queueworker.go
+++ b/actpool/queueworker.go
@@ -238,8 +238,14 @@ func (worker *queueWorker) Reset(ctx context.Context) {
 			worker.emptyAccounts.Set(from, struct{}{})
 			return
 		}
+		var pendingNonce uint64
+		if protocol.MustGetFeatureCtx(ctx).UseZeroNonceForFreshAccount {
+			pendingNonce = confirmedState.PendingNonceConsideringFreshAccount()
+		} else {
+			pendingNonce = confirmedState.PendingNonce()
+		}
 		// Remove all actions that are committed to new block
-		acts := queue.UpdateAccountState(confirmedState.PendingNonce(), confirmedState.Balance)
+		acts := queue.UpdateAccountState(pendingNonce, confirmedState.Balance)
 		acts2 := queue.UpdateQueue()
 		worker.ap.removeInvalidActs(append(acts, acts2...))
 		// Delete the queue entry if it becomes empty


### PR DESCRIPTION
# Description
the nonce of queue whose account is legacy fresh isn't updated by `PendingNonceConsideringFreshAccount()` after `UseZeroNonceForFreshAccount` is activated

Fixes #4156 

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
