### PR TITLE
[api] correct candidate selfstake

### DIFF
--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -466,7 +466,7 @@ func (c *candSR) readStateCandidates(ctx context.Context, req *iotexapi.ReadStak
 	limit := int(req.GetPagination().GetLimit())
 	candidates := getPageOfCandidates(c.AllCandidates(), offset, limit)
 
-	list, err := toIoTeXTypesCandidateListV2(c, candidates, !protocol.MustGetFeatureCtx(ctx).EnforceLegacyEndorsement)
+	list, err := toIoTeXTypesCandidateListV2(c, candidates, protocol.MustGetFeatureCtx(ctx))
 	return list, c.Height(), err
 }
 
@@ -475,7 +475,7 @@ func (c *candSR) readStateCandidateByName(ctx context.Context, req *iotexapi.Rea
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	list, err := toIoTeXTypesCandidateV2(c, cand, !protocol.MustGetFeatureCtx(ctx).EnforceLegacyEndorsement)
+	list, err := toIoTeXTypesCandidateV2(c, cand, protocol.MustGetFeatureCtx(ctx))
 	return list, c.Height(), err
 }
 
@@ -505,7 +505,7 @@ func (c *candSR) readStateCandidateByAddress(ctx context.Context, req *iotexapi.
 	if cand == nil {
 		return &iotextypes.CandidateV2{}, c.Height(), nil
 	}
-	candV2, err := toIoTeXTypesCandidateV2(c, cand, !protocol.MustGetFeatureCtx(ctx).EnforceLegacyEndorsement)
+	candV2, err := toIoTeXTypesCandidateV2(c, cand, protocol.MustGetFeatureCtx(ctx))
 	return candV2, c.Height(), err
 }
 

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -340,7 +340,7 @@ func (p *Protocol) handleStakingIndexer(ctx context.Context, epochStartHeight ui
 	if err != nil && errors.Cause(err) != state.ErrStateNotExist {
 		return err
 	}
-	candidateList, err := toIoTeXTypesCandidateListV2(csr, all, !protocol.MustGetFeatureCtx(ctx).EnforceLegacyEndorsement)
+	candidateList, err := toIoTeXTypesCandidateListV2(csr, all, protocol.MustGetFeatureCtx(ctx))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

A new bug is found in the staking protocol, that is self-staked data is not cleared in candidate after unstake self-stake bucket operatio.  This bug fix will require the next hard fork. For now, returned candidates will be repaired in the API.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
