### PR TITLE
return bucket not exist for the filter function in kvstore with buffer

### DIFF
--- a/db/kvstorewithbuffer.go
+++ b/db/kvstorewithbuffer.go
@@ -195,8 +195,13 @@ func (kvb *kvStoreWithBuffer) MustDelete(ns string, key []byte) {
 }
 
 func (kvb *kvStoreWithBuffer) Filter(ns string, cond Condition, minKey, maxKey []byte) ([][]byte, [][]byte, error) {
+	var bucketNotExist bool
 	fk, fv, err := kvb.store.Filter(ns, cond, minKey, maxKey)
-	if err != nil {
+	switch errors.Cause(err) {
+	case ErrBucketNotExist: // fall through
+		bucketNotExist = true
+	case nil:
+	default: // err != nil
 		return fk, fv, err
 	}
 
@@ -211,6 +216,7 @@ func (kvb *kvStoreWithBuffer) Filter(ns string, cond Condition, minKey, maxKey [
 		if entry.Namespace() != ns {
 			continue
 		}
+		bucketNotExist = false
 		k, v := entry.Key(), entry.Value()
 
 		if checkMin && bytes.Compare(k, minKey) == -1 {
@@ -243,6 +249,9 @@ func (kvb *kvStoreWithBuffer) Filter(ns string, cond Condition, minKey, maxKey [
 				}
 			}
 		}
+	}
+	if bucketNotExist {
+		return nil, nil, ErrBucketNotExist
 	}
 	return fk, fv, nil
 }


### PR DESCRIPTION
In the implementation of KVStore, e.g., boltdb, error ErrBucketNotExist is returned when the bucket doesn't exist. If the kvstore returns an error, the error will be returned without going through the data stored in buffer. This PR fixes the bug and eventually return error ErrBucketNotExist if no such namespace found in the buffer.

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
