### PR TITLE
[filedao] impl sized file dao

### DIFF
--- a/blockchain/filedao/blockstore.go
+++ b/blockchain/filedao/blockstore.go
@@ -36,7 +36,6 @@ func convertToBlockStore(blk *block.Block) (blockstore, error) {
 	if err != nil {
 		return nil, err
 	}
-	data = append(data, blockstoreDefaultVersion)
 	data = append(data, byteutil.Uint64ToBytesBigEndian(uint64(len(tmp)))...)
 	data = append(data, tmp...)
 	txLog := blk.TransactionLog()

--- a/blockchain/filedao/blockstore.go
+++ b/blockchain/filedao/blockstore.go
@@ -1,0 +1,102 @@
+package filedao
+
+import (
+	"fmt"
+
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+)
+
+const (
+	blockstoreDefaultVersion = byte(0)
+	blockstoreHeaderSize     = 8
+)
+
+type (
+	// blockstore is a byte slice that contains a block, its receipts and transaction logs
+	// the first 8 bytes is the size of the block
+	// the next n bytes is the serialized block and receipts, n is the size of the block
+	// the rest bytes is the serialized transaction logs
+	blockstore []byte
+)
+
+var (
+	errInvalidBlockstore = fmt.Errorf("invalid blockstore")
+)
+
+func convertToBlockStore(blk *block.Block) (blockstore, error) {
+	data := make(blockstore, 0)
+	s := &block.Store{
+		Block:    blk,
+		Receipts: blk.Receipts,
+	}
+	tmp, err := s.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, blockstoreDefaultVersion)
+	data = append(data, byteutil.Uint64ToBytesBigEndian(uint64(len(tmp)))...)
+	data = append(data, tmp...)
+	txLog := blk.TransactionLog()
+	if txLog != nil {
+		tmp = txLog.Serialize()
+		data = append(data, tmp...)
+	}
+	return data, nil
+}
+
+func (s blockstore) Block(deser *block.Deserializer) (*block.Block, error) {
+	size := s.blockSize()
+	bs, err := deser.DeserializeBlockStore(s[blockstoreHeaderSize : size+blockstoreHeaderSize])
+	if err != nil {
+		return nil, err
+	}
+	bs.Block.Receipts = bs.Receipts
+	return bs.Block, nil
+}
+
+func (s blockstore) TransactionLogs() (*iotextypes.TransactionLogs, error) {
+	size := s.blockSize()
+	if uint64(len(s)) == size+blockstoreHeaderSize {
+		return nil, nil
+	}
+	return block.DeserializeSystemLogPb(s[size+blockstoreHeaderSize:])
+}
+
+func (s blockstore) Serialize() []byte {
+	return append([]byte{blockstoreDefaultVersion}, s...)
+}
+
+func (s *blockstore) Deserialize(data []byte) error {
+	if len(data) == 0 {
+		return errInvalidBlockstore
+	}
+	switch data[0] {
+	case blockstoreDefaultVersion:
+		bs := blockstore(data[1:])
+		if err := bs.Validate(); err != nil {
+			return err
+		}
+		*s = bs
+		return nil
+	default:
+		return errInvalidBlockstore
+	}
+}
+
+func (s blockstore) blockSize() uint64 {
+	return byteutil.BytesToUint64BigEndian(s[:blockstoreHeaderSize])
+}
+
+func (s blockstore) Validate() error {
+	if len(s) < blockstoreHeaderSize {
+		return errInvalidBlockstore
+	}
+	blkSize := s.blockSize()
+	if uint64(len(s)) < blkSize+blockstoreHeaderSize {
+		return errInvalidBlockstore
+	}
+	return nil
+}

