### PR TITLE
test: replace gomonkey with xgo

### DIFF
--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/agiledragon/gomonkey/v2"
 	"github.com/ethereum/go-ethereum/eth/tracers"
 	"github.com/ethereum/go-ethereum/eth/tracers/logger"
 	"github.com/golang/mock/gomock"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/iotexproject/iotex-core
 go 1.21
 
 require (
-	github.com/agiledragon/gomonkey/v2 v2.11.0
 	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cespare/xxhash/v2 v2.2.0
@@ -95,6 +94,7 @@ require (
 	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/supranational/blst v0.3.11 // indirect
 	github.com/whyrusleeping/tar-utils v0.0.0-20180509141711-8c6c8ba81d5c // indirect
+	github.com/xhd2015/xgo/runtime v1.0.15
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/tools v0.15.0 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/aclements/go-gg v0.0.0-20170118225347-6dbb4e4fefb0/go.mod h1:55qNq4vc
 github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
-github.com/agiledragon/gomonkey/v2 v2.11.0 h1:5oxSgA+tC1xuGsrIorR+sYiziYltmJyEZ9qA25b6l5U=
-github.com/agiledragon/gomonkey/v2 v2.11.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20210923152817-c3b6e2f0c527/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -1533,6 +1531,8 @@ github.com/x-cray/logrus-prefixed-formatter v0.5.2/go.mod h1:2duySbKsL6M18s5GU7V
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
+github.com/xhd2015/xgo/runtime v1.0.15 h1:8l1F0d2V5pO9VoY8jeUbC4AZwMs6rnr5NRewhXV8K8s=
+github.com/xhd2015/xgo/runtime v1.0.15/go.mod h1:Z9uVy/NhTPeR3pvQoOdRvlYnSosJvrM7BySVGPsht6o=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=


### PR DESCRIPTION
# Description
This PR changes test cases that use gomonkey, replacing that with xgo.

The xgo, which is a native-go solution of monkey patching, have the following advantages compared to gomonkey:
- Compatibility
  -  xgo provides support through go1.17 to go1.22, for all OS and Arch, while gomonkey has limited support
- Stability
  - xgo does not need to modify readonly area, so on MacOS developers does not need any extra setup
- Concurrent Safety
  - xgo has built-in concurrent safety, patchings are isolated among goroutines, tests do not affect each other. While gomonkey is not concurrently safe
- Simplicity
  - xgo provides a powerful API named `Patch`, which can smartly recognize the target to mock

With this introduction of xgo and removal of gomonkey, future tests can use xgo reliably.

The xgo project: https://github.com/xhd2015/xgo

## Type of change
- [x] Code refactor or improvement

# How Has This Been Tested?
- [x] make test

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

To run the tests, xgo needs to be installed:
```sh
# macOS and Linux (and WSL)
curl -fsSL https://github.com/xhd2015/xgo/raw/master/install.sh | bash

# windows
powershell -c "irm github.com/xhd2015/xgo/raw/master/install.ps1|iex"
```

Then run:
```sh
cd chaosmeta-inject-operator 
xgo test -v  ./...
```

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
