### PR TITLE
 [ioctl][ws] change field string exp_param to []string exp_params and add exp_params_files

### DIFF
--- a/ioctl/cmd/ws/wsprojectconfig.go
+++ b/ioctl/cmd/ws/wsprojectconfig.go
@@ -140,7 +140,7 @@ func init() {
 
 type projectConfig struct {
 	Version       string      `json:"version"`
-	VMType        uint64      `json:"vmType"`
+	VMType        uint64      `json:"vmTypeID"`
 	Output        interface{} `json:"output"`
 	CodeExpParams []string    `json:"codeExpParams,omitempty"`
 	Code          string      `json:"code"`


### PR DESCRIPTION
this is a part of this pr: https://github.com/iotexproject/w3bstream/pull/602.
The intention is to change the expParam field to be an array for better integration capabilities with additional proving systems.
Because these additional params can be very large, the flag `exp_params_files` `-f` is also quite usefull, to reduce config size and remove the step of having to manually copy values.
In the case of eg. the zokrates proving system these would be the key files.
Also w3bstream seems to have changed to `vmTypeID` instead of `vmType` (see.  https://github.com/iotexproject/w3bstream/blob/88e44ef031ac919429b3507f91e434199cf7bac4/test/project/10000#L5) so this is also addressed in one commit.