### PR TITLE
[factory] move SimulateExecution() out of factory interface

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -613,6 +613,7 @@ func SimulateExecution(
 	sm protocol.StateManager,
 	caller address.Address,
 	ex action.TxDataForSimulation,
+	opts ...protocol.SimulateOption,
 ) ([]byte, *action.Receipt, error) {
 	ctx, span := tracer.NewSpan(ctx, "evm.SimulateExecution")
 	defer span.End()
@@ -632,7 +633,16 @@ func SimulateExecution(
 	if err != nil {
 		return nil, nil, err
 	}
-	ctx = protocol.WithBlockCtx(
+	cfg := &protocol.SimulateOptionConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	if cfg.PreOpt != nil {
+		if err := cfg.PreOpt(sm); err != nil {
+			return nil, nil, err
+		}
+	}
+	ctx = protocol.WithFeatureCtx(protocol.WithBlockCtx(
 		ctx,
 		protocol.BlockCtx{
 			BlockHeight:    bcCtx.Tip.Height + 1,
@@ -642,8 +652,6 @@ func SimulateExecution(
 			BaseFee:        protocol.CalcBaseFee(g.Blockchain, &bcCtx.Tip),
 			ExcessBlobGas:  protocol.CalcExcessBlobGas(bcCtx.Tip.ExcessBlobGas, bcCtx.Tip.BlobGasUsed),
 		},
-	)
-
-	ctx = protocol.WithFeatureCtx(ctx)
+	))
 	return ExecuteContract(ctx, sm, ex)
 }

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -293,7 +293,11 @@ func readExecution(
 		GetBlockTime:   getBlockTimeForTest,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	return sf.SimulateExecution(ctx, addr, elp)
+	ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	return evm.SimulateExecution(ctx, ws, addr, elp)
 }
 
 func (sct *SmartContractTest) runExecutions(

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -293,7 +293,7 @@ func readExecution(
 		GetBlockTime:   getBlockTimeForTest,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+	ws, err := sf.WorkingSet(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1820,7 +1820,11 @@ func (core *coreService) ReadContractStorage(ctx context.Context, addr address.A
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	return core.sf.ReadContractStorage(ctx, addr, key)
+	ws, err := core.sf.WorkingSetNotWritable(ctx, 0, false)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return evm.ReadContractStorage(ctx, ws, addr, key)
 }
 
 func (core *coreService) ReceiveBlock(blk *block.Block) error {
@@ -1969,7 +1973,11 @@ func (core *coreService) simulateExecution(ctx context.Context, addr address.Add
 		GetBlockTime:   core.getBlockTime,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	return core.sf.SimulateExecution(ctx, addr, elp, opts...)
+	ws, err := core.sf.WorkingSetNotWritable(ctx, 0, false)
+	if err != nil {
+		return nil, nil, status.Error(codes.Internal, err.Error())
+	}
+	return evm.SimulateExecution(ctx, ws, addr, elp, opts...)
 }
 
 func filterReceipts(receipts []*action.Receipt, actHash hash.Hash256) *action.Receipt {

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1820,7 +1820,7 @@ func (core *coreService) ReadContractStorage(ctx context.Context, addr address.A
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	ws, err := core.sf.WorkingSetNotWritable(ctx, 0, false)
+	ws, err := core.sf.WorkingSet(ctx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -1973,7 +1973,7 @@ func (core *coreService) simulateExecution(ctx context.Context, addr address.Add
 		GetBlockTime:   core.getBlockTime,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	ws, err := core.sf.WorkingSetNotWritable(ctx, 0, false)
+	ws, err := core.sf.WorkingSet(ctx)
 	if err != nil {
 		return nil, nil, status.Error(codes.Internal, err.Error())
 	}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -735,7 +735,7 @@ func (builder *Builder) registerRollDPoSProtocol() error {
 				GetBlockTime:   getBlockTime,
 				DepositGasFunc: rewarding.DepositGas,
 			})
-			ws, err := factory.WorkingSetNotWritable(ctx, 0, false)
+			ws, err := factory.WorkingSet(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -735,7 +735,11 @@ func (builder *Builder) registerRollDPoSProtocol() error {
 				GetBlockTime:   getBlockTime,
 				DepositGasFunc: rewarding.DepositGas,
 			})
-			data, _, err := factory.SimulateExecution(ctx, addr, elp)
+			ws, err := factory.WorkingSetNotWritable(ctx, 0, false)
+			if err != nil {
+				return nil, err
+			}
+			data, _, err := evm.SimulateExecution(ctx, ws, addr, elp)
 			return data, err
 		},
 		candidatesutil.CandidatesFromDB,

--- a/e2etest/staking_test.go
+++ b/e2etest/staking_test.go
@@ -125,8 +125,11 @@ func TestStakingContract(t *testing.T) {
 				GetBlockTime:   fakeGetBlockTime,
 				DepositGasFunc: rewarding.DepositGas,
 			})
-			data, _, err := sf.SimulateExecution(ctx, addr, elp)
-
+			ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+			if err != nil {
+				return nil, err
+			}
+			data, _, err := evm.SimulateExecution(ctx, ws, addr, elp)
 			return data, err
 		})
 		require.NoError(err)

--- a/e2etest/staking_test.go
+++ b/e2etest/staking_test.go
@@ -125,7 +125,7 @@ func TestStakingContract(t *testing.T) {
 				GetBlockTime:   fakeGetBlockTime,
 				DepositGasFunc: rewarding.DepositGas,
 			})
-			ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+			ws, err := sf.WorkingSet(ctx)
 			if err != nil {
 				return nil, err
 			}

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -1224,7 +1224,7 @@ func testSimulateExecution(ctx context.Context, sf Factory, t *testing.T) {
 		},
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+	ws, err := sf.WorkingSet(ctx)
 	require.NoError(err)
 	_, _, err = evm.SimulateExecution(ctx, ws, addr, elp)
 	require.NoError(err)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -1224,7 +1224,9 @@ func testSimulateExecution(ctx context.Context, sf Factory, t *testing.T) {
 		},
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	_, _, err = sf.SimulateExecution(ctx, addr, elp)
+	ws, err := sf.WorkingSetNotWritable(ctx, 0, false)
+	require.NoError(err)
+	_, _, err = evm.SimulateExecution(ctx, ws, addr, elp)
 	require.NoError(err)
 }
 

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/iotexproject/go-pkgs/cache"
 	"github.com/iotexproject/go-pkgs/hash"
-	"github.com/iotexproject/iotex-address/address"
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
@@ -30,7 +29,6 @@ import (
 	"github.com/iotexproject/iotex-core/v2/db/batch"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/pkg/prometheustimer"
-	"github.com/iotexproject/iotex-core/v2/pkg/tracer"
 	"github.com/iotexproject/iotex-core/v2/pkg/util/byteutil"
 	"github.com/iotexproject/iotex-core/v2/state"
 )
@@ -261,46 +259,21 @@ func (sdb *stateDB) NewBlockBuilder(
 	return blkBuilder, nil
 }
 
-// SimulateExecution simulates a running of smart contract operation, this is done off the network since it does not
-// cause any state change
-func (sdb *stateDB) SimulateExecution(
-	ctx context.Context,
-	caller address.Address,
-	elp action.Envelope,
-	opts ...protocol.SimulateOption,
-) ([]byte, *action.Receipt, error) {
-	ctx, span := tracer.NewSpan(ctx, "stateDB.SimulateExecution")
-	defer span.End()
-
-	sdb.mutex.RLock()
-	currHeight := sdb.currentChainHeight
-	sdb.mutex.RUnlock()
-	ws, err := sdb.newWorkingSet(ctx, currHeight+1)
+func (sdb *stateDB) WorkingSetNotWritable(ctx context.Context, height uint64, isArchive bool) (protocol.StateManager, error) {
+	var (
+		ws  *workingSet
+		err error
+	)
+	if !isArchive {
+		sdb.mutex.RLock()
+		height = sdb.currentChainHeight
+		sdb.mutex.RUnlock()
+	}
+	ws, err = sdb.newWorkingSet(ctx, height+1)
 	if err != nil {
-		return nil, nil, err
+		return nil, errors.Wrap(err, "failed to obtain working set from state factory")
 	}
-	cfg := &protocol.SimulateOptionConfig{}
-	for _, opt := range opts {
-		opt(cfg)
-	}
-	if cfg.PreOpt != nil {
-		if err := cfg.PreOpt(ws); err != nil {
-			return nil, nil, err
-		}
-	}
-	return evm.SimulateExecution(ctx, ws, caller, elp)
-}
-
-// ReadContractStorage reads contract's storage
-func (sdb *stateDB) ReadContractStorage(ctx context.Context, contract address.Address, key []byte) ([]byte, error) {
-	sdb.mutex.RLock()
-	currHeight := sdb.currentChainHeight
-	sdb.mutex.RUnlock()
-	ws, err := sdb.newWorkingSet(ctx, currHeight+1)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to generate working set from state db")
-	}
-	return evm.ReadContractStorage(ctx, ws, contract, key)
+	return ws, nil
 }
 
 // PutBlock persists all changes in RunActions() into the DB

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -259,21 +259,15 @@ func (sdb *stateDB) NewBlockBuilder(
 	return blkBuilder, nil
 }
 
-func (sdb *stateDB) WorkingSetNotWritable(ctx context.Context, height uint64, isArchive bool) (protocol.StateManager, error) {
-	var (
-		ws  *workingSet
-		err error
-	)
-	if !isArchive {
-		sdb.mutex.RLock()
-		height = sdb.currentChainHeight
-		sdb.mutex.RUnlock()
-	}
-	ws, err = sdb.newWorkingSet(ctx, height+1)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to obtain working set from state factory")
-	}
-	return ws, nil
+func (sdb *stateDB) WorkingSet(ctx context.Context) (protocol.StateManager, error) {
+	sdb.mutex.RLock()
+	height := sdb.currentChainHeight
+	sdb.mutex.RUnlock()
+	return sdb.newWorkingSet(ctx, height+1)
+}
+
+func (sdb *stateDB) WorkingSetAtHeight(ctx context.Context, height uint64) (protocol.StateManager, error) {
+	return sdb.newWorkingSet(ctx, height+1)
 }
 
 // PutBlock persists all changes in RunActions() into the DB

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -247,17 +247,32 @@ func (mr *MockFactoryMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockFactory)(nil).Validate), arg0, arg1)
 }
 
