### PR TITLE
[api] native action only support legacyTx

### DIFF
--- a/action/protocol/generic_validator.go
+++ b/action/protocol/generic_validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 
 	"github.com/iotexproject/iotex-core/action"
 	"github.com/iotexproject/iotex-core/state"
@@ -129,6 +130,9 @@ func (v *GenericValidator) Validate(ctx context.Context, selp *action.SealedEnve
 					return errors.Wrap(err, "failed to validate blob sidecar")
 				}
 			}
+		}
+		if selp.Encoding() == uint32(iotextypes.Encoding_IOTEX_PROTOBUF) && selp.Version() != action.LegacyTxType {
+			return errors.Wrap(action.ErrInvalidAct, "protobuf encoding only supports legacy tx")
 		}
 	}
 	return nil


### PR DESCRIPTION
# Description

Because when native actions are converted into eth transactions, the HomeStead Signer is used, which does not support accessList, dynamicFeeTx, and blobTx, which will cause errors when querying related transactions and blocks using web3 API. 

Therefore, we reject native actions if is not legacyTx

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