--- a/blockchain/filedao/blockstore_test.go
+++ b/blockchain/filedao/blockstore_test.go
@@ -1,0 +1,40 @@
+package filedao
+
+import (
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/blockchain/block"
+)
+
+func TestBlockStore(t *testing.T) {
+	r := require.New(t)
+	builder := block.NewTestingBuilder()
+	blk := createTestingBlock(builder, 1, hash.ZeroHash256)
+	bs, err := convertToBlockStore(blk)
+	r.NoError(err)
+	data := bs.Serialize()
+	dbs := new(blockstore)
+	r.NoError(dbs.Deserialize(data))
+	r.Equal(bs[:], (*dbs)[:], "serialized block store should be equal to deserialized block store")
+	// check deserialized block
+	deser := block.NewDeserializer(0)
+	dBlk, err := dbs.Block(deser)
+	r.NoError(err)
+	dTxLogs, err := dbs.TransactionLogs()
+	r.NoError(err)
+	r.NoError(fillTransactionLog(dBlk.Receipts, dTxLogs.Logs))
+	r.Equal(blk.Header, dBlk.Header)
+	r.Equal(blk.Body, dBlk.Body)
+	r.Equal(blk.Footer, dBlk.Footer)
+	r.Equal(len(blk.Receipts), len(dBlk.Receipts))
+	for i := range blk.Receipts {
+		r.Equal(blk.Receipts[i].Hash(), dBlk.Receipts[i].Hash())
+		r.Equal(len(blk.Receipts[i].TransactionLogs()), len(dBlk.Receipts[i].TransactionLogs()))
+		for j := range blk.Receipts[i].TransactionLogs() {
+			r.Equal(blk.Receipts[i].TransactionLogs()[j], dBlk.Receipts[i].TransactionLogs()[j])
+		}
+	}
+}

