### PR TITLE
[action] remove DecodeRawTx()

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,10 +11,10 @@
 /config/	        @CoderZhi @dustinxie @Liuhaai @envestcc @millken
 /p2p/		    @CoderZhi @dustinxie @Liuhaai @envestcc
 /action/		    @CoderZhi @dustinxie @Liuhaai @envestcc
-/blockchain/	    @CoderZhi @dustinxie @Liuhaai
-/blockindex/	    @CoderZhi @dustinxie @Liuhaai
-/crypto/		    @CoderZhi @dustinxie @Liuhaai
-/db/		        @CoderZhi @dustinxie @Liuhaai
+/blockchain/	    @CoderZhi @dustinxie @Liuhaai @envestcc
+/blockindex/	    @CoderZhi @dustinxie @Liuhaai @envestcc
+/crypto/		    @CoderZhi @dustinxie @Liuhaai @envestcc
+/db/		        @CoderZhi @dustinxie @Liuhaai @envestcc
 /dispatcher/	    @CoderZhi @dustinxie @Liuhaai @envestcc
 /pkg/		    @CoderZhi @dustinxie @Liuhaai
 /server/		    @CoderZhi @dustinxie @Liuhaai

--- a/api/web3server.go
+++ b/api/web3server.go
@@ -465,25 +465,16 @@ func (svr *web3Handler) sendRawTransaction(in *gjson.Result) (interface{}, error
 		pubkey   crypto.PublicKey
 		err      error
 	)
-	if g := cs.Genesis(); g.IsSumatra(cs.TipHeight()) {
-		tx, err = action.DecodeEtherTx(dataStr.String())
-		if err != nil {
-			return nil, err
-		}
-		if tx.Protected() && tx.ChainId().Uint64() != uint64(cs.EVMNetworkID()) {
-			return nil, errors.Wrapf(errInvalidEvmChainID, "expect chainID = %d, got %d", cs.EVMNetworkID(), tx.ChainId().Uint64())
-		}
-		encoding, sig, pubkey, err = action.ExtractTypeSigPubkey(tx)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		tx, sig, pubkey, err = action.DecodeRawTx(dataStr.String(), cs.EVMNetworkID())
-		if err != nil {
-			return nil, err
-		}
-		// before Sumatra height, all tx are EIP-155 format
-		encoding = iotextypes.Encoding_ETHEREUM_EIP155
+	tx, err = action.DecodeEtherTx(dataStr.String())
+	if err != nil {
+		return nil, err
+	}
+	if tx.Protected() && tx.ChainId().Uint64() != uint64(cs.EVMNetworkID()) {
+		return nil, errors.Wrapf(errInvalidEvmChainID, "expect chainID = %d, got %d", cs.EVMNetworkID(), tx.ChainId().Uint64())
+	}
+	encoding, sig, pubkey, err = action.ExtractTypeSigPubkey(tx)
+	if err != nil {
+		return nil, err
 	}
 	elp, err := svr.ethTxToEnvelope(tx)
 	if err != nil {

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/iotexproject/iotex-core/action"
 	apitypes "github.com/iotexproject/iotex-core/api/types"
 	"github.com/iotexproject/iotex-core/blockchain/block"
-	"github.com/iotexproject/iotex-core/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/test/identityset"
 	"github.com/iotexproject/iotex-core/test/mock/mock_apicoreservice"
 	mock_apitypes "github.com/iotexproject/iotex-core/test/mock/mock_apiresponder"
@@ -434,8 +433,6 @@ func TestSendRawTransaction(t *testing.T) {
 	defer ctrl.Finish()
 	core := mock_apicoreservice.NewMockCoreService(ctrl)
 	web3svr := &web3Handler{core, nil, _defaultBatchRequestLimit}
-	core.EXPECT().Genesis().Return(genesis.Default)
-	core.EXPECT().TipHeight().Return(uint64(0))
 	core.EXPECT().EVMNetworkID().Return(uint32(1))
 	core.EXPECT().ChainID().Return(uint32(1))
 	core.EXPECT().Account(gomock.Any()).Return(&iotextypes.AccountMeta{IsContract: true}, nil, nil)


### PR DESCRIPTION
# Description
After v1.13.0, `DecodeEtherTx()` is used to decode web3 action. `DecodeRawTx` is obsolete and can be removed

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
