### PR TITLE
[staking] refactor statereader to support multiple contract indexers

### DIFF
--- a/action/protocol/staking/contractstake_indexer.go
+++ b/action/protocol/staking/contractstake_indexer.go
@@ -6,9 +6,6 @@
 package staking
 
 import (
-	"context"
-	"math/big"
-
 	"github.com/iotexproject/iotex-address/address"
 )
 
@@ -16,9 +13,6 @@ type (
 
 	// ContractStakingIndexer defines the interface of contract staking reader
 	ContractStakingIndexer interface {
-		// CandidateVotes returns the total staked votes of a candidate
-		// candidate identified by owner address
-		CandidateVotes(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error)
 		// Buckets returns active buckets
 		Buckets(height uint64) ([]*VoteBucket, error)
 		// BucketsByIndices returns active buckets by indices
@@ -27,6 +21,12 @@ type (
 		BucketsByCandidate(ownerAddr address.Address, height uint64) ([]*VoteBucket, error)
 		// TotalBucketCount returns the total number of buckets including burned buckets
 		TotalBucketCount(height uint64) (uint64, error)
+		// ContractAddress returns the contract address
+		ContractAddress() string
+	}
+	// ContractStakingIndexerWithBucketType defines the interface of contract staking reader with bucket type
+	ContractStakingIndexerWithBucketType interface {
+		ContractStakingIndexer
 		// BucketTypes returns the active bucket types
 		BucketTypes(height uint64) ([]*ContractStakingBucketType, error)
 	}

--- a/action/protocol/staking/contractstake_indexer_mock.go
+++ b/action/protocol/staking/contractstake_indexer_mock.go
@@ -5,8 +5,6 @@
 package staking
 
 import (
-	context "context"
-	big "math/big"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -34,21 +32,6 @@ func NewMockContractStakingIndexer(ctrl *gomock.Controller) *MockContractStaking
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockContractStakingIndexer) EXPECT() *MockContractStakingIndexerMockRecorder {
 	return m.recorder
-}
-
-// BucketTypes mocks base method.
-func (m *MockContractStakingIndexer) BucketTypes(height uint64) ([]*ContractStakingBucketType, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BucketTypes", height)
-	ret0, _ := ret[0].([]*ContractStakingBucketType)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// BucketTypes indicates an expected call of BucketTypes.
-func (mr *MockContractStakingIndexerMockRecorder) BucketTypes(height interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketTypes", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketTypes), height)
 }
 
 // Buckets mocks base method.
@@ -96,19 +79,18 @@ func (mr *MockContractStakingIndexerMockRecorder) BucketsByIndices(arg0, arg1 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByIndices", reflect.TypeOf((*MockContractStakingIndexer)(nil).BucketsByIndices), arg0, arg1)
 }
 
-// CandidateVotes mocks base method.
-func (m *MockContractStakingIndexer) CandidateVotes(ctx context.Context, ownerAddr address.Address, height uint64) (*big.Int, error) {
+// ContractAddress mocks base method.
+func (m *MockContractStakingIndexer) ContractAddress() string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CandidateVotes", ctx, ownerAddr, height)
-	ret0, _ := ret[0].(*big.Int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "ContractAddress")
+	ret0, _ := ret[0].(string)
+	return ret0
 }
 
-// CandidateVotes indicates an expected call of CandidateVotes.
-func (mr *MockContractStakingIndexerMockRecorder) CandidateVotes(ctx, ownerAddr, height interface{}) *gomock.Call {
+// ContractAddress indicates an expected call of ContractAddress.
+func (mr *MockContractStakingIndexerMockRecorder) ContractAddress() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CandidateVotes", reflect.TypeOf((*MockContractStakingIndexer)(nil).CandidateVotes), ctx, ownerAddr, height)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractAddress", reflect.TypeOf((*MockContractStakingIndexer)(nil).ContractAddress))
 }
 
 // TotalBucketCount mocks base method.
@@ -124,4 +106,116 @@ func (m *MockContractStakingIndexer) TotalBucketCount(height uint64) (uint64, er
 func (mr *MockContractStakingIndexerMockRecorder) TotalBucketCount(height interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBucketCount", reflect.TypeOf((*MockContractStakingIndexer)(nil).TotalBucketCount), height)
+}
+
+// MockContractStakingIndexerWithBucketType is a mock of ContractStakingIndexerWithBucketType interface.
+type MockContractStakingIndexerWithBucketType struct {
+	ctrl     *gomock.Controller
+	recorder *MockContractStakingIndexerWithBucketTypeMockRecorder
+}
+
+// MockContractStakingIndexerWithBucketTypeMockRecorder is the mock recorder for MockContractStakingIndexerWithBucketType.
+type MockContractStakingIndexerWithBucketTypeMockRecorder struct {
+	mock *MockContractStakingIndexerWithBucketType
+}
+
+// NewMockContractStakingIndexerWithBucketType creates a new mock instance.
+func NewMockContractStakingIndexerWithBucketType(ctrl *gomock.Controller) *MockContractStakingIndexerWithBucketType {
+	mock := &MockContractStakingIndexerWithBucketType{ctrl: ctrl}
+	mock.recorder = &MockContractStakingIndexerWithBucketTypeMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockContractStakingIndexerWithBucketType) EXPECT() *MockContractStakingIndexerWithBucketTypeMockRecorder {
+	return m.recorder
+}
+
+// BucketTypes mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) BucketTypes(height uint64) ([]*ContractStakingBucketType, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BucketTypes", height)
+	ret0, _ := ret[0].([]*ContractStakingBucketType)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BucketTypes indicates an expected call of BucketTypes.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) BucketTypes(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketTypes", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).BucketTypes), height)
+}
+
+// Buckets mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) Buckets(height uint64) ([]*VoteBucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Buckets", height)
+	ret0, _ := ret[0].([]*VoteBucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Buckets indicates an expected call of Buckets.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) Buckets(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Buckets", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).Buckets), height)
+}
+
+// BucketsByCandidate mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) BucketsByCandidate(ownerAddr address.Address, height uint64) ([]*VoteBucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BucketsByCandidate", ownerAddr, height)
+	ret0, _ := ret[0].([]*VoteBucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BucketsByCandidate indicates an expected call of BucketsByCandidate.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) BucketsByCandidate(ownerAddr, height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByCandidate", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).BucketsByCandidate), ownerAddr, height)
+}
+
+// BucketsByIndices mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) BucketsByIndices(arg0 []uint64, arg1 uint64) ([]*VoteBucket, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BucketsByIndices", arg0, arg1)
+	ret0, _ := ret[0].([]*VoteBucket)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// BucketsByIndices indicates an expected call of BucketsByIndices.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) BucketsByIndices(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BucketsByIndices", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).BucketsByIndices), arg0, arg1)
+}
+
+// ContractAddress mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) ContractAddress() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ContractAddress")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// ContractAddress indicates an expected call of ContractAddress.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) ContractAddress() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractAddress", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).ContractAddress))
+}
+
+// TotalBucketCount mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) TotalBucketCount(height uint64) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TotalBucketCount", height)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// TotalBucketCount indicates an expected call of TotalBucketCount.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) TotalBucketCount(height interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TotalBucketCount", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).TotalBucketCount), height)
 }

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -705,7 +705,12 @@ func (p *Protocol) contractStakingVotes(ctx context.Context, candidate address.A
 			if b.isUnstaked() {
 				continue
 			}
-			votes.Add(votes, p.calculateVoteWeight(b, false))
+			if featureCtx.FixContractStakingWeightedVotes {
+				votes.Add(votes, p.calculateVoteWeight(b, false))
+			} else {
+				votes.Add(votes, b.StakedAmount)
+			}
+
 		}
 	}
 	return votes, nil

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -21,22 +21,24 @@ import (
 type (
 	// compositeStakingStateReader is the compositive staking state reader, which combine native and contract staking
 	compositeStakingStateReader struct {
-		contractIndexer ContractStakingIndexer
-		nativeIndexer   *CandidatesBucketsIndexer
-		nativeSR        CandidateStateReader
+		contractIndexers    []ContractStakingIndexer
+		nativeIndexer       *CandidatesBucketsIndexer
+		nativeSR            CandidateStateReader
+		calculateVoteWeight func(v *VoteBucket, selfStake bool) *big.Int
 	}
 )
 
 // newCompositeStakingStateReader creates a new compositive staking state reader
-func newCompositeStakingStateReader(contractIndexer ContractStakingIndexer, nativeIndexer *CandidatesBucketsIndexer, sr protocol.StateReader) (*compositeStakingStateReader, error) {
+func newCompositeStakingStateReader(nativeIndexer *CandidatesBucketsIndexer, sr protocol.StateReader, calculateVoteWeight func(v *VoteBucket, selfStake bool) *big.Int, contractIndexers ...ContractStakingIndexer) (*compositeStakingStateReader, error) {
 	nativeSR, err := ConstructBaseView(sr)
 	if err != nil {
 		return nil, err
 	}
 	return &compositeStakingStateReader{
-		contractIndexer: contractIndexer,
-		nativeIndexer:   nativeIndexer,
-		nativeSR:        nativeSR,
+		contractIndexers:    contractIndexers,
+		nativeIndexer:       nativeIndexer,
+		nativeSR:            nativeSR,
+		calculateVoteWeight: calculateVoteWeight,
 	}, nil
 }
 
@@ -72,16 +74,20 @@ func (c *compositeStakingStateReader) readStateBuckets(ctx context.Context, req 
 		return buckets, height, nil
 	}
 
-	// read LSD buckets
-	lsdBuckets, err := c.contractIndexer.Buckets(inputHeight)
+	// read nft buckets
+	nftBuckets := make([]*VoteBucket, 0)
+	for _, indexer := range c.contractIndexers {
+		bkts, err := indexer.Buckets(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		nftBuckets = append(nftBuckets, bkts...)
+	}
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), nftBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
-	if err != nil {
-		return nil, 0, err
-	}
-	// merge native and LSD buckets
+	// merge native and nft buckets
 	buckets.Buckets = append(buckets.Buckets, lsdIoTeXBuckets.Buckets...)
 	buckets.Buckets = getPageOfArray(buckets.Buckets, int(req.GetPagination().GetOffset()), int(req.GetPagination().GetLimit()))
 	return buckets, height, err
@@ -99,12 +105,16 @@ func (c *compositeStakingStateReader) readStateBucketsByVoter(ctx context.Contex
 	}
 
 	// read LSD buckets
-	lsdBuckets, err := c.contractIndexer.Buckets(height)
-	if err != nil {
-		return nil, 0, err
+	nftBuckets := make([]*VoteBucket, 0)
+	for _, indexer := range c.contractIndexers {
+		bkts, err := indexer.Buckets(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		nftBuckets = append(nftBuckets, bkts...)
 	}
-	lsdBuckets = filterBucketsByVoter(lsdBuckets, req.GetVoterAddress())
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
+	nftBuckets = filterBucketsByVoter(nftBuckets, req.GetVoterAddress())
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), nftBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -126,20 +136,24 @@ func (c *compositeStakingStateReader) readStateBucketsByCandidate(ctx context.Co
 		return buckets, height, err
 	}
 
-	// read LSD buckets
+	// read nft buckets
 	candidate := c.nativeSR.GetCandidateByName(req.GetCandName())
 	if candidate == nil {
 		return &iotextypes.VoteBucketList{}, height, nil
 	}
-	lsdBuckets, err := c.contractIndexer.BucketsByCandidate(candidate.GetIdentifier(), height)
+	nftBuckets := make([]*VoteBucket, 0)
+	for _, indexer := range c.contractIndexers {
+		bkts, err := indexer.BucketsByCandidate(candidate.GetIdentifier(), height)
+		if err != nil {
+			return nil, 0, err
+		}
+		nftBuckets = append(nftBuckets, bkts...)
+	}
+	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), nftBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
-	lsdIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
-	if err != nil {
-		return nil, 0, err
-	}
-	// merge native and LSD buckets
+	// merge native and nft buckets
 	buckets.Buckets = append(buckets.Buckets, lsdIoTeXBuckets.Buckets...)
 	buckets.Buckets = getPageOfArray(buckets.Buckets, int(req.GetPagination().GetOffset()), int(req.GetPagination().GetLimit()))
 	return buckets, height, err
@@ -155,12 +169,16 @@ func (c *compositeStakingStateReader) readStateBucketByIndices(ctx context.Conte
 		return buckets, height, nil
 	}
 
-	// read LSD buckets
-	lsdBuckets, err := c.contractIndexer.BucketsByIndices(req.GetIndex(), height)
-	if err != nil {
-		return nil, 0, err
+	// read nft buckets
+	nftBuckets := make([]*VoteBucket, 0)
+	for _, indexer := range c.contractIndexers {
+		bkts, err := indexer.BucketsByIndices(req.GetIndex(), height)
+		if err != nil {
+			return nil, 0, err
+		}
+		nftBuckets = append(nftBuckets, bkts...)
 	}
-	lsbIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), lsdBuckets)
+	lsbIoTeXBuckets, err := toIoTeXTypesVoteBucketList(c.nativeSR.SR(), nftBuckets)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -177,16 +195,18 @@ func (c *compositeStakingStateReader) readStateBucketCount(ctx context.Context, 
 	if !c.isContractStakingEnabled() {
 		return bucketCnt, height, nil
 	}
-	buckets, err := c.contractIndexer.Buckets(height)
-	if err != nil {
-		return nil, 0, err
+	for _, indexer := range c.contractIndexers {
+		buckets, err := indexer.Buckets(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		bucketCnt.Active += uint64(len(buckets))
+		tbc, err := indexer.TotalBucketCount(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		bucketCnt.Total += tbc
 	}
-	bucketCnt.Active += uint64(len(buckets))
-	tbc, err := c.contractIndexer.TotalBucketCount(height)
-	if err != nil {
-		return nil, 0, err
-	}
-	bucketCnt.Total += tbc
 	return bucketCnt, height, nil
 }
 
@@ -224,8 +244,10 @@ func (c *compositeStakingStateReader) readStateCandidates(ctx context.Context, r
 		return candidates, height, nil
 	}
 	for _, candidate := range candidates.Candidates {
-		if err = addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
-			return nil, 0, err
+		for _, indexer := range c.contractIndexers {
+			if err = c.addContractStakingVotes(ctx, candidate, indexer, height); err != nil {
+				return nil, 0, err
+			}
 		}
 	}
 	return candidates, height, nil
@@ -242,8 +264,10 @@ func (c *compositeStakingStateReader) readStateCandidateByName(ctx context.Conte
 	if !protocol.MustGetFeatureCtx(ctx).AddContractStakingVotes {
 		return candidate, height, nil
 	}
-	if err := addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
-		return nil, 0, err
+	for _, indexer := range c.contractIndexers {
+		if err := c.addContractStakingVotes(ctx, candidate, indexer, height); err != nil {
+			return nil, 0, err
+		}
 	}
 	return candidate, height, nil
 }
@@ -259,8 +283,10 @@ func (c *compositeStakingStateReader) readStateCandidateByAddress(ctx context.Co
 	if !protocol.MustGetFeatureCtx(ctx).AddContractStakingVotes {
 		return candidate, height, nil
 	}
-	if err := addContractStakingVotes(ctx, candidate, c.contractIndexer, height); err != nil {
-		return nil, 0, err
+	for _, indexer := range c.contractIndexers {
+		if err := c.addContractStakingVotes(ctx, candidate, indexer, height); err != nil {
+			return nil, 0, err
+		}
 	}
 	return candidate, height, nil
 }
@@ -279,24 +305,38 @@ func (c *compositeStakingStateReader) readStateTotalStakingAmount(ctx context.Co
 		return accountMeta, height, nil
 	}
 	// add contract staking amount
-	buckets, err := c.contractIndexer.Buckets(height)
-	if err != nil {
-		return nil, 0, err
-	}
-	for _, bucket := range buckets {
-		amount.Add(amount, bucket.StakedAmount)
+	for _, indexer := range c.contractIndexers {
+		bkts, err := indexer.Buckets(height)
+		if err != nil {
+			return nil, 0, err
+		}
+		for _, bucket := range bkts {
+			amount.Add(amount, bucket.StakedAmount)
+		}
 	}
 
 	accountMeta.Balance = amount.String()
 	return accountMeta, height, nil
 }
 
-func (c *compositeStakingStateReader) readStateContractStakingBucketTypes(ctx context.Context, _ *iotexapi.ReadStakingDataRequest_ContractStakingBucketTypes) (*iotextypes.ContractStakingBucketTypeList, uint64, error) {
+func (c *compositeStakingStateReader) readStateContractStakingBucketTypes(ctx context.Context, req *iotexapi.ReadStakingDataRequest_ContractStakingBucketTypes) (*iotextypes.ContractStakingBucketTypeList, uint64, error) {
 	if !c.isContractStakingEnabled() {
 		return &iotextypes.ContractStakingBucketTypeList{}, c.nativeSR.Height(), nil
 	}
 	height := c.nativeSR.Height()
-	bts, err := c.contractIndexer.BucketTypes(height)
+	var targetIndexer ContractStakingIndexerWithBucketType
+	for _, indexer := range c.contractIndexers {
+		if indexer.ContractAddress() == req.GetContractAddress() {
+			if bt, ok := indexer.(ContractStakingIndexerWithBucketType); ok {
+				targetIndexer = bt
+			}
+			break
+		}
+	}
+	if targetIndexer == nil {
+		return &iotextypes.ContractStakingBucketTypeList{}, height, nil
+	}
+	bts, err := targetIndexer.BucketTypes(height)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -311,11 +351,10 @@ func (c *compositeStakingStateReader) readStateContractStakingBucketTypes(ctx co
 }
 
 func (c *compositeStakingStateReader) isContractStakingEnabled() bool {
-	return c.contractIndexer != nil
+	return len(c.contractIndexers) > 0
 }
 
-// TODO: move into compositeStakingStateReader
-func addContractStakingVotes(ctx context.Context, candidate *iotextypes.CandidateV2, contractStakingSR ContractStakingIndexer, height uint64) error {
+func (c *compositeStakingStateReader) addContractStakingVotes(ctx context.Context, candidate *iotextypes.CandidateV2, contractStakingSR ContractStakingIndexer, height uint64) error {
 	votes, ok := big.NewInt(0).SetString(candidate.TotalWeightedVotes, 10)
 	if !ok {
 		return errors.Errorf("invalid total weighted votes %s", candidate.TotalWeightedVotes)
@@ -324,11 +363,16 @@ func addContractStakingVotes(ctx context.Context, candidate *iotextypes.Candidat
 	if err != nil {
 		return err
 	}
-	contractVotes, err := contractStakingSR.CandidateVotes(ctx, addr, height)
+	btks, err := contractStakingSR.BucketsByCandidate(addr, height)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "failed to get BucketsByCandidate from contractStakingIndexerV2")
 	}
-	votes.Add(votes, contractVotes)
+	for _, b := range btks {
+		if b.isUnstaked() {
+			continue
+		}
+		votes.Add(votes, c.calculateVoteWeight(b, false))
+	}
 	candidate.TotalWeightedVotes = votes.String()
 	return nil
 }

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -363,11 +363,11 @@ func (c *compositeStakingStateReader) addContractStakingVotes(ctx context.Contex
 	if err != nil {
 		return err
 	}
-	btks, err := contractStakingSR.BucketsByCandidate(addr, height)
+	bkts, err := contractStakingSR.BucketsByCandidate(addr, height)
 	if err != nil {
 		return errors.Wrap(err, "failed to get BucketsByCandidate from contractStakingIndexerV2")
 	}
-	for _, b := range btks {
+	for _, b := range bkts {
 		if b.isUnstaked() {
 			continue
 		}

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -92,6 +92,11 @@ func (s *Indexer) StartHeight() uint64 {
 	return s.config.ContractDeployHeight
 }
 
+// ContractAddress returns the contract address
+func (s *Indexer) ContractAddress() string {
+	return s.config.ContractAddress
+}
+
 // CandidateVotes returns the candidate votes
 func (s *Indexer) CandidateVotes(ctx context.Context, candidate address.Address, height uint64) (*big.Int, error) {
 	if s.isIgnored(height) {


### PR DESCRIPTION
# Description

This refactoring will simplify the integration work of the coming new staking contract indexer, with the main changes including:

- removing `CandidateVotes()` from the indexer interface, with vote counting implementation move to the staking protocol
- adding `ContractAddress()` in the indexer interface
- introducing `[]indexers` in statereader, and implementation of various read interfaces based on it.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
