### PR TITLE
[action] AntiqueTx to handle out-of-band version value

### DIFF
--- a/action/actctx.go
+++ b/action/actctx.go
@@ -164,14 +164,15 @@ func (act *AbstractAction) fromProto(pb *iotextypes.ActionCore) error {
 
 func (act *AbstractAction) convertToTx() TxCommonInternal {
 	switch act.version {
-	case AntiqueTxType:
+	case AntiqueTxType, _outOfBandTxType18879571:
 		tx := AntiqueTx{
-			LegacyTx{
+			LegacyTx: LegacyTx{
 				chainID:  act.chainID,
 				nonce:    act.nonce,
 				gasLimit: act.gasLimit,
 				gasPrice: &big.Int{},
 			},
+			version: act.version,
 		}
 		if act.gasPrice != nil {
 			tx.gasPrice.Set(act.gasPrice)

--- a/action/actctx.go
+++ b/action/actctx.go
@@ -6,7 +6,6 @@
 package action
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/core/types"
@@ -164,20 +163,6 @@ func (act *AbstractAction) fromProto(pb *iotextypes.ActionCore) error {
 
 func (act *AbstractAction) convertToTx() TxCommonInternal {
 	switch act.version {
-	case AntiqueTxType, _outOfBandTxType18879571:
-		tx := AntiqueTx{
-			LegacyTx: LegacyTx{
-				chainID:  act.chainID,
-				nonce:    act.nonce,
-				gasLimit: act.gasLimit,
-				gasPrice: &big.Int{},
-			},
-			version: act.version,
-		}
-		if act.gasPrice != nil {
-			tx.gasPrice.Set(act.gasPrice)
-		}
-		return &tx
 	case LegacyTxType:
 		tx := LegacyTx{
 			chainID:  act.chainID,
@@ -221,6 +206,18 @@ func (act *AbstractAction) convertToTx() TxCommonInternal {
 			blob:       act.blobData,
 		}
 	default:
-		panic(fmt.Sprintf("unsupported action version = %d", act.version))
+		tx := AntiqueTx{
+			LegacyTx: LegacyTx{
+				chainID:  act.chainID,
+				nonce:    act.nonce,
+				gasLimit: act.gasLimit,
+				gasPrice: &big.Int{},
+			},
+			version: act.version,
+		}
+		if act.gasPrice != nil {
+			tx.gasPrice.Set(act.gasPrice)
+		}
+		return &tx
 	}
 }

--- a/action/action.go
+++ b/action/action.go
@@ -24,6 +24,11 @@ const (
 	BlobTxType       = 4
 )
 
+var (
+	// block height = 18879571, tx d03127451c120caed0c4e2ed91c58872231192e027daad3760c475e5aa2feffd used this value
+	_outOfBandTxType18879571 uint32 = 4689
+)
+
 type (
 	// Action is the action can be Executed in protocols. The method is added to avoid mistakenly used empty interface as action.
 	Action interface {

--- a/action/action.go
+++ b/action/action.go
@@ -24,11 +24,6 @@ const (
 	BlobTxType       = 4
 )
 
-var (
-	// block height = 18879571, tx d03127451c120caed0c4e2ed91c58872231192e027daad3760c475e5aa2feffd used this value
-	_outOfBandTxType18879571 uint32 = 4689
-)
-
 type (
 	// Action is the action can be Executed in protocols. The method is added to avoid mistakenly used empty interface as action.
 	Action interface {

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -286,7 +286,7 @@ func (elp *envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
 func (elp *envelope) loadProtoTxCommon(pbAct *iotextypes.ActionCore) error {
 	var err error
 	switch pbAct.Version {
-	case AntiqueTxType:
+	case AntiqueTxType, _outOfBandTxType18879571:
 		tx := AntiqueTx{}
 		if err = tx.fromProto(pbAct); err == nil {
 			elp.common = &tx

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -6,7 +6,6 @@
 package action
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -286,11 +285,6 @@ func (elp *envelope) LoadProto(pbAct *iotextypes.ActionCore) error {
 func (elp *envelope) loadProtoTxCommon(pbAct *iotextypes.ActionCore) error {
 	var err error
 	switch pbAct.Version {
-	case AntiqueTxType, _outOfBandTxType18879571:
-		tx := AntiqueTx{}
-		if err = tx.fromProto(pbAct); err == nil {
-			elp.common = &tx
-		}
 	case LegacyTxType:
 		tx := LegacyTx{}
 		if err = tx.fromProto(pbAct); err == nil {
@@ -312,7 +306,10 @@ func (elp *envelope) loadProtoTxCommon(pbAct *iotextypes.ActionCore) error {
 			elp.common = &tx
 		}
 	default:
-		panic(fmt.Sprintf("unsupported action version = %d", pbAct.Version))
+		tx := AntiqueTx{}
+		if err = tx.fromProto(pbAct); err == nil {
+			elp.common = &tx
+		}
 	}
 	return err
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -144,6 +144,7 @@ type (
 		SufficentBalanceGuarantee               bool
 		EnableCancunEVM                         bool
 		UnfoldContainerBeforeValidate           bool
+		EnableNewTxTypes                        bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -301,6 +302,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			SufficentBalanceGuarantee:               g.IsVanuatu(height),
 			EnableCancunEVM:                         g.IsVanuatu(height),
 			UnfoldContainerBeforeValidate:           g.IsVanuatu(height),
+			EnableNewTxTypes:                        g.IsVanuatu(height),
 		},
 	)
 }

--- a/action/tx_antique.go
+++ b/action/tx_antique.go
@@ -16,26 +16,36 @@ var _ TxCommonInternal = (*AntiqueTx)(nil)
 // AntiqueTx is same as LegacyTx, with the only difference that version = 0
 type AntiqueTx struct {
 	LegacyTx
+	version uint32
 }
 
 // NewAntiqueTx creates a new antique transaction
-func NewAntiqueTx(chainID uint32, nonce uint64, gasLimit uint64, gasPrice *big.Int) *AntiqueTx {
+func NewAntiqueTx(chainID, version uint32, nonce uint64, gasLimit uint64, gasPrice *big.Int) *AntiqueTx {
 	return &AntiqueTx{
-		LegacyTx{
+		LegacyTx: LegacyTx{
 			chainID:  chainID,
 			nonce:    nonce,
 			gasLimit: gasLimit,
 			gasPrice: gasPrice,
 		},
+		version: version,
 	}
 }
 
 func (tx *AntiqueTx) Version() uint32 {
-	return AntiqueTxType
+	return tx.version
 }
 
 func (tx *AntiqueTx) toProto() *iotextypes.ActionCore {
 	actCore := tx.LegacyTx.toProto()
-	actCore.Version = AntiqueTxType
+	actCore.Version = tx.version
 	return actCore
+}
+
+func (tx *AntiqueTx) fromProto(pb *iotextypes.ActionCore) error {
+	if err := tx.LegacyTx.fromProto(pb); err != nil {
+		return err
+	}
+	tx.version = pb.GetVersion()
+	return nil
 }

--- a/action/tx_antique_test.go
+++ b/action/tx_antique_test.go
@@ -60,7 +60,7 @@ func TestAntiqueTx(t *testing.T) {
 		r.Equal(tx, tx1)
 	})
 	ab := AbstractAction{
-		version:   _outOfBandTxType18879571,
+		version:   18879571,
 		chainID:   8,
 		nonce:     3,
 		gasLimit:  2024,
@@ -78,7 +78,7 @@ func TestAntiqueTx(t *testing.T) {
 			nonce:    3,
 			gasLimit: 2024,
 		},
-		version: _outOfBandTxType18879571,
+		version: 18879571,
 	}
 	t.Run("convert", func(t *testing.T) {
 		for _, price := range []*big.Int{
@@ -93,7 +93,7 @@ func TestAntiqueTx(t *testing.T) {
 			} else {
 				expect.gasPrice = new(big.Int).Set(price)
 			}
-			r.EqualValues(_outOfBandTxType18879571, antique.Version())
+			r.EqualValues(18879571, antique.Version())
 			r.Equal(expect, antique)
 		}
 	})
@@ -106,7 +106,7 @@ func TestAntiqueTx(t *testing.T) {
 			r.NoError(elp.loadProtoTxCommon(expect.toProto()))
 			antique, ok := elp.common.(*AntiqueTx)
 			r.True(ok)
-			r.EqualValues(_outOfBandTxType18879571, antique.Version())
+			r.EqualValues(18879571, antique.Version())
 			if price == nil {
 				expect.gasPrice = new(big.Int)
 			}

--- a/action/tx_antique_test.go
+++ b/action/tx_antique_test.go
@@ -23,12 +23,13 @@ func TestAntiqueTx(t *testing.T) {
 	r := require.New(t)
 	t.Run("proto", func(t *testing.T) {
 		tx := &AntiqueTx{
-			LegacyTx{
+			LegacyTx: LegacyTx{
 				chainID:  8,
 				nonce:    3,
 				gasLimit: 2024,
 				gasPrice: big.NewInt(31),
 			},
+			version: AntiqueTxType,
 		}
 		r.EqualValues(AntiqueTxType, tx.Version())
 		r.EqualValues(8, tx.ChainID())
@@ -47,18 +48,19 @@ func TestAntiqueTx(t *testing.T) {
 		pb := iotextypes.ActionCore{}
 		r.NoError(proto.Unmarshal(b, &pb))
 		tx1 := &AntiqueTx{
-			LegacyTx{
+			LegacyTx: LegacyTx{
 				chainID:  88,
 				nonce:    33,
 				gasLimit: 22,
 				gasPrice: big.NewInt(5),
 			},
+			version: 355,
 		}
 		r.NoError(tx1.fromProto(&pb))
 		r.Equal(tx, tx1)
 	})
 	ab := AbstractAction{
-		version:   AntiqueTxType,
+		version:   _outOfBandTxType18879571,
 		chainID:   8,
 		nonce:     3,
 		gasLimit:  2024,
@@ -71,11 +73,12 @@ func TestAntiqueTx(t *testing.T) {
 		},
 	}
 	expect := &AntiqueTx{
-		LegacyTx{
+		LegacyTx: LegacyTx{
 			chainID:  8,
 			nonce:    3,
 			gasLimit: 2024,
 		},
+		version: _outOfBandTxType18879571,
 	}
 	t.Run("convert", func(t *testing.T) {
 		for _, price := range []*big.Int{
@@ -90,7 +93,7 @@ func TestAntiqueTx(t *testing.T) {
 			} else {
 				expect.gasPrice = new(big.Int).Set(price)
 			}
-			r.EqualValues(AntiqueTxType, antique.Version())
+			r.EqualValues(_outOfBandTxType18879571, antique.Version())
 			r.Equal(expect, antique)
 		}
 	})
@@ -103,7 +106,7 @@ func TestAntiqueTx(t *testing.T) {
 			r.NoError(elp.loadProtoTxCommon(expect.toProto()))
 			antique, ok := elp.common.(*AntiqueTx)
 			r.True(ok)
-			r.EqualValues(AntiqueTxType, antique.Version())
+			r.EqualValues(_outOfBandTxType18879571, antique.Version())
 			if price == nil {
 				expect.gasPrice = new(big.Int)
 			}


### PR DESCRIPTION
# Description
at block height = 18879571, tx d03127451c120caed0c4e2ed91c58872231192e027daad3760c475e5aa2feffd used the value `ActionCore.Version = 4689` 

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
