### PR TITLE
[staking] ReadState API support Candidate ID

### DIFF
--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -478,11 +478,20 @@ func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.Rea
 }
 
 func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.ReadStakingDataRequest_CandidateByAddress) (*iotextypes.CandidateV2, uint64, error) {
-	owner, err := address.FromString(req.GetOwnerAddr())
-	if err != nil {
-		return nil, 0, err
+	var cand *Candidate
+	if len(req.GetOwnerAddr()) > 0 {
+		owner, err := address.FromString(req.GetOwnerAddr())
+		if err != nil {
+			return nil, 0, err
+		}
+		cand = c.GetCandidateByOwner(owner)
+	} else {
+		id, err := address.FromString(req.GetId())
+		if err != nil {
+			return nil, 0, err
+		}
+		cand = c.GetByIdentifier(id)
 	}
-	cand := c.GetCandidateByOwner(owner)
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}

--- a/action/protocol/staking/ethabi/common/candidatebyaddress.go
+++ b/action/protocol/staking/ethabi/common/candidatebyaddress.go
@@ -76,7 +76,7 @@ func (r *CandidateByAddressStateContext) EncodeToEth(resp *iotexapi.ReadStateRes
 
 	data, err := r.Method.Outputs.Pack(cand)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(data), nil
 }

--- a/action/protocol/staking/ethabi/common/types.go
+++ b/action/protocol/staking/ethabi/common/types.go
@@ -39,6 +39,7 @@ type (
 
 	// CandidateEth struct for eth
 	CandidateEth struct {
+		Id                 common.Address
 		OwnerAddress       common.Address
 		OperatorAddress    common.Address
 		RewardAddress      common.Address
@@ -129,6 +130,11 @@ func EncodeCandidateToEth(candidate *iotextypes.CandidateV2) (*CandidateEth, err
 	} else {
 		return nil, ErrConvertBigNumber
 	}
+	addr, err = addrutil.IoAddrToEvmAddr(candidate.Id)
+	if err != nil {
+		return nil, err
+	}
+	result.Id = addr
 	return result, nil
 }
 

--- a/action/protocol/staking/ethabi/stakebase_test.go
+++ b/action/protocol/staking/ethabi/stakebase_test.go
@@ -43,6 +43,7 @@ func TestEncodeCandidateToEth(t *testing.T) {
 		TotalWeightedVotes: "10000000000000000000",
 		SelfStakeBucketIdx: 100,
 		SelfStakingTokens:  "5000000000000000000",
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
 	}
 
 	cand, err := stakingComm.EncodeCandidateToEth(candidate)
@@ -55,6 +56,7 @@ func TestEncodeCandidateToEth(t *testing.T) {
 	r.EqualValues("10000000000000000000", cand.TotalWeightedVotes.String())
 	r.EqualValues(100, cand.SelfStakeBucketIdx)
 	r.EqualValues("5000000000000000000", cand.SelfStakingTokens.String())
+	r.EqualValues("0x0000000000000000000000000000000000000001", cand.Id.Hex())
 }
 
 func TestEncodeCandidateToEthErrorOwnerAddress(t *testing.T) {

--- a/action/protocol/staking/ethabi/v1/stakecandidatebyaddress_test.go
+++ b/action/protocol/staking/ethabi/v1/stakecandidatebyaddress_test.go
@@ -51,6 +51,7 @@ func TestCandidateByAddressToEth(t *testing.T) {
 		TotalWeightedVotes: "10000000000000000000",
 		SelfStakeBucketIdx: 100,
 		SelfStakingTokens:  "5000000000000000000",
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
 	}
 
 	candidateBytes, _ := proto.Marshal(candidate)

--- a/action/protocol/staking/ethabi/v1/stakecandidatebyname_test.go
+++ b/action/protocol/staking/ethabi/v1/stakecandidatebyname_test.go
@@ -51,6 +51,7 @@ func TestCandidateByNameToEth(t *testing.T) {
 		TotalWeightedVotes: "10000000000000000000",
 		SelfStakeBucketIdx: 100,
 		SelfStakingTokens:  "5000000000000000000",
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
 	}
 
 	candidateBytes, _ := proto.Marshal(candidate)

--- a/action/protocol/staking/ethabi/v1/stakecandidates_test.go
+++ b/action/protocol/staking/ethabi/v1/stakecandidates_test.go
@@ -56,6 +56,7 @@ func TestCandidatesToEth(t *testing.T) {
 				TotalWeightedVotes: "10000000000000000000",
 				SelfStakeBucketIdx: 100,
 				SelfStakingTokens:  "5000000000000000000",
+				Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
 			}, {
 				OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyzm8z5y",
 				OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9ldnhfk",
@@ -64,6 +65,7 @@ func TestCandidatesToEth(t *testing.T) {
 				TotalWeightedVotes: "11000000000000000000",
 				SelfStakeBucketIdx: 101,
 				SelfStakingTokens:  "6000000000000000000",
+				Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyzm8z5y",
 			},
 		},
 	}

--- a/action/protocol/staking/ethabi/v3/builder.go
+++ b/action/protocol/staking/ethabi/v3/builder.go
@@ -17,6 +17,14 @@ func BuildReadStateRequest(data []byte) (protocol.StateContext, error) {
 		return newCompositeBucketsByIndexesStateContext(data[4:])
 	case hex.EncodeToString(_compositeBucketsByVoterMethod.ID):
 		return newCompositeBucketsByVoterStateContext(data[4:])
+	case hex.EncodeToString(_candidatesMethod.ID):
+		return newCandidatesStateContext(data[4:])
+	case hex.EncodeToString(_candidateByNameMethod.ID):
+		return newCandidateByNameStateContext(data[4:])
+	case hex.EncodeToString(_candidateByAddressMethod.ID):
+		return newCandidateByAddressStateContext(data[4:])
+	case hex.EncodeToString(_candidateByIDMethod.ID):
+		return newCandidateByIDStateContext(data[4:])
 	default:
 		return nil, stakingComm.ErrInvalidCallSig
 	}

--- a/action/protocol/staking/ethabi/v3/stake_candidatebyaddress.go
+++ b/action/protocol/staking/ethabi/v3/stake_candidatebyaddress.go
@@ -1,0 +1,83 @@
+package v3
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+
+	"github.com/iotexproject/iotex-core/action/protocol/abiutil"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+const _candidateByAddressInterfaceABI = `[
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "ownerAddress",
+				"type": "address"
+			}
+		],
+		"name": "candidateByAddressV3",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "ownerAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "operatorAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "rewardAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "string",
+						"name": "name",
+						"type": "string"
+					},
+					{
+						"internalType": "uint256",
+						"name": "totalWeightedVotes",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint64",
+						"name": "selfStakeBucketIdx",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "selfStakingTokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "address",
+						"name": "id",
+						"type": "address"
+					}
+				],
+				"internalType": "struct IStaking.CandidateV3",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var _candidateByAddressMethod abi.Method
+
+func init() {
+	_candidateByAddressMethod = abiutil.MustLoadMethod(_candidateByAddressInterfaceABI, "candidateByAddressV3")
+}
+
+func newCandidateByAddressStateContext(data []byte) (*stakingComm.CandidateByAddressStateContext, error) {
+	return stakingComm.NewCandidateByAddressStateContext(data, &_candidateByAddressMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS)
+}

--- a/action/protocol/staking/ethabi/v3/stake_candidatebyid.go
+++ b/action/protocol/staking/ethabi/v3/stake_candidatebyid.go
@@ -120,7 +120,7 @@ func NewCandidateByIDStateContext(data []byte, methodABI *abi.Method, apiMethod 
 		return nil, err
 	}
 	return &stakingComm.CandidateByAddressStateContext{
-		&protocol.BaseStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
 			Parameter: &protocol.Parameters{
 				MethodName: methodBytes,
 				Arguments:  [][]byte{argumentsBytes},

--- a/action/protocol/staking/ethabi/v3/stake_candidatebyid.go
+++ b/action/protocol/staking/ethabi/v3/stake_candidatebyid.go
@@ -1,0 +1,131 @@
+package v3
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/abiutil"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+const _candidateByIDInterfaceABI = `[
+	{
+		"inputs": [
+			{
+				"internalType": "address",
+				"name": "id",
+				"type": "address"
+			}
+		],
+		"name": "candidateByIDV3",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "ownerAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "operatorAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "rewardAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "string",
+						"name": "name",
+						"type": "string"
+					},
+					{
+						"internalType": "uint256",
+						"name": "totalWeightedVotes",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint64",
+						"name": "selfStakeBucketIdx",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "selfStakingTokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "address",
+						"name": "id",
+						"type": "address"
+					}
+				],
+				"internalType": "struct IStaking.CandidateV3",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var _candidateByIDMethod abi.Method
+
+func init() {
+	_candidateByIDMethod = abiutil.MustLoadMethod(_candidateByIDInterfaceABI, "candidateByIDV3")
+}
+
+func newCandidateByIDStateContext(data []byte) (*stakingComm.CandidateByAddressStateContext, error) {
+	return NewCandidateByIDStateContext(data, &_candidateByIDMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS)
+}
+
+func NewCandidateByIDStateContext(data []byte, methodABI *abi.Method, apiMethod iotexapi.ReadStakingDataMethod_Name) (*stakingComm.CandidateByAddressStateContext, error) {
+	paramsMap := map[string]interface{}{}
+	ok := false
+	if err := methodABI.Inputs.UnpackIntoMap(paramsMap, data); err != nil {
+		return nil, err
+	}
+	var idAddress common.Address
+	if idAddress, ok = paramsMap["id"].(common.Address); !ok {
+		return nil, stakingComm.ErrDecodeFailure
+	}
+	id, err := address.FromBytes(idAddress[:])
+	if err != nil {
+		return nil, err
+	}
+
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: apiMethod,
+	}
+	methodBytes, err := proto.Marshal(method)
+	if err != nil {
+		return nil, err
+	}
+	arguments := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_CandidateByAddress_{
+			CandidateByAddress: &iotexapi.ReadStakingDataRequest_CandidateByAddress{
+				Id: id.String(),
+			},
+		},
+	}
+	argumentsBytes, err := proto.Marshal(arguments)
+	if err != nil {
+		return nil, err
+	}
+	return &stakingComm.CandidateByAddressStateContext{
+		&protocol.BaseStateContext{
+			Parameter: &protocol.Parameters{
+				MethodName: methodBytes,
+				Arguments:  [][]byte{argumentsBytes},
+			},
+			Method: methodABI,
+		},
+	}, nil
+}