--- a/blockchain/filedao/sized.go
+++ b/blockchain/filedao/sized.go
@@ -1,0 +1,324 @@
+package filedao
+
+import (
+	"context"
+	"os"
+	"sync"
+
+	"github.com/holiman/billy"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/db"
+	"github.com/iotexproject/iotex-core/pkg/log"
+	"github.com/iotexproject/iotex-core/pkg/util/byteutil"
+)
+
+type (
+	blockstore []byte
+	sizedDao   struct {
+		size    uint64
+		dataDir string
+
+		store billy.Database
+
+		tip          uint64
+		base         uint64
+		heightToHash map[uint64]hash.Hash256
+		hashToHeight map[hash.Hash256]uint64
+		heightToID   map[uint64]uint64
+		lock         sync.RWMutex
+
+		deser *block.Deserializer
+	}
+)
+
+func NewSizedFileDao(size uint64, dataDir string, deser *block.Deserializer) (FileDAO, error) {
+	return &sizedDao{
+		size:         size,
+		dataDir:      dataDir,
+		heightToHash: make(map[uint64]hash.Hash256),
+		hashToHeight: make(map[hash.Hash256]uint64),
+		heightToID:   make(map[uint64]uint64),
+		deser:        deser,
+	}, nil
+}
+
+func (sd *sizedDao) Start(ctx context.Context) error {
+	dir := sd.dataDir
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return errors.Wrap(err, "failed to create blob store directory")
+	}
+
+	var fails []uint64
+	index := func(id uint64, size uint32, blob []byte) {
+		blk, err := blockstore(blob).Block(sd.deser)
+		if err != nil {
+			fails = append(fails, id)
+			log.L().Warn("Failed to decode block", zap.Error(err))
+			return
+		}
+		h := blk.HashBlock()
+		height := blk.Height()
+		sd.hashToHeight[h] = height
+		sd.heightToHash[height] = h
+		sd.heightToID[height] = id
+		if height > sd.tip || sd.tip == 0 {
+			sd.tip = height
+		}
+		if height < sd.base || sd.base == 0 {
+			sd.base = height
+		}
+	}
+
+	store, err := billy.Open(billy.Options{Path: dir}, newSlotter(), index)
+	if err != nil {
+		return errors.Wrap(err, "failed to open blob store")
+	}
+	sd.store = store
+	if len(fails) > 0 {
+		return errors.Errorf("failed to decode blocks %v", fails)
+	}
+	return nil
+}
+
+func (sd *sizedDao) Stop(ctx context.Context) error {
+	return sd.store.Close()
+}
+
+func (sd *sizedDao) PutBlock(ctx context.Context, blk *block.Block) error {
+	if blk.Height() != sd.tip+1 {
+		return ErrInvalidTipHeight
+	}
+	data, err := serializeBlock(blk)
+	if err != nil {
+		return err
+	}
+
+	sd.lock.Lock()
+	defer sd.lock.Unlock()
+	if blk.Height() != sd.tip+1 {
+		return ErrInvalidTipHeight
+	}
+	id, err := sd.store.Put(data)
+	if err != nil {
+		return err
+	}
+	sd.tip++
+	hash := blk.HashBlock()
+	sd.heightToHash[sd.tip] = hash
+	sd.hashToHeight[hash] = sd.tip
+	sd.heightToID[sd.tip] = id
+
+	if sd.tip-sd.base > sd.size {
+		sd.drop()
+	}
+	return nil
+}
+
+func (sd *sizedDao) Height() (uint64, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	return sd.tip, nil
+}
+
+func (sd *sizedDao) GetBlockHash(height uint64) (hash.Hash256, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	h, ok := sd.heightToHash[height]
+	if !ok {
+		return hash.ZeroHash256, db.ErrNotExist
+	}
+	return h, nil
+}
+
+func (sd *sizedDao) GetBlockHeight(h hash.Hash256) (uint64, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	height, ok := sd.hashToHeight[h]
+	if !ok {
+		return 0, db.ErrNotExist
+	}
+	return height, nil
+}
+
+func (sd *sizedDao) GetBlock(h hash.Hash256) (*block.Block, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	height, ok := sd.hashToHeight[h]
+	if !ok {
+		return nil, db.ErrNotExist
+	}
+	return sd.getBlock(height)
+}
+
+func (sd *sizedDao) GetBlockByHeight(height uint64) (*block.Block, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	return sd.getBlock(height)
+}
+
+func (sd *sizedDao) GetReceipts(height uint64) ([]*action.Receipt, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	blk, err := sd.getBlock(height)
+	if err != nil {
+		return nil, err
+	}
+	return blk.Receipts, nil
+}
+
+func (sd *sizedDao) ContainsTransactionLog() bool {
+	return true
+}
+
+func (sd *sizedDao) TransactionLogs(height uint64) (*iotextypes.TransactionLogs, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	id, ok := sd.heightToID[height]
+	if !ok {
+		return nil, db.ErrNotExist
+	}
+	data, err := sd.store.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return blockstore(data).TransactionLogs()
+}
+
+func (sd *sizedDao) DeleteTipBlock() error {
+	panic("not supported")
+}
+
+func (sd *sizedDao) Header(h hash.Hash256) (*block.Header, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	height, ok := sd.hashToHeight[h]
+	if !ok {
+		return nil, db.ErrNotExist
+	}
+	blk, err := sd.getBlock(height)
+	if err != nil {
+		return nil, err
+	}
+	return &blk.Header, nil
+}
+
+func (sd *sizedDao) HeaderByHeight(height uint64) (*block.Header, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	blk, err := sd.getBlock(height)
+	if err != nil {
+		return nil, err
+	}
+	return &blk.Header, nil
+}
+
+func (sd *sizedDao) FooterByHeight(height uint64) (*block.Footer, error) {
+	sd.lock.RLock()
+	defer sd.lock.RUnlock()
+	blk, err := sd.getBlock(height)
+	if err != nil {
+		return nil, err
+	}
+	return &blk.Footer, nil
+}
+
+func (sd *sizedDao) getBlock(height uint64) (*block.Block, error) {
+	id, ok := sd.heightToID[height]
+	if !ok {
+		return nil, db.ErrNotExist
+	}
+	data, err := sd.store.Get(id)
+	if err != nil {
+		return nil, err
+	}
+	return blockstore(data).Block(sd.deser)
+}
+
+func (sd *sizedDao) drop() {
+	id := sd.heightToID[sd.base]
+	if err := sd.store.Delete(id); err != nil {
+		log.L().Error("Failed to delete block", zap.Error(err))
+		return
+	}
+	hash := sd.heightToHash[sd.base]
+	delete(sd.heightToHash, sd.base)
+	delete(sd.heightToID, sd.base)
+	delete(sd.hashToHeight, hash)
+	sd.base++
+}
+
+func serializeBlock(blk *block.Block) (blockstore, error) {
+	data := make(blockstore, 0)
+	s := &block.Store{
+		Block:    blk,
+		Receipts: blk.Receipts,
+	}
+	tmp, err := s.Serialize()
+	if err != nil {
+		return nil, err
+	}
+	data = append(data, byteutil.Uint64ToBytesBigEndian(uint64(len(tmp)))...)
+	data = append(data, tmp...)
+	txLog := blk.TransactionLog()
+	if txLog != nil {
+		tmp = txLog.Serialize()
+		data = append(data, tmp...)
+	}
+	return data, nil
+}
+
+func (s blockstore) Block(deser *block.Deserializer) (*block.Block, error) {
+	size, err := s.blockSize()
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(s)) < size+8 {
+		return nil, errors.New("blockstore is too short")
+	}
+	bs, err := deser.DeserializeBlockStore(s[8 : size+8])
+	if err != nil {
+		return nil, err
+	}
+	bs.Block.Receipts = bs.Receipts
+	return bs.Block, nil
+}
+
+func (s blockstore) TransactionLogs() (*iotextypes.TransactionLogs, error) {
+	size, err := s.blockSize()
+	if err != nil {
+		return nil, err
+	}
+	if uint64(len(s)) < size+8 {
+		return nil, errors.New("blockstore is too short")
+	} else if uint64(len(s)) == size+8 {
+		return nil, nil
+	}
+
+	return block.DeserializeSystemLogPb(s[size+8:])
+}
+
+func (s blockstore) blockSize() (uint64, error) {
+	if len(s) < 8 {
+		return 0, errors.New("blockstore is too short")
+	}
+	return byteutil.BytesToUint64BigEndian(s[:8]), nil
+}
+
+func newSlotter() func() (uint32, bool) {
+	// TODO: set emptySize and delta according to the actual block size
+	emptySize := uint32(1024)
+	delta := uint32(2048)
+	slotsize := uint32(emptySize) // empty block
+	slotsize -= uint32(delta)     // underflows, it's ok, will overflow back in the first return
+
+	return func() (size uint32, done bool) {
+		slotsize += delta
+		return slotsize, false
+	}
+}

