### PR TITLE
[eip1559] basefee into rewardingpool

### DIFF
--- a/action/protocol/account/transfer.go
+++ b/action/protocol/account/transfer.go
@@ -100,7 +100,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, elp action.Envelope, sm p
 		}
 		if fCtx.FixDoubleChargeGas {
 			if p.depositGas != nil {
-				depositLog, err = p.depositGas(ctx, sm, gasFee, protocol.BurnGasOption(baseFee, iotextypes.TransactionLogType_NATIVE_TRANSFER))
+				depositLog, err = p.depositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
 				if err != nil {
 					return nil, err
 				}
@@ -142,7 +142,7 @@ func (p *Protocol) handleTransfer(ctx context.Context, elp action.Envelope, sm p
 
 	if fCtx.FixDoubleChargeGas {
 		if p.depositGas != nil {
-			depositLog, err = p.depositGas(ctx, sm, gasFee, protocol.BurnGasOption(baseFee, iotextypes.TransactionLogType_NATIVE_TRANSFER))
+			depositLog, err = p.depositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
 			if err != nil {
 				return nil, err
 			}

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -267,11 +267,11 @@ func ExecuteContract(
 		}
 	}
 	if consumedGas > 0 {
-		gasFee, baseFee, err := protocol.SplitGas(ctx, execution, consumedGas)
+		priorityFee, baseFee, err := protocol.SplitGas(ctx, execution, consumedGas)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to split gas")
 		}
-		depositLog, err = ps.helperCtx.DepositGasFunc(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
+		depositLog, err = ps.helperCtx.DepositGasFunc(ctx, sm, baseFee, protocol.PriorityFeeOption(priorityFee))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -271,7 +271,7 @@ func ExecuteContract(
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to split gas")
 		}
-		depositLog, err = ps.helperCtx.DepositGasFunc(ctx, sm, gasFee, protocol.BurnGasOption(baseFee, iotextypes.TransactionLogType_NATIVE_TRANSFER))
+		depositLog, err = ps.helperCtx.DepositGasFunc(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -60,7 +60,7 @@ func TestExecuteContractFailure(t *testing.T) {
 		GetBlockTime: func(uint64) (time.Time, error) {
 			return time.Time{}, nil
 		},
-		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.Option) ([]*action.TransactionLog, error) {
+		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
 			return nil, nil
 		},
 	})

--- a/action/protocol/poll/consortium.go
+++ b/action/protocol/poll/consortium.go
@@ -127,7 +127,7 @@ func (cc *consortiumCommittee) CreateGenesisStates(ctx context.Context, sm proto
 			return hash.ZeroHash256, nil
 		},
 		GetBlockTime: getBlockTime,
-		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.Option) ([]*action.TransactionLog, error) {
+		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
 			return nil, nil
 		},
 	})

--- a/action/protocol/poll/staking_committee.go
+++ b/action/protocol/poll/staking_committee.go
@@ -135,7 +135,7 @@ func (sc *stakingCommittee) CreateGenesisStates(ctx context.Context, sm protocol
 			// make sure the returned timestamp is after the current block time so that evm upgrades based on timestamp (Shanghai and onwards) are disabled
 			return blkCtx.BlockTimeStamp.Add(5 * time.Second), nil
 		},
-		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.Option) ([]*action.TransactionLog, error) {
+		DepositGasFunc: func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
 			return nil, nil
 		},
 	})

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
-	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
@@ -81,23 +80,21 @@ type ActionHandler interface {
 }
 
 type (
-	Options struct {
-		BurnAmount  *big.Int
-		BurnLogType iotextypes.TransactionLogType
+	DepositOptionCfg struct {
+		PriorityFee *big.Int
 	}
 
-	Option func(*Options)
+	DepositOption func(*DepositOptionCfg)
 )
 
-func BurnGasOption(amount *big.Int, logType iotextypes.TransactionLogType) Option {
-	return func(opts *Options) {
-		opts.BurnAmount = amount
-		opts.BurnLogType = logType
+func PriorityFeeOption(priorityFee *big.Int) DepositOption {
+	return func(opts *DepositOptionCfg) {
+		opts.PriorityFee = priorityFee
 	}
 }
 
 // DepositGas deposits gas to rewarding pool and burns baseFee
-type DepositGas func(context.Context, StateManager, *big.Int, ...Option) ([]*action.TransactionLog, error)
+type DepositGas func(context.Context, StateManager, *big.Int, ...DepositOption) ([]*action.TransactionLog, error)
 
 // View stores the view for all protocols
 type View map[string]interface{}

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -126,12 +126,13 @@ func SplitGas(ctx context.Context, tx action.TxDynamicGas, usedGas uint64) (*big
 		baseFee = MustGetBlockchainCtx(ctx).Tip.BaseFee
 		gas     = new(big.Int).SetUint64(usedGas)
 	)
+	if baseFee == nil {
+		// treat as basefee if before enabling EIP-1559
+		return new(big.Int), new(big.Int).Mul(tx.GasFeeCap(), gas), nil
+	}
 	priority, err := action.EffectiveGasTip(tx, baseFee)
 	if err != nil {
 		return nil, nil, err
-	}
-	if baseFee == nil {
-		return priority.Mul(priority, gas), nil, nil
 	}
 	// after enabling EIP-1559, fee is split into 2 parts
 	// priority fee goes to the rewarding pool (or block producer) as before

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -82,6 +82,7 @@ type ActionHandler interface {
 type (
 	DepositOptionCfg struct {
 		PriorityFee *big.Int
+		BlobGasFee  *big.Int
 	}
 
 	DepositOption func(*DepositOptionCfg)
@@ -90,6 +91,12 @@ type (
 func PriorityFeeOption(priorityFee *big.Int) DepositOption {
 	return func(opts *DepositOptionCfg) {
 		opts.PriorityFee = priorityFee
+	}
+}
+
+func BlobGasFeeOption(blobGasFee *big.Int) DepositOption {
+	return func(opts *DepositOptionCfg) {
+		opts.BlobGasFee = blobGasFee
 	}
 }
 

--- a/action/protocol/rewarding/fund.go
+++ b/action/protocol/rewarding/fund.go
@@ -178,6 +178,13 @@ func DepositGas(ctx context.Context, sm protocol.StateManager, amount *big.Int, 
 		}
 		logs = append(logs, slogs...)
 	}
+	if !isZero(cfg.BlobGasFee) {
+		slogs, err := rp.Deposit(ctx, sm, cfg.BlobGasFee, iotextypes.TransactionLogType_BLOB_FEE)
+		if err != nil {
+			return nil, err
+		}
+		logs = append(logs, slogs...)
+	}
 	return logs, nil
 }
 

--- a/action/protocol/rewarding/fund.go
+++ b/action/protocol/rewarding/fund.go
@@ -87,14 +87,7 @@ func (p *Protocol) Deposit(
 	// Add balance to fund
 	var (
 		f    = fund{}
-		tLog = []*action.TransactionLog{
-			{
-				Type:      transactionLogType,
-				Sender:    actionCtx.Caller.String(),
-				Recipient: address.RewardingPoolAddr,
-				Amount:    amount,
-			},
-		}
+		tLog = []*action.TransactionLog{}
 	)
 	if !isZero(amount) {
 		tLog = append(tLog, &action.TransactionLog{

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -428,7 +428,7 @@ func (p *Protocol) settleAction(
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to split gas")
 		}
-		depositLog, err := DepositGas(ctx, sm, gasFee, protocol.BurnGasOption(baseFee, iotextypes.TransactionLogType_NATIVE_TRANSFER))
+		depositLog, err := DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
 		if err != nil {
 			return nil, err
 		}

--- a/action/protocol/rewarding/protocol.go
+++ b/action/protocol/rewarding/protocol.go
@@ -424,11 +424,11 @@ func (p *Protocol) settleAction(
 	}
 	skipUpdateForSystemAction := protocol.MustGetFeatureCtx(ctx).FixGasAndNonceUpdate
 	if !isSystemAction || !skipUpdateForSystemAction {
-		gasFee, baseFee, err := protocol.SplitGas(ctx, act, actionCtx.IntrinsicGas)
+		priorityFee, baseFee, err := protocol.SplitGas(ctx, act, actionCtx.IntrinsicGas)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to split gas")
 		}
-		depositLog, err := DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
+		depositLog, err := DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(priorityFee))
 		if err != nil {
 			return nil, err
 		}

--- a/action/protocol/staking/handler_stake_migrate_test.go
+++ b/action/protocol/staking/handler_stake_migrate_test.go
@@ -153,7 +153,7 @@ func TestHandleStakeMigrate(t *testing.T) {
 	r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[1].Status)
 	excPrtl := execution.NewProtocol(
 		func(u uint64) (hash.Hash256, error) { return hash.ZeroHash256, nil },
-		func(context.Context, protocol.StateManager, *big.Int, ...protocol.Option) ([]*action.TransactionLog, error) {
+		func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
 			return nil, nil
 		},
 		func(uint64) (time.Time, error) { return time.Now(), nil },

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -3307,7 +3307,7 @@ func setupAccount(sm protocol.StateManager, addr address.Address, balance int64)
 	return accountutil.StoreAccount(sm, addr, account)
 }
 
-func depositGas(ctx context.Context, sm protocol.StateManager, gasFee *big.Int, opts ...protocol.Option) ([]*action.TransactionLog, error) {
+func depositGas(ctx context.Context, sm protocol.StateManager, gasFee *big.Int, opts ...protocol.DepositOption) ([]*action.TransactionLog, error) {
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	// Subtract balance from caller
 	acc, err := accountutil.LoadAccount(sm, actionCtx.Caller)

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -698,11 +698,11 @@ func (p *Protocol) settleAction(
 		actionCtx = protocol.MustGetActionCtx(ctx)
 		blkCtx    = protocol.MustGetBlockCtx(ctx)
 	)
-	gasFee, baseFee, err := protocol.SplitGas(ctx, act, gasToBeDeducted)
+	priorityFee, baseFee, err := protocol.SplitGas(ctx, act, gasToBeDeducted)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split gas")
 	}
-	depositLog, err := p.helperCtx.DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
+	depositLog, err := p.helperCtx.DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(priorityFee))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to deposit gas")
 	}

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -702,7 +702,7 @@ func (p *Protocol) settleAction(
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to split gas")
 	}
-	depositLog, err := p.helperCtx.DepositGas(ctx, sm, gasFee, protocol.BurnGasOption(baseFee, iotextypes.TransactionLogType_NATIVE_TRANSFER))
+	depositLog, err := p.helperCtx.DepositGas(ctx, sm, baseFee, protocol.PriorityFeeOption(gasFee))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to deposit gas")
 	}

--- a/action/rlp_tx_test.go
+++ b/action/rlp_tx_test.go
@@ -291,24 +291,6 @@ var (
 	}
 )
 
-func TestNewEthSignerError(t *testing.T) {
-	require := require.New(t)
-	singer, err := NewEthSigner(iotextypes.Encoding_ETHEREUM_ACCESSLIST, 1)
-	require.ErrorIs(err, ErrInvalidAct)
-	require.Nil(singer)
-
-	tx := types.NewTx(&types.DynamicFeeTx{
-		To:        nil,
-		Nonce:     4,
-		Value:     big.NewInt(4),
-		Gas:       4,
-		GasTipCap: big.NewInt(44),
-		GasFeeCap: big.NewInt(1045),
-	})
-	_, _, _, err = ExtractTypeSigPubkey(tx)
-	require.ErrorIs(err, ErrNotSupported)
-}
-
 func TestEthTxDecodeVerify(t *testing.T) {
 	require := require.New(t)
 	var (

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/iotexproject/iotex-address v0.2.8
 	github.com/iotexproject/iotex-antenna-go/v2 v2.5.1
 	github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d
-	github.com/iotexproject/iotex-proto v0.6.4-0.20240921015631-53754f857c48
+	github.com/iotexproject/iotex-proto v0.6.4-0.20240921011815-fc5513dc9564
 	github.com/ipfs/go-ipfs-api v0.7.0
 	github.com/libp2p/go-libp2p v0.32.2
 	github.com/mackerelio/go-osstat v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -1186,8 +1186,6 @@ github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.m
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
 github.com/iotexproject/iotex-proto v0.6.4-0.20240921011815-fc5513dc9564 h1:k2jID4GQObL6rBXVsDNolNp6Vwbzs8o/3UrzxsmsZkU=
 github.com/iotexproject/iotex-proto v0.6.4-0.20240921011815-fc5513dc9564/go.mod h1:Hxct427jhlu08PHQ44Jwh//hZVhXKq+XO/Mdqwc6dNc=
-github.com/iotexproject/iotex-proto v0.6.4-0.20240921015631-53754f857c48 h1:TwlS6DHX+feaUezPjkKvBWsd9KOvbNvkxVTjKsfuvfU=
-github.com/iotexproject/iotex-proto v0.6.4-0.20240921015631-53754f857c48/go.mod h1:Hxct427jhlu08PHQ44Jwh//hZVhXKq+XO/Mdqwc6dNc=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=
 github.com/ipfs/bbloom v0.0.4/go.mod h1:cS9YprKXpoZ9lT0n/Mw/a6/aFV6DTjTLYHeA+gyqMG0=
 github.com/ipfs/boxo v0.8.1/go.mod h1:xJ2hVb4La5WyD7GvKYE0lq2g1rmQZoCD2K4WNrV6aZI=

--- a/go.sum
+++ b/go.sum
@@ -1184,6 +1184,8 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.5.1/go.mod h1:8pDZcM45M0gY6jm3PoM
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d h1:/j1xCAC9YiG/8UKqYvycS/v3ddVsb1G7AMyLXOjeYI0=
 github.com/iotexproject/iotex-election v0.3.5-0.20210611041425-20ddf674363d/go.mod h1:GRWevxtqQ4gPMrd7Qxhr29/7aTgvjiTp+rFI9KMMZEo=
 github.com/iotexproject/iotex-proto v0.5.0/go.mod h1:Xg6REkv+nTZN+OC22xXIQuqKdTWWHwOAJEXCoMpDwtI=
+github.com/iotexproject/iotex-proto v0.6.4-0.20240921011815-fc5513dc9564 h1:k2jID4GQObL6rBXVsDNolNp6Vwbzs8o/3UrzxsmsZkU=
+github.com/iotexproject/iotex-proto v0.6.4-0.20240921011815-fc5513dc9564/go.mod h1:Hxct427jhlu08PHQ44Jwh//hZVhXKq+XO/Mdqwc6dNc=
 github.com/iotexproject/iotex-proto v0.6.4-0.20240921015631-53754f857c48 h1:TwlS6DHX+feaUezPjkKvBWsd9KOvbNvkxVTjKsfuvfU=
 github.com/iotexproject/iotex-proto v0.6.4-0.20240921015631-53754f857c48/go.mod h1:Hxct427jhlu08PHQ44Jwh//hZVhXKq+XO/Mdqwc6dNc=
 github.com/ipfs/bbloom v0.0.1/go.mod h1:oqo8CVWsJFMOZqTglBG4wydCE4IQA/G2/SEofB0rjUI=

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -215,7 +215,7 @@ func (ws *workingSet) handleBlob(ctx context.Context, act *action.SealedEnvelope
 	receipt.BlobGasUsed = act.BlobGas()
 	receipt.BlobGasPrice = block.CalcBlobFee(protocol.MustGetBlockchainCtx(ctx).Tip.ExcessBlobGas)
 	blobFee := new(big.Int).Mul(receipt.BlobGasPrice, new(big.Int).SetUint64(receipt.BlobGasUsed))
-	logs, err := rewarding.DepositGas(ctx, ws, nil, protocol.BurnGasOption(blobFee, iotextypes.TransactionLogType_BLOB_FEE))
+	logs, err := rewarding.DepositGas(ctx, ws, new(big.Int), protocol.BlobGasFeeOption(blobFee))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description

The basefee introduced by EIP-1559 used to be burned directly, but now it has been changed to be transferred to the rewarding pool.

## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
