### PR TITLE
[staking] Add endorsement info in bucket fetch apis

### DIFF
--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -371,7 +371,7 @@ func (c *candSR) readStateBuckets(ctx context.Context, req *iotexapi.ReadStaking
 	offset := int(req.GetPagination().GetOffset())
 	limit := int(req.GetPagination().GetLimit())
 	buckets := getPageOfBuckets(all, offset, limit)
-	pbBuckets, err := toIoTeXTypesVoteBucketList(buckets)
+	pbBuckets, err := toIoTeXTypesVoteBucketList(c.SR(), buckets)
 	return pbBuckets, height, err
 }
 
@@ -396,7 +396,7 @@ func (c *candSR) readStateBucketsByVoter(ctx context.Context, req *iotexapi.Read
 	offset := int(req.GetPagination().GetOffset())
 	limit := int(req.GetPagination().GetLimit())
 	buckets = getPageOfBuckets(buckets, offset, limit)
-	pbBuckets, err := toIoTeXTypesVoteBucketList(buckets)
+	pbBuckets, err := toIoTeXTypesVoteBucketList(c.SR(), buckets)
 	return pbBuckets, height, err
 }
 
@@ -421,7 +421,7 @@ func (c *candSR) readStateBucketsByCandidate(ctx context.Context, req *iotexapi.
 	offset := int(req.GetPagination().GetOffset())
 	limit := int(req.GetPagination().GetLimit())
 	buckets = getPageOfBuckets(buckets, offset, limit)
-	pbBuckets, err := toIoTeXTypesVoteBucketList(buckets)
+	pbBuckets, err := toIoTeXTypesVoteBucketList(c.SR(), buckets)
 	return pbBuckets, height, err
 }
 
@@ -434,7 +434,7 @@ func (c *candSR) readStateBucketByIndices(ctx context.Context, req *iotexapi.Rea
 	if err != nil {
 		return nil, height, err
 	}
-	pbBuckets, err := toIoTeXTypesVoteBucketList(buckets)
+	pbBuckets, err := toIoTeXTypesVoteBucketList(c.SR(), buckets)
 	return pbBuckets, height, err
 }
 

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -314,7 +314,7 @@ func (p *Protocol) handleStakingIndexer(epochStartHeight uint64, sm protocol.Sta
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
 	}
-	buckets, err := toIoTeXTypesVoteBucketList(allBuckets)
+	buckets, err := toIoTeXTypesVoteBucketList(sm, allBuckets)
 	if err != nil {
 		return err
 	}

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -77,7 +77,7 @@ func (c *compositeStakingStateReader) readStateBuckets(ctx context.Context, req 
 	if err != nil {
 		return nil, 0, err
 	}
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(lsdBuckets)
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -104,7 +104,7 @@ func (c *compositeStakingStateReader) readStateBucketsByVoter(ctx context.Contex
 		return nil, 0, err
 	}
 	lsdBuckets = filterBucketsByVoter(lsdBuckets, req.GetVoterAddress())
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(lsdBuckets)
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -135,7 +135,7 @@ func (c *compositeStakingStateReader) readStateBucketsByCandidate(ctx context.Co
 	if err != nil {
 		return nil, 0, err
 	}
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(lsdBuckets)
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -160,7 +160,7 @@ func (c *compositeStakingStateReader) readStateBucketByIndices(ctx context.Conte
 	if err != nil {
 		return nil, 0, err
 	}
-	lsbIoTeXBuckets, err := toIoTeXTypesVoteBucketList(lsdBuckets)
+	lsbIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde
+	github.com/iotexproject/iotex-proto v0.5.15-0.20240327004259-da069334c7da
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -669,6 +669,8 @@ github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.m
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
 github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde h1:rs5eACTonHCALTwT9rhqMUEVYMQgbnNYMZQ85jJUlBY=
 github.com/iotexproject/iotex-proto v0.5.15-0.20240105060115-b12b162afdde/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.5.15-0.20240327004259-da069334c7da h1:JfIb2QG5XHnWMFhTRyWZJTmjbfgbT15VdfXhjRT45cw=
+github.com/iotexproject/iotex-proto v0.5.15-0.20240327004259-da069334c7da/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
# Description

Add `endorsementExpireHeight` in bucket returned in fetch apis, it means with following values:
- 0: no endorsement exist
- 18446744073709551615: endorsed and has not been withdraw yet
- (0, 18446744073709551615): withdraw has been called, value is representing the expire height

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
