### PR TITLE
[action] pass Envelope to protocol.Handle() and Validate()

### DIFF
--- a/action/action.go
+++ b/action/action.go
@@ -42,6 +42,10 @@ type (
 	hasDestination interface {
 		Destination() string
 	}
+
+	hasSize interface {
+		Size() uint32
+	}
 )
 
 // Sign signs the action using sender's private key

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -28,6 +28,7 @@ type (
 		Destination() (string, bool)
 		Cost() (*big.Int, error)
 		IntrinsicGas() (uint64, error)
+		Size() uint32
 		Action() Action
 		ToEthTx(uint32, iotextypes.Encoding) (*types.Transaction, error)
 		Proto() *iotextypes.ActionCore
@@ -60,6 +61,15 @@ func (elp *envelope) Cost() (*big.Int, error) {
 // IntrinsicGas returns intrinsic gas of action.
 func (elp *envelope) IntrinsicGas() (uint64, error) {
 	return elp.payload.IntrinsicGas()
+}
+
+// Size returns the size of envelope
+func (elp *envelope) Size() uint32 {
+	size := elp.BasicActionSize()
+	if s, ok := elp.payload.(hasSize); ok {
+		size += s.Size()
+	}
+	return size
 }
 
 // Action returns the action payload.

--- a/action/execution.go
+++ b/action/execution.go
@@ -31,6 +31,7 @@ const (
 
 var (
 	_ hasDestination      = (*Execution)(nil)
+	_ hasSize             = (*Execution)(nil)
 	_ EthCompatibleAction = (*Execution)(nil)
 	_ TxData              = (*Execution)(nil)
 )

--- a/action/execution.go
+++ b/action/execution.go
@@ -163,7 +163,12 @@ func fromAccessListProto(list []*iotextypes.AccessTuple) types.AccessList {
 
 // TotalSize returns the total size of this Execution
 func (ex *Execution) TotalSize() uint32 {
-	size := ex.BasicActionSize()
+	return ex.BasicActionSize() + ex.Size()
+}
+
+// Size returns the size of this Execution
+func (ex *Execution) Size() uint32 {
+	var size uint32
 	if ex.amount != nil && len(ex.amount.Bytes()) > 0 {
 		size += uint32(len(ex.amount.Bytes()))
 	}

--- a/action/execution.go
+++ b/action/execution.go
@@ -162,11 +162,6 @@ func fromAccessListProto(list []*iotextypes.AccessTuple) types.AccessList {
 	return accessList
 }
 
-// TotalSize returns the total size of this Execution
-func (ex *Execution) TotalSize() uint32 {
-	return ex.BasicActionSize() + ex.Size()
-}
-
 // Size returns the size of this Execution
 func (ex *Execution) Size() uint32 {
 	var size uint32

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -28,6 +28,7 @@ func TestExecutionSignVerify(t *testing.T) {
 	ex, err := NewExecution(contractAddr.String(), 2, big.NewInt(10), uint64(100000), big.NewInt(10), data)
 	require.NoError(err)
 	require.EqualValues(21, ex.BasicActionSize())
+	require.EqualValues(66, ex.Size())
 	require.EqualValues(87, ex.TotalSize())
 
 	bd := &EnvelopeBuilder{}
@@ -49,6 +50,7 @@ func TestExecutionSignVerify(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(selp)
 	require.EqualValues(21, ex.BasicActionSize())
+	require.EqualValues(66, ex.Size())
 	require.EqualValues(87, ex.TotalSize())
 
 	// verify signature

--- a/action/execution_test.go
+++ b/action/execution_test.go
@@ -29,7 +29,6 @@ func TestExecutionSignVerify(t *testing.T) {
 	require.NoError(err)
 	require.EqualValues(21, ex.BasicActionSize())
 	require.EqualValues(66, ex.Size())
-	require.EqualValues(87, ex.TotalSize())
 
 	bd := &EnvelopeBuilder{}
 	eb := bd.SetNonce(ex.nonce).
@@ -38,6 +37,7 @@ func TestExecutionSignVerify(t *testing.T) {
 		SetAction(ex).Build()
 	elp, ok := eb.(*envelope)
 	require.True(ok)
+	require.EqualValues(87, eb.Size())
 
 	w := AssembleSealedEnvelope(elp, executorKey.PublicKey(), []byte("lol"))
 	require.Error(w.VerifySignature())
@@ -49,10 +49,6 @@ func TestExecutionSignVerify(t *testing.T) {
 	selp, err := Sign(elp, executorKey)
 	require.NoError(err)
 	require.NotNil(selp)
-	require.EqualValues(21, ex.BasicActionSize())
-	require.EqualValues(66, ex.Size())
-	require.EqualValues(87, ex.TotalSize())
-
 	// verify signature
 	require.NoError(selp.VerifySignature())
 }

--- a/action/protocol/account/protocol.go
+++ b/action/protocol/account/protocol.go
@@ -64,8 +64,8 @@ func FindProtocol(registry *protocol.Registry) *Protocol {
 }
 
 // Handle handles an account
-func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	switch act := act.(type) {
+func (p *Protocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	switch act := elp.Action().(type) {
 	case *action.Transfer:
 		return p.handleTransfer(ctx, act, sm)
 	}
@@ -73,10 +73,9 @@ func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.St
 }
 
 // Validate validates an account action
-func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	switch act := act.(type) {
-	case *action.Transfer:
-		if err := p.validateTransfer(ctx, act); err != nil {
+func (p *Protocol) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	if _, ok := elp.Action().(*action.Transfer); ok {
+		if err := p.validateTransfer(ctx, elp); err != nil {
 			return errors.Wrap(err, "error when validating transfer action")
 		}
 	}

--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -166,11 +166,13 @@ func (p *Protocol) handleTransfer(ctx context.Context, tsf *action.Transfer, sm 
 }
 
 // validateTransfer validates a transfer
-func (p *Protocol) validateTransfer(ctx context.Context, tsf *action.Transfer) error {
+func (p *Protocol) validateTransfer(ctx context.Context, elp action.Envelope) error {
 	// Reject oversized transfer
-	if tsf.TotalSize() > TransferSizeLimit {
+	if elp.Size() > TransferSizeLimit {
 		return action.ErrOversizedData
 	}
+	// already asserted the payload is action.Transfer on the call stack
+	tsf := elp.Action().(*action.Transfer)
 	var (
 		fCtx = protocol.MustGetFeatureCtx(ctx)
 		err  error

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -62,8 +62,8 @@ func FindProtocol(registry *protocol.Registry) *Protocol {
 }
 
 // Handle handles an execution
-func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	exec, ok := act.(*action.Execution)
+func (p *Protocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	exec, ok := elp.Action().(*action.Execution)
 	if !ok {
 		return nil, nil
 	}
@@ -82,8 +82,8 @@ func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.St
 }
 
 // Validate validates an execution
-func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.StateReader) error {
-	exec, ok := act.(*action.Execution)
+func (p *Protocol) Validate(ctx context.Context, elp action.Envelope, _ protocol.StateReader) error {
+	exec, ok := elp.Action().(*action.Execution)
 	if !ok {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, _ protocol.S
 	fCtx := protocol.MustGetFeatureCtx(ctx)
 	if fCtx.ExecutionSizeLimit32KB {
 		sizeLimit = _executionSizeLimit32KB
-		dataSize = exec.TotalSize()
+		dataSize = elp.Size()
 	}
 
 	// Reject oversize execution

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -656,16 +656,21 @@ func TestProtocol_Validate(t *testing.T) {
 		{"exceed 48KB", genesis.Default.SumatraBlockHeight, uint64(48*1024) + 1, action.ErrOversizedData},
 	}
 
+	builder := action.EnvelopeBuilder{}
 	for i := range cases {
 		t.Run(cases[i].name, func(t *testing.T) {
 			ex, err := action.NewExecution("2", uint64(1), big.NewInt(0), uint64(0), big.NewInt(0), make([]byte, cases[i].size))
 			require.NoError(err)
+			elp := builder.SetNonce(ex.Nonce()).
+				SetGasLimit(ex.GasLimit()).
+				SetGasPrice(ex.GasPrice()).
+				SetAction(ex).Build()
 			ctx := genesis.WithGenesisContext(context.Background(), config.Default.Genesis)
 			ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
 				BlockHeight: cases[i].height,
 			})
 			ctx = protocol.WithFeatureCtx(ctx)
-			require.Equal(cases[i].expectErr, errors.Cause(p.Validate(ctx, ex, nil)))
+			require.Equal(cases[i].expectErr, errors.Cause(p.Validate(ctx, elp, nil)))
 		})
 	}
 }

--- a/action/protocol/mock_protocol.go
+++ b/action/protocol/mock_protocol.go
@@ -50,7 +50,7 @@ func (mr *MockProtocolMockRecorder) ForceRegister(arg0 interface{}) *gomock.Call
 }
 
 // Handle mocks base method.
-func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Action, arg2 StateManager) (*action.Receipt, error) {
+func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Envelope, arg2 StateManager) (*action.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*action.Receipt)
@@ -361,7 +361,7 @@ func (m *MockActionValidator) EXPECT() *MockActionValidatorMockRecorder {
 }
 
 // Validate mocks base method.
-func (m *MockActionValidator) Validate(arg0 context.Context, arg1 action.Action, arg2 StateReader) error {
+func (m *MockActionValidator) Validate(arg0 context.Context, arg1 action.Envelope, arg2 StateReader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -398,7 +398,7 @@ func (m *MockActionHandler) EXPECT() *MockActionHandlerMockRecorder {
 }
 
 // Handle mocks base method.
-func (m *MockActionHandler) Handle(arg0 context.Context, arg1 action.Action, arg2 StateManager) (*action.Receipt, error) {
+func (m *MockActionHandler) Handle(arg0 context.Context, arg1 action.Envelope, arg2 StateManager) (*action.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*action.Receipt)

--- a/action/protocol/poll/consortium.go
+++ b/action/protocol/poll/consortium.go
@@ -175,12 +175,12 @@ func (cc *consortiumCommittee) CreatePostSystemActions(ctx context.Context, sr p
 	return createPostSystemActions(ctx, sr, cc)
 }
 
-func (cc *consortiumCommittee) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	return handle(ctx, act, sm, cc.indexer, cc.addr.String())
+func (cc *consortiumCommittee) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	return handle(ctx, elp.Action(), sm, cc.indexer, cc.addr.String())
 }
 
-func (cc *consortiumCommittee) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	return validate(ctx, sr, cc, act)
+func (cc *consortiumCommittee) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	return validate(ctx, sr, cc, elp.Action())
 }
 
 func (cc *consortiumCommittee) ReadState(

--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -106,12 +106,12 @@ func (p *governanceChainCommitteeProtocol) CreatePreStates(ctx context.Context, 
 	return p.sh.CreatePreStates(ctx, sm, p.indexer)
 }
 
-func (p *governanceChainCommitteeProtocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	return handle(ctx, act, sm, p.indexer, p.addr.String())
+func (p *governanceChainCommitteeProtocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	return handle(ctx, elp.Action(), sm, p.indexer, p.addr.String())
 }
 
-func (p *governanceChainCommitteeProtocol) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	return validate(ctx, sr, p, act)
+func (p *governanceChainCommitteeProtocol) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	return validate(ctx, sr, p, elp.Action())
 }
 
 func (p *governanceChainCommitteeProtocol) candidatesByGravityChainHeight(height uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -378,10 +378,7 @@ func TestHandle(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(tsf).Build()
-		selp, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp)
-		receipt, err := p.Handle(ctx, selp.Action(), nil)
+		receipt, err := p.Handle(ctx, elp, nil)
 		require.NoError(err)
 		require.Nil(receipt)
 	})
@@ -398,10 +395,7 @@ func TestHandle(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act2).Build()
-		selp2, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp2)
-		caller := selp2.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx2 = protocol.WithBlockCtx(
 			ctx2,
@@ -416,7 +410,7 @@ func TestHandle(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		receipt, err := p.Handle(ctx2, selp2.Action(), sm2)
+		receipt, err := p.Handle(ctx2, elp, sm2)
 		require.NoError(err)
 		require.NotNil(receipt)
 
@@ -445,10 +439,7 @@ func TestHandle(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act2).Build()
-		selp2, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp2)
-		caller := selp2.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx2 = protocol.WithBlockCtx(
 			ctx2,
@@ -463,7 +454,7 @@ func TestHandle(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p.Validate(ctx2, selp2.Action(), sm2)
+		err = p.Validate(ctx2, elp, sm2)
 		require.Contains(err.Error(), "Only producer could create this protocol")
 	})
 	t.Run("Duplicate candidate", func(t *testing.T) {
@@ -480,10 +471,7 @@ func TestHandle(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act3).Build()
-		selp3, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp3)
-		caller := selp3.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx3 = protocol.WithBlockCtx(
 			ctx3,
@@ -498,7 +486,7 @@ func TestHandle(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p.Validate(ctx3, selp3.Action(), sm3)
+		err = p.Validate(ctx3, elp, sm3)
 		require.Contains(err.Error(), "duplicate candidate")
 	})
 	t.Run("Delegate's length is not equal", func(t *testing.T) {
@@ -514,10 +502,7 @@ func TestHandle(t *testing.T) {
 		elp4 := bd4.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act4).Build()
-		selp4, err := action.Sign(elp4, senderKey)
-		require.NoError(err)
-		require.NotNil(selp4)
-		caller := selp4.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx4 = protocol.WithBlockCtx(
 			ctx4,
@@ -532,7 +517,7 @@ func TestHandle(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p4.Validate(ctx4, selp4.Action(), sm4)
+		err = p4.Validate(ctx4, elp4, sm4)
 		require.Contains(err.Error(), "the proposed delegate list length")
 	})
 	t.Run("Candidate's vote is not equal", func(t *testing.T) {
@@ -548,10 +533,7 @@ func TestHandle(t *testing.T) {
 		elp5 := bd5.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act5).Build()
-		selp5, err := action.Sign(elp5, senderKey)
-		require.NoError(err)
-		require.NotNil(selp5)
-		caller := selp5.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx5 = protocol.WithBlockCtx(
 			ctx5,
@@ -566,7 +548,7 @@ func TestHandle(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p5.Validate(ctx5, selp5.Action(), sm5)
+		err = p5.Validate(ctx5, elp5, sm5)
 		require.Contains(err.Error(), "delegates are not as expected")
 	})
 }

--- a/action/protocol/poll/lifelong_protocol.go
+++ b/action/protocol/poll/lifelong_protocol.go
@@ -62,15 +62,15 @@ func (p *lifeLongDelegatesProtocol) CreateGenesisStates(
 	return setCandidates(ctx, sm, nil, p.delegates, uint64(1))
 }
 
-func (p *lifeLongDelegatesProtocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	if err := validate(ctx, sm, p, act); err != nil {
+func (p *lifeLongDelegatesProtocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	if err := validate(ctx, sm, p, elp.Action()); err != nil {
 		return nil, err
 	}
-	return handle(ctx, act, sm, nil, p.addr.String())
+	return handle(ctx, elp.Action(), sm, nil, p.addr.String())
 }
 
-func (p *lifeLongDelegatesProtocol) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	return validate(ctx, sr, p, act)
+func (p *lifeLongDelegatesProtocol) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	return validate(ctx, sr, p, elp.Action())
 }
 
 func (p *lifeLongDelegatesProtocol) CalculateCandidatesByHeight(ctx context.Context, _ protocol.StateReader, _ uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/lifelong_protocol_test.go
+++ b/action/protocol/poll/lifelong_protocol_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 IoTeX Foundation
+// Copyright (c) 2024 IoTeX Foundation
 // This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
 // or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
 // This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/action/protocol"
 	"github.com/iotexproject/iotex-core/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/blockchain/genesis"
@@ -92,7 +93,8 @@ func TestProtocol_Handle_WithLifeLong(t *testing.T) {
 	require.NoError(err)
 
 	ctx = protocol.WithFeatureWithHeightCtx(ctx)
-	receipt, error := p.Handle(ctx, nil, sm)
+	elp := (&action.EnvelopeBuilder{}).SetAction(&action.GrantReward{}).Build()
+	receipt, error := p.Handle(ctx, elp, sm)
 	require.Nil(receipt)
 	require.NoError(error)
 }

--- a/action/protocol/poll/nativestakingV2.go
+++ b/action/protocol/poll/nativestakingV2.go
@@ -69,12 +69,12 @@ func (ns *nativeStakingV2) CreatePostSystemActions(ctx context.Context, sr proto
 	return createPostSystemActions(ctx, sr, ns)
 }
 
-func (ns *nativeStakingV2) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	return handle(ctx, act, sm, ns.candIndexer, ns.addr.String())
+func (ns *nativeStakingV2) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	return handle(ctx, elp.Action(), sm, ns.candIndexer, ns.addr.String())
 }
 
-func (ns *nativeStakingV2) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	return validate(ctx, sr, ns, act)
+func (ns *nativeStakingV2) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	return validate(ctx, sr, ns, elp.Action())
 }
 
 func (ns *nativeStakingV2) CalculateCandidatesByHeight(ctx context.Context, sr protocol.StateReader, height uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/staking_command.go
+++ b/action/protocol/poll/staking_command.go
@@ -84,16 +84,16 @@ func (sc *stakingCommand) CreatePostSystemActions(ctx context.Context, sr protoc
 	return createPostSystemActions(ctx, sr, sc)
 }
 
-func (sc *stakingCommand) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
+func (sc *stakingCommand) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
 	if sc.useV2(ctx, sm) {
-		return sc.stakingV2.Handle(ctx, act, sm)
+		return sc.stakingV2.Handle(ctx, elp, sm)
 	}
-	return sc.stakingV1.Handle(ctx, act, sm)
+	return sc.stakingV1.Handle(ctx, elp, sm)
 }
 
-func (sc *stakingCommand) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
+func (sc *stakingCommand) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
 	// no height here,  v1 v2 has the same validate method, so directly use common one
-	return validate(ctx, sr, sc, act)
+	return validate(ctx, sr, sc, elp.Action())
 }
 
 func (sc *stakingCommand) CalculateCandidatesByHeight(ctx context.Context, sr protocol.StateReader, height uint64) (state.CandidateList, error) {

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -190,16 +190,16 @@ func (sc *stakingCommittee) CreatePostSystemActions(ctx context.Context, sr prot
 	return createPostSystemActions(ctx, sr, sc)
 }
 
-func (sc *stakingCommittee) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
-	receipt, err := sc.governanceStaking.Handle(ctx, act, sm)
+func (sc *stakingCommittee) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	receipt, err := sc.governanceStaking.Handle(ctx, elp, sm)
 	if err := sc.persistNativeBuckets(ctx, receipt, err); err != nil {
 		return nil, err
 	}
 	return receipt, err
 }
 
-func (sc *stakingCommittee) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	return validate(ctx, sr, sc, act)
+func (sc *stakingCommittee) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	return validate(ctx, sr, sc, elp.Action())
 }
 
 func (sc *stakingCommittee) Name() string {

--- a/action/protocol/poll/staking_committee_test.go
+++ b/action/protocol/poll/staking_committee_test.go
@@ -214,10 +214,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(tsf).Build()
-		selp, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp)
-		receipt, err := p.Handle(ctx, selp.Action(), nil)
+		receipt, err := p.Handle(ctx, elp, nil)
 		require.NoError(err)
 		require.Nil(receipt)
 	})
@@ -234,10 +231,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act2).Build()
-		selp2, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp2)
-		receipt, err := p.Handle(ctx2, selp2.Action(), sm2)
+		receipt, err := p.Handle(ctx2, elp, sm2)
 		require.NoError(err)
 		require.NotNil(receipt)
 
@@ -264,10 +258,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act2).Build()
-		selp2, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp2)
-		caller := selp2.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx2 = protocol.WithBlockCtx(
 			ctx2,
@@ -282,7 +273,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p.Validate(ctx2, selp2.Action(), sm2)
+		err = p.Validate(ctx2, elp, sm2)
 		require.Contains(err.Error(), "Only producer could create this protocol")
 	})
 
@@ -301,10 +292,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp := bd.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act3).Build()
-		selp3, err := action.Sign(elp, senderKey)
-		require.NoError(err)
-		require.NotNil(selp3)
-		caller := selp3.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx3 = protocol.WithBlockCtx(
 			ctx3,
@@ -319,7 +307,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p.Validate(ctx3, selp3.Action(), sm3)
+		err = p.Validate(ctx3, elp, sm3)
 		require.Contains(err.Error(), "duplicate candidate")
 	})
 
@@ -337,10 +325,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp4 := bd4.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act4).Build()
-		selp4, err := action.Sign(elp4, senderKey)
-		require.NoError(err)
-		require.NotNil(selp4)
-		caller := selp4.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx4 = protocol.WithBlockCtx(
 			ctx4,
@@ -356,7 +341,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 			},
 		)
 		ctx4 = protocol.WithFeatureWithHeightCtx(ctx4)
-		err = p4.Validate(ctx4, selp4.Action(), sm4)
+		err = p4.Validate(ctx4, elp4, sm4)
 		require.Contains(err.Error(), "the proposed delegate list length")
 	})
 
@@ -373,10 +358,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 		elp5 := bd5.SetGasLimit(uint64(100000)).
 			SetGasPrice(big.NewInt(10)).
 			SetAction(act5).Build()
-		selp5, err := action.Sign(elp5, senderKey)
-		require.NoError(err)
-		require.NotNil(selp5)
-		caller := selp5.SenderAddress()
+		caller := senderKey.PublicKey().Address()
 		require.NotNil(caller)
 		ctx5 = protocol.WithBlockCtx(
 			ctx5,
@@ -391,7 +373,7 @@ func TestHandle_StakingCommittee(t *testing.T) {
 				Caller: caller,
 			},
 		)
-		err = p5.Validate(ctx5, selp5.Action(), sm5)
+		err = p5.Validate(ctx5, elp5, sm5)
 		require.Contains(err.Error(), "delegates are not as expected")
 	})
 }

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -69,14 +69,14 @@ type PostSystemActionsCreator interface {
 
 // ActionValidator is the interface of validating an action
 type ActionValidator interface {
-	Validate(context.Context, action.Action, StateReader) error
+	Validate(context.Context, action.Envelope, StateReader) error
 }
 
 // ActionHandler is the interface for the action handlers. For each incoming action, the assembled actions will be
 // called one by one to process it. ActionHandler implementation is supposed to parse the sub-type of the action to
 // decide if it wants to handle this action or not.
 type ActionHandler interface {
-	Handle(context.Context, action.Action, StateManager) (*action.Receipt, error)
+	Handle(context.Context, action.Envelope, StateManager) (*action.Receipt, error)
 }
 
 type (

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -183,8 +183,8 @@ func createGrantRewardAction(rewardType int, height uint64) action.Envelope {
 }
 
 // Validate validates a reward action
-func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	switch act := act.(type) {
+func (p *Protocol) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	switch act := elp.Action().(type) {
 	case *action.GrantReward:
 		actionCtx := protocol.MustGetActionCtx(ctx)
 		if !address.Equal(protocol.MustGetBlockCtx(ctx).Producer, actionCtx.Caller) {
@@ -204,12 +204,13 @@ func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.
 // Handle handles the actions on the rewarding protocol
 func (p *Protocol) Handle(
 	ctx context.Context,
-	act action.Action,
+	elp action.Envelope,
 	sm protocol.StateManager,
 ) (*action.Receipt, error) {
 	// TODO: simplify the boilerplate
 	var (
 		si                = sm.Snapshot()
+		act               = elp.Action()
 		dynamicGasAct, ok = act.(action.TxDynamicGas)
 	)
 	if !ok {

--- a/action/protocol/rewarding/protocol_test.go
+++ b/action/protocol/rewarding/protocol_test.go
@@ -221,7 +221,7 @@ func TestProtocol_Validate(t *testing.T) {
 	g := genesis.Default
 	g.NewfoundlandBlockHeight = 0
 	p := NewProtocol(g.Rewarding)
-	act := createGrantRewardAction(0, uint64(0)).Action()
+	act := createGrantRewardAction(0, uint64(0))
 	ctx := protocol.WithBlockCtx(
 		context.Background(),
 		protocol.BlockCtx{
@@ -378,10 +378,7 @@ func TestProtocol_Handle(t *testing.T) {
 		SetGasLimit(deposit.GasLimit()).
 		SetAction(&deposit).
 		Build()
-	se1, err := action.Sign(e1, identityset.PrivateKey(0))
-	require.NoError(t, err)
-
-	_, err = p.Handle(ctx, se1.Action(), sm)
+	_, err = p.Handle(ctx, e1, sm)
 	require.NoError(t, err)
 	balance, _, err := p.TotalBalance(ctx, sm)
 	require.NoError(t, err)
@@ -390,8 +387,6 @@ func TestProtocol_Handle(t *testing.T) {
 	// Grant
 	// Test for createGrantRewardAction
 	e2 := createGrantRewardAction(0, uint64(0))
-	se2, err := action.Sign(e2, identityset.PrivateKey(0))
-	require.NoError(t, err)
 	ctx = protocol.WithActionCtx(
 		ctx,
 		protocol.ActionCtx{
@@ -400,7 +395,7 @@ func TestProtocol_Handle(t *testing.T) {
 			Nonce:    0,
 		},
 	)
-	receipt, err := p.Handle(ctx, se2.Action(), sm)
+	receipt, err := p.Handle(ctx, e2, sm)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(iotextypes.ReceiptStatus_Success), receipt.Status)
 	assert.Equal(t, 1, len(receipt.Logs()))
@@ -413,7 +408,7 @@ func TestProtocol_Handle(t *testing.T) {
 		},
 	)
 	// Grant the block reward again should fail
-	receipt, err = p.Handle(ctx, se2.Action(), sm)
+	receipt, err = p.Handle(ctx, e2, sm)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(iotextypes.ReceiptStatus_Failure), receipt.Status)
 
@@ -426,8 +421,6 @@ func TestProtocol_Handle(t *testing.T) {
 		SetGasLimit(claim.GasLimit()).
 		SetAction(&claim).
 		Build()
-	se3, err := action.Sign(e3, identityset.PrivateKey(0))
-	require.NoError(t, err)
 	ctx = protocol.WithActionCtx(
 		ctx,
 		protocol.ActionCtx{
@@ -436,7 +429,7 @@ func TestProtocol_Handle(t *testing.T) {
 			Nonce:    2,
 		},
 	)
-	_, err = p.Handle(ctx, se3.Action(), sm)
+	_, err = p.Handle(ctx, e3, sm)
 	require.NoError(t, err)
 	balance, _, err = p.TotalBalance(ctx, sm)
 	require.NoError(t, err)

--- a/action/protocol/rolldpos/epoch.go
+++ b/action/protocol/rolldpos/epoch.go
@@ -98,7 +98,7 @@ func ProtocolAddr() address.Address {
 }
 
 // Handle handles a modification
-func (p *Protocol) Handle(context.Context, action.Action, protocol.StateManager) (*action.Receipt, error) {
+func (p *Protocol) Handle(context.Context, action.Envelope, protocol.StateManager) (*action.Receipt, error) {
 	return nil, nil
 }
 

--- a/action/protocol/staking/handler_candidate_selfstake_test.go
+++ b/action/protocol/staking/handler_candidate_selfstake_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
 package staking
 
 import (
@@ -425,6 +430,8 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 			require.NoError(setupAccount(sm, test.caller, test.initBalance))
 			act := action.NewCandidateActivate(nonce, test.gasLimit, test.gasPrice, test.bucketID)
 			IntrinsicGas, _ := act.IntrinsicGas()
+			elp := builder.SetNonce(act.Nonce()).SetGasLimit(act.GasLimit()).
+				SetGasPrice(act.GasPrice()).SetAction(act).Build()
 			ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
 				Caller:       test.caller,
 				GasPrice:     test.gasPrice,
@@ -441,11 +448,11 @@ func TestProtocol_HandleCandidateSelfStake(t *testing.T) {
 			cfg.TsunamiBlockHeight = 1
 			ctx = genesis.WithGenesisContext(ctx, cfg)
 			ctx = protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
-			require.Equal(test.err, errors.Cause(p.Validate(ctx, act, sm)))
+			require.Equal(test.err, errors.Cause(p.Validate(ctx, elp, sm)))
 			if test.err != nil {
 				return
 			}
-			r, err := p.Handle(ctx, act, sm)
+			r, err := p.Handle(ctx, elp, sm)
 			require.NoError(err)
 			if r != nil {
 				require.Equal(uint64(test.status), r.Status)

--- a/action/protocol/staking/handler_candidate_transfer_ownership_test.go
+++ b/action/protocol/staking/handler_candidate_transfer_ownership_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
 package staking
 
 import (
@@ -201,8 +206,9 @@ func TestProtocol_HandleCandidateTransferOwnership(t *testing.T) {
 			require.NoError(setupAccount(sm, test.caller, test.initBalance))
 			act, err := action.NewCandidateTransferOwnership(test.nonce, test.gasLimit, test.gasPrice, test.owner.String(), test.payload)
 			require.NoError(err)
-
 			IntrinsicGas, _ := act.IntrinsicGas()
+			elp := builder.SetNonce(act.Nonce()).SetGasLimit(act.GasLimit()).
+				SetGasPrice(act.GasPrice()).SetAction(act).Build()
 			ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
 				Caller:       test.caller,
 				GasPrice:     test.gasPrice,
@@ -219,7 +225,7 @@ func TestProtocol_HandleCandidateTransferOwnership(t *testing.T) {
 			cfg.UpernavikBlockHeight = 1 // enable candidate owner transfer feature
 			ctx = genesis.WithGenesisContext(ctx, cfg)
 			ctx = protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
-			require.NoError(p.Validate(ctx, act, sm))
+			require.NoError(p.Validate(ctx, elp, sm))
 			_, _, err = p.handleCandidateTransferOwnership(ctx, act, csm)
 			if test.err != nil {
 				require.Error(err)

--- a/action/protocol/staking/handler_stake_migrate.go
+++ b/action/protocol/staking/handler_stake_migrate.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
 package staking
 
 import (
@@ -197,7 +202,11 @@ func (p *Protocol) createNFTBucket(ctx context.Context, exeAct *action.Execution
 	if exctPtl == nil {
 		return nil, errors.New("execution protocol is not registered")
 	}
-	excReceipt, err := exctPtl.Handle(ctx, exeAct, sm)
+	elp := (&action.EnvelopeBuilder{}).SetNonce(exeAct.Nonce()).
+		SetGasLimit(exeAct.GasLimit()).
+		SetGasPrice(exeAct.GasPrice()).
+		SetAction(exeAct).Build()
+	excReceipt, err := exctPtl.Handle(ctx, elp, sm)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to handle execution action")
 	}

--- a/action/protocol/staking/handler_stake_migrate_test.go
+++ b/action/protocol/staking/handler_stake_migrate_test.go
@@ -1,3 +1,8 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
 package staking
 
 import (
@@ -97,8 +102,8 @@ func TestHandleStakeMigrate(t *testing.T) {
 			IntrinsicGas: instriGas,
 			Nonce:        act.Nonce(),
 		})
-		r.NoError(p.Validate(ctx, act.Action(), sm))
-		return p.Handle(ctx, act.Action(), sm)
+		r.NoError(p.Validate(ctx, act.Envelope, sm))
+		return p.Handle(ctx, act.Envelope, sm)
 	}
 	runBlock := func(ctx context.Context, p *Protocol, sm protocol.StateManager, height uint64, t time.Time, acts ...*action.SealedEnvelope) ([]*action.Receipt, []error) {
 		ctx = protocol.WithBlockchainCtx(ctx, protocol.BlockchainCtx{
@@ -254,7 +259,7 @@ func TestHandleStakeMigrate(t *testing.T) {
 	t.Run("error from contract call", func(t *testing.T) {
 		pa := NewPatches()
 		defer pa.Reset()
-		pa.ApplyMethodFunc(excPrtl, "Handle", func(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
+		pa.ApplyMethodFunc(excPrtl, "Handle", func(ctx context.Context, act action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
 			return nil, errors.New("execution failed error")
 		})
 		sm.EXPECT().Revert(gomock.Any()).Return(nil).Times(1)

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -394,7 +394,7 @@ func (p *Protocol) Commit(ctx context.Context, sm protocol.StateManager) error {
 }
 
 // Handle handles a staking message
-func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.StateManager) (*action.Receipt, error) {
+func (p *Protocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
 	featureWithHeightCtx := protocol.MustGetFeatureWithHeightCtx(ctx)
 	height, err := sm.Height()
 	if err != nil {
@@ -404,7 +404,7 @@ func (p *Protocol) Handle(ctx context.Context, act action.Action, sm protocol.St
 	if err != nil {
 		return nil, err
 	}
-	return p.handle(ctx, act, csm)
+	return p.handle(ctx, elp.Action(), csm)
 }
 
 func (p *Protocol) handle(ctx context.Context, act action.Action, csm CandidateStateManager) (*action.Receipt, error) {
@@ -474,11 +474,11 @@ func (p *Protocol) handle(ctx context.Context, act action.Action, csm CandidateS
 }
 
 // Validate validates a staking message
-func (p *Protocol) Validate(ctx context.Context, act action.Action, sr protocol.StateReader) error {
-	if act == nil {
+func (p *Protocol) Validate(ctx context.Context, elp action.Envelope, sr protocol.StateReader) error {
+	if elp == nil || elp.Action() == nil {
 		return action.ErrNilAction
 	}
-	switch act := act.(type) {
+	switch act := elp.Action().(type) {
 	case *action.CreateStake:
 		return p.validateCreateStake(ctx, act)
 	case *action.Unstake:

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -27,6 +27,7 @@ const (
 
 var (
 	_ hasDestination      = (*Transfer)(nil)
+	_ hasSize             = (*Transfer)(nil)
 	_ EthCompatibleAction = (*Transfer)(nil)
 )
 

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -75,11 +75,6 @@ func (tsf *Transfer) Recipient() string { return tsf.recipient }
 // Destination returns the recipient address as destination.
 func (tsf *Transfer) Destination() string { return tsf.recipient }
 
-// TotalSize returns the total size of this Transfer
-func (tsf *Transfer) TotalSize() uint32 {
-	return tsf.BasicActionSize() + tsf.Size()
-}
-
 // Size returns the total size of this Transfer
 func (tsf *Transfer) Size() uint32 {
 	var size uint32

--- a/action/transfer.go
+++ b/action/transfer.go
@@ -76,7 +76,12 @@ func (tsf *Transfer) Destination() string { return tsf.recipient }
 
 // TotalSize returns the total size of this Transfer
 func (tsf *Transfer) TotalSize() uint32 {
-	size := tsf.BasicActionSize()
+	return tsf.BasicActionSize() + tsf.Size()
+}
+
+// Size returns the total size of this Transfer
+func (tsf *Transfer) Size() uint32 {
+	var size uint32
 	if tsf.amount != nil && len(tsf.amount.Bytes()) > 0 {
 		size += uint32(len(tsf.amount.Bytes()))
 	}

--- a/action/transfer_test.go
+++ b/action/transfer_test.go
@@ -23,6 +23,7 @@ func TestTransferSignVerify(t *testing.T) {
 	tsf, err := NewTransfer(1, big.NewInt(10), recipientAddr.String(), []byte{}, uint64(100000), big.NewInt(10))
 	require.NoError(err)
 	require.EqualValues(21, tsf.BasicActionSize())
+	require.EqualValues(66, tsf.Size())
 	require.EqualValues(87, tsf.TotalSize())
 
 	bd := &EnvelopeBuilder{}
@@ -44,6 +45,7 @@ func TestTransferSignVerify(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(selp)
 	require.EqualValues(21, tsf.BasicActionSize())
+	require.EqualValues(66, tsf.Size())
 	require.EqualValues(87, tsf.TotalSize())
 
 	// verify signature
@@ -79,7 +81,8 @@ func TestTransfer(t *testing.T) {
 	require.Equal(senderKey.PublicKey().HexString(), w.SrcPubkey().HexString())
 	require.Equal(recipientAddr.String(), tsf.Recipient())
 	require.Equal(recipientAddr.String(), tsf.Destination())
-	require.Equal(uint32(87), tsf.TotalSize())
+	require.EqualValues(66, tsf.Size())
+	require.EqualValues(87, tsf.TotalSize())
 
 	gas, err := tsf.IntrinsicGas()
 	require.NoError(err)

--- a/action/transfer_test.go
+++ b/action/transfer_test.go
@@ -24,7 +24,6 @@ func TestTransferSignVerify(t *testing.T) {
 	require.NoError(err)
 	require.EqualValues(21, tsf.BasicActionSize())
 	require.EqualValues(66, tsf.Size())
-	require.EqualValues(87, tsf.TotalSize())
 
 	bd := &EnvelopeBuilder{}
 	eb := bd.SetNonce(tsf.nonce).
@@ -33,6 +32,7 @@ func TestTransferSignVerify(t *testing.T) {
 		SetAction(tsf).Build()
 	elp, ok := eb.(*envelope)
 	require.True(ok)
+	require.EqualValues(87, eb.Size())
 
 	w := AssembleSealedEnvelope(elp, senderKey.PublicKey(), []byte("lol"))
 	require.Error(w.VerifySignature())
@@ -44,10 +44,6 @@ func TestTransferSignVerify(t *testing.T) {
 	selp, err := Sign(elp, senderKey)
 	require.NoError(err)
 	require.NotNil(selp)
-	require.EqualValues(21, tsf.BasicActionSize())
-	require.EqualValues(66, tsf.Size())
-	require.EqualValues(87, tsf.TotalSize())
-
 	// verify signature
 	require.NoError(selp.VerifySignature())
 }
@@ -68,6 +64,7 @@ func TestTransfer(t *testing.T) {
 		SetAction(tsf).Build()
 	elp, ok := eb.(*envelope)
 	require.True(ok)
+	require.EqualValues(87, eb.Size())
 
 	w := AssembleSealedEnvelope(elp, senderKey.PublicKey(), []byte("lol"))
 	require.Error(w.VerifySignature())
@@ -82,7 +79,6 @@ func TestTransfer(t *testing.T) {
 	require.Equal(recipientAddr.String(), tsf.Recipient())
 	require.Equal(recipientAddr.String(), tsf.Destination())
 	require.EqualValues(66, tsf.Size())
-	require.EqualValues(87, tsf.TotalSize())
 
 	gas, err := tsf.IntrinsicGas()
 	require.NoError(err)

--- a/misc/scripts/mockgen.sh
+++ b/misc/scripts/mockgen.sh
@@ -63,6 +63,12 @@ mockgen -destination=./test/mock/mock_actioniterator/mock_actioniterator.go  \
         -package=mock_actioniterator \
         ActionIterator
 
+mockgen -destination=./action/protocol/mock_protocol.go  \
+        -source=./action/protocol/protocol.go \
+        -self_package=github.com/iotexproject/iotex-core/action/protocol \
+        -package=protocol \
+        Protocol
+
 mkdir -p ./test/mock/mock_poll
 mockgen -destination=./test/mock/mock_poll/mock_poll.go  \
         -source=./action/protocol/poll/protocol.go \

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -186,7 +186,7 @@ func (ws *workingSet) runAction(
 		return nil, err
 	}
 	for _, actionHandler := range reg.All() {
-		receipt, err := actionHandler.Handle(ctx, selp.Action(), ws)
+		receipt, err := actionHandler.Handle(ctx, selp.Envelope, ws)
 		if err != nil {
 			return nil, errors.Wrapf(
 				err,
@@ -474,7 +474,7 @@ func (ws *workingSet) process(ctx context.Context, actions []*action.SealedEnvel
 		}
 		for _, p := range reg.All() {
 			if validator, ok := p.(protocol.ActionValidator); ok {
-				if err := validator.Validate(ctxWithActionContext, act.Action(), ws); err != nil {
+				if err := validator.Validate(ctxWithActionContext, act.Envelope, ws); err != nil {
 					return err
 				}
 			}
@@ -580,7 +580,7 @@ func (ws *workingSet) pickAndRunActions(
 			if err == nil {
 				for _, p := range reg.All() {
 					if validator, ok := p.(protocol.ActionValidator); ok {
-						if err = validator.Validate(actionCtx, nextAction.Action(), ws); err != nil {
+						if err = validator.Validate(actionCtx, nextAction.Envelope, ws); err != nil {
 							break
 						}
 					}

--- a/test/mock/mock_envelope/mock_envelope.go
+++ b/test/mock/mock_envelope/mock_envelope.go
@@ -232,6 +232,20 @@ func (mr *MockEnvelopeMockRecorder) SetNonce(n interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNonce", reflect.TypeOf((*MockEnvelope)(nil).SetNonce), n)
 }
 
+// Size mocks base method.
+func (m *MockEnvelope) Size() uint32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Size")
+	ret0, _ := ret[0].(uint32)
+	return ret0
+}
+
+// Size indicates an expected call of Size.
+func (mr *MockEnvelopeMockRecorder) Size() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Size", reflect.TypeOf((*MockEnvelope)(nil).Size))
+}
+
 // ToEthTx mocks base method.
 func (m *MockEnvelope) ToEthTx(arg0 uint32, arg1 iotextypes.Encoding) (*types.Transaction, error) {
 	m.ctrl.T.Helper()

--- a/test/mock/mock_poll/mock_poll.go
+++ b/test/mock/mock_poll/mock_poll.go
@@ -126,7 +126,7 @@ func (mr *MockProtocolMockRecorder) ForceRegister(arg0 interface{}) *gomock.Call
 }
 
 // Handle mocks base method.
-func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Action, arg2 protocol.StateManager) (*action.Receipt, error) {
+func (m *MockProtocol) Handle(arg0 context.Context, arg1 action.Envelope, arg2 protocol.StateManager) (*action.Receipt, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Handle", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*action.Receipt)
@@ -220,7 +220,7 @@ func (mr *MockProtocolMockRecorder) Register(arg0 interface{}) *gomock.Call {
 }
 
 // Validate mocks base method.
-func (m *MockProtocol) Validate(arg0 context.Context, arg1 action.Action, arg2 protocol.StateReader) error {
+func (m *MockProtocol) Validate(arg0 context.Context, arg1 action.Envelope, arg2 protocol.StateReader) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Validate", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
# Description
1. All our actions include a data field `AbstractAction`, while the envelope struct also contains `AbstractAction`.
2. the only reason is b/c `transfer` and `execution` has a `TotalSize()` method that needs to access fields in `AbstractAction`
3. added an interface `Envelope.Size()` to reflect the total size for transfer and execution 
4. pass `Envelope` to protocol's `Handle()` and `Validate()` method

## benefits:
1. simplify code and data structure
2. better readability, less clumsy code
3. for example, `SignedTransfer` now has 7 inputs, after this is done, it will reduce to 3 inputs

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
