### PR TITLE
[blockindex] remove deprecated DeleteTipBlock

### DIFF
--- a/blockchain/blockdao/blockindexer.go
+++ b/blockchain/blockdao/blockindexer.go
@@ -25,7 +25,6 @@ type (
 		Stop(ctx context.Context) error
 		Height() (uint64, error)
 		PutBlock(context.Context, *block.Block) error
-		DeleteTipBlock(context.Context, *block.Block) error
 	}
 
 	// BlockIndexerWithStart defines an interface to accept block to build index from a start height

--- a/blockindex/sync_indexers.go
+++ b/blockindex/sync_indexers.go
@@ -69,16 +69,6 @@ func (ig *SyncIndexers) PutBlock(ctx context.Context, blk *block.Block) error {
 	return nil
 }
 
-// DeleteTipBlock deletes the tip block from the indexers in the group
-func (ig *SyncIndexers) DeleteTipBlock(ctx context.Context, blk *block.Block) error {
-	for _, indexer := range ig.indexers {
-		if err := indexer.DeleteTipBlock(ctx, blk); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // StartHeight returns the minimum start height of the indexers in the group
 func (ig *SyncIndexers) StartHeight() uint64 {
 	return ig.minStartHeight


### PR DESCRIPTION
# Description

DeleteTipBlock has been deprecated, removing it from blockindexer

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
