### PR TITLE
[factory] fix statedb WorkingSetAtHeight

### DIFF
--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -2356,7 +2356,7 @@ func testHistoryForAccount(t *testing.T, statetx bool) {
 	// check history account's balance
 	if statetx {
 		_, err = sf.WorkingSetAtHeight(ctx, 0)
-		require.Equal(factory.ErrNotSupported, errors.Cause(err))
+		require.NoError(err)
 	} else {
 		sr, err := sf.WorkingSetAtHeight(ctx, bc.TipHeight()-1)
 		require.NoError(err)
@@ -2404,7 +2404,7 @@ func testHistoryForContract(t *testing.T, statetx bool) {
 	// check the the original balance again
 	if statetx {
 		_, err = sf.WorkingSetAtHeight(ctx, bc.TipHeight()-1)
-		require.Equal(factory.ErrNotSupported, errors.Cause(err))
+		require.NoError(err)
 	} else {
 		sr, err := sf.WorkingSetAtHeight(ctx, bc.TipHeight()-1)
 		require.NoError(err)

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -575,7 +575,7 @@ func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 	if statetx {
 		// statetx not support archive mode yet
 		_, err = sf.WorkingSetAtHeight(ctx, 0)
-		require.Equal(t, ErrNotSupported, errors.Cause(err))
+		require.NoError(t, err)
 	} else {
 		_, err = sf.WorkingSetAtHeight(ctx, 10)
 		if !archive {

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -268,7 +268,7 @@ func (sdb *stateDB) WorkingSet(ctx context.Context) (protocol.StateManager, erro
 
 func (sdb *stateDB) WorkingSetAtHeight(ctx context.Context, height uint64) (protocol.StateManager, error) {
 	// TODO: implement archive mode
-	return nil, ErrNotSupported
+	return sdb.newWorkingSet(ctx, height)
 }
 
 // PutBlock persists all changes in RunActions() into the DB


### PR DESCRIPTION
# Description
as title, the return value of `WorkingSetAtHeight` is actually NOT used, but return an error stops the code from continuing to execute.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
