### PR TITLE
[api] candidates v1 temporarily changes to max uint32 from max uint64

### DIFF
--- a/action/protocol/staking/ethabi/v1/stake_candidatebyaddress.go
+++ b/action/protocol/staking/ethabi/v1/stake_candidatebyaddress.go
@@ -74,6 +74,6 @@ func init() {
 }
 
 func newCandidateByAddressStateContext(data []byte) (*stakingComm.CandidateByAddressStateContext, error) {
-	return stakingComm.NewCandidateByAddressStateContext(data, &_candidateByAddressMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS)
+	return stakingComm.NewCandidateByAddressStateContext(data, &_candidateByAddressMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_ADDRESS, stakingComm.WithNoSelfStakeBucketIndexAsMaxUint32())
 
 }

--- a/action/protocol/staking/ethabi/v1/stake_candidatebyname.go
+++ b/action/protocol/staking/ethabi/v1/stake_candidatebyname.go
@@ -74,5 +74,5 @@ func init() {
 }
 
 func newCandidateByNameStateContext(data []byte) (*stakingComm.CandidateByNameStateContext, error) {
-	return stakingComm.NewCandidateByNameStateContext(data, &_candidateByNameMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME)
+	return stakingComm.NewCandidateByNameStateContext(data, &_candidateByNameMethod, iotexapi.ReadStakingDataMethod_CANDIDATE_BY_NAME, stakingComm.WithNoSelfStakeBucketIndexAsMaxUint32())
 }

--- a/action/protocol/staking/ethabi/v1/stake_candidates.go
+++ b/action/protocol/staking/ethabi/v1/stake_candidates.go
@@ -79,5 +79,5 @@ func init() {
 }
 
 func newCandidatesStateContext(data []byte) (*stakingComm.CandidatesStateContext, error) {
-	return stakingComm.NewCandidatesStateContext(data, &_candidatesMethod, iotexapi.ReadStakingDataMethod_CANDIDATES)
+	return stakingComm.NewCandidatesStateContext(data, &_candidatesMethod, iotexapi.ReadStakingDataMethod_CANDIDATES, stakingComm.WithNoSelfStakeBucketIndexAsMaxUint32())
 }


### PR DESCRIPTION
# Description

In the staking v1 version api, the PR temporarily changes `SelfStakeBucketIndex` to max uint32 if its value equals to max uint64 , to assist the older version of iopay in resolving overflow issues. This code can be removed after the iopay update.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
