### PR TITLE
Ignore user actions when PutPollResult exist

### DIFF
--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -8,6 +8,7 @@ package factory
 import (
 	"context"
 	"math/big"
+	"slices"
 	"sort"
 	"time"
 
@@ -653,8 +654,14 @@ func (ws *workingSet) pickAndRunActions(
 		blobLimit           = params.MaxBlobGasPerBlock / params.BlobTxBlobGasPerBlob
 		deadline            *time.Time
 		fullGas             = blkCtx.GasLimit
+		hasPutPollResult    = slices.ContainsFunc(postSystemActions, func(e *action.SealedEnvelope) bool {
+			_, ok := e.Action().(*action.PutPollResult)
+			return ok
+		})
 	)
-	if ap != nil {
+	// TODO: remove this if all delegates are updated with correct validation sequence
+	// this is a temporary solution to avoid putpollresult validation failure when exist staking action in same block
+	if ap != nil && !hasPutPollResult {
 		if dl, ok := ctx.Deadline(); ok {
 			deadline = &dl
 		}


### PR DESCRIPTION
# Description

To fix the issue where validation fails when both `putpollresult` and `staking` actions exist in one block, we ignore the user transaction during minting block with `putpollresult`

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
