### PR TITLE
[api] fix estimateGas for migrateStake

### DIFF
--- a/action/protocol/managers.go
+++ b/action/protocol/managers.go
@@ -93,3 +93,16 @@ type (
 		Reset()
 	}
 )
+
+type (
+	SimulateOption       func(*SimulateOptionConfig)
+	SimulateOptionConfig struct {
+		PreOpt func(StateManager) error
+	}
+)
+
+func WithSimulatePreOpt(fn func(StateManager) error) SimulateOption {
+	return func(so *SimulateOptionConfig) {
+		so.PreOpt = fn
+	}
+}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -138,7 +138,7 @@ type (
 		// EstimateGasForNonExecution  estimates action gas except execution
 		EstimateGasForNonExecution(action.Action) (uint64, error)
 		// EstimateExecutionGasConsumption estimate gas consumption for execution action
-		EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address) (uint64, error)
+		EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address, opts ...protocol.SimulateOption) (uint64, error)
 		// LogsInBlockByHash filter logs in the block by hash
 		LogsInBlockByHash(filter *logfilter.LogFilter, blockHash hash.Hash256) ([]*action.Log, error)
 		// LogsInRange filter logs among [start, end] blocks
@@ -1514,11 +1514,22 @@ func (core *coreService) EstimateMigrateStakeGasConsumption(ctx context.Context,
 		GasLimit:       g.BlockGasLimitByHeight(header.Height() + 1),
 		Producer:       zeroAddr,
 	})
+
 	exec, err := staking.FindProtocol(core.registry).ConstructExecution(ctx, ms, core.sf)
 	if err != nil {
 		return 0, err
 	}
-	gas, err := core.EstimateExecutionGasConsumption(ctx, exec, caller)
+	gas, err := core.EstimateExecutionGasConsumption(ctx, exec, caller, protocol.WithSimulatePreOpt(func(sm protocol.StateManager) error {
+		// add amount to the sender account
+		sender, err := accountutil.LoadAccount(sm, caller)
+		if err != nil {
+			return err
+		}
+		if err = sender.AddBalance(exec.Amount()); err != nil {
+			return err
+		}
+		return accountutil.StoreAccount(sm, caller, sender)
+	}))
 	if err != nil {
 		return 0, err
 	}
@@ -1530,7 +1541,7 @@ func (core *coreService) EstimateMigrateStakeGasConsumption(ctx context.Context,
 }
 
 // EstimateExecutionGasConsumption estimate gas consumption for execution action
-func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address) (uint64, error) {
+func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address, opts ...protocol.SimulateOption) (uint64, error) {
 	ctx = genesis.WithGenesisContext(ctx, core.bc.Genesis())
 	state, err := accountutil.AccountState(ctx, core.sf, callerAddr)
 	if err != nil {
@@ -1553,7 +1564,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		blockGasLimit = g.BlockGasLimitByHeight(core.bc.TipHeight())
 	)
 	sc.SetGasLimit(blockGasLimit)
-	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc)
+	enough, receipt, err := core.isGasLimitEnough(ctx, callerAddr, sc, opts...)
 	if err != nil {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
@@ -1565,7 +1576,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 	}
 	estimatedGas := receipt.GasConsumed
 	sc.SetGasLimit(estimatedGas)
-	enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
+	enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc, opts...)
 	if err != nil && err != action.ErrInsufficientFunds {
 		return 0, status.Error(codes.Internal, err.Error())
 	}
