### PR TITLE
[staking] fix alias for non-stop node

### DIFF
--- a/action/protocol/staking/builder.go
+++ b/action/protocol/staking/builder.go
@@ -8,6 +8,7 @@ type (
 	BuilderConfig struct {
 		Staking                  genesis.Staking
 		PersistStakingPatchBlock uint64
+		FixAliasForNonStopHeight uint64
 		StakingPatchDir          string
 		Revise                   ReviseConfig
 	}

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -74,6 +74,8 @@ type (
 		StreamingBlockBufferSize uint64 `yaml:"streamingBlockBufferSize"`
 		// PersistStakingPatchBlock is the block to persist staking patch
 		PersistStakingPatchBlock uint64 `yaml:"persistStakingPatchBlock"`
+		// FixAliasForNonStopHeight is the height to fix candidate alias for a non-stopping node
+		FixAliasForNonStopHeight uint64 `yaml:"fixAliasForNonStopHeight"`
 		// FactoryDBType is the type of factory db
 		FactoryDBType string `yaml:"factoryDBType"`
 		// MintTimeout is the timeout for minting
@@ -120,6 +122,7 @@ var (
 		WorkingSetCacheSize:           20,
 		StreamingBlockBufferSize:      200,
 		PersistStakingPatchBlock:      19778037,
+		FixAliasForNonStopHeight:      19778036,
 		FactoryDBType:                 db.DBBolt,
 		MintTimeout:                   1500 * time.Millisecond, // valued with block accept ttl - 500ms(tolerate network delay)
 	}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -667,6 +667,7 @@ func (builder *Builder) registerStakingProtocol() error {
 		&staking.BuilderConfig{
 			Staking:                  builder.cfg.Genesis.Staking,
 			PersistStakingPatchBlock: builder.cfg.Chain.PersistStakingPatchBlock,
+			FixAliasForNonStopHeight: builder.cfg.Chain.FixAliasForNonStopHeight,
 			StakingPatchDir:          builder.cfg.Chain.StakingPatchDir,
 			Revise: staking.ReviseConfig{
 				VoteWeight:                  builder.cfg.Genesis.VoteWeightCalConsts,


### PR DESCRIPTION
# Description
If a full-node runs from 0 without stopping, it will stop at Okhotsk height for the candidate alias bug. This PR fix the issue by manually resetting the candidate states in `CreatePreStates`

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [x] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
