### PR TITLE
[API] increase api listener limit

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	BatchRequestLimit int `yaml:"batchRequestLimit"`
 	// WebsocketRateLimit is the maximum number of messages per second per client.
 	WebsocketRateLimit int `yaml:"websocketRateLimit"`
+	// ListenerLimit is the maximum number of listeners.
+	ListenerLimit int `yaml:"listenerLimit"`
 }
 
 // DefaultConfig is the default config
@@ -38,4 +40,5 @@ var DefaultConfig = Config{
 	RangeQueryLimit:    1000,
 	BatchRequestLimit:  _defaultBatchRequestLimit,
 	WebsocketRateLimit: 5,
+	ListenerLimit:      5000,
 }

--- a/api/context.go
+++ b/api/context.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"context"
+	"sync"
+)
+
+type (
+	streamContextKey struct{}
+
+	StreamContext struct {
+		listenerIDs map[string]struct{}
+		mutex       sync.Mutex
+	}
+)
+
+func (sc *StreamContext) AddListener(id string) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	sc.listenerIDs[id] = struct{}{}
+}
+
+func (sc *StreamContext) RemoveListener(id string) {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	delete(sc.listenerIDs, id)
+}
+
+func (sc *StreamContext) ListenerIDs() []string {
+	sc.mutex.Lock()
+	defer sc.mutex.Unlock()
+	ids := make([]string, 0, len(sc.listenerIDs))
+	for id := range sc.listenerIDs {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func WithStreamContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, streamContextKey{}, &StreamContext{
+		listenerIDs: make(map[string]struct{}),
+	})
+}
+
+func StreamFromContext(ctx context.Context) (*StreamContext, bool) {
+	sc, ok := ctx.Value(streamContextKey{}).(*StreamContext)
+	return sc, ok
+}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -279,7 +279,7 @@ func newCoreService(
 		ap:            actPool,
 		cfg:           cfg,
 		registry:      registry,
-		chainListener: NewChainListener(500),
+		chainListener: NewChainListener(cfg.ListenerLimit),
 		gs:            gasstation.NewGasStation(chain, dao, cfg.GasStation),
 		readCache:     NewReadCache(),
 		getBlockTime:  getBlockTime,

--- a/api/grpcserver_test.go
+++ b/api/grpcserver_test.go
@@ -358,6 +358,9 @@ func TestGrpcServer_StreamBlocks(t *testing.T) {
 			}()
 			return "", nil
 		})
+		listener.EXPECT().RemoveResponder(gomock.Any()).DoAndReturn(func(string) (bool, error) {
+			return true, nil
+		})
 		core.EXPECT().ChainListener().Return(listener)
 		err := grpcSvr.StreamBlocks(&iotexapi.StreamBlocksRequest{}, nil)
 		require.NoError(err)
@@ -389,6 +392,9 @@ func TestGrpcServer_StreamLogs(t *testing.T) {
 				g.errChan <- nil
 			}()
 			return "", nil
+		})
+		listener.EXPECT().RemoveResponder(gomock.Any()).DoAndReturn(func(string) (bool, error) {
+			return true, nil
 		})
 		core.EXPECT().ChainListener().Return(listener)
 		err := grpcSvr.StreamLogs(&iotexapi.StreamLogsRequest{Filter: &iotexapi.LogsFilter{}}, nil)

--- a/api/listener.go
+++ b/api/listener.go
@@ -63,6 +63,7 @@ func (cl *chainListener) Stop() error {
 		return nil
 	})
 	cl.streamMap.Reset()
+	apiLimitMtcs.WithLabelValues("listener").Set(float64(cl.streamMap.Count()))
 	return nil
 }
 
@@ -105,6 +106,7 @@ func (cl *chainListener) AddResponder(responder apitypes.Responder) (string, err
 	}
 
 	cl.streamMap.Set(listenerID, responder)
+	apiLimitMtcs.WithLabelValues("listener").Set(float64(cl.streamMap.Count()))
 	return listenerID, nil
 }
 
@@ -122,6 +124,7 @@ func (cl *chainListener) RemoveResponder(listenerID string) (bool, error) {
 		return false, errListenerNotFound
 	}
 	r.Exit()
+	apiLimitMtcs.WithLabelValues("listener").Set(float64(cl.streamMap.Count() - 1))
 	return cl.streamMap.Delete(listenerID), nil
 }
 

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -1,0 +1,14 @@
+package api
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	apiLimitMtcs = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "iotex_api_limit_metrics",
+		Help: "api limit metrics.",
+	}, []string{"limit"})
+)
+
+func init() {
+	prometheus.MustRegister(apiLimitMtcs)
+}

