### PR TITLE
Fix candidate BaseView was changed before commit

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -156,6 +156,7 @@ type (
 		FixRevertSnapshot                       bool
 		TimestampedStakingContract              bool
 		MakeUpBlockReward                       bool
+		CandidatePreStateView                   bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -317,6 +318,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixRevertSnapshot:                       g.IsVanuatu(height),
 			TimestampedStakingContract:              g.IsWake(height),
 			MakeUpBlockReward:                       g.IsWake(height),
+			CandidatePreStateView:                   !g.IsWake(height),
 		},
 	)
 }

--- a/action/protocol/staking/bucket_pool_test.go
+++ b/action/protocol/staking/bucket_pool_test.go
@@ -181,6 +181,6 @@ func TestBucketPool(t *testing.T) {
 	c, err := ConstructBaseView(sm)
 	r.NoError(err)
 	pool = c.BaseView().bucketPool
-	r.Equal(total.Add(total, tests[0].amount), pool.Total())
-	r.Equal(count+1, pool.Count())
+	r.Equal(total, pool.Total())
+	r.Equal(count, pool.Count())
 }

--- a/action/protocol/staking/bucket_pool_test.go
+++ b/action/protocol/staking/bucket_pool_test.go
@@ -145,11 +145,10 @@ func TestBucketPool(t *testing.T) {
 			total.Sub(total, v.amount)
 			count--
 		}
