### PR TITLE
[blocksync] Fix estimate tip height

### DIFF
--- a/chainservice/builder_test.go
+++ b/chainservice/builder_test.go
@@ -1,0 +1,32 @@
+package chainservice
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mohae/deepcopy"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+func TestEstimateTipHeight(t *testing.T) {
+	r := require.New(t)
+	cfg := deepcopy.Copy(config.Default).(config.Config)
+	sk := identityset.PrivateKey(1)
+	t.Run("after dardanelles", func(t *testing.T) {
+		blk, err := block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.DardanellesBlockHeight + 1).SignAndBuild(sk)
+		r.NoError(err)
+		r.Equal(blk.Height()+2, estimateTipHeight(&cfg, &blk, 10*time.Second))
+	})
+	t.Run("before dardanelles", func(t *testing.T) {
+		blk, err := block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.DardanellesBlockHeight - 100).SignAndBuild(sk)
+		r.NoError(err)
+		r.Equal(blk.Height()+1, estimateTipHeight(&cfg, &blk, 10*time.Second))
+		blk, err = block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.DardanellesBlockHeight - 1).SignAndBuild(sk)
+		r.NoError(err)
+		r.Equal(blk.Height()+3, estimateTipHeight(&cfg, &blk, 20*time.Second))
+	})
+}


### PR DESCRIPTION
# Description

The current estimate of the latest height is incorrect, which will cause the verification of blocks to fail when the blob has expired during synchronization with lagging nodes.

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