-// WorkingSetNotWritable mocks base method.
-func (m *MockFactory) WorkingSetNotWritable(arg0 context.Context, arg1 uint64, arg2 bool) (protocol.StateManager, error) {
+// WorkingSet mocks base method.
+func (m *MockFactory) WorkingSet(arg0 context.Context) (protocol.StateManager, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WorkingSetNotWritable", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "WorkingSet", arg0)
 	ret0, _ := ret[0].(protocol.StateManager)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// WorkingSetNotWritable indicates an expected call of WorkingSetNotWritable.
-func (mr *MockFactoryMockRecorder) WorkingSetNotWritable(arg0, arg1, arg2 interface{}) *gomock.Call {
+// WorkingSet indicates an expected call of WorkingSet.
+func (mr *MockFactoryMockRecorder) WorkingSet(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkingSetNotWritable", reflect.TypeOf((*MockFactory)(nil).WorkingSetNotWritable), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkingSet", reflect.TypeOf((*MockFactory)(nil).WorkingSet), arg0)
+}
+
+// WorkingSetAtHeight mocks base method.
+func (m *MockFactory) WorkingSetAtHeight(arg0 context.Context, arg1 uint64) (protocol.StateManager, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkingSetAtHeight", arg0, arg1)
+	ret0, _ := ret[0].(protocol.StateManager)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkingSetAtHeight indicates an expected call of WorkingSetAtHeight.
+func (mr *MockFactoryMockRecorder) WorkingSetAtHeight(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkingSetAtHeight", reflect.TypeOf((*MockFactory)(nil).WorkingSetAtHeight), arg0, arg1)
 }

--- a/test/mock/mock_factory/mock_factory.go
+++ b/test/mock/mock_factory/mock_factory.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	address "github.com/iotexproject/iotex-address/address"
 	action "github.com/iotexproject/iotex-core/v2/action"
 	protocol "github.com/iotexproject/iotex-core/v2/action/protocol"
 	actpool "github.com/iotexproject/iotex-core/v2/actpool"
@@ -98,21 +97,6 @@ func (mr *MockFactoryMockRecorder) PutBlock(arg0, arg1 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBlock", reflect.TypeOf((*MockFactory)(nil).PutBlock), arg0, arg1)
 }
 
-// ReadContractStorage mocks base method.
-func (m *MockFactory) ReadContractStorage(arg0 context.Context, arg1 address.Address, arg2 []byte) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadContractStorage", arg0, arg1, arg2)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReadContractStorage indicates an expected call of ReadContractStorage.
-func (mr *MockFactoryMockRecorder) ReadContractStorage(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadContractStorage", reflect.TypeOf((*MockFactory)(nil).ReadContractStorage), arg0, arg1, arg2)
-}
-
 // ReadView mocks base method.
 func (m *MockFactory) ReadView(arg0 string) (interface{}, error) {
 	m.ctrl.T.Helper()
@@ -140,27 +124,6 @@ func (m *MockFactory) Register(arg0 protocol.Protocol) error {
 func (mr *MockFactoryMockRecorder) Register(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockFactory)(nil).Register), arg0)
-}
-
-// SimulateExecution mocks base method.
-func (m *MockFactory) SimulateExecution(arg0 context.Context, arg1 address.Address, arg2 action.Envelope, arg3 ...protocol.SimulateOption) ([]byte, *action.Receipt, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
-	for _, a := range arg3 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "SimulateExecution", varargs...)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(*action.Receipt)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// SimulateExecution indicates an expected call of SimulateExecution.
-func (mr *MockFactoryMockRecorder) SimulateExecution(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulateExecution", reflect.TypeOf((*MockFactory)(nil).SimulateExecution), varargs...)
 }
 
 // Start mocks base method.
@@ -282,4 +245,19 @@ func (m *MockFactory) Validate(arg0 context.Context, arg1 *block.Block) error {
 func (mr *MockFactoryMockRecorder) Validate(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Validate", reflect.TypeOf((*MockFactory)(nil).Validate), arg0, arg1)
+}
+
+// WorkingSetNotWritable mocks base method.
+func (m *MockFactory) WorkingSetNotWritable(arg0 context.Context, arg1 uint64, arg2 bool) (protocol.StateManager, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WorkingSetNotWritable", arg0, arg1, arg2)
+	ret0, _ := ret[0].(protocol.StateManager)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WorkingSetNotWritable indicates an expected call of WorkingSetNotWritable.
+func (mr *MockFactoryMockRecorder) WorkingSetNotWritable(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WorkingSetNotWritable", reflect.TypeOf((*MockFactory)(nil).WorkingSetNotWritable), arg0, arg1, arg2)
 }


### PR DESCRIPTION
# Description
2 methods don't need to be in the `factory` interface.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
