### PR TITLE
[staking] Read contract votes from protocol view

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -157,6 +157,7 @@ type (
 		TimestampedStakingContract              bool
 		PreStateSystemAction                    bool
 		MakeUpBlockReward                       bool
+		CreatePostActionStates                  bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -319,6 +320,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			TimestampedStakingContract:              g.IsWake(height),
 			PreStateSystemAction:                    !g.IsWake(height),
 			MakeUpBlockReward:                       g.IsWake(height),
+			CreatePostActionStates:                  g.IsWake(height),
 		},
 	)
 }

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -144,6 +144,9 @@ func createPostSystemActions(ctx context.Context, sr protocol.StateReader, p Pro
 			epochNum+1,
 		)
 	}
+	if err != nil {
+		log.L().Warn("failed to prepare delegates for next epoch", zap.Error(err))
+	}
 
 	nonce := uint64(0)
 	pollAction := action.NewPutPollResult(nextEpochHeight, l)

--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -81,6 +81,11 @@ type ActionHandler interface {
 	Handle(context.Context, action.Envelope, StateManager) (*action.Receipt, error)
 }
 
+// PostActionHandler is the interface for the post action handlers. For each incoming action, the assembled actions
+type PostActionHandler interface {
+	HandleReceipt(ctx context.Context, elp action.Envelope, sm StateManager, receipt *action.Receipt) error
+}
+
 type (
 	DepositOptionCfg struct {
 		PriorityFee *big.Int

--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -10,10 +10,12 @@ import (
 	"math/big"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-address/address"
 
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/state"
 )
 
@@ -107,9 +109,14 @@ func (csm *candSM) SR() protocol.StateReader {
 
 // DirtyView is csm's current state, which reflects base view + applying delta saved in csm's dock
 func (csm *candSM) DirtyView() *ViewData {
+	v, err := csm.StateManager.ReadView(_protocolID)
+	if err != nil {
+		log.S().Panic("failed to read view", zap.Error(err))
+	}
 	return &ViewData{
-		candCenter: csm.candCenter,
-		bucketPool: csm.bucketPool,
+		candCenter:     csm.candCenter,
+		bucketPool:     csm.bucketPool,
+		contractsStake: v.(*ViewData).contractsStake,
 	}
 }
 

--- a/action/protocol/staking/candidate_statereader.go
+++ b/action/protocol/staking/candidate_statereader.go
@@ -146,8 +146,9 @@ func ConstructBaseView(sr protocol.StateReader) (CandidateStateReader, error) {
 		StateReader: sr,
 		height:      height,
 		view: &ViewData{
-			candCenter: view.candCenter,
-			bucketPool: view.bucketPool,
+			candCenter:     view.candCenter,
+			bucketPool:     view.bucketPool,
+			contractsStake: view.contractsStake,
 		},
 	}, nil
 }

--- a/action/protocol/staking/contractstake_indexer.go
+++ b/action/protocol/staking/contractstake_indexer.go
@@ -6,6 +6,7 @@
 package staking
 
 import (
+	"context"
 	_ "embed"
 	"strings"
 	"time"
@@ -37,6 +38,8 @@ type (
 		TotalBucketCount(height uint64) (uint64, error)
 		// ContractAddress returns the contract address
 		ContractAddress() string
+		// StartView returns the contract stake view
+		StartView(ctx context.Context) (ContractStakeView, error)
 	}
 	// ContractStakingIndexerWithBucketType defines the interface of contract staking reader with bucket type
 	ContractStakingIndexerWithBucketType interface {

--- a/action/protocol/staking/contractstake_indexer_mock.go
+++ b/action/protocol/staking/contractstake_indexer_mock.go
@@ -5,6 +5,7 @@
 package staking
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -106,6 +107,21 @@ func (m *MockContractStakingIndexer) Height() (uint64, error) {
 func (mr *MockContractStakingIndexerMockRecorder) Height() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContractStakingIndexer)(nil).Height))
+}
+
+// StartView mocks base method.
+func (m *MockContractStakingIndexer) StartView(ctx context.Context) (ContractStakeView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartView", ctx)
+	ret0, _ := ret[0].(ContractStakeView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartView indicates an expected call of StartView.
+func (mr *MockContractStakingIndexerMockRecorder) StartView(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartView", reflect.TypeOf((*MockContractStakingIndexer)(nil).StartView), ctx)
 }
 
 // TotalBucketCount mocks base method.
@@ -233,6 +249,21 @@ func (m *MockContractStakingIndexerWithBucketType) Height() (uint64, error) {
 func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) Height() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Height", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).Height))
+}
+
+// StartView mocks base method.
+func (m *MockContractStakingIndexerWithBucketType) StartView(ctx context.Context) (ContractStakeView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartView", ctx)
+	ret0, _ := ret[0].(ContractStakeView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartView indicates an expected call of StartView.
+func (mr *MockContractStakingIndexerWithBucketTypeMockRecorder) StartView(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartView", reflect.TypeOf((*MockContractStakingIndexerWithBucketType)(nil).StartView), ctx)
 }
 
 // TotalBucketCount mocks base method.

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -462,6 +462,7 @@ func TestProtocol_ActiveCandidates(t *testing.T) {
 	sm.EXPECT().Height().DoAndReturn(func() (uint64, error) {
 		return blkHeight, nil
 	}).AnyTimes()
+	csIndexer.EXPECT().StartView(gomock.Any()).Return(nil, nil)
 
 	v, err := p.Start(ctx, sm)
 	require.NoError(err)

--- a/blockindex/contractstaking/event_handler.go
+++ b/blockindex/contractstaking/event_handler.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iotexproject/iotex-address/address"
 
 	"github.com/iotexproject/iotex-core/v2/action"
-	"github.com/iotexproject/iotex-core/v2/blockchain/block"
 	"github.com/iotexproject/iotex-core/v2/db/batch"
 )
 
@@ -374,7 +373,7 @@ func newContractStakingEventHandler(cache *contractStakingCache) *contractStakin
 	}
 }
 
-func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, blk *block.Block, log *action.Log) error {
+func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, height uint64, log *action.Log) error {
 	// get event abi
 	abiEvent, err := _stakingInterface.EventByID(common.Hash(log.Topics[0]))
 	if err != nil {
@@ -390,17 +389,17 @@ func (eh *contractStakingEventHandler) HandleEvent(ctx context.Context, blk *blo
 	// handle different kinds of event
 	switch abiEvent.Name {
 	case "BucketTypeActivated":
-		return eh.handleBucketTypeActivatedEvent(event, blk.Height())
+		return eh.handleBucketTypeActivatedEvent(event, height)
 	case "BucketTypeDeactivated":
-		return eh.handleBucketTypeDeactivatedEvent(event, blk.Height())
+		return eh.handleBucketTypeDeactivatedEvent(event, height)
 	case "Staked":
-		return eh.handleStakedEvent(event, blk.Height())
+		return eh.handleStakedEvent(event, height)
 	case "Locked":
 		return eh.handleLockedEvent(event)
 	case "Unlocked":
-		return eh.handleUnlockedEvent(event, blk.Height())
+		return eh.handleUnlockedEvent(event, height)
 	case "Unstaked":
-		return eh.handleUnstakedEvent(event, blk.Height())
+		return eh.handleUnstakedEvent(event, height)
 	case "Merged":
 		return eh.handleMergedEvent(event)
 	case "BucketExpanded":

--- a/blockindex/contractstaking/indexer.go
+++ b/blockindex/contractstaking/indexer.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
 
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
 	"github.com/iotexproject/iotex-core/v2/db"
 	"github.com/iotexproject/iotex-core/v2/pkg/util/byteutil"
@@ -33,6 +34,7 @@ type (
 		kvstore db.KVStore            // persistent storage, used to initialize index cache at startup
 		cache   *contractStakingCache // in-memory index for clean data, used to query index data
 		config  Config                // indexer config
+		started bool
 	}
 
 	// Config is the config for contract staking indexer
@@ -69,10 +71,35 @@ func NewContractStakingIndexer(kvStore db.KVStore, config Config) (*Indexer, err
 
 // Start starts the indexer
 func (s *Indexer) Start(ctx context.Context) error {
+	if s.started {
+		return nil
+	}
+	return s.start(ctx)
+}
+
+// StartView starts the indexer view
+func (s *Indexer) StartView(ctx context.Context) (staking.ContractStakeView, error) {
+	if !s.started {
+		if err := s.start(ctx); err != nil {
+			return nil, err
+		}
+	}
+	return &stakeView{
+		helper: s,
+		cache:  s.cache.Clone(),
+		height: s.cache.Height(),
+	}, nil
+}
+
+func (s *Indexer) start(ctx context.Context) error {
 	if err := s.kvstore.Start(ctx); err != nil {
 		return err
 	}
-	return s.loadFromDB()
+	if err := s.loadFromDB(); err != nil {
+		return err
+	}
+	s.started = true
+	return nil
 }
 
 // Stop stops the indexer
@@ -81,6 +108,7 @@ func (s *Indexer) Stop(ctx context.Context) error {
 		return err
 	}
 	s.cache = newContractStakingCache(s.config)
+	s.started = false
 	return nil
 }
 
@@ -187,7 +215,7 @@ func (s *Indexer) PutBlock(ctx context.Context, blk *block.Block) error {
 			if log.Address != s.config.ContractAddress {
 				continue
 			}
-			if err := handler.HandleEvent(ctx, blk, log); err != nil {
+			if err := handler.HandleEvent(ctx, blk.Height(), log); err != nil {
 				return err
 			}
 		}

--- a/blockindex/contractstaking/stakeview.go
+++ b/blockindex/contractstaking/stakeview.go
@@ -1,0 +1,60 @@
+package contractstaking
+
+import (
+	"context"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+)
+
+type stakeView struct {
+	helper *Indexer
+	cache  *contractStakingCache
+	height uint64
+}
+
+func (s *stakeView) Clone() staking.ContractStakeView {
+	return &stakeView{
+		helper: s.helper,
+		cache:  s.cache.Clone(),
+		height: s.height,
+	}
+}
+
+func (s *stakeView) BucketsByCandidate(candidate address.Address) ([]*Bucket, error) {
+	return s.cache.bucketsByCandidate(candidate, s.height)
+}
+
+func (s *stakeView) CreatePreStates(ctx context.Context) error {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	s.height = blkCtx.BlockHeight
+	return nil
+}
+
+func (s *stakeView) Handle(ctx context.Context, receipt *action.Receipt) error {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	// new event handler for this receipt
+	handler := newContractStakingEventHandler(s.cache)
+
+	// handle events of receipt
+	if receipt.Status != uint64(iotextypes.ReceiptStatus_Success) {
+		return nil
+	}
+	for _, log := range receipt.Logs() {
+		if log.Address != s.helper.config.ContractAddress {
+			continue
+		}
+		if err := handler.HandleEvent(ctx, blkCtx.BlockHeight, log); err != nil {
+			return err
+		}
+	}
+	_, delta := handler.Result()
+	// update cache
+	if err := s.cache.Merge(delta, blkCtx.BlockHeight); err != nil {
+		return err
+	}
+	return nil
+}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -275,6 +275,8 @@ func (builder *Builder) buildBlockDAO(forTest bool) error {
 	// indexers in synchronizedIndexers will need to run PutBlock() one by one
 	// factory is dependent on sgdIndexer and contractStakingIndexer, so it should be put in the first place
 	synchronizedIndexers := []blockdao.BlockIndexer{builder.cs.factory}
+	// TODO: the three contract staking indexers should be removed from blockdao indexers
+	// and commit them in statedb instead. Otherwise, their processing will be executed twice for each block.
 	if builder.cs.contractStakingIndexer != nil {
 		synchronizedIndexers = append(synchronizedIndexers, builder.cs.contractStakingIndexer)
 	}

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -429,7 +429,7 @@ func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Has
 	go func() {
 		blk, err := fork.MintNewBlock(startTime, privateKey, prevHash)
 		if err != nil {
-			ctx.logger().Error("failed to mint new block", zap.Error(err))
+			ctx.Logger().Error("failed to mint new block", zap.Error(err))
 			return
 		}
 		ctx.Logger().Debug("prepared a new block", zap.Uint64("height", blk.Height()), zap.Time("timestamp", blk.Timestamp()))

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -432,7 +432,7 @@ func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Has
 			ctx.logger().Error("failed to mint new block", zap.Error(err))
 			return
 		}
-		ctx.logger().Debug("prepared a new block", zap.Uint64("height", blk.Height()), zap.Time("timestamp", blk.Timestamp()))
+		ctx.Logger().Debug("prepared a new block", zap.Uint64("height", blk.Height()), zap.Time("timestamp", blk.Timestamp()))
 	}()
 	return nil
 }

--- a/systemcontractindex/common.go
+++ b/systemcontractindex/common.go
@@ -22,6 +22,7 @@ type IndexerCommon struct {
 	startHeight     uint64
 	height          uint64
 	contractAddress string
+	started         bool
 }
 
 // NewIndexerCommon creates a new IndexerCommon
@@ -45,12 +46,22 @@ func (s *IndexerCommon) Start(ctx context.Context) error {
 		return err
 	}
 	s.height = h
+	s.started = true
 	return nil
+}
+
+// Started returns true if the indexer is started
+func (s *IndexerCommon) Started() bool {
+	return s.started
 }
 
 // Stop stops the indexer
 func (s *IndexerCommon) Stop(ctx context.Context) error {
-	return s.kvstore.Stop(ctx)
+	if err := s.kvstore.Stop(ctx); err != nil {
+		return err
+	}
+	s.started = false
+	return nil
 }
 
 // KVStore returns the kvstore

--- a/systemcontractindex/common.go
+++ b/systemcontractindex/common.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/db"
 	"github.com/iotexproject/iotex-core/v2/db/batch"
+	"github.com/iotexproject/iotex-core/v2/pkg/lifecycle"
 	"github.com/iotexproject/iotex-core/v2/pkg/util/byteutil"
 )
 
@@ -22,7 +23,7 @@ type IndexerCommon struct {
 	startHeight     uint64
 	height          uint64
 	contractAddress string
-	started         bool
+	lifecycle.Readiness
 }
 
 // NewIndexerCommon creates a new IndexerCommon
@@ -46,13 +47,13 @@ func (s *IndexerCommon) Start(ctx context.Context) error {
 		return err
 	}
 	s.height = h
-	s.started = true
+	s.TurnOn()
 	return nil
 }
 
 // Started returns true if the indexer is started
 func (s *IndexerCommon) Started() bool {
-	return s.started
+	return s.IsReady()
 }
 
 // Stop stops the indexer
@@ -60,7 +61,7 @@ func (s *IndexerCommon) Stop(ctx context.Context) error {
 	if err := s.kvstore.Stop(ctx); err != nil {
 		return err
 	}
-	s.started = false
+	s.TurnOff()
 	return nil
 }
 

--- a/systemcontractindex/stakingindex/mute_handler.go
+++ b/systemcontractindex/stakingindex/mute_handler.go
@@ -39,9 +39,9 @@ func (eh *eventMuteHandler) HandleStakedEvent(event *abiutil.EventParam) error {
 	if !ok {
 		return errors.Errorf("no owner for token id %d", tokenIDParam.Uint64())
 	}
-	createdAt := eh.block.Height()
+	createdAt := eh.blockCtx.BlockHeight
 	if eh.timestamped {
-		createdAt = uint64(eh.block.Timestamp().Unix())
+		createdAt = uint64(eh.blockCtx.BlockTimeStamp.Unix())
 	}
 	bucket := &Bucket{
 		Candidate:      delegateParam,

--- a/systemcontractindex/stakingindex/stakeview.go
+++ b/systemcontractindex/stakingindex/stakeview.go
@@ -1,0 +1,69 @@
+package stakingindex
+
+import (
+	"context"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+)
+
+type stakeView struct {
+	helper *Indexer
+	cache  *cache
+	height uint64
+}
+
+func (s *stakeView) Clone() staking.ContractStakeView {
+	return &stakeView{
+		helper: s.helper,
+		cache:  s.cache.Copy(),
+		height: s.height,
+	}
+}
+func (s *stakeView) BucketsByCandidate(candidate address.Address) ([]*VoteBucket, error) {
+	idxs := s.cache.BucketIdsByCandidate(candidate)
+	bkts := s.cache.Buckets(idxs)
+	// filter out muted buckets
+	idxsFiltered := make([]uint64, 0, len(bkts))
+	bktsFiltered := make([]*Bucket, 0, len(bkts))
+	for i := range bkts {
+		if !bkts[i].Muted {
+			idxsFiltered = append(idxsFiltered, idxs[i])
+			bktsFiltered = append(bktsFiltered, bkts[i])
+		}
+	}
+	vbs := batchAssembleVoteBucket(idxsFiltered, bktsFiltered, s.helper.common.ContractAddress(), s.helper.genBlockDurationFn(s.height))
+	return vbs, nil
+}
+
+func (s *stakeView) CreatePreStates(ctx context.Context) error {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	s.height = blkCtx.BlockHeight
+	return nil
+}
+
+func (s *stakeView) Handle(ctx context.Context, receipt *action.Receipt) error {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	var handler stakingEventHandler
+	eventHandler := newEventHandler(s.helper.bucketNS, s.cache, blkCtx, s.helper.timestamped)
+	if s.helper.muteHeight > 0 && blkCtx.BlockHeight >= s.helper.muteHeight {
+		handler = newEventMuteHandler(eventHandler)
+	} else {
+		handler = eventHandler
+	}
+	if receipt.Status != uint64(iotextypes.ReceiptStatus_Success) {
+		return nil
+	}
+	for _, log := range receipt.Logs() {
+		if log.Address != s.helper.common.ContractAddress() {
+			continue
+		}
+		if err := s.helper.handleEvent(ctx, handler, log); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

This PR fixes the issue of validation failure when minting block include the putpollresult transaction in advance. The cause of this issue was that the contract staking indexer was one block behind when preparing the next proposal.

Now, the contract staking states are stored in the protocol's view, and a PostActionHandler has been added during execution to ensure that contract staking data can be updated immediately after each transaction execution.

Can review them in order by commit:
- staking protocol bdc28e1a0f79c32456b898fe98559405ab9d5ca8
- v1 contract indexer 3ef41632c6cbb597b9ecaeaa4656011eab4509f2
- v2&v3 contract indexer 0d62ee7cae9bd97ca76e1e522d3cd3383478ae31

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
