### PR TITLE
[blockdao] Optimize derialization when retrieving receipts

### DIFF
--- a/api/grpcserver_integrity_test.go
+++ b/api/grpcserver_integrity_test.go
@@ -2344,7 +2344,7 @@ func TestGrpcServer_GetActionByActionHashIntegrity(t *testing.T) {
 	}()
 
 	for _, test := range _getActionByActionHashTest {
-		ret, _, _, _, err := svr.core.ActionByActionHash(test.h)
+		ret, _, _, err := svr.core.ActionByActionHash(test.h)
 		require.NoError(err)
 		require.Equal(test.expectedNounce, ret.Envelope.Nonce())
 	}

--- a/blockchain/block/block_deserializer_test.go
+++ b/blockchain/block/block_deserializer_test.go
@@ -45,10 +45,10 @@ func TestBlockStoreDeserializer(t *testing.T) {
 	require.NotNil(storeProto)
 
 	bd := Deserializer{}
-	store1, err := bd.FromBlockStoreProto(storeProto)
+	store1, err := bd.BlockFromBlockStoreProto(storeProto)
 	require.NoError(err)
 
-	require.Equal(store1.Block.height, store.Block.height)
-	require.Equal(store1.Block.Header.prevBlockHash, store.Block.Header.prevBlockHash)
-	require.Equal(store1.Block.Header.blockSig, store.Block.Header.blockSig)
+	require.Equal(store1.height, store.Block.height)
+	require.Equal(store1.Header.prevBlockHash, store.Block.Header.prevBlockHash)
+	require.Equal(store1.Header.blockSig, store.Block.Header.blockSig)
 }

--- a/blockchain/filedao/filedao_v2.go
+++ b/blockchain/filedao/filedao_v2.go
@@ -37,18 +37,19 @@ var (
 type (
 	// fileDAOv2 handles chain db file after file split activation at v1.1.2
 	fileDAOv2 struct {
-		filename     string
-		header       *FileHeader
-		tip          *FileTip
-		blkBuffer    *stagingBuffer
-		blkCache     cache.LRUCache
-		receiptCache cache.LRUCache
-		kvStore      db.KVStore
-		batch        batch.KVStoreBatch
-		hashStore    db.CountingIndex // store block hash
-		blkStore     db.CountingIndex // store raw blocks
-		sysStore     db.CountingIndex // store transaction log
-		deser        *block.Deserializer
+		filename        string
+		header          *FileHeader
+		tip             *FileTip
+		blkBuffer       *stagingBuffer
+		blkStorePbCache cache.LRUCache
+		blkCache        cache.LRUCache
+		receiptCache    cache.LRUCache
+		kvStore         db.KVStore
+		batch           batch.KVStoreBatch
+		hashStore       db.CountingIndex // store block hash
+		blkStore        db.CountingIndex // store raw blocks
+		sysStore        db.CountingIndex // store transaction log
+		deser           *block.Deserializer
 	}
 )
 
@@ -69,11 +70,12 @@ func newFileDAOv2(bottom uint64, cfg db.Config, deser *block.Deserializer) (*fil
 		tip: &FileTip{
 			Height: bottom - 1,
 		},
-		blkCache:     cache.NewThreadSafeLruCache(64),
-		receiptCache: cache.NewThreadSafeLruCache(64),
-		kvStore:      db.NewBoltDB(cfg),
-		batch:        batch.NewBatch(),
-		deser:        deser,
+		blkStorePbCache: cache.NewThreadSafeLruCache(16),
+		blkCache:        cache.NewThreadSafeLruCache(256),
+		receiptCache:    cache.NewThreadSafeLruCache(256),
+		kvStore:         db.NewBoltDB(cfg),
+		batch:           batch.NewBatch(),
+		deser:           deser,
 	}
 	return &fd, nil
 }
