### PR TITLE
[workingset] remove action from actpool upon tx container error

### DIFF
--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -39,6 +39,7 @@ var (
 	)
 
 	errInvalidSystemActionLayout = errors.New("system action layout is invalid")
+	errUnfoldTxContainer         = errors.New("failed to unfold tx container")
 )
 
 func init() {
@@ -161,7 +162,7 @@ func (ws *workingSet) runAction(
 	if protocol.MustGetFeatureCtx(ctx).UseTxContainer {
 		if container, ok := selp.Action().(action.TxContainer); ok {
 			if err := container.Unfold(selp, ctx, ws.checkContract); err != nil {
-				return nil, errors.Wrapf(err, "Failed to unfold EVM tx inside the container")
+				return nil, errors.Wrap(errUnfoldTxContainer, err.Error())
 			}
 		}
 	}
@@ -593,7 +594,7 @@ func (ws *workingSet) pickAndRunActions(
 				// do nothing
 			case action.ErrChainID:
 				continue
-			case action.ErrGasLimit:
+			case action.ErrGasLimit, errUnfoldTxContainer:
 				actionIterator.PopAccount()
 				continue
 			default:


### PR DESCRIPTION
# Description
if unfolding a tx returns error, the tx should be removed from actpool so it won't keep stuck there

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
