### PR TITLE
[staking] Fix unstake not clean selfstake

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -144,6 +144,7 @@ type (
 		SufficentBalanceGuarantee               bool
 		EnableCancunEVM                         bool
 		UnfoldContainerBeforeValidate           bool
+		UnstakedButNotClearSelfStakeAmount      bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -301,6 +302,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			SufficentBalanceGuarantee:               g.IsVanuatu(height),
 			EnableCancunEVM:                         g.IsVanuatu(height),
 			UnfoldContainerBeforeValidate:           g.IsVanuatu(height),
+			UnstakedButNotClearSelfStakeAmount:      !g.IsVanuatu(height),
 		},
 	)
 }

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -179,16 +179,25 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 	}
 	// TODO: cannot unstake if selected as candidates in this or next epoch
 
-	// update bucket
-	bucket.UnstakeStartTime = blkCtx.BlockTimeStamp.UTC()
-	if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
-		return log, errors.Wrapf(err, "failed to update bucket for voter %s", bucket.Owner.String())
+	if featureCtx.UnstakedButNotClearSelfStakeAmount {
+		// update bucket
+		bucket.UnstakeStartTime = blkCtx.BlockTimeStamp.UTC()
+		if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
+			return log, errors.Wrapf(err, "failed to update bucket for voter %s", bucket.Owner.String())
+		}
 	}
 	selfStake, err := isSelfStakeBucket(featureCtx, csm, bucket)
 	if err != nil {
 		return log, &handleError{
 			err:           err,
 			failureStatus: iotextypes.ReceiptStatus_ErrUnknown,
+		}
+	}
+	if !featureCtx.UnstakedButNotClearSelfStakeAmount {
+		// update bucket
+		bucket.UnstakeStartTime = blkCtx.BlockTimeStamp.UTC()
+		if err := csm.updateBucket(act.BucketIndex(), bucket); err != nil {
+			return log, errors.Wrapf(err, "failed to update bucket for voter %s", bucket.Owner.String())
 		}
 	}
 	weightedVote := p.calculateVoteWeight(bucket, selfStake)
@@ -201,6 +210,9 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 	// clear candidate's self stake if the bucket is self staking
 	if selfStake {
 		candidate.SelfStake = big.NewInt(0)
+		if !featureCtx.UnstakedButNotClearSelfStakeAmount {
+			candidate.SelfStakeBucketIdx = candidateNoSelfStakeBucketIndex
+		}
 	}
 	if err := csm.Upsert(candidate); err != nil {
 		return log, csmErrorToHandleError(candidate.GetIdentifier().String(), err)

--- a/action/protocol/staking/vote_reviser.go
+++ b/action/protocol/staking/vote_reviser.go
@@ -26,6 +26,7 @@ type (
 		ReviseHeights               []uint64
 		CorrectCandsHeight          uint64
 		SelfStakeBucketReviseHeight uint64
+		CorrectCandSelfStakeHeight  uint64
 	}
 )
 
@@ -46,6 +47,12 @@ func (vr *VoteReviser) Revise(ctx protocol.FeatureCtx, csm CandidateStateManager
 		case errors.Cause(err) == state.ErrStateNotExist:
 		case err != nil:
 			return err
+		}
+		if vr.shouldCorrectCandSelfStake(height) {
+			cands, err = vr.correctCandSelfStake(ctx, csm, height, cands)
+			if err != nil {
+				return err
+			}
 		}
 		if vr.shouldReviseSelfStakeBuckets(height) {
 			cands, err = vr.reviseSelfStakeBuckets(ctx, csm, height, cands)
@@ -115,6 +122,31 @@ func (vr *VoteReviser) reviseSelfStakeBuckets(ctx protocol.FeatureCtx, csm Candi
 	return cands, nil
 }
 
+func (vr *VoteReviser) correctCandSelfStake(ctx protocol.FeatureCtx, csm CandidateStateManager, height uint64, cands CandidateList) (CandidateList, error) {
+	// revise selfstake
+	for _, cand := range cands {
+		if cand.SelfStakeBucketIdx == candidateNoSelfStakeBucketIndex {
+			cand.SelfStake = big.NewInt(0)
+			continue
+		}
+		sb, err := csm.getBucket(cand.SelfStakeBucketIdx)
+		switch errors.Cause(err) {
+		case state.ErrStateNotExist:
+			// bucket has been withdrawn
+			cand.SelfStakeBucketIdx = candidateNoSelfStakeBucketIndex
+			cand.SelfStake = big.NewInt(0)
+		case nil:
+			if sb.isUnstaked() {
+				cand.SelfStakeBucketIdx = candidateNoSelfStakeBucketIndex
+				cand.SelfStake = big.NewInt(0)
+			}
+		default:
+			return nil, errors.Wrapf(err, "failed to get bucket with index %d", cand.SelfStakeBucketIdx)
+		}
+	}
+	return cands, nil
+}
+
 func (vr *VoteReviser) result(height uint64) (CandidateList, bool) {
 	cands, ok := vr.cache[height]
 	if !ok {
@@ -136,7 +168,8 @@ func (vr *VoteReviser) isCacheExist(height uint64) bool {
 func (vr *VoteReviser) NeedRevise(height uint64) bool {
 	return slices.Contains(vr.cfg.ReviseHeights, height) ||
 		vr.shouldReviseSelfStakeBuckets(height) ||
-		vr.shouldReviseAlias(height)
+		vr.shouldReviseAlias(height) ||
+		vr.shouldCorrectCandSelfStake(height)
 }
 
 // NeedCorrectCands returns true if height needs to correct candidates
@@ -146,6 +179,10 @@ func (vr *VoteReviser) shouldReviseAlias(height uint64) bool {
 
 func (vr *VoteReviser) shouldReviseSelfStakeBuckets(height uint64) bool {
 	return vr.cfg.SelfStakeBucketReviseHeight == height
+}
+
+func (vr *VoteReviser) shouldCorrectCandSelfStake(height uint64) bool {
+	return vr.cfg.CorrectCandSelfStakeHeight == height
 }
 
 func (vr *VoteReviser) calculateVoteWeight(csm CandidateStateManager, height uint64, cands CandidateList) (CandidateList, error) {

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -660,6 +660,7 @@ func (builder *Builder) registerStakingProtocol() error {
 				ReviseHeights:               []uint64{builder.cfg.Genesis.GreenlandBlockHeight, builder.cfg.Genesis.HawaiiBlockHeight},
 				CorrectCandsHeight:          builder.cfg.Genesis.OkhotskBlockHeight,
 				SelfStakeBucketReviseHeight: builder.cfg.Genesis.UpernavikBlockHeight,
+				CorrectCandSelfStakeHeight:  builder.cfg.Genesis.VanuatuBlockHeight,
 			},
 		},
 		builder.cs.candBucketsIndexer,


### PR DESCRIPTION
# Description

Fixes #4336 , including two parts:
- clean selfstake when handling unstake action in staking protocol
- revise candiate selfstake at VanuatuBlockHeight

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
