### PR TITLE
[actpool] Fix queueWorker blocked by timeout action

### DIFF
--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -436,7 +436,7 @@ func (ap *actPool) context(ctx context.Context) context.Context {
 }
 
 func (ap *actPool) enqueue(ctx context.Context, act *action.SealedEnvelope, replace bool) error {
-	var errChan = make(chan error) // unused errChan will be garbage-collected
+	var errChan = make(chan error, 1) // unused errChan will be garbage-collected
 	ap.jobQueue[ap.allocatedWorker(act.SenderAddress())] <- workerJob{
 		ctx,
 		act,


### PR DESCRIPTION
# Description

The queueWorker will be blocked when put result back to a channel but the action is already timeout, b/c the `workerJob.errChan` is a channel without buffer. 

This PR change the `errChan` to a buffered channel, thus queueWorker can put result to the channel even if there is no goroutine to retrive from this channel.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