--- a/action/protocol/staking/ethabi/v3/stake_candidatebyname.go
+++ b/action/protocol/staking/ethabi/v3/stake_candidatebyname.go
@@ -1,0 +1,83 @@
+package v3
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+
+	"github.com/iotexproject/iotex-core/action/protocol/abiutil"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+const _candidateByNameInterfaceABI = `[
+	{
+		"inputs": [
+			{
+				"internalType": "string",
+				"name": "candName",
+				"type": "string"
+			}
+		],
+		"name": "candidateByNameV3",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "ownerAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "operatorAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "rewardAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "string",
+						"name": "name",
+						"type": "string"
+					},
+					{
+						"internalType": "uint256",
+						"name": "totalWeightedVotes",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint64",
+						"name": "selfStakeBucketIdx",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "selfStakingTokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "address",
+						"name": "id",
+						"type": "address"
+					}
+				],
+				"internalType": "struct IStaking.CandidateV3",
+				"name": "",
+				"type": "tuple"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var _candidateByNameMethod abi.Method
+
+func init() {
+	_candidateByNameMethod = abiutil.MustLoadMethod(_candidateByNameInterfaceABI, "candidateByNameV3")
+}
+
+func newCandidateByNameStateContext(data []byte) (*stakingComm.CandidateByNameStateContext, error) {
+	return stakingComm.NewCandidateByNameStateContext(data, &_candidateByNameMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME)
+}

--- a/action/protocol/staking/ethabi/v3/stake_candidates.go
+++ b/action/protocol/staking/ethabi/v3/stake_candidates.go
@@ -1,0 +1,88 @@
+package v3
+
+import (
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+
+	"github.com/iotexproject/iotex-core/action/protocol/abiutil"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+const _candidatesInterfaceABI = `[
+	{
+		"inputs": [
+			{
+				"internalType": "uint32",
+				"name": "offset",
+				"type": "uint32"
+			},
+			{
+				"internalType": "uint32",
+				"name": "limit",
+				"type": "uint32"
+			}
+		],
+		"name": "candidatesV3",
+		"outputs": [
+			{
+				"components": [
+					{
+						"internalType": "address",
+						"name": "ownerAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "operatorAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "address",
+						"name": "rewardAddress",
+						"type": "address"
+					},
+					{
+						"internalType": "string",
+						"name": "name",
+						"type": "string"
+					},
+					{
+						"internalType": "uint256",
+						"name": "totalWeightedVotes",
+						"type": "uint256"
+					},
+					{
+						"internalType": "uint64",
+						"name": "selfStakeBucketIdx",
+						"type": "uint64"
+					},
+					{
+						"internalType": "uint256",
+						"name": "selfStakingTokens",
+						"type": "uint256"
+					},
+					{
+						"internalType": "address",
+						"name": "id",
+						"type": "address"
+					}
+				],
+				"internalType": "struct IStaking.CandidateV3[]",
+				"name": "",
+				"type": "tuple[]"
+			}
+		],
+		"stateMutability": "view",
+		"type": "function"
+	}
+]`
+
+var _candidatesMethod abi.Method
+
+func init() {
+	_candidatesMethod = abiutil.MustLoadMethod(_candidatesInterfaceABI, "candidatesV3")
+}
+
+func newCandidatesStateContext(data []byte) (*stakingComm.CandidatesStateContext, error) {
+	return stakingComm.NewCandidatesStateContext(data, &_candidatesMethod, iotexapi.ReadStakingDataMethod_CANDIDATES)
+}

--- a/action/protocol/staking/ethabi/v3/stakecandidatebyaddress_test.go
+++ b/action/protocol/staking/ethabi/v3/stakecandidatebyaddress_test.go
@@ -1,0 +1,77 @@
+package v3
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+func TestBuildReadStateRequestCandidateByAddress(t *testing.T) {
+	r := require.New(t)
+
+	// addr, err := address.FromString("io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv")
+	// r.NoError(err)
+	// data, err := _candidateByAddressMethod.Inputs.Pack(common.BytesToAddress(addr.Bytes()))
+	// r.NoError(err)
+	// data = append(_candidateByAddressMethod.ID, data...)
+	// t.Logf("data: %s", hex.EncodeToString(data))
+
+	data, _ := hex.DecodeString("c03df7300000000000000000000000000000000000000000000000000000000000000001")
+	req, err := BuildReadStateRequest(data)
+
+	r.Nil(err)
+	r.EqualValues("*common.CandidateByAddressStateContext", reflect.TypeOf(req).String())
+
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS,
+	}
+	methodBytes, _ := proto.Marshal(method)
+	r.EqualValues(methodBytes, req.Parameters().MethodName)
+
+	arguments := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_CandidateByAddress_{
+			CandidateByAddress: &iotexapi.ReadStakingDataRequest_CandidateByAddress{
+				OwnerAddr: "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+			},
+		},
+	}
+	argumentsBytes, _ := proto.Marshal(arguments)
+	r.EqualValues([][]byte{argumentsBytes}, req.Parameters().Arguments)
+}
+
+func TestCandidateByAddressToEth(t *testing.T) {
+	r := require.New(t)
+
+	candidate := &iotextypes.CandidateV2{
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz75y8gn",
+		RewardAddress:      "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrrzsj4p",
+		Name:               "hello",
+		TotalWeightedVotes: "10000000000000000000",
+		SelfStakeBucketIdx: 100,
+		SelfStakingTokens:  "5000000000000000000",
+	}
+
+	candidateBytes, _ := proto.Marshal(candidate)
+	resp := &iotexapi.ReadStateResponse{
+		Data: candidateBytes,
+	}
+
+	ctx := &stakingComm.CandidateByAddressStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
+			Method: &_candidateByAddressMethod,
+		},
+	}
+	data, err := ctx.EncodeToEth(resp)
+	r.Nil(err)
+	r.EqualValues("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000004563918244f400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", data)
+}

--- a/action/protocol/staking/ethabi/v3/stakecandidatebyid_test.go
+++ b/action/protocol/staking/ethabi/v3/stakecandidatebyid_test.go
@@ -1,0 +1,77 @@
+package v3
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	stakingComm "github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+func TestBuildReadStateRequestCandidateByID(t *testing.T) {
+	r := require.New(t)
+
+	// addr, err := address.FromString("io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv")
+	// r.NoError(err)
+	// data, err := _candidateByIDMethod.Inputs.Pack(common.BytesToAddress(addr.Bytes()))
+	// r.NoError(err)
+	// data = append(_candidateByIDMethod.ID, data...)
+	// t.Logf("data: %s", hex.EncodeToString(data))
+
+	data, _ := hex.DecodeString("794368820000000000000000000000000000000000000000000000000000000000000001")
+	req, err := BuildReadStateRequest(data)
+
+	r.Nil(err)
+	r.EqualValues("*common.CandidateByAddressStateContext", reflect.TypeOf(req).String())
+
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS,
+	}
+	methodBytes, _ := proto.Marshal(method)
+	r.EqualValues(methodBytes, req.Parameters().MethodName)
+
+	arguments := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_CandidateByAddress_{
+			CandidateByAddress: &iotexapi.ReadStakingDataRequest_CandidateByAddress{
+				Id: "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+			},
+		},
+	}
+	argumentsBytes, _ := proto.Marshal(arguments)
+	r.EqualValues([][]byte{argumentsBytes}, req.Parameters().Arguments)
+}
+
+func TestCandidateByIDToEth(t *testing.T) {
+	r := require.New(t)
+
+	candidate := &iotextypes.CandidateV2{
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz75y8gn",
+		RewardAddress:      "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrrzsj4p",
+		Name:               "hello",
+		TotalWeightedVotes: "10000000000000000000",
+		SelfStakeBucketIdx: 100,
+		SelfStakingTokens:  "5000000000000000000",
+	}
+
+	candidateBytes, _ := proto.Marshal(candidate)
+	resp := &iotexapi.ReadStateResponse{
+		Data: candidateBytes,
+	}
+
+	ctx := &stakingComm.CandidateByAddressStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
+			Method: &_candidateByIDMethod,
+		},
+	}
+	data, err := ctx.EncodeToEth(resp)
+	r.Nil(err)
+	r.EqualValues("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000004563918244f400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", data)
+}

--- a/action/protocol/staking/ethabi/v3/stakecandidatebyname_test.go
+++ b/action/protocol/staking/ethabi/v3/stakecandidatebyname_test.go
@@ -1,0 +1,75 @@
+package v3
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+func TestBuildReadStateRequestCandidateByName(t *testing.T) {
+	r := require.New(t)
+
+	// data, err := _candidateByNameMethod.Inputs.Pack("hello")
+	// r.NoError(err)
+	// data = append(_candidateByNameMethod.ID, data...)
+	// t.Logf("data: %s", hex.EncodeToString(data))
+
+	data, _ := hex.DecodeString("a81707940000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000")
+	req, err := BuildReadStateRequest(data)
+
+	r.Nil(err)
+	r.EqualValues("*common.CandidateByNameStateContext", reflect.TypeOf(req).String())
+
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME,
+	}
+	methodBytes, _ := proto.Marshal(method)
+	r.EqualValues(methodBytes, req.Parameters().MethodName)
+
+	arguments := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_CandidateByName_{
+			CandidateByName: &iotexapi.ReadStakingDataRequest_CandidateByName{
+				CandName: "hello",
+			},
+		},
+	}
+	argumentsBytes, _ := proto.Marshal(arguments)
+	r.EqualValues([][]byte{argumentsBytes}, req.Parameters().Arguments)
+}
+
+func TestCandidateByNameToEth(t *testing.T) {
+	r := require.New(t)
+
+	candidate := &iotextypes.CandidateV2{
+		Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+		OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz75y8gn",
+		RewardAddress:      "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrrzsj4p",
+		Name:               "hello",
+		TotalWeightedVotes: "10000000000000000000",
+		SelfStakeBucketIdx: 100,
+		SelfStakingTokens:  "5000000000000000000",
+	}
+
+	candidateBytes, _ := proto.Marshal(candidate)
+	resp := &iotexapi.ReadStateResponse{
+		Data: candidateBytes,
+	}
+
+	ctx := &common.CandidateByNameStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
+			Method: &_candidateByNameMethod,
+		},
+	}
+	data, err := ctx.EncodeToEth(resp)
+	r.Nil(err)
+	r.EqualValues("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000004563918244f400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000", data)
+}

--- a/action/protocol/staking/ethabi/v3/stakecandidates_test.go
+++ b/action/protocol/staking/ethabi/v3/stakecandidates_test.go
@@ -1,0 +1,110 @@
+package v3
+
+import (
+	"encoding/hex"
+	"reflect"
+	"testing"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/action/protocol"
+	"github.com/iotexproject/iotex-core/action/protocol/staking/ethabi/common"
+)
+
+func TestBuildReadStateRequestCandidates(t *testing.T) {
+	r := require.New(t)
+
+	// data, err := _candidatesMethod.Inputs.Pack(uint32(1), uint32(2))
+	// r.NoError(err)
+	// data = append(_candidatesMethod.ID, data...)
+	// t.Logf("data: %s", hex.EncodeToString(data))
+	data, _ := hex.DecodeString("b591758b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002")
+	req, err := BuildReadStateRequest(data)
+
+	r.Nil(err)
+	r.EqualValues("*common.CandidatesStateContext", reflect.TypeOf(req).String())
+
+	method := &iotexapi.ReadStakingDataMethod{
+		Method: iotexapi.ReadStakingDataMethod_CANDIDATES,
+	}
+	methodBytes, _ := proto.Marshal(method)
+	r.EqualValues(methodBytes, req.Parameters().MethodName)
+
+	arguments := &iotexapi.ReadStakingDataRequest{
+		Request: &iotexapi.ReadStakingDataRequest_Candidates_{
+			Candidates: &iotexapi.ReadStakingDataRequest_Candidates{
+				Pagination: &iotexapi.PaginationParam{
+					Offset: 1,
+					Limit:  2,
+				},
+			},
+		},
+	}
+	argumentsBytes, _ := proto.Marshal(arguments)
+	r.EqualValues([][]byte{argumentsBytes}, req.Parameters().Arguments)
+}
+
+func TestCandidatesToEth(t *testing.T) {
+	r := require.New(t)
+
+	candidates := &iotextypes.CandidateListV2{
+		Candidates: []*iotextypes.CandidateV2{
+			{
+				Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+				OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqps833xv",
+				OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqz75y8gn",
+				RewardAddress:      "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqrrzsj4p",
+				Name:               "hello",
+				TotalWeightedVotes: "10000000000000000000",
+				SelfStakeBucketIdx: 100,
+				SelfStakingTokens:  "5000000000000000000",
+			}, {
+				Id:                 "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyzm8z5y",
+				OwnerAddress:       "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqyzm8z5y",
+				OperatorAddress:    "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq9ldnhfk",
+				RewardAddress:      "io1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqx37xp8f",
+				Name:               "world",
+				TotalWeightedVotes: "11000000000000000000",
+				SelfStakeBucketIdx: 101,
+				SelfStakingTokens:  "6000000000000000000",
+			},
+		},
+	}
+	candidatesBytes, _ := proto.Marshal(candidates)
+	resp := &iotexapi.ReadStateResponse{
+		Data: candidatesBytes,
+	}
+
+	ctx := &common.CandidatesStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
+			Method: &_candidatesMethod,
+		},
+	}
+	data, err := ctx.EncodeToEth(resp)
+	r.Nil(err)
+	r.EqualValues("000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000018000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000008ac7230489e8000000000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000004563918244f400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000568656c6c6f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000006000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000098a7d9b8314c0000000000000000000000000000000000000000000000000000000000000000006500000000000000000000000000000000000000000000000053444835ec58000000000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000005776f726c64000000000000000000000000000000000000000000000000000000", data)
+}
+
+func TestCandidatesToEthEmptyCandidates(t *testing.T) {
+	r := require.New(t)
+
+	candidates := &iotextypes.CandidateListV2{
+		Candidates: []*iotextypes.CandidateV2{},
+	}
+	candidatesBytes, _ := proto.Marshal(candidates)
+	resp := &iotexapi.ReadStateResponse{
+		Data: candidatesBytes,
+	}
+
+	ctx := &common.CandidatesStateContext{
+		BaseStateContext: &protocol.BaseStateContext{
+			Method: &_candidatesMethod,
+		},
+	}
+	data, err := ctx.EncodeToEth(resp)
+	r.Nil(err)
+	r.EqualValues("00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000", data)
+}

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -913,8 +913,9 @@ func (p *Protocol) generateCandidateID(owner address.Address, height uint64, csm
 	if isValidID(owner) {
 		return owner, nil
 	}
-	for i := range make([]struct{}, 1000) {
-		b := hash.Hash160b(append(owner.Bytes(), append(byteutil.Uint64ToBytesBigEndian(height), byteutil.Uint64ToBytesBigEndian(uint64(i))...)...))
+	h := append(owner.Bytes(), byteutil.Uint64ToBytesBigEndian(height)...)
+	for i := 0; i < 1000; i++ {
+		b := hash.Hash160b(append(h, byteutil.Uint64ToBytesBigEndian(uint64(i))...))
 		addr, err := address.FromBytes(b[:])
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to generate candidate ID")

--- a/e2etest/native_staking_test.go
+++ b/e2etest/native_staking_test.go
@@ -752,13 +752,13 @@ func TestCandidateTransferOwnership(t *testing.T) {
 
 		test.run([]*testcase{
 			{
-				name: "old owner cannot register again",
+				name: "old owner can register again after ownership transfer",
 				preActs: []*actionWithTime{
 					{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(oldOwnerID).String()), "cand1", identityset.Address(1).String(), identityset.Address(1).String(), identityset.Address(oldOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(oldOwnerID), action.WithChainID(chainID))), time.Now()},
 					{mustNoErr(action.SignedCandidateTransferOwnership(test.nonceMgr.pop(identityset.Address(oldOwnerID).String()), identityset.Address(newOwnerID).String(), nil, gasLimit, gasPrice, identityset.PrivateKey(oldOwnerID), action.WithChainID(chainID))), time.Now()},
 				},
 				act:    &actionWithTime{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(oldOwnerID).String()), "cand2", identityset.Address(2).String(), identityset.Address(1).String(), identityset.Address(oldOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(oldOwnerID), action.WithChainID(chainID))), time.Now()},
-				expect: []actionExpect{&basicActionExpect{nil, uint64(iotextypes.ReceiptStatus_ErrCandidateAlreadyExist), ""}},
+				expect: []actionExpect{successExpect, &candidateExpect{"cand2", &iotextypes.CandidateV2{Id: "", Name: "cand2", OperatorAddress: identityset.Address(2).String(), RewardAddress: identityset.Address(1).String(), TotalWeightedVotes: "1245621408203087110422302", SelfStakingTokens: registerAmount.String(), OwnerAddress: identityset.Address(oldOwnerID).String(), SelfStakeBucketIdx: 1}}},
 			},
 			{
 				name:   "new owner cannot register again",
@@ -772,8 +772,8 @@ func TestCandidateTransferOwnership(t *testing.T) {
 			},
 			{
 				name:   "new owner can register again",
-				act:    &actionWithTime{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(newOwnerID).String()), "cand2", identityset.Address(2).String(), identityset.Address(1).String(), identityset.Address(newOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(newOwnerID), action.WithChainID(chainID))), time.Now()},
-				expect: []actionExpect{successExpect, &candidateExpect{"cand2", &iotextypes.CandidateV2{Name: "cand2", OperatorAddress: identityset.Address(2).String(), RewardAddress: identityset.Address(1).String(), TotalWeightedVotes: "1245621408203087110422302", SelfStakingTokens: registerAmount.String(), OwnerAddress: identityset.Address(newOwnerID).String(), SelfStakeBucketIdx: 1}}},
+				act:    &actionWithTime{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(newOwnerID).String()), "cand3", identityset.Address(3).String(), identityset.Address(1).String(), identityset.Address(newOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(newOwnerID), action.WithChainID(chainID))), time.Now()},
+				expect: []actionExpect{successExpect, &candidateExpect{"cand3", &iotextypes.CandidateV2{Name: "cand3", OperatorAddress: identityset.Address(3).String(), RewardAddress: identityset.Address(1).String(), TotalWeightedVotes: "1245621408203087110422302", SelfStakingTokens: registerAmount.String(), OwnerAddress: identityset.Address(newOwnerID).String(), SelfStakeBucketIdx: 2}}},
 			},
 		})
 	})

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed
+	github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.6.1
+	github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a
+	github.com/iotexproject/iotex-proto v0.6.2-0.20240613025333-7b433c49fbca
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.5.1/go.mod h1:8pDZcM45M0gY6jm3PoM
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d h1:/j1xCAC9YiG/8UKqYvycS/v3ddVsb1G7AMyLXOjeYI0=
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.mod h1:GRWevxtqQ4gPMrd7Qxhr29/7aTgvjiTp+rFI9KMMZEo=
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
-github.com/iotexproject/iotex-proto v0.6.1 h1:eUKd2x7zL94ctH8EBJ5O2ZaK8fweCgOkLyPKmPviFgc=
-github.com/iotexproject/iotex-proto v0.6.1/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed h1:pugQouxR0jm4siY7I5Ym6Z7qv44qjQy2ZGJT36YAgOs=
+github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -666,6 +666,8 @@ github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.m
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
 github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed h1:pugQouxR0jm4siY7I5Ym6Z7qv44qjQy2ZGJT36YAgOs=
 github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a h1:Whicbz8PFqdcu6le54x+BLMvctTBPYHv1YfshYQMA9c=
+github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/go.sum
+++ b/go.sum
@@ -668,6 +668,8 @@ github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed h1:pugQ
 github.com/iotexproject/iotex-proto v0.6.1-0.20240523093948-2d77d9ca73ed/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a h1:Whicbz8PFqdcu6le54x+BLMvctTBPYHv1YfshYQMA9c=
 github.com/iotexproject/iotex-proto v0.6.2-0.20240606042751-3d5a3403fe5a/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.6.2-0.20240613025333-7b433c49fbca h1:0/rfqTTmxHisIG4JIlj4ngli+YNh4HcYZTyF6SEua3w=
+github.com/iotexproject/iotex-proto v0.6.2-0.20240613025333-7b433c49fbca/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=


### PR DESCRIPTION
# Description

Due to the introduction of a new `ID` as a unique identifier by the Candidate, the following modifications need to be made to the API: 
- Upgrade the `candidateByAddress`, `candidateByName`, and `candidates` APIs to v3, adding 'id' to the returned results. 
- Add a new API called `candidateByID`; the original meaning of the `candidateByAddress` is to query based on the owner's address.

It's based on https://github.com/iotexproject/iotex-proto/pull/151

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
