### PR TITLE
[api] Fix parsing of log filter

### DIFF
--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -256,7 +256,11 @@ func parseLogRequest(in gjson.Result) (*filterObject, error) {
 				}
 				logReq.Topics = append(logReq.Topics, topicArr)
 			} else {
-				logReq.Topics = append(logReq.Topics, []string{util.Remove0xPrefix(topics.String())})
+				if topics.String() == "" {
+					logReq.Topics = append(logReq.Topics, []string{})
+				} else {
+					logReq.Topics = append(logReq.Topics, []string{util.Remove0xPrefix(topics.String())})
+				}
 			}
 		}
 	}

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -249,19 +249,15 @@ func parseLogRequest(in gjson.Result) (*filterObject, error) {
 			logReq.Address = append(logReq.Address, addr.String())
 		}
 		for _, topics := range req.Get("topics").Array() {
+			var topicArr []string
 			if topics.IsArray() {
-				var topicArr []string
 				for _, topic := range topics.Array() {
 					topicArr = append(topicArr, util.Remove0xPrefix(topic.String()))
 				}
-				logReq.Topics = append(logReq.Topics, topicArr)
-			} else {
-				if topics.String() == "" {
-					logReq.Topics = append(logReq.Topics, []string{})
-				} else {
-					logReq.Topics = append(logReq.Topics, []string{util.Remove0xPrefix(topics.String())})
-				}
+			} else if str := topics.String(); str != "" {
+				topicArr = append(topicArr, util.Remove0xPrefix(str))
 			}
+			logReq.Topics = append(logReq.Topics, topicArr)
 		}
 	}
 	return &logReq, nil


### PR DESCRIPTION
# Description

When parsing the topic filter, `nil` should be parsed as `[]string{}` instead of `[]string{""}`.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