-
 		if v.commit {
 			r.NoError(csm.Commit(ctx))
 			// after commit, value should reflect in base view
-			c, err := ConstructBaseView(sm)
+			c, err := ConstructCandidateStateReader(ctx, sm)
 			r.NoError(err)
 			pool = c.BaseView().bucketPool
 			r.Equal(total, pool.Total())
@@ -157,7 +156,7 @@ func TestBucketPool(t *testing.T) {
 		}
 
 		if !testGreenland && v.postGreenland {
-			c, err := ConstructBaseView(sm)
+			c, err := ConstructCandidateStateReader(ctx, sm)
 			r.NoError(err)
 			_, err = sm.PutState(c.BaseView().bucketPool.total, protocol.NamespaceOption(_stakingNameSpace), protocol.KeyOption(_bucketPoolAddrKey))
 			r.NoError(err)
@@ -178,7 +177,7 @@ func TestBucketPool(t *testing.T) {
 	r.NoError(csm.DebitBucketPool(tests[0].amount, true))
 	sm.Snapshot()
 
-	c, err := ConstructBaseView(sm)
+	c, err := ConstructCandidateStateReader(ctx, sm)
 	r.NoError(err)
 	pool = c.BaseView().bucketPool
 	r.Equal(total, pool.Total())

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -76,7 +76,7 @@ type (
 func NewCandidateStateManager(sm protocol.StateManager) (CandidateStateManager, error) {
 	// TODO: we can store csm in a local cache, just as how statedb store the workingset
 	// b/c most time the sm is used before, no need to create another clone
-	view, err := ConstructView(sm)
+	view, err := constructViewData(sm)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -76,14 +76,13 @@ type (
 func NewCandidateStateManager(sm protocol.StateManager) (CandidateStateManager, error) {
 	// TODO: we can store csm in a local cache, just as how statedb store the workingset
 	// b/c most time the sm is used before, no need to create another clone
-	csr, err := ConstructBaseView(sm)
+	view, err := ConstructView(sm)
 	if err != nil {
 		return nil, err
 	}
 
 	// make a copy of candidate center and bucket pool, so they can be modified by csm
 	// and won't affect base view until being committed
-	view := csr.BaseView()
 	return &candSM{
 		StateManager: sm,
 		candCenter:   view.candCenter,

--- a/action/protocol/staking/candidate_statereader_test.go
+++ b/action/protocol/staking/candidate_statereader_test.go
@@ -6,13 +6,16 @@
 package staking
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/iotexproject/iotex-core/v2/action/protocol"
-	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 )
 
 func Test_CandidateStateReader(t *testing.T) {
@@ -22,7 +25,8 @@ func Test_CandidateStateReader(t *testing.T) {
 	sm := testdb.NewMockStateManager(ctrl)
 	h, err := sm.Height()
 	require.NoError(err)
-	csr, err := ConstructBaseView(sm)
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.Default)
+	csr, err := ConstructCandidateStateReader(ctx, sm)
 	require.Equal(err, protocol.ErrNoName)
 	view, _, err := CreateBaseView(sm, false)
 	require.NoError(err)

--- a/action/protocol/staking/handler_stake_migrate.go
+++ b/action/protocol/staking/handler_stake_migrate.go
@@ -167,7 +167,7 @@ func (p *Protocol) withdrawBucket(ctx context.Context, withdrawer *state.Account
 }
 
 func (p *Protocol) ConstructExecution(ctx context.Context, act *action.MigrateStake, nonce, gas uint64, gasPrice *big.Int, sr protocol.StateReader) (action.Envelope, error) {
-	csr, err := ConstructBaseView(sr)
+	csr, err := ConstructCandidateStateReader(ctx, sr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create baseview")
 	}

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -303,7 +303,7 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 		featureCtx = protocol.MustGetFeatureCtx(ctx)
 	)
 	if blkCtx.BlockHeight == g.GreenlandBlockHeight {
-		csr, err := ConstructBaseView(sm)
+		csr, err := ConstructCandidateStateReader(ctx, sm)
 		if err != nil {
 			return err
 		}
@@ -356,7 +356,7 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 }
 
 func (p *Protocol) handleStakingIndexer(ctx context.Context, epochStartHeight uint64, sm protocol.StateManager) error {
-	csr, err := ConstructBaseView(sm)
+	csr, err := ConstructCandidateStateReader(ctx, sm)
 	if err != nil {
 		return err
 	}
@@ -587,7 +587,7 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get StateReader height")
 	}
-	c, err := ConstructBaseView(sr)
+	c, err := ConstructCandidateStateReader(ctx, sr)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get ActiveCandidates")
 	}
@@ -637,7 +637,7 @@ func (p *Protocol) ReadState(ctx context.Context, sr protocol.StateReader, metho
 	if p.contractStakingIndexerV3 != nil {
 		indexers = append(indexers, NewDelayTolerantIndexer(p.contractStakingIndexerV3, time.Second))
 	}
-	stakeSR, err := newCompositeStakingStateReader(p.candBucketsIndexer, sr, p.calculateVoteWeight, indexers...)
+	stakeSR, err := newCompositeStakingStateReader(ctx, p.candBucketsIndexer, sr, p.calculateVoteWeight, indexers...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -651,7 +651,7 @@ func (p *Protocol) ReadState(ctx context.Context, sr protocol.StateReader, metho
 	if rp := rolldpos.FindProtocol(protocol.MustGetRegistry(ctx)); rp != nil {
 		epochStartHeight = rp.GetEpochHeight(rp.GetEpochNum(inputHeight))
 	}
-	nativeSR, err := ConstructBaseView(sr)
+	nativeSR, err := ConstructCandidateStateReader(ctx, sr)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/action/protocol/staking/staking_statereader.go
+++ b/action/protocol/staking/staking_statereader.go
@@ -29,8 +29,8 @@ type (
 )
 
 // newCompositeStakingStateReader creates a new compositive staking state reader
-func newCompositeStakingStateReader(nativeIndexer *CandidatesBucketsIndexer, sr protocol.StateReader, calculateVoteWeight func(v *VoteBucket, selfStake bool) *big.Int, contractIndexers ...ContractStakingIndexer) (*compositeStakingStateReader, error) {
-	nativeSR, err := ConstructBaseView(sr)
+func newCompositeStakingStateReader(ctx context.Context, nativeIndexer *CandidatesBucketsIndexer, sr protocol.StateReader, calculateVoteWeight func(v *VoteBucket, selfStake bool) *big.Int, contractIndexers ...ContractStakingIndexer) (*compositeStakingStateReader, error) {
+	nativeSR, err := ConstructCandidateStateReader(ctx, sr)
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/staking/staking_statereader_test.go
+++ b/action/protocol/staking/staking_statereader_test.go
@@ -118,6 +118,12 @@ func TestStakingStateReader(t *testing.T) {
 					count:  1,
 				},
 			},
+			base: Snapshot{
+				size:    candCenter.size,
+				changes: 0,
+				amount:  new(big.Int).Set(big.NewInt(100)),
+				count:   1,
+			},
 		}
 		states := make([][]byte, len(testNativeBuckets))
 		for i := range states {

--- a/action/protocol/staking/staking_statereader_test.go
+++ b/action/protocol/staking/staking_statereader_test.go
@@ -143,7 +143,7 @@ func TestStakingStateReader(t *testing.T) {
 			}
 			return buckets, nil
 		}).AnyTimes()
-		stakeSR, err := newCompositeStakingStateReader(nil, sf, func(v *VoteBucket, selfStake bool) *big.Int {
+		stakeSR, err := newCompositeStakingStateReader(genesis.WithGenesisContext(context.Background(), genesis.TestDefault()), nil, sf, func(v *VoteBucket, selfStake bool) *big.Int {
 			return v.StakedAmount
 		}, contractIndexer)
 		r.NoError(err)

--- a/action/protocol/staking/vote_reviser_test.go
+++ b/action/protocol/staking/vote_reviser_test.go
@@ -26,7 +26,9 @@ func TestVoteReviser(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	sm := testdb.NewMockStateManagerWithoutHeightFunc(ctrl)
-	sm.EXPECT().Height().Return(uint64(0), nil).Times(4)
+	sm.EXPECT().Height().DoAndReturn(func() (uint64, error) {
+		return 0, nil
+	}).Times(3)
 	csm := newCandidateStateManager(sm)
 	csr := newCandidateStateReader(sm)
 	_, err := sm.PutState(


### PR DESCRIPTION
# Description

This PR aims to Fix `Candidate Base View` has been changed before commit, which break `PutPollResult` validation in fullsync (e.g. 33732721 block).
- keep base view unchanged before wake height
- changed to updated view after wake height

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
