### PR TITLE
[actpool] remove zombie txs in allActions

### DIFF
--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -182,7 +182,7 @@ func (q *actQueue) cleanTimeout() []*action.SealedEnvelope {
 	)
 	for i := 0; i < size; {
 		nonce := q.ascQueue[i].nonce
-		if timeNow.After(q.ascQueue[i].deadline) && nonce > q.pendingNonce {
+		if timeNow.After(q.ascQueue[i].deadline) && (nonce < q.accountNonce || nonce > q.pendingNonce) {
 			removedFromQueue = append(removedFromQueue, q.items[nonce])
 			delete(q.items, nonce)
 			delete(q.pendingBalance, nonce)

--- a/actpool/queueworker.go
+++ b/actpool/queueworker.go
@@ -234,7 +234,9 @@ func (worker *queueWorker) Reset(ctx context.Context) {
 		confirmedState, err := accountutil.AccountState(ctx, worker.ap.sf, addr)
 		if err != nil {
 			log.L().Error("Error when removing confirmed actions", zap.Error(err))
+			pendingActs := queue.AllActs()
 			queue.Reset()
+			worker.ap.removeInvalidActs(pendingActs)
 			worker.emptyAccounts.Set(from, struct{}{})
 			return
 		}


### PR DESCRIPTION
# Description
There are zombie transactions left in `ap.allActions` and `ap.accountDesActs`, but couldn't be found in queueWorker 
<img width="841" alt="image" src="https://github.com/iotexproject/iotex-core/assets/55118568/b61581f0-4d24-4ef8-8130-cf988a67b9dc">



Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
