### PR TITLE
[action] Reject new actions before HF activated

### DIFF
--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -469,6 +469,10 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.
 		return p.validateCandidateRegister(ctx, act)
 	case *action.CandidateUpdate:
 		return p.validateCandidateUpdate(ctx, act)
+	case *action.CandidateActivate:
+		return p.validateCandidateActivate(ctx, act)
+	case *action.CandidateEndorsement:
+		return p.validateCandidateEndorsement(ctx, act)
 	}
 	return nil
 }

--- a/action/protocol/staking/validations.go
+++ b/action/protocol/staking/validations.go
@@ -84,3 +84,17 @@ func (p *Protocol) validateCandidateUpdate(ctx context.Context, act *action.Cand
 	}
 	return nil
 }
+
+func (p *Protocol) validateCandidateEndorsement(ctx context.Context, act *action.CandidateEndorsement) error {
+	if protocol.MustGetFeatureCtx(ctx).DisableDelegateEndorsement {
+		return errors.Wrap(action.ErrInvalidAct, "candidate endorsement is disabled")
+	}
+	return nil
+}
+
+func (p *Protocol) validateCandidateActivate(ctx context.Context, act *action.CandidateActivate) error {
+	if protocol.MustGetFeatureCtx(ctx).DisableDelegateEndorsement {
+		return errors.Wrap(action.ErrInvalidAct, "candidate activate is disabled")
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

New actions (i.e. CandidateEndorsement and CandidateActivate) should be rejected before HF is activated, otherwise it may lead to forks if anyone send the two actions.

After this change, there also be difference with last version:
- Old Behaviour: Not be added into actpool for action decode error
- New Behaviour: Action can be added into actpool, but will be droped when mint block for validation error

But the difference will not cause forks.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
