### PR TITLE
[api] clear candidate selfstake if endorsement expired

### DIFF
--- a/action/protocol/staking/candidate_center.go
+++ b/action/protocol/staking/candidate_center.go
@@ -593,7 +593,7 @@ func (cb *candBase) collision(d *Candidate) (address.Address, address.Address, a
 		oper = c.GetIdentifier()
 	}
 
-	if c, hit := cb.selfStkBucketMap[d.SelfStakeBucketIdx]; hit && !address.Equal(c.GetIdentifier(), d.GetIdentifier()) {
+	if c, hit := cb.selfStkBucketMap[d.SelfStakeBucketIdx]; d.isSelfStakeBucketSettled() && hit && !address.Equal(c.GetIdentifier(), d.GetIdentifier()) {
 		self = c.GetIdentifier()
 	}
 	return name, owner, oper, self

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -67,6 +67,7 @@ type (
 		ContainsSelfStakingBucket(uint64) bool
 		GetByIdentifier(address.Address) *Candidate
 		SR() protocol.StateReader
+		BucketGetByIndex
 	}
 
 	candSM struct {

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -474,7 +474,7 @@ func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.Rea
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	return cand.toIoTeXTypes(), c.Height(), nil
+	return toIoTeXTypesCandidateV2(c.SR(), cand), c.Height(), nil
 }
 
 func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.ReadStakingDataRequest_CandidateByAddress) (*iotextypes.CandidateV2, uint64, error) {
@@ -503,7 +503,7 @@ func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	return cand.toIoTeXTypes(), c.Height(), nil
+	return toIoTeXTypesCandidateV2(c.SR(), cand), c.Height(), nil
 }
 
 func (c *candSR) readStateTotalStakingAmount(ctx context.Context, _ *iotexapi.ReadStakingDataRequest_TotalStakingAmount) (*iotextypes.AccountMeta, uint64, error) {

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -466,7 +466,8 @@ func (c *candSR) readStateCandidates(ctx context.Context, req *iotexapi.ReadStak
 	limit := int(req.GetPagination().GetLimit())
 	candidates := getPageOfCandidates(c.AllCandidates(), offset, limit)
 
-	return toIoTeXTypesCandidateListV2(c.SR(), candidates), c.Height(), nil
+	list, err := toIoTeXTypesCandidateListV2(c.SR(), candidates)
+	return list, c.Height(), err
 }
 
 func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.ReadStakingDataRequest_CandidateByName) (*iotextypes.CandidateV2, uint64, error) {
@@ -474,7 +475,8 @@ func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.Rea
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	return toIoTeXTypesCandidateV2(c.SR(), cand), c.Height(), nil
+	list, err := toIoTeXTypesCandidateV2(c.SR(), cand)
+	return list, c.Height(), err
 }
 
 func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.ReadStakingDataRequest_CandidateByAddress) (*iotextypes.CandidateV2, uint64, error) {
@@ -503,7 +505,8 @@ func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	return toIoTeXTypesCandidateV2(c.SR(), cand), c.Height(), nil
+	candV2, err := toIoTeXTypesCandidateV2(c.SR(), cand)
+	return candV2, c.Height(), err
 }
 
 func (c *candSR) readStateTotalStakingAmount(ctx context.Context, _ *iotexapi.ReadStakingDataRequest_TotalStakingAmount) (*iotextypes.AccountMeta, uint64, error) {

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -466,7 +466,7 @@ func (c *candSR) readStateCandidates(ctx context.Context, req *iotexapi.ReadStak
 	limit := int(req.GetPagination().GetLimit())
 	candidates := getPageOfCandidates(c.AllCandidates(), offset, limit)
 
-	return toIoTeXTypesCandidateListV2(candidates), c.Height(), nil
+	return toIoTeXTypesCandidateListV2(c.SR(), candidates), c.Height(), nil
 }
 
 func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.ReadStakingDataRequest_CandidateByName) (*iotextypes.CandidateV2, uint64, error) {

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -466,7 +466,7 @@ func (c *candSR) readStateCandidates(ctx context.Context, req *iotexapi.ReadStak
 	limit := int(req.GetPagination().GetLimit())
 	candidates := getPageOfCandidates(c.AllCandidates(), offset, limit)
 
-	list, err := toIoTeXTypesCandidateListV2(c.SR(), candidates)
+	list, err := toIoTeXTypesCandidateListV2(c, candidates)
 	return list, c.Height(), err
 }
 
@@ -475,7 +475,7 @@ func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.Rea
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	list, err := toIoTeXTypesCandidateV2(c.SR(), cand)
+	list, err := toIoTeXTypesCandidateV2(c, cand)
 	return list, c.Height(), err
 }
 