@@ -81,12 +83,13 @@ func newFileDAOv2(bottom uint64, cfg db.Config, deser *block.Deserializer) (*fil
 // openFileDAOv2 opens an existing v2 file
 func openFileDAOv2(cfg db.Config, deser *block.Deserializer) *fileDAOv2 {
 	return &fileDAOv2{
-		filename:     cfg.DbPath,
-		blkCache:     cache.NewThreadSafeLruCache(64),
-		receiptCache: cache.NewThreadSafeLruCache(64),
-		kvStore:      db.NewBoltDB(cfg),
-		batch:        batch.NewBatch(),
-		deser:        deser,
+		filename:        cfg.DbPath,
+		blkStorePbCache: cache.NewThreadSafeLruCache(16),
+		blkCache:        cache.NewThreadSafeLruCache(256),
+		receiptCache:    cache.NewThreadSafeLruCache(256),
+		kvStore:         db.NewBoltDB(cfg),
+		batch:           batch.NewBatch(),
+		deser:           deser,
 	}
 }
 

--- a/blockchain/filedao/filedao_v2.go
+++ b/blockchain/filedao/filedao_v2.go
@@ -37,17 +37,18 @@ var (
 type (
 	// fileDAOv2 handles chain db file after file split activation at v1.1.2
 	fileDAOv2 struct {
-		filename  string
-		header    *FileHeader
-		tip       *FileTip
-		blkBuffer *stagingBuffer
-		blkCache  cache.LRUCache
-		kvStore   db.KVStore
-		batch     batch.KVStoreBatch
-		hashStore db.CountingIndex // store block hash
-		blkStore  db.CountingIndex // store raw blocks
-		sysStore  db.CountingIndex // store transaction log
-		deser     *block.Deserializer
+		filename     string
+		header       *FileHeader
+		tip          *FileTip
+		blkBuffer    *stagingBuffer
+		blkCache     cache.LRUCache
+		receiptCache cache.LRUCache
+		kvStore      db.KVStore
+		batch        batch.KVStoreBatch
+		hashStore    db.CountingIndex // store block hash
+		blkStore     db.CountingIndex // store raw blocks
+		sysStore     db.CountingIndex // store transaction log
+		deser        *block.Deserializer
 	}
 )
 
@@ -68,10 +69,11 @@ func newFileDAOv2(bottom uint64, cfg db.Config, deser *block.Deserializer) (*fil
 		tip: &FileTip{
 			Height: bottom - 1,
 		},
-		blkCache: cache.NewThreadSafeLruCache(16),
-		kvStore:  db.NewBoltDB(cfg),
-		batch:    batch.NewBatch(),
-		deser:    deser,
+		blkCache:     cache.NewThreadSafeLruCache(64),
+		receiptCache: cache.NewThreadSafeLruCache(64),
+		kvStore:      db.NewBoltDB(cfg),
+		batch:        batch.NewBatch(),
+		deser:        deser,
 	}
 	return &fd, nil
 }
@@ -79,11 +81,12 @@ func newFileDAOv2(bottom uint64, cfg db.Config, deser *block.Deserializer) (*fil
 // openFileDAOv2 opens an existing v2 file
 func openFileDAOv2(cfg db.Config, deser *block.Deserializer) *fileDAOv2 {
 	return &fileDAOv2{
-		filename: cfg.DbPath,
-		blkCache: cache.NewThreadSafeLruCache(16),
-		kvStore:  db.NewBoltDB(cfg),
-		batch:    batch.NewBatch(),
-		deser:    deser,
+		filename:     cfg.DbPath,
+		blkCache:     cache.NewThreadSafeLruCache(64),
+		receiptCache: cache.NewThreadSafeLruCache(64),
+		kvStore:      db.NewBoltDB(cfg),
+		batch:        batch.NewBatch(),
+		deser:        deser,
 	}
 }
 
@@ -185,19 +188,19 @@ func (fd *fileDAOv2) GetBlockByHeight(height uint64) (*block.Block, error) {
 	if height == 0 {
 		return block.GenesisBlock(), nil
 	}
-	blkInfo, err := fd.getBlockStore(height)
+	blk, err := fd.getBlock(height)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get block at height %d", height)
 	}
-	return blkInfo.Block, nil
+	return blk, nil
 }
 
 func (fd *fileDAOv2) GetReceipts(height uint64) ([]*action.Receipt, error) {
-	blkInfo, err := fd.getBlockStore(height)
+	receipts, err := fd.getReceipt(height)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to get receipts at height %d", height)
 	}
-	return blkInfo.Receipts, nil
+	return receipts, nil
 }
 
 func (fd *fileDAOv2) ContainsTransactionLog() bool {

--- a/blockchain/filedao/filedao_v2_util.go
+++ b/blockchain/filedao/filedao_v2_util.go
@@ -171,7 +171,6 @@ func (fd *fileDAOv2) highestBlockOfStoreTip() uint64 {
 	return fd.header.Start + fd.blkStore.Size()*fd.header.BlockStoreSize - 1
 }
 
-// TODO: refactor getBlock with getReceipt
 func (fd *fileDAOv2) getBlock(height uint64) (*block.Block, error) {
 	if !fd.ContainsHeight(height) {
 		return nil, db.ErrNotExist

--- a/blockchain/filedao/testing.go
+++ b/blockchain/filedao/testing.go
@@ -66,10 +66,12 @@ func newFileDAOv2InMem(bottom uint64) (*fileDAOv2, error) {
 		tip: &FileTip{
 			Height: bottom - 1,
 		},
-		blkCache: cache.NewThreadSafeLruCache(16),
-		kvStore:  db.NewMemKVStore(),
-		batch:    batch.NewBatch(),
-		deser:    block.NewDeserializer(_defaultEVMNetworkID),
+		blkStorePbCache: cache.NewThreadSafeLruCache(16),
+		blkCache:        cache.NewThreadSafeLruCache(256),
+		receiptCache:    cache.NewThreadSafeLruCache(256),
+		kvStore:         db.NewMemKVStore(),
+		batch:           batch.NewBatch(),
+		deser:           block.NewDeserializer(_defaultEVMNetworkID),
 	}
 	return &fd, nil
 }

--- a/test/mock/mock_apicoreservice/mock_apicoreservice.go
+++ b/test/mock/mock_apicoreservice/mock_apicoreservice.go
@@ -78,15 +78,14 @@ func (mr *MockCoreServiceMockRecorder) Action(actionHash, checkPending interface
 }
 
 // ActionByActionHash mocks base method.
-func (m *MockCoreService) ActionByActionHash(h hash.Hash256) (*action.SealedEnvelope, hash.Hash256, uint64, uint32, error) {
+func (m *MockCoreService) ActionByActionHash(h hash.Hash256) (*action.SealedEnvelope, *block.Block, uint32, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ActionByActionHash", h)
 	ret0, _ := ret[0].(*action.SealedEnvelope)
-	ret1, _ := ret[1].(hash.Hash256)
-	ret2, _ := ret[2].(uint64)
-	ret3, _ := ret[3].(uint32)
-	ret4, _ := ret[4].(error)
-	return ret0, ret1, ret2, ret3, ret4
+	ret1, _ := ret[1].(*block.Block)
+	ret2, _ := ret[2].(uint32)
+	ret3, _ := ret[3].(error)
+	return ret0, ret1, ret2, ret3
 }
 
 // ActionByActionHash indicates an expected call of ActionByActionHash.


### PR DESCRIPTION
# Description
`getTransactionReceipt` is monitored to consume lots of cpu resources when serving for web3 requests.


<img width="1252" alt="image" src="https://github.com/iotexproject/iotex-core/assets/55118568/672928bf-6e16-4f80-9ade-4287e9f72bae">

Block and Receipt are deserialized and cached separtedly to reduce duplicate computing


Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
