### PR TITLE
[actpool] check blob count before verifying proof

### DIFF
--- a/actpool/actqueue.go
+++ b/actpool/actqueue.go
@@ -60,8 +60,6 @@ type actQueue struct {
 	clock          clock.Clock
 	ttl            time.Duration
 	mu             sync.RWMutex
-	// count of blob txs in the queue
-	blobCount int
 }
 
 // NewActQueue create a new action queue
@@ -139,12 +137,8 @@ func (q *actQueue) Put(act *action.SealedEnvelope) error {
 			}
 		}
 		q.updateFromNonce(nonce)
+		q.ap.removeInvalidActs([]*action.SealedEnvelope{actInPool})
 		return nil
-	}
-	// check max number of blob txs per account
-	isBlobTx := len(act.BlobHashes()) > 0
-	if isBlobTx && q.blobCount >= int(q.ap.cfg.MaxNumBlobsPerAcct) {
-		return errors.Wrap(action.ErrNonceTooHigh, "too many blob txs in the queue")
 	}
 	nttl := &nonceWithTTL{nonce: nonce, deadline: q.clock.Now().Add(q.ttl)}
 	heap.Push(&q.ascQueue, nttl)
@@ -152,9 +146,6 @@ func (q *actQueue) Put(act *action.SealedEnvelope) error {
 	q.items[nonce] = act
 	if nonce == q.pendingNonce {
 		q.updateFromNonce(q.pendingNonce)
-	}
-	if isBlobTx {
-		q.blobCount++
 	}
 	return nil
 }
@@ -216,9 +207,6 @@ func (q *actQueue) cleanTimeout() []*action.SealedEnvelope {
 		nonce := q.ascQueue[i].nonce
 		if timeNow.After(q.ascQueue[i].deadline) && nonce > q.pendingNonce {
 			removedFromQueue = append(removedFromQueue, q.items[nonce])
-			if len(q.items[nonce].BlobHashes()) > 0 {
-				q.blobCount--
-			}
 			delete(q.items, nonce)
 			delete(q.pendingBalance, nonce)
 			q.ascQueue[i] = q.ascQueue[size-1]
@@ -255,9 +243,6 @@ func (q *actQueue) UpdateAccountState(nonce uint64, balance *big.Int) []*action.
 		heap.Remove(&q.descQueue, nttl.descIdx)
 		nonce := nttl.nonce
 		removed = append(removed, q.items[nonce])
-		if len(q.items[nonce].BlobHashes()) > 0 {
-			q.blobCount--
-		}
 		delete(q.items, nonce)
 
 	}
@@ -303,7 +288,6 @@ func (q *actQueue) Reset() {
 	q.pendingBalance = make(map[uint64]*big.Int)
 	q.accountNonce = 0
 	q.accountBalance = big.NewInt(0)
-	q.blobCount = 0
 }
 
 // PendingActs creates a consecutive nonce-sorted slice of actions
@@ -377,8 +361,5 @@ func (q *actQueue) PopActionWithLargestNonce() *action.SealedEnvelope {
 	item := q.items[itemMeta.nonce]
 	delete(q.items, itemMeta.nonce)
 	q.updateFromNonce(itemMeta.nonce)
-	if len(item.BlobHashes()) > 0 {
-		q.blobCount--
-	}
 	return item
 }

--- a/actpool/actqueue_test.go
+++ b/actpool/actqueue_test.go
@@ -61,7 +61,10 @@ func TestNoncePriorityQueue(t *testing.T) {
 
 func TestActQueuePut(t *testing.T) {
 	require := require.New(t)
-	q := NewActQueue(nil, "", 1, big.NewInt(maxBalance)).(*actQueue)
+	ctrl := gomock.NewController(t)
+	ap, err := NewActPool(genesis.Default, mock_chainmanager.NewMockStateReader(ctrl), DefaultConfig)
+	require.NoError(err)
+	q := NewActQueue(ap.(*actPool), "", 1, big.NewInt(maxBalance)).(*actQueue)
 	tsf1, err := action.SignedTransfer(_addr2, _priKey1, 2, big.NewInt(100), nil, uint64(0), big.NewInt(1))
 	require.NoError(err)
 	require.NoError(q.Put(tsf1))

--- a/actpool/queueworker.go
+++ b/actpool/queueworker.go
@@ -105,6 +105,7 @@ func (worker *queueWorker) Handle(job workerJob) error {
 	}
 
 	worker.ap.allActions.Set(actHash, act)
+	worker.ap.onAdded(act)
 	isBlobTx := len(act.BlobHashes()) > 0 // only store blob tx
 	if worker.ap.store != nil && isBlobTx {
 		if err := worker.ap.store.Put(act); err != nil {

--- a/actpool/validator.go
+++ b/actpool/validator.go
@@ -1,0 +1,57 @@
+package actpool
+
+import (
+	"context"
+	"sync"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/action"
+)
+
+type blobValidator struct {
+	blobCntLimitPerAcc uint64
+	blobCntPerAcc      map[string]uint64
+	mutex              sync.RWMutex
+}
+
+func newBlobValidator(blobCntLimitPerAcc uint64) *blobValidator {
+	return &blobValidator{
+		blobCntLimitPerAcc: blobCntLimitPerAcc,
+		blobCntPerAcc:      make(map[string]uint64),
+	}
+}
+
+func (v *blobValidator) Validate(ctx context.Context, act *action.SealedEnvelope) error {
+	if len(act.BlobHashes()) == 0 {
+		return nil
+	}
+	v.mutex.RLock()
+	defer v.mutex.RUnlock()
+	// check max number of blob txs per account
+	sender := act.SenderAddress().String()
+	if v.blobCntPerAcc[sender] >= v.blobCntLimitPerAcc {
+		return errors.Wrap(action.ErrNonceTooHigh, "too many blob txs in the queue")
+	}
+	return nil
+}
+
+func (v *blobValidator) OnAdded(act *action.SealedEnvelope) {
+	if len(act.BlobHashes()) == 0 {
+		return
+	}
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	sender := act.SenderAddress().String()
+	v.blobCntPerAcc[sender]++
+}
+
+func (v *blobValidator) OnRemoved(act *action.SealedEnvelope) {
+	if len(act.BlobHashes()) == 0 {
+		return
+	}
+	v.mutex.Lock()
+	defer v.mutex.Unlock()
+	sender := act.SenderAddress().String()
+	v.blobCntPerAcc[sender]--
+}

--- a/actpool/validator.go
+++ b/actpool/validator.go
@@ -5,8 +5,10 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/action"
+	"github.com/iotexproject/iotex-core/pkg/log"
 )
 
 type blobValidator struct {
@@ -53,5 +55,9 @@ func (v *blobValidator) OnRemoved(act *action.SealedEnvelope) {
 	v.mutex.Lock()
 	defer v.mutex.Unlock()
 	sender := act.SenderAddress().String()
+	if v.blobCntPerAcc[sender] == 0 {
+		log.L().Warn("blob count per account is already 0", zap.String("sender", sender))
+		return
+	}
 	v.blobCntPerAcc[sender]--
 }


### PR DESCRIPTION
# Description

Move blob count per account checking before proof verification in actpool, because verification is time-consuming calling.

Implement it in two steps:
- add subscriber in actpool to knowing actions for other components
- make a new validator to wrap the checking, and put it front to generic_validator

## Type of change
Please delete options that are not relevant.
- [x] Code refactor or improvement

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