@@ -505,7 +505,7 @@ func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	candV2, err := toIoTeXTypesCandidateV2(c.SR(), cand)
+	candV2, err := toIoTeXTypesCandidateV2(c, cand)
 	return candV2, c.Height(), err
 }
 

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -680,10 +680,12 @@ func (p *Protocol) handleCandidateRegister(ctx context.Context, act *action.Cand
 	c := csm.GetByOwner(owner)
 	ownerExist := c != nil
 	// cannot collide with existing owner (with selfstake != 0)
-	if ownerExist && c.SelfStake.Cmp(big.NewInt(0)) != 0 {
-		return log, nil, &handleError{
-			err:           ErrInvalidOwner,
-			failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,
+	if ownerExist {
+		if !featureCtx.CandidateIdentifiedByOwner || (featureCtx.CandidateIdentifiedByOwner && c.SelfStake.Cmp(big.NewInt(0)) != 0) {
+			return log, nil, &handleError{
+				err:           ErrInvalidOwner,
+				failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,
+			}
 		}
 	}
 	// cannot collide with existing identifier

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -326,7 +326,7 @@ func (p *Protocol) handleStakingIndexer(epochStartHeight uint64, sm protocol.Sta
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
 	}
-	candidateList := toIoTeXTypesCandidateListV2(all)
+	candidateList := toIoTeXTypesCandidateListV2(sm, all)
 	return p.candBucketsIndexer.PutCandidates(epochStartHeight, candidateList)
 }
 

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -309,7 +309,10 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 }
 
 func (p *Protocol) handleStakingIndexer(epochStartHeight uint64, sm protocol.StateManager) error {
-	csr := newCandidateStateReader(sm)
+	csr, err := ConstructBaseView(sm)
+	if err != nil {
+		return err
+	}
 	allBuckets, _, err := csr.getAllBuckets()
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
@@ -326,7 +329,7 @@ func (p *Protocol) handleStakingIndexer(epochStartHeight uint64, sm protocol.Sta
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
 	}
-	candidateList, err := toIoTeXTypesCandidateListV2(sm, all)
+	candidateList, err := toIoTeXTypesCandidateListV2(csr, all)
 	if err != nil {
 		return err
 	}
@@ -484,7 +487,7 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.
 	return nil
 }
 
-func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidateStateReader, cand *Candidate) (bool, error) {
+func (p *Protocol) isActiveCandidate(ctx context.Context, csr CandidiateStateCommon, cand *Candidate) (bool, error) {
 	if cand.SelfStake.Cmp(p.config.RegistrationConsts.MinSelfStake) < 0 {
 		return false, nil
 	}

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -326,7 +326,10 @@ func (p *Protocol) handleStakingIndexer(epochStartHeight uint64, sm protocol.Sta
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
 	}
-	candidateList := toIoTeXTypesCandidateListV2(sm, all)
+	candidateList, err := toIoTeXTypesCandidateListV2(sm, all)
+	if err != nil {
+		return err
+	}
 	return p.candBucketsIndexer.PutCandidates(epochStartHeight, candidateList)
 }
 

--- a/action/protocol/staking/read_state.go
+++ b/action/protocol/staking/read_state.go
@@ -62,10 +62,9 @@ func getPageOfBuckets(buckets []*VoteBucket, offset, limit int) []*VoteBucket {
 	return getPageOfArray(buckets, offset, limit)
 }
 
-func toIoTeXTypesCandidateV2(sr protocol.StateReader, cand *Candidate) (*iotextypes.CandidateV2, error) {
-	csr := newCandidateStateReader(sr)
-	esr := NewEndorsementStateReader(sr)
-	height, _ := sr.Height()
+func toIoTeXTypesCandidateV2(csr CandidateStateReader, cand *Candidate) (*iotextypes.CandidateV2, error) {
+	esr := NewEndorsementStateReader(csr.SR())
+	height, _ := csr.SR().Height()
 	needClear := func(c *Candidate) (bool, error) {
 		if !c.isSelfStakeBucketSettled() {
 			return false, nil
@@ -102,12 +101,12 @@ func toIoTeXTypesCandidateV2(sr protocol.StateReader, cand *Candidate) (*iotexty
 	return c, nil
 }
 
-func toIoTeXTypesCandidateListV2(sr protocol.StateReader, candidates CandidateList) (*iotextypes.CandidateListV2, error) {
+func toIoTeXTypesCandidateListV2(csr CandidateStateReader, candidates CandidateList) (*iotextypes.CandidateListV2, error) {
 	res := iotextypes.CandidateListV2{
 		Candidates: make([]*iotextypes.CandidateV2, 0, len(candidates)),
 	}
 	for _, c := range candidates {
-		cand, err := toIoTeXTypesCandidateV2(sr, c)
+		cand, err := toIoTeXTypesCandidateV2(csr, c)
 		if err != nil {
 			return nil, err
 		}

--- a/action/protocol/staking/staking_statereader_test.go
+++ b/action/protocol/staking/staking_statereader_test.go
@@ -37,7 +37,7 @@ func TestStakingStateReader(t *testing.T) {
 			Reward:             identityset.Address(1),
 			Name:               "cand1",
 			Votes:              big.NewInt(10),
-			SelfStakeBucketIdx: 0,
+			SelfStakeBucketIdx: candidateNoSelfStakeBucketIndex,
 			SelfStake:          big.NewInt(10),
 		},
 		{
@@ -46,7 +46,7 @@ func TestStakingStateReader(t *testing.T) {
 			Reward:             identityset.Address(2),
 			Name:               "cand2",
 			Votes:              big.NewInt(0),
-			SelfStakeBucketIdx: 0,
+			SelfStakeBucketIdx: candidateNoSelfStakeBucketIndex,
 			SelfStake:          big.NewInt(0),
 		},
 	}


### PR DESCRIPTION
# Description
To make it easier to understand the API returning candidates, clear the self-stake if endorsement has expired but not been updated yet.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
