### PR TITLE
[staking] only validate duplicate candidate id after HF

### DIFF
--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -699,12 +699,12 @@ func (p *Protocol) handleCandidateRegister(ctx context.Context, act *action.Cand
 			}
 		}
 		candID = id
-	}
-	c = csm.GetByIdentifier(candID)
-	if c != nil {
-		return log, nil, &handleError{
-			err:           ErrInvalidOwner,
-			failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,
+		c = csm.GetByIdentifier(candID)
+		if c != nil {
+			return log, nil, &handleError{
+				err:           ErrInvalidOwner,
+				failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,
+			}
 		}
 	}
 	// cannot collide with existing name

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -699,8 +699,7 @@ func (p *Protocol) handleCandidateRegister(ctx context.Context, act *action.Cand
 			}
 		}
 		candID = id
-		c = csm.GetByIdentifier(candID)
-		if c != nil {
+		if csm.GetByIdentifier(candID) != nil {
 			return log, nil, &handleError{
 				err:           ErrInvalidOwner,
 				failureStatus: iotextypes.ReceiptStatus_ErrCandidateAlreadyExist,


### PR DESCRIPTION
# Description

The check for duplicate candidate IDs during registration should be placed after the hard fork, as the ID is introduced only after the hard fork.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
