### PR TITLE
add endorsement op but only allow legacy

### DIFF
--- a/action/candidate_endorsement.go
+++ b/action/candidate_endorsement.go
@@ -35,23 +35,84 @@ const (
 			"outputs": [],
 			"stateMutability": "nonpayable",
 			"type": "function"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "uint64",
+					"name": "bucketIndex",
+					"type": "uint64"
+				}
+			],
+			"name": "endorseCandidate",
+			"outputs": [],
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "uint64",
+					"name": "bucketIndex",
+					"type": "uint64"
+				}
+			],
+			"name": "intentToRevokeEndorsement",
+			"outputs": [],
+			"stateMutability": "nonpayable",
+			"type": "function"
+		},
+		{
+			"inputs": [
+				{
+					"internalType": "uint64",
+					"name": "bucketIndex",
+					"type": "uint64"
+				}
+			],
+			"name": "revokeEndorsement",
+			"outputs": [],
+			"stateMutability": "nonpayable",
+			"type": "function"
 		}
 	]`
 )
 
-var (
-	candidateEndorsementMethod abi.Method
+// CandidateEndorsementOp defines the operation of CandidateEndorsement
+const (
+	// CandidateEndorsementOpLegacy is the operation to endorse or unendorse a candidate in legacy version
+	CandidateEndorsementOpLegacy CandidateEndorsementOp = iota
+	// CandidateEndorsementOpEndorse is the operation to endorse a candidate
+	CandidateEndorsementOpEndorse
+	// CandidateEndorsementOpIntentToRevoke is the operation to intent to revoke an endorsement
+	CandidateEndorsementOpIntentToRevoke
+	// CandidateEndorsementOpRevoke is the operation to revoke an endorsement
+	CandidateEndorsementOpRevoke
 )
 
-// CandidateEndorsement is the action to endorse or unendorse a candidate
-type CandidateEndorsement struct {
-	AbstractAction
+var (
+	candidateEndorsementLegacyMethod         abi.Method
+	candidateEndorsementEndorseMethod        abi.Method
+	caniddateEndorsementIntentToRevokeMethod abi.Method
+	candidateEndorsementRevokeMethod         abi.Method
+)
 
-	// bucketIndex is the bucket index want to be endorsed or unendorsed
-	bucketIndex uint64
-	// endorse is true if the action is to endorse a candidate, false if unendorse
-	endorse bool
-}
+type (
+	// CandidateEndorsement is the action to endorse or unendorse a candidate
+	CandidateEndorsement struct {
+		AbstractAction
+
+		// bucketIndex is the bucket index want to be endorsed or unendorsed
+		bucketIndex uint64
+		// endorse is true if the action is to endorse a candidate, false if unendorse
+		endorse bool
+		// op is the operation of the endorsement
+		op CandidateEndorsementOp
+	}
+
+	// CandidateEndorsementOp defines the operation of CandidateEndorsement
+	CandidateEndorsementOp uint8
+)
 
 func init() {
 	candidateEndorsementInterface, err := abi.JSON(strings.NewReader(candidateEndorsementInterfaceABI))
@@ -59,20 +120,27 @@ func init() {
 		panic(err)
 	}
 	var ok bool
-	candidateEndorsementMethod, ok = candidateEndorsementInterface.Methods["candidateEndorsement"]
+	candidateEndorsementLegacyMethod, ok = candidateEndorsementInterface.Methods["candidateEndorsement"]
 	if !ok {
 		panic("fail to load the candidateEndorsement method")
+	}
+	candidateEndorsementEndorseMethod, ok = candidateEndorsementInterface.Methods["endorseCandidate"]
+	if !ok {
+		panic("fail to load the endorseCandidate method")
+	}
+	caniddateEndorsementIntentToRevokeMethod, ok = candidateEndorsementInterface.Methods["intentToRevokeEndorsement"]
+	if !ok {
+		panic("fail to load the intentToRevokeEndorsement method")
+	}
+	candidateEndorsementRevokeMethod, ok = candidateEndorsementInterface.Methods["revokeEndorsement"]
+	if !ok {
+		panic("fail to load the revokeEndorsement method")
 	}
 }
 
 // BucketIndex returns the bucket index of the action
 func (act *CandidateEndorsement) BucketIndex() uint64 {
 	return act.bucketIndex
-}
-
-// IsEndorse returns true if the action is to endorse a candidate
-func (act *CandidateEndorsement) IsEndorse() bool {
-	return act.endorse
 }
 
 // IntrinsicGas returns the intrinsic gas of a CandidateEndorsement
@@ -90,11 +158,28 @@ func (act *CandidateEndorsement) Cost() (*big.Int, error) {
 	return fee, nil
 }
 
+// IsLegacy returns true if the action is in legacy version
+func (act *CandidateEndorsement) IsLegacy() bool {
+	return act.op == CandidateEndorsementOpLegacy
+}
+
+// Op returns the operation of the endorsement
+func (act *CandidateEndorsement) Op() CandidateEndorsementOp {
+	if act.op == CandidateEndorsementOpLegacy {
+		if act.endorse {
+			return CandidateEndorsementOpEndorse
+		}
+		return CandidateEndorsementOpIntentToRevoke
+	}
+	return act.op
+}
+
 // Proto converts CandidateEndorsement to protobuf's Action
 func (act *CandidateEndorsement) Proto() *iotextypes.CandidateEndorsement {
 	return &iotextypes.CandidateEndorsement{
 		BucketIndex: act.bucketIndex,
 		Endorse:     act.endorse,
+		Op:          uint32(act.op),
 	}
 }
 
@@ -104,16 +189,34 @@ func (act *CandidateEndorsement) LoadProto(pbAct *iotextypes.CandidateEndorsemen
 		return ErrNilProto
 	}
 	act.bucketIndex = pbAct.GetBucketIndex()
+	act.op = CandidateEndorsementOp(pbAct.GetOp())
 	act.endorse = pbAct.GetEndorse()
 	return nil
 }
 
 func (act *CandidateEndorsement) encodeABIBinary() ([]byte, error) {
-	data, err := candidateEndorsementMethod.Inputs.Pack(act.bucketIndex, act.endorse)
+	var method abi.Method
+	switch act.op {
+	case CandidateEndorsementOpLegacy:
+		data, err := candidateEndorsementLegacyMethod.Inputs.Pack(act.bucketIndex, act.endorse)
+		if err != nil {
+			return nil, err
+		}
+		return append(candidateEndorsementLegacyMethod.ID, data...), nil
+	case CandidateEndorsementOpEndorse:
+		method = candidateEndorsementEndorseMethod
+	case CandidateEndorsementOpIntentToRevoke:
+		method = caniddateEndorsementIntentToRevokeMethod
+	case CandidateEndorsementOpRevoke:
+		method = candidateEndorsementRevokeMethod
+	default:
+		return nil, errors.New("invalid operation")
+	}
+	data, err := method.Inputs.Pack(act.bucketIndex)
 	if err != nil {
 		return nil, err
 	}
-	return append(candidateEndorsementMethod.ID, data...), nil
+	return append(method.ID, data...), nil
 }
 
 // ToEthTx returns an Ethereum transaction which corresponds to this action
@@ -132,8 +235,8 @@ func (act *CandidateEndorsement) ToEthTx(_ uint32) (*types.Transaction, error) {
 	}), nil
 }
 
-// NewCandidateEndorsement returns a CandidateEndorsement action
-func NewCandidateEndorsement(nonce, gasLimit uint64, gasPrice *big.Int, bucketIndex uint64, endorse bool) *CandidateEndorsement {
+// NewCandidateEndorsementLegacy returns a CandidateEndorsement action
+func NewCandidateEndorsementLegacy(nonce, gasLimit uint64, gasPrice *big.Int, bucketIndex uint64, endorse bool) *CandidateEndorsement {
 	return &CandidateEndorsement{
 		AbstractAction: AbstractAction{
 			version:  version.ProtocolVersion,
@@ -146,28 +249,69 @@ func NewCandidateEndorsement(nonce, gasLimit uint64, gasPrice *big.Int, bucketIn
 	}
 }
 
+// NewCandidateEndorsement returns a CandidateEndorsement action
+func NewCandidateEndorsement(nonce, gasLimit uint64, gasPrice *big.Int, bucketIndex uint64, op CandidateEndorsementOp) (*CandidateEndorsement, error) {
+	if op == CandidateEndorsementOpLegacy {
+		return nil, errors.New("invalid operation")
+	}
+	return &CandidateEndorsement{
+		AbstractAction: AbstractAction{
+			version:  version.ProtocolVersion,
+			nonce:    nonce,
+			gasLimit: gasLimit,
+			gasPrice: gasPrice,
+		},
+		bucketIndex: bucketIndex,
+		op:          op,
+	}, nil
+}
+
 // NewCandidateEndorsementFromABIBinary parses the smart contract input and creates an action
 func NewCandidateEndorsementFromABIBinary(data []byte) (*CandidateEndorsement, error) {
+	if len(data) <= 4 {
+		return nil, errDecodeFailure
+	}
 	var (
 		paramsMap = map[string]any{}
 		cr        CandidateEndorsement
+		method    abi.Method
 	)
-	// sanity check
-	if len(data) <= 4 || !bytes.Equal(candidateEndorsementMethod.ID, data[:4]) {
+	switch {
+	case bytes.Equal(candidateEndorsementLegacyMethod.ID, data[:4]):
+		if err := candidateEndorsementLegacyMethod.Inputs.UnpackIntoMap(paramsMap, data[4:]); err != nil {
+			return nil, err
+		}
+		bucketID, ok := paramsMap["bucketIndex"].(uint64)
+		if !ok {
+			return nil, errDecodeFailure
+		}
+		endorse, ok := paramsMap["endorse"].(bool)
+		if !ok {
+			return nil, errDecodeFailure
+		}
+		cr.bucketIndex = bucketID
+		cr.endorse = endorse
+		cr.op = CandidateEndorsementOpLegacy
+		return &cr, nil
+	case bytes.Equal(candidateEndorsementEndorseMethod.ID, data[:4]):
+		method = candidateEndorsementEndorseMethod
+		cr.op = CandidateEndorsementOpEndorse
+	case bytes.Equal(caniddateEndorsementIntentToRevokeMethod.ID, data[:4]):
+		method = caniddateEndorsementIntentToRevokeMethod
+		cr.op = CandidateEndorsementOpIntentToRevoke
+	case bytes.Equal(candidateEndorsementRevokeMethod.ID, data[:4]):
+		method = candidateEndorsementRevokeMethod
+		cr.op = CandidateEndorsementOpRevoke
+	default:
 		return nil, errDecodeFailure
 	}
-	if err := candidateEndorsementMethod.Inputs.UnpackIntoMap(paramsMap, data[4:]); err != nil {
+	if err := method.Inputs.UnpackIntoMap(paramsMap, data[4:]); err != nil {
 		return nil, err
 	}
 	bucketID, ok := paramsMap["bucketIndex"].(uint64)
 	if !ok {
 		return nil, errDecodeFailure
 	}
-	endorse, ok := paramsMap["endorse"].(bool)
-	if !ok {
-		return nil, errDecodeFailure
-	}
 	cr.bucketIndex = bucketID
-	cr.endorse = endorse
 	return &cr, nil
 }

--- a/action/protocol/staking/endorsement.go
+++ b/action/protocol/staking/endorsement.go
@@ -29,6 +29,7 @@ type (
 
 	// Endorsement is a struct that contains the expire height of the Endorsement
 	Endorsement struct {
+		// ExpireHeight is the height an endorsement is expired in legacy mode and it is the earliest height that can revoke the endorsement in new mode
 		ExpireHeight uint64
 	}
 )
@@ -47,13 +48,20 @@ func (s EndorsementStatus) String() string {
 	}
 }
 
-// Status returns the status of the endorsement
-func (e *Endorsement) Status(height uint64) EndorsementStatus {
+func (e *Endorsement) LegacyStatus(height uint64) EndorsementStatus {
 	if e.ExpireHeight == endorsementNotExpireHeight {
 		return Endorsed
 	}
 	if height >= e.ExpireHeight {
 		return EndorseExpired
+	}
+	return UnEndorsing
+}
+
+// Status returns the status of the endorsement
+func (e *Endorsement) Status(height uint64) EndorsementStatus {
+	if height < e.ExpireHeight {
+		return Endorsed
 	}
 	return UnEndorsing
 }

--- a/action/protocol/staking/endorsement_statemanager.go
+++ b/action/protocol/staking/endorsement_statemanager.go
@@ -55,7 +55,7 @@ func (esr *EndorsementStateReader) Status(bucketIndex, height uint64) (Endorseme
 	endorse, err := esr.Get(bucketIndex)
 	switch errors.Cause(err) {
 	case nil:
-		status = endorse.Status(height)
+		status = endorse.LegacyStatus(height)
 	case state.ErrStateNotExist:
 		status = EndorseExpired
 		err = nil

--- a/action/protocol/staking/handler_candidate_endorsement.go
+++ b/action/protocol/staking/handler_candidate_endorsement.go
@@ -28,11 +28,12 @@ func (p *Protocol) handleCandidateEndorsement(ctx context.Context, act *action.C
 	if cand == nil {
 		return log, nil, errCandNotExist
 	}
-	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes(), []byte{byteutil.BoolToByte(act.IsEndorse())})
+	isEndorse := act.Op() == action.CandidateEndorsementOpEndorse
+	log.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes(), []byte{byteutil.BoolToByte(isEndorse)})
 
 	esm := NewEndorsementStateManager(csm.SM())
 	expireHeight := uint64(0)
-	if act.IsEndorse() {
+	if isEndorse {
 		// handle endorsement
 		if err := p.validateEndorsement(ctx, csm, esm, actCtx.Caller, bucket, cand); err != nil {
 			return log, nil, err

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -331,7 +331,7 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 			true,
 			&appendAction{
 				func() action.Action {
-					act := action.NewCandidateEndorsement(0, uint64(1000000), big.NewInt(1000), 1, false)
+					act := action.NewCandidateEndorsementLegacy(0, uint64(1000000), big.NewInt(1000), 1, false)
 					return act
 				},
 				iotextypes.ReceiptStatus_Success,
@@ -367,7 +367,7 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 			true,
 			&appendAction{
 				func() action.Action {
-					act := action.NewCandidateEndorsement(0, uint64(1000000), big.NewInt(1000), 1, false)
+					act := action.NewCandidateEndorsementLegacy(0, uint64(1000000), big.NewInt(1000), 1, false)
 					return act
 				},
 				iotextypes.ReceiptStatus_Success,
@@ -496,7 +496,7 @@ func TestProtocol_HandleCandidateEndorsement(t *testing.T) {
 				sm, p, _, _ = initTestStateFromIds(test.initBucketCfgIds, test.initCandidateCfgIds)
 			}
 			require.NoError(setupAccount(sm, test.caller, test.initBalance))
-			act := action.NewCandidateEndorsement(nonce, test.gasLimit, test.gasPrice, test.bucketID, test.endorse)
+			act := action.NewCandidateEndorsementLegacy(nonce, test.gasLimit, test.gasPrice, test.bucketID, test.endorse)
 			IntrinsicGas, _ := act.IntrinsicGas()
 			ctx := protocol.WithActionCtx(context.Background(), protocol.ActionCtx{
 				Caller:       test.caller,

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -821,7 +821,7 @@ func isSelfStakeBucket(featureCtx protocol.FeatureCtx, csc CandidiateStateCommon
 	if err != nil {
 		return false, err
 	}
-	return endorse.Status(height) != EndorseExpired, nil
+	return endorse.LegacyStatus(height) != EndorseExpired, nil
 }
 
 func isSelfOwnedBucket(csc CandidiateStateCommon, bucket *VoteBucket) bool {

--- a/action/protocol/staking/read_state.go
+++ b/action/protocol/staking/read_state.go
@@ -86,7 +86,7 @@ func toIoTeXTypesCandidateV2(csr CandidateStateReader, cand *Candidate) (*iotext
 			}
 			return false, err
 		}
-		return endorse.Status(height) == EndorseExpired, nil
+		return endorse.LegacyStatus(height) == EndorseExpired, nil
 	}
 	c := cand.toIoTeXTypes()
 	// clear self-stake bucket if endorsement is expired but not updated yet

--- a/action/protocol/staking/validations.go
+++ b/action/protocol/staking/validations.go
@@ -89,6 +89,10 @@ func (p *Protocol) validateCandidateEndorsement(ctx context.Context, act *action
 	if protocol.MustGetFeatureCtx(ctx).DisableDelegateEndorsement {
 		return errors.Wrap(action.ErrInvalidAct, "candidate endorsement is disabled")
 	}
+	if !act.IsLegacy() {
+		return errors.Wrap(action.ErrInvalidAct, "only legacy endorsement is supported")
+
+	}
 	return nil
 }
 

--- a/action/rlp_tx_test.go
+++ b/action/rlp_tx_test.go
@@ -745,8 +745,8 @@ func TestEthTxDecodeVerifyV2(t *testing.T) {
 			txto:     MustNoErrorV(address.FromBytes(address.StakingProtocolAddrHash[:])).String(),
 			txamount: big.NewInt(0),
 			txdata: append(
-				candidateEndorsementMethod.ID,
-				MustNoErrorV(candidateEndorsementMethod.Inputs.Pack(uint64(17), false))...,
+				candidateEndorsementLegacyMethod.ID,
+				MustNoErrorV(candidateEndorsementLegacyMethod.Inputs.Pack(uint64(17), false))...,
 			),
 			action: &CandidateEndorsement{
 				AbstractAction: AbstractAction{

--- a/action/signedaction.go
+++ b/action/signedaction.go
@@ -169,7 +169,7 @@ func SignedCandidateEndorsement(
 	registererPriKey crypto.PrivateKey,
 	options ...SignedActionOption,
 ) (*SealedEnvelope, error) {
-	cu := NewCandidateEndorsement(nonce, gasLimit, gasPrice, bucketIndex, endorse)
+	cu := NewCandidateEndorsementLegacy(nonce, gasLimit, gasPrice, bucketIndex, endorse)
 	bd := &EnvelopeBuilder{}
 	bd = bd.SetNonce(nonce).
 		SetGasPrice(gasPrice).

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.6.3-0.20240614133238-9b4c754212d4
+	github.com/iotexproject/iotex-proto v0.6.3-0.20240621080045-f49a68db3adf
 	github.com/ipfs/go-ipfs-api v0.2.0
 	github.com/libp2p/go-libp2p-core v0.8.5
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -664,8 +664,8 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.5.1/go.mod h1:8pDZcM45M0gY6jm3PoM
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d h1:/j1xCAC9YiG/8UKqYvycS/v3ddVsb1G7AMyLXOjeYI0=
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.mod h1:GRWevxtqQ4gPMrd7Qxhr29/7aTgvjiTp+rFI9KMMZEo=
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
-github.com/iotexproject/iotex-proto v0.6.3-0.20240614133238-9b4c754212d4 h1:zpU/obpQdKyZnnNJ3APMEkua3I5wMa8WLvFW4cb+BSA=
-github.com/iotexproject/iotex-proto v0.6.3-0.20240614133238-9b4c754212d4/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
+github.com/iotexproject/iotex-proto v0.6.3-0.20240621080045-f49a68db3adf h1:vkFvu3MnSw8WOhG7BSlH7AfWit/RBXxw+J0KUv9gcy4=
+github.com/iotexproject/iotex-proto v0.6.3-0.20240621080045-f49a68db3adf/go.mod h1:wQpCk3Df0fPID+K8ohiICGj+cWRmcQ3wanT+aSrnIPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.2/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
 github.com/ipfs/go-cid v0.0.3/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=

--- a/ioctl/cmd/action/stake2endorse.go
+++ b/ioctl/cmd/action/stake2endorse.go
@@ -101,7 +101,7 @@ func doEndorsement(bucketIndex uint64, isEndorse bool) error {
 	if err != nil {
 		return output.NewError(0, "failed to get nonce ", err)
 	}
-	s2t := action.NewCandidateEndorsement(nonce, gasLimit, gasPriceRau, bucketIndex, isEndorse)
+	s2t := action.NewCandidateEndorsementLegacy(nonce, gasLimit, gasPriceRau, bucketIndex, isEndorse)
 	return SendAction(
 		(&action.EnvelopeBuilder{}).
 			SetNonce(nonce).


### PR DESCRIPTION
In this PR, a new field `Op` is introduced. `OpLegacy`, the default value, is for the current implementation of `CandidateEndorsement` action. And the others are new ops.

As it has been gated in action/protocol/staking/validations.go, only legacy actions are allowed. A follow up PR will add a hardfork to allow the new ops.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
