### PR TITLE
[api] fix inaccurate result of getLogs

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1455,7 +1455,7 @@ func (core *coreService) LogsInRange(filter *logfilter.LogFilter, start, end, pa
 		for j := range logsInBlk[i] {
 			logs = append(logs, logsInBlk[i][j])
 			hashes = append(hashes, HashInBlk[i])
-			if len(logs) >= int(paginationSize) {
+			if paginationSize > 0 && len(logs) >= int(paginationSize) {
 				return logs, hashes, nil
 			}
 		}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1471,20 +1471,24 @@ func (core *coreService) LogsInRange(filter *logfilter.LogFilter, start, end, pa
 }
 
 func (core *coreService) correctQueryRange(start, end uint64) (uint64, uint64, error) {
+	bfTipHeight, err := core.bfIndexer.Height()
+	if err != nil {
+		return 0, 0, err
+	}
 	if start == 0 {
-		start = core.bc.TipHeight()
+		start = bfTipHeight
 	}
 	if end == 0 {
-		end = core.bc.TipHeight()
+		end = bfTipHeight
 	}
 	if start > end {
 		return 0, 0, errors.New("invalid start or end height")
 	}
-	if start > core.bc.TipHeight() {
+	if start > bfTipHeight {
 		return 0, 0, errors.New("start block > tip height")
 	}
-	if end > core.bc.TipHeight() {
-		end = core.bc.TipHeight()
+	if end > bfTipHeight {
+		end = bfTipHeight
 	}
 	return start, end, nil
 }

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1401,12 +1401,6 @@ func (core *coreService) LogsInRange(filter *logfilter.LogFilter, start, end, pa
 	if err != nil {
 		return nil, nil, err
 	}
-	if paginationSize == 0 {
-		paginationSize = 1000
-	}
-	if paginationSize > 5000 {
-		paginationSize = 5000
-	}
 	// getLogs via range Blooom filter [start, end]
 	blockNumbers, err := core.bfIndexer.FilterBlocksInRange(filter, start, end, paginationSize)
 	if err != nil {


### PR DESCRIPTION
# Description

getLogs has two issues: 
1. if bfIndexer behinds dao 1 height, the returned result may be incorrect. 
3. Modifying the page size internally may result in missing returned results.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
