### PR TITLE
[evm] remove redundant gas limit check

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -115,8 +115,9 @@ type (
 		FixContractStakingWeightedVotes         bool
 		ExecutionSizeLimit32KB                  bool
 		UseZeroNonceForFreshAccount             bool
-		SharedGasWithDapp                       bool
 		DisableDelegateEndorsement              bool
+		RedundantGasCheck                       bool
+		SharedGasWithDapp                       bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -257,8 +258,9 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixContractStakingWeightedVotes:         g.IsRedsea(height),
 			ExecutionSizeLimit32KB:                  !g.IsSumatra(height),
 			UseZeroNonceForFreshAccount:             g.IsSumatra(height),
-			SharedGasWithDapp:                       g.IsToBeEnabled(height),
 			DisableDelegateEndorsement:              !g.IsToBeEnabled(height),
+			RedundantGasCheck:                       !g.IsToBeEnabled(height),
+			SharedGasWithDapp:                       g.IsToBeEnabled(height),
 		},
 	)
 }


### PR DESCRIPTION
# Description
1. currently, we rely on error  (other than `ErrChainID` and `ErrGasLimit`) returned from Handle() causing the tx to be invalidated, and not included into the block
2. hence remove the check inside EVM to fix the potential issue about zero-type conversion we discussed
3. a completely right solution would be:
    inside each protocol.Handle(), call `ws.Snapshot()` first
    move the zero-type conversion code in here
    if hitting an error, call `ws.Revert()`

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