--- a/blockchain/filedao/sized_test.go
+++ b/blockchain/filedao/sized_test.go
@@ -1,0 +1,59 @@
+package filedao
+
+import (
+	"context"
+	"crypto/tls"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/blockchain/block"
+)
+
+func TestBlockSize(t *testing.T) {
+	r := require.New(t)
+	conn, err := grpc.NewClient("api.mainnet.iotex.one:443", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
+	r.NoError(err)
+	defer conn.Close()
+
+	cli := iotexapi.NewAPIServiceClient(conn)
+	for _, h := range []uint64{29276276} {
+		resp, err := cli.GetRawBlocks(context.Background(), &iotexapi.GetRawBlocksRequest{
+			StartHeight:         h,
+			Count:               1,
+			WithReceipts:        true,
+			WithTransactionLogs: true,
+		})
+		r.NoError(err)
+		r.Len(resp.Blocks, 1)
+		deserializer := block.NewDeserializer(4689)
+		blk, err := deserializer.FromBlockProto(resp.Blocks[0].Block)
+		r.NoError(err)
+		receipts := make([]*action.Receipt, 0, len(resp.Blocks[0].Receipts))
+		for _, receiptpb := range resp.Blocks[0].Receipts {
+			receipt := &action.Receipt{}
+			receipt.ConvertFromReceiptPb(receiptpb)
+			receipts = append(receipts, receipt)
+		}
+		blk.Receipts = receipts
+		data, err := convertToBlockStore(blk)
+		r.NoError(err)
+		t.Logf("block %d size= %d", h, len(data))
+	}
+}
+
+func TestSizedDao(t *testing.T) {
+	r := require.New(t)
+	dao, err := NewSizedFileDao(10, t.TempDir(), block.NewDeserializer(4089))
+	r.NoError(err)
+
+	ctx := context.Background()
+	r.NoError(dao.Start(ctx))
+	r.NoError(testCommitBlocks(t, dao, 1, 100, hash.ZeroHash256))
+	r.NoError(dao.Stop(ctx))
+}

--- a/blockchain/filedao/sized_test.go
+++ b/blockchain/filedao/sized_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBlockSize(t *testing.T) {
-	// t.Skip("used for estimating block size")
+	t.Skip("used for estimating block size")
 	r := require.New(t)
 	conn, err := grpc.NewClient("api.mainnet.iotex.one:443", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
 	r.NoError(err)

--- a/blockchain/filedao/sized_test.go
+++ b/blockchain/filedao/sized_test.go
@@ -13,9 +13,11 @@ import (
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/blockchain/block"
+	"github.com/iotexproject/iotex-core/db"
 )
 
 func TestBlockSize(t *testing.T) {
+	// t.Skip("used for estimating block size")
 	r := require.New(t)
 	conn, err := grpc.NewClient("api.mainnet.iotex.one:443", grpc.WithTransportCredentials(credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})))
 	r.NoError(err)
@@ -41,19 +43,142 @@ func TestBlockSize(t *testing.T) {
 			receipts = append(receipts, receipt)
 		}
 		blk.Receipts = receipts
+		r.NoError(fillTransactionLog(receipts, resp.Blocks[0].TransactionLogs.Logs))
 		data, err := convertToBlockStore(blk)
 		r.NoError(err)
 		t.Logf("block %d size= %d", h, len(data))
 	}
 }
 
