### PR TITLE
[api] convert container tx in actpool

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1159,7 +1159,7 @@ func (core *coreService) UnconfirmedActionsByAddress(address string, start uint6
 
 	var res []*iotexapi.ActionInfo
 	for i := start; i < uint64(len(selps)) && i < start+count; i++ {
-		if act, err := core.pendingAction(selps[i]); err == nil {
+		if act, err := core.actionToApiProto(selps[i]); err == nil {
 			res = append(res, act)
 		}
 	}
@@ -1342,10 +1342,19 @@ func (core *coreService) committedAction(selp *action.SealedEnvelope, blkHash ha
 	}, nil
 }
 
-func (core *coreService) pendingAction(selp *action.SealedEnvelope) (*iotexapi.ActionInfo, error) {
+func (core *coreService) actionToApiProto(selp *action.SealedEnvelope) (*iotexapi.ActionInfo, error) {
 	actHash, err := selp.Hash()
 	if err != nil {
 		return nil, err
+	}
+	if container, ok := selp.Envelope.(action.TxContainer); ok {
+		ctx, err := core.bc.Context(context.Background())
+		if err != nil {
+			return nil, err
+		}
+		if err := container.Unfold(selp, ctx, core.checkContract); err != nil {
+			return nil, err
+		}
 	}
 	sender := selp.SenderAddress()
 	return &iotexapi.ActionInfo{
@@ -1376,7 +1385,28 @@ func (core *coreService) getAction(actHash hash.Hash256, checkPending bool) (*io
 	if err != nil {
 		return nil, err
 	}
-	return core.pendingAction(selp)
+	return core.actionToApiProto(selp)
+}
+
+func (core *coreService) checkContract(ctx context.Context, to *common.Address) (bool, bool, bool, error) {
+	if to == nil {
+		return true, false, false, nil
+	}
+	var (
+		addr, _ = address.FromBytes(to.Bytes())
+		ioAddr  = addr.String()
+	)
+	if ioAddr == address.StakingProtocolAddr {
+		return false, true, false, nil
+	}
+	if ioAddr == address.RewardingProtocol {
+		return false, false, true, nil
+	}
+	sender, err := accountutil.AccountState(ctx, core.sf, addr)
+	if err != nil {
+		return false, false, false, errors.Wrapf(err, "failed to get account of %s", to.Hex())
+	}
+	return sender.IsContract(), false, false, nil
 }
 
 func (core *coreService) reverseActionsInBlock(blk *block.Block, reverseStart, count uint64) []*iotexapi.ActionInfo {

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -481,14 +481,20 @@ func newGetTransactionResult(
 		tmp := ethTx.To().String()
 		to = &tmp
 	}
-
-	signer, err := action.NewEthSigner(iotextypes.Encoding(selp.Encoding()), evmChainID)
-	if err != nil {
-		return nil, err
-	}
-	tx, err := action.RawTxToSignedTx(ethTx, signer, selp.Signature())
-	if err != nil {
-		return nil, err
+	var (
+		tx *types.Transaction
+	)
+	if _, ok := selp.Envelope.(action.TxContainer); ok {
+		tx = ethTx
+	} else {
+		signer, err := action.NewEthSigner(iotextypes.Encoding(selp.Encoding()), evmChainID)
+		if err != nil {
+			return nil, err
+		}
+		tx, err = action.RawTxToSignedTx(ethTx, signer, selp.Signature())
+		if err != nil {
+			return nil, err
+		}
 	}
 	return &getTransactionResult{
 		blockHash: blkHash,


### PR DESCRIPTION
# Description
Root-cause of issue 4485 is that tx is still pending (in actpool) so it is in container format, so we need to convert it to concrete tx type before returning to `eth_getTransactionByHash`.

Fixes #4485

The code change has been tested locally to fix the hardhat deploy issue

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
