### PR TITLE
[api] remove height check for message batcher

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -493,18 +493,15 @@ func (core *coreService) SendAction(ctx context.Context, in *iotextypes.Action) 
 		}
 		return "", st.Err()
 	}
-	// If there is no error putting into local actpool,
-	// Broadcast it to the network
-	msg := in
-	if ge := core.bc.Genesis(); ge.IsQuebec(core.bc.TipHeight()) {
+	// If there is no error putting into local actpool, broadcast it to the network
+	if core.messageBatcher != nil {
 		err = core.messageBatcher.Put(&batch.Message{
 			ChainID: core.bc.ChainID(),
 			Target:  nil,
-			Data:    msg,
+			Data:    in,
 		})
 	} else {
-		//TODO: remove height check after activated
-		err = core.broadcastHandler(ctx, core.bc.ChainID(), msg)
+		err = core.broadcastHandler(ctx, core.bc.ChainID(), in)
 	}
 	if err != nil {
 		l.Warn("Failed to broadcast SendAction request.", zap.Error(err))


### PR DESCRIPTION
# Description
message batcher batches actions together and send in one shot to improve p2p network efficiency. It is gated to enable at an earlier hard-fork height. Now that hard-fork has passed, so we can remove the height check

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