@@ -1575,7 +1586,7 @@ func (core *coreService) EstimateExecutionGasConsumption(ctx context.Context, sc
 		for low <= high {
 			mid := (low + high) / 2
 			sc.SetGasLimit(mid)
-			enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc)
+			enough, _, err = core.isGasLimitEnough(ctx, callerAddr, sc, opts...)
 			if err != nil && err != action.ErrInsufficientFunds {
 				return 0, status.Error(codes.Internal, err.Error())
 			}
@@ -1595,6 +1606,7 @@ func (core *coreService) isGasLimitEnough(
 	ctx context.Context,
 	caller address.Address,
 	sc *action.Execution,
+	opts ...protocol.SimulateOption,
 ) (bool, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "Server.isGasLimitEnough")
 	defer span.End()
@@ -1603,7 +1615,7 @@ func (core *coreService) isGasLimitEnough(
 		return false, nil, err
 	}
 
-	_, receipt, err := core.simulateExecution(ctx, caller, sc, core.dao.GetBlockHash, core.getBlockTime)
+	_, receipt, err := core.simulateExecution(ctx, caller, sc, core.dao.GetBlockHash, core.getBlockTime, opts...)
 	if err != nil {
 		return false, nil, err
 	}
@@ -1909,13 +1921,13 @@ func (core *coreService) traceTx(ctx context.Context, txctx *tracers.Context, co
 	return retval, receipt, tracer, err
 }
 
-func (core *coreService) simulateExecution(ctx context.Context, addr address.Address, exec *action.Execution, getBlockHash evm.GetBlockHash, getBlockTime evm.GetBlockTime) ([]byte, *action.Receipt, error) {
+func (core *coreService) simulateExecution(ctx context.Context, addr address.Address, exec *action.Execution, getBlockHash evm.GetBlockHash, getBlockTime evm.GetBlockTime, opts ...protocol.SimulateOption) ([]byte, *action.Receipt, error) {
 	ctx = evm.WithHelperCtx(ctx, evm.HelperContext{
 		GetBlockHash:   getBlockHash,
 		GetBlockTime:   getBlockTime,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	return core.sf.SimulateExecution(ctx, addr, exec)
+	return core.sf.SimulateExecution(ctx, addr, exec, opts...)
 }
 
 func filterReceipts(receipts []*action.Receipt, actHash hash.Hash256) *action.Receipt {

--- a/state/factory/factory.go
+++ b/state/factory/factory.go
@@ -86,7 +86,7 @@ type (
 		Validate(context.Context, *block.Block) error
 		// NewBlockBuilder creates block builder
 		NewBlockBuilder(context.Context, actpool.ActPool, func(action.Envelope) (*action.SealedEnvelope, error)) (*block.Builder, error)
-		SimulateExecution(context.Context, address.Address, *action.Execution) ([]byte, *action.Receipt, error)
+		SimulateExecution(context.Context, address.Address, *action.Execution, ...protocol.SimulateOption) ([]byte, *action.Receipt, error)
 		ReadContractStorage(context.Context, address.Address, []byte) ([]byte, error)
 		PutBlock(context.Context, *block.Block) error
 		DeleteTipBlock(context.Context, *block.Block) error
@@ -388,6 +388,7 @@ func (sf *factory) SimulateExecution(
 	ctx context.Context,
 	caller address.Address,
 	ex *action.Execution,
+	opts ...protocol.SimulateOption,
 ) ([]byte, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "factory.SimulateExecution")
 	defer span.End()
@@ -398,7 +399,15 @@ func (sf *factory) SimulateExecution(
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to obtain working set from state factory")
 	}
-
+	cfg := &protocol.SimulateOptionConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.PreOpt != nil {
+		if err := cfg.PreOpt(ws); err != nil {
+			return nil, nil, err
+		}
+	}
 	return evm.SimulateExecution(ctx, ws, caller, ex)
 }
 

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -267,6 +267,7 @@ func (sdb *stateDB) SimulateExecution(
 	ctx context.Context,
 	caller address.Address,
 	ex *action.Execution,
+	opts ...protocol.SimulateOption,
 ) ([]byte, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "stateDB.SimulateExecution")
 	defer span.End()
@@ -278,7 +279,15 @@ func (sdb *stateDB) SimulateExecution(
 	if err != nil {
 		return nil, nil, err
 	}
-
+	cfg := &protocol.SimulateOptionConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.PreOpt != nil {
+		if err := cfg.PreOpt(ws); err != nil {
+			return nil, nil, err
+		}
+	}
 	return evm.SimulateExecution(ctx, ws, caller, ex)
 }
 

--- a/test/mock/mock_apicoreservice/mock_apicoreservice.go
+++ b/test/mock/mock_apicoreservice/mock_apicoreservice.go
@@ -15,6 +15,7 @@ import (
 	hash "github.com/iotexproject/go-pkgs/hash"
 	address "github.com/iotexproject/iotex-address/address"
 	action "github.com/iotexproject/iotex-core/action"
+	protocol "github.com/iotexproject/iotex-core/action/protocol"
 	logfilter "github.com/iotexproject/iotex-core/api/logfilter"
 	apitypes "github.com/iotexproject/iotex-core/api/types"
 	block "github.com/iotexproject/iotex-core/blockchain/block"
@@ -290,18 +291,23 @@ func (mr *MockCoreServiceMockRecorder) EpochMeta(epochNum interface{}) *gomock.C
 }
 
 // EstimateExecutionGasConsumption mocks base method.
-func (m *MockCoreService) EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address) (uint64, error) {
+func (m *MockCoreService) EstimateExecutionGasConsumption(ctx context.Context, sc *action.Execution, callerAddr address.Address, opts ...protocol.SimulateOption) (uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EstimateExecutionGasConsumption", ctx, sc, callerAddr)
+	varargs := []interface{}{ctx, sc, callerAddr}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "EstimateExecutionGasConsumption", varargs...)
 	ret0, _ := ret[0].(uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EstimateExecutionGasConsumption indicates an expected call of EstimateExecutionGasConsumption.
-func (mr *MockCoreServiceMockRecorder) EstimateExecutionGasConsumption(ctx, sc, callerAddr interface{}) *gomock.Call {
+func (mr *MockCoreServiceMockRecorder) EstimateExecutionGasConsumption(ctx, sc, callerAddr interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateExecutionGasConsumption", reflect.TypeOf((*MockCoreService)(nil).EstimateExecutionGasConsumption), ctx, sc, callerAddr)
+	varargs := append([]interface{}{ctx, sc, callerAddr}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EstimateExecutionGasConsumption", reflect.TypeOf((*MockCoreService)(nil).EstimateExecutionGasConsumption), varargs...)
 }
 
 // EstimateGasForAction mocks base method.

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -143,9 +143,13 @@ func (mr *MockFactoryMockRecorder) Register(arg0 interface{}) *gomock.Call {
 }
 
 // SimulateExecution mocks base method.
-func (m *MockFactory) SimulateExecution(arg0 context.Context, arg1 address.Address, arg2 *action.Execution) ([]byte, *action.Receipt, error) {
+func (m *MockFactory) SimulateExecution(arg0 context.Context, arg1 address.Address, arg2 *action.Execution, arg3 ...protocol.SimulateOption) ([]byte, *action.Receipt, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SimulateExecution", arg0, arg1, arg2)
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "SimulateExecution", varargs...)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(*action.Receipt)
 	ret2, _ := ret[2].(error)
@@ -153,9 +157,10 @@ func (m *MockFactory) SimulateExecution(arg0 context.Context, arg1 address.Addre
 }
 
 // SimulateExecution indicates an expected call of SimulateExecution.
-func (mr *MockFactoryMockRecorder) SimulateExecution(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockFactoryMockRecorder) SimulateExecution(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateExecution", reflect.TypeOf((*MockFactory)(nil).SimulateExecution), arg0, arg1, arg2)
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateExecution", reflect.TypeOf((*MockFactory)(nil).SimulateExecution), varargs...)
 }
 
 // Start mocks base method.


### PR DESCRIPTION
# Description

When estimating the gas for the `MigrateStake` transaction, the `amount` of the native bucket is not returned to the sender. If the sender's balance is insufficient for the bucket amount, an `insufficient balance for transfer` error will be returned.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
