### PR TITLE
[api]disable debug_trace APIs before archive mode is supported

### DIFF
--- a/api/web3server.go
+++ b/api/web3server.go
@@ -225,10 +225,11 @@ func (svr *web3Handler) handleWeb3Req(ctx context.Context, web3Req *gjson.Result
 		res, err = svr.subscribe(web3Req, writer)
 	case "eth_unsubscribe":
 		res, err = svr.unsubscribe(web3Req)
-	case "debug_traceTransaction":
-		res, err = svr.traceTransaction(ctx, web3Req)
-	case "debug_traceCall":
-		res, err = svr.traceCall(ctx, web3Req)
+	//TODO: enable debug api after archive mode is supported
+	// case "debug_traceTransaction":
+	// 	res, err = svr.traceTransaction(ctx, web3Req)
+	// case "debug_traceCall":
+	// 	res, err = svr.traceCall(ctx, web3Req)
 	case "eth_coinbase", "eth_getUncleCountByBlockHash", "eth_getUncleCountByBlockNumber",
 		"eth_sign", "eth_signTransaction", "eth_sendTransaction", "eth_getUncleByBlockHashAndIndex",
 		"eth_getUncleByBlockNumberAndIndex", "eth_pendingTransactions":


### PR DESCRIPTION
# Description
The trace APIs we implement cannot get the state of the transaction at that time, and most of the results obtained by calling the trace APIs is wrong (eg. #4208) . Enable this feature after archive mode supports it.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