-func TestSizedDao(t *testing.T) {
+func TestSizedDaoIntegrity(t *testing.T) {
 	r := require.New(t)
-	dao, err := NewSizedFileDao(10, t.TempDir(), block.NewDeserializer(4089))
-	r.NoError(err)
-
+	desr := block.NewDeserializer(4689)
 	ctx := context.Background()
+	blocks := make([]*block.Block, 0, 20)
+	builder := block.NewTestingBuilder()
+	h := hash.ZeroHash256
+	for i := 1; i <= cap(blocks); i++ {
+		blk := createTestingBlock(builder, uint64(i), h)
+		blocks = append(blocks, blk)
+		h = blk.HashBlock()
+		t.Logf("block height %d hash: %x", i, h)
+	}
+	// case: putblocks 1 - 10
+	datadir := t.TempDir()
+	dao, err := NewSizedFileDao(10, datadir, desr)
+	r.NoError(err)
 	r.NoError(dao.Start(ctx))
-	r.NoError(testCommitBlocks(t, dao, 1, 100, hash.ZeroHash256))
+	for i := 0; i < 10; i++ {
+		r.NoError(dao.PutBlock(ctx, blocks[i]))
+	}
+	// verify
+	testVerifyChainDB(t, dao, 1, 10)
+	// case: put block not expected
+	r.ErrorIs(dao.PutBlock(ctx, blocks[8]), ErrInvalidTipHeight)
+	r.ErrorIs(dao.PutBlock(ctx, blocks[9]), ErrInvalidTipHeight)
+	r.ErrorIs(dao.PutBlock(ctx, blocks[11]), ErrInvalidTipHeight)
+	// case: put blocks 11 - 20
+	for i := 10; i < 20; i++ {
+		r.NoError(dao.PutBlock(ctx, blocks[i]))
+		blk, err := dao.GetBlockByHeight(11)
+		r.NoError(err)
+		r.Equal(blocks[10].HashBlock(), blk.HashBlock(), "height %d", i)
+	}
+	// verify new blocks added and old blocks removed
+	testVerifyChainDB(t, dao, 11, 20)
+	testVerifyChainDBNotExists(t, dao, blocks[:10])
+	// case: reload
 	r.NoError(dao.Stop(ctx))
+	dao, err = NewSizedFileDao(10, datadir, desr)
+	r.NoError(err)
+	r.NoError(dao.Start(ctx))
+	// verify blocks reloaded
+	testVerifyChainDB(t, dao, 11, 20)
+	testVerifyChainDBNotExists(t, dao, blocks[:10])
+	// case: damaged db
+	inner := dao.(*sizedDao)
+	_, err = inner.store.Put([]byte("damaged"))
+	r.NoError(err)
+	r.NoError(dao.Stop(ctx))
+	dao, err = NewSizedFileDao(10, datadir, desr)
+	r.NoError(err)
+	// verify invalid data is ignored
+	r.NoError(dao.Start(ctx))
+	testVerifyChainDB(t, dao, 11, 20)
+	testVerifyChainDBNotExists(t, dao, blocks[:10])
+	// case: remove non-continous blocks
+	inner = dao.(*sizedDao)
+	inner.store.Delete(inner.heightToID[15])
+	r.NoError(dao.Stop(ctx))
+	dao, err = NewSizedFileDao(10, datadir, desr)
+	r.NoError(err)
+	// verify blocks 11 - 15 are removed
+	r.NoError(dao.Start(ctx))
+	testVerifyChainDB(t, dao, 16, 20)
+	testVerifyChainDBNotExists(t, dao, blocks[:15])
+	r.NoError(dao.Stop(ctx))
+}
+
+func TestSizedDaoStorage(t *testing.T) {
+	r := require.New(t)
+	desr := block.NewDeserializer(4689)
+	ctx := context.Background()
+
+	datadir := t.TempDir()
+	dao, err := NewSizedFileDao(10, datadir, desr)
+	r.NoError(err)
+	r.NoError(dao.Start(ctx))
+
+	// put empty block
+	height := uint64(1)
+	builder := block.NewTestingBuilder()
+	h := hash.ZeroHash256
+	blk := createTestingBlock(builder, height, h)
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	// put block with 5 actions
+	blk = createTestingBlock(builder, height, h, withActionNum(5))
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	// put block with 100 actions
+	blk = createTestingBlock(builder, height, h, withActionNum(100))
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	// put block with 1000 actions
+	blk = createTestingBlock(builder, height, h, withActionNum(1000))
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	// put block with 5000 actions
+	blk = createTestingBlock(builder, height, h, withActionNum(5000))
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	// put block with 10000 actions
+	blk = createTestingBlock(builder, height, h, withActionNum(10000))
+	height++
+	h = blk.HashBlock()
+	r.NoError(dao.PutBlock(ctx, blk))
+	r.NoError(dao.Stop(ctx))
+}
+
+func testVerifyChainDBNotExists(t *testing.T, fd FileDAO, blocks []*block.Block) {
+	r := require.New(t)
+	for _, blk := range blocks {
+		_, err := fd.GetBlockHash(blk.Height())
+		r.ErrorIs(err, db.ErrNotExist)
+		_, err = fd.GetBlockHeight(blk.HashBlock())
+		r.ErrorIs(err, db.ErrNotExist)
+		_, err = fd.GetBlockByHeight(blk.Height())
+		r.ErrorIs(err, db.ErrNotExist)
+		_, err = fd.GetBlock(blk.HashBlock())
+		r.ErrorIs(err, db.ErrNotExist)
+		_, err = fd.GetReceipts(blk.Height())
+		r.ErrorIs(err, db.ErrNotExist)
+		_, err = fd.TransactionLogs(blk.Height())
+		r.ErrorIs(err, db.ErrNotExist)
+	}
 }


### PR DESCRIPTION
# Description

This PR implement another `FileDAO`, which only store fixed number of latest blocks. 

It is designed to be used as block storage for delegate nodes, as delegate nodes only need to store the most recent n blocks, rather than all historical blocks, which would be wasteful. Additionally, compared to the previous FileDAO, this time the storage engine has also been changed, from KV to using Billy, which is more efficient for storing small amounts of data.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
