### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/db/db_pebble_test.go
+++ b/db/db_pebble_test.go
@@ -7,14 +7,12 @@ package db
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/v2/db/batch"
-	"github.com/iotexproject/iotex-core/v2/testutil"
 )
 
 type kvTest struct {
@@ -24,11 +22,7 @@ type kvTest struct {
 
 func TestPebbleDB(t *testing.T) {
 	r := require.New(t)
-	testPath, err := os.MkdirTemp("", "test-pebble")
-	r.NoError(err)
-	defer func() {
-		testutil.CleanupPath(testPath)
-	}()
+	testPath := t.TempDir()
 
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -131,11 +125,7 @@ func TestPebbleDB(t *testing.T) {
 
 func TestPebbleDB_Filter(t *testing.T) {
 	r := require.New(t)
-	testPath, err := os.MkdirTemp("", "test-pebble")
-	r.NoError(err)
-	defer func() {
-		testutil.CleanupPath(testPath)
-	}()
+	testPath := t.TempDir()
 
 	cfg := DefaultConfig
 	cfg.DbPath = testPath
@@ -189,11 +179,7 @@ func TestPebbleDB_Filter(t *testing.T) {
 
 func TestPebbleDB_Foreach(t *testing.T) {
 	r := require.New(t)
-	testPath, err := os.MkdirTemp("", "test-pebble")
-	r.NoError(err)
-	defer func() {
-		testutil.CleanupPath(testPath)
-	}()
+	testPath := t.TempDir()
 
 	cfg := DefaultConfig
 	cfg.DbPath = testPath

--- a/server/itx/server_test.go
+++ b/server/itx/server_test.go
@@ -7,7 +7,6 @@ package itx
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -83,8 +82,7 @@ func newConfig(t *testing.T) (config.Config, func()) {
 	require.NoError(err)
 	contractIndexPath, err := testutil.PathOfTempFile("contractindxer.db")
 	require.NoError(err)
-	testActionStorePath, err := os.MkdirTemp(os.TempDir(), "actionstore")
-	require.NoError(err)
+	testActionStorePath := t.TempDir()
 	cfg := config.Default
 	cfg.API.GRPCPort = testutil.RandomPort()
 	cfg.API.HTTPPort = testutil.RandomPort()


### PR DESCRIPTION
# Description

 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir


## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [x] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