--- a/api/serverV2.go
+++ b/api/serverV2.go
@@ -67,7 +67,7 @@ func NewServerV2(
 	wrappedWeb3Handler := otelhttp.NewHandler(newHTTPHandler(web3Handler), "web3.jsonrpc")
 
 	limiter := rate.NewLimiter(rate.Limit(cfg.WebsocketRateLimit), 1)
-	wrappedWebsocketHandler := otelhttp.NewHandler(NewWebsocketHandler(web3Handler, limiter), "web3.websocket")
+	wrappedWebsocketHandler := otelhttp.NewHandler(NewWebsocketHandler(coreAPI, web3Handler, limiter), "web3.websocket")
 
 	return &ServerV2{
 		core:         coreAPI,

--- a/api/serverV2_test.go
+++ b/api/serverV2_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -106,4 +109,9 @@ func TestServerV2(t *testing.T) {
 		}
 		require.Greater(10, i)
 	})
+
+	cli, _ := ethclient.Dial("http://localhost:8545")
+	ch := make(chan types.Log)
+	sub, _ := cli.SubscribeFilterLogs(context.Background(), ethereum.FilterQuery{}, ch)
+	sub.Unsubscribe()
 }

--- a/api/serverV2_test.go
+++ b/api/serverV2_test.go
@@ -8,9 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/websocket"
 	"github.com/pkg/errors"
@@ -31,7 +28,7 @@ func TestServerV2(t *testing.T) {
 		core:         core,
 		grpcServer:   NewGRPCServer(core, testutil.RandomPort()),
 		httpSvr:      NewHTTPServer("", testutil.RandomPort(), newHTTPHandler(web3Handler)),
-		websocketSvr: NewHTTPServer("", testutil.RandomPort(), NewWebsocketHandler(web3Handler, nil)),
+		websocketSvr: NewHTTPServer("", testutil.RandomPort(), NewWebsocketHandler(core, web3Handler, nil)),
 	}
 	ctx := context.Background()
 
@@ -109,9 +106,4 @@ func TestServerV2(t *testing.T) {
 		}
 		require.Greater(10, i)
 	})
-
-	cli, _ := ethclient.Dial("http://localhost:8545")
-	ch := make(chan types.Log)
-	sub, _ := cli.SubscribeFilterLogs(context.Background(), ethereum.FilterQuery{}, ch)
-	sub.Unsubscribe()
 }

--- a/api/web3server_test.go
+++ b/api/web3server_test.go
@@ -1125,34 +1125,39 @@ func TestSubscribe(t *testing.T) {
 
 	t.Run("newHeads subscription", func(t *testing.T) {
 		in := gjson.Parse(`{"params":["newHeads"]}`)
-		ret, err := web3svr.subscribe(&in, writer)
+		sc, _ := StreamFromContext(WithStreamContext(context.Background()))
+		ret, err := web3svr.subscribe(sc, &in, writer)
 		require.NoError(err)
 		require.Equal("streamid_1", ret.(string))
 	})
 
 	t.Run("logs subscription", func(t *testing.T) {
 		in := gjson.Parse(`{"params":["logs",{"fromBlock":"1","fromBlock":"2","address":["0x0000000000000000000000000000000000000001"],"topics":[["0x5f746f70696331"]]}]}`)
-		ret, err := web3svr.subscribe(&in, writer)
+		sc, _ := StreamFromContext(WithStreamContext(context.Background()))
+		ret, err := web3svr.subscribe(sc, &in, writer)
 		require.NoError(err)
 		require.Equal("streamid_1", ret.(string))
 	})
 
 	t.Run("logs topic not array", func(t *testing.T) {
 		in := gjson.Parse(`{"params":["logs",{"fromBlock":"1","fromBlock":"2","address":["0x0000000000000000000000000000000000000001"],"topics":["0x5f746f70696331"]}]}`)
-		ret, err := web3svr.subscribe(&in, writer)
+		sc, _ := StreamFromContext(WithStreamContext(context.Background()))
+		ret, err := web3svr.subscribe(sc, &in, writer)
 		require.NoError(err)
 		require.Equal("streamid_1", ret.(string))
 	})
 
 	t.Run("nil params", func(t *testing.T) {
 		inNil := gjson.Parse(`{"params":[]}`)
-		_, err := web3svr.subscribe(&inNil, writer)
+		sc, _ := StreamFromContext(WithStreamContext(context.Background()))
+		_, err := web3svr.subscribe(sc, &inNil, writer)
 		require.EqualError(err, errInvalidFormat.Error())
 	})
 
 	t.Run("nil logs", func(t *testing.T) {
 		inNil := gjson.Parse(`{"params":["logs"]}`)
-		_, err := web3svr.subscribe(&inNil, writer)
+		sc, _ := StreamFromContext(WithStreamContext(context.Background()))
+		_, err := web3svr.subscribe(sc, &inNil, writer)
 		require.EqualError(err, errInvalidFormat.Error())
 	})
 }


### PR DESCRIPTION
# Description

Temporarily relax #4373 , increase global listen limits to 5000 from 500

Ultimately, the api `eth_subscribe` and `eth_unsubscribe` should only take effect for websockets, and related listeners should be cleaned up after the connection is disconnected. The limitations can also be revised to apply to the number of listeners per connection.

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
