### PR TITLE
adjust wake block interval and block reward

### DIFF
--- a/action/protocol/rewarding/reward_test.go
+++ b/action/protocol/rewarding/reward_test.go
@@ -42,7 +42,7 @@ func TestProtocol_GrantBlockReward(t *testing.T) {
 		isWakeBlock bool
 	}{
 		{big.NewInt(10), big.NewInt(200), false},
-		{big.NewInt(48), big.NewInt(300), true},
+		{big.NewInt(40), big.NewInt(300), true},
 	} {
 		testProtocol(t, func(t *testing.T, ctx context.Context, sm protocol.StateManager, p *Protocol) {
 			if tv.isWakeBlock {

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -42,7 +42,7 @@ func defaultConfig() Genesis {
 			Timestamp:                 1553558500,
 			BlockGasLimit:             20000000,
 			TsunamiBlockGasLimit:      50000000,
-			WakeBlockGasLimit:         30000000,
+			WakeBlockGasLimit:         25000000,
 			ActionGasLimit:            5000000,
 			BlockInterval:             10 * time.Second,
 			NumSubEpochs:              15,

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -47,7 +47,7 @@ func defaultConfig() Genesis {
 			BlockInterval:             10 * time.Second,
 			NumSubEpochs:              15,
 			DardanellesNumSubEpochs:   30,
-			WakeNumSubEpochs:          50,
+			WakeNumSubEpochs:          60,
 			NumDelegates:              24,
 			NumCandidateDelegates:     36,
 			TimeBasedRotation:         true,
@@ -188,7 +188,7 @@ func defaultConfig() Genesis {
 			FoundationBonusP2StartEpoch:    9698,
 			FoundationBonusP2EndEpoch:      18458,
 			ProductivityThreshold:          85,
-			WakeBlockRewardStr:             "4800000000000000000",
+			WakeBlockRewardStr:             "4000000000000000000",
 		},
 		Staking: Staking{
 			VoteWeightCalConsts: VoteWeightCalConsts{

--- a/blockchain/genesis/genesis_test.go
+++ b/blockchain/genesis/genesis_test.go
@@ -148,11 +148,6 @@ func TestDeployerWhitelist(t *testing.T) {
 
 func TestWakeBlockReward(t *testing.T) {
 	r := require.New(t)
-	four, five := unit.ConvertIotxToRau(4), unit.ConvertIotxToRau(5)
-	four.Add(four, five)
-	four.Rsh(four, 1)
 	wake := Default.WakeBlockReward()
-	// wake block reward = 4.8, between 4.5 and 5
-	r.Equal(1, wake.Cmp(four))
-	r.Equal(-1, wake.Cmp(five))
+	r.Equal(0, wake.Cmp(unit.ConvertIotxToRau(4)))
 }

--- a/blockchain/genesis/genesis_test.go
+++ b/blockchain/genesis/genesis_test.go
@@ -101,8 +101,8 @@ func TestTsunamiBlockGasLimit(t *testing.T) {
 		{cfg.TsunamiBlockHeight - 1, 20000000},
 		{cfg.TsunamiBlockHeight, 50000000},
 		{cfg.WakeBlockHeight - 1, 50000000},
-		{cfg.WakeBlockHeight, 30000000},
-		{cfg.ToBeEnabledBlockHeight, 30000000},
+		{cfg.WakeBlockHeight, 25000000},
+		{cfg.ToBeEnabledBlockHeight, 25000000},
 	} {
 		r.Equal(v.gasLimit, cfg.BlockGasLimitByHeight(v.height))
 	}

--- a/chainservice/builder_test.go
+++ b/chainservice/builder_test.go
@@ -25,8 +25,8 @@ func TestEstimateTipHeight(t *testing.T) {
 		blk, err = block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.WakeBlockHeight - 3).SignAndBuild(sk)
 		r.NoError(err)
 		r.Equal(blk.Height()+2, estimateTipHeight(&cfg, &blk, 10*time.Second))
-		r.Equal(blk.Height()+3, estimateTipHeight(&cfg, &blk, 13*time.Second))
-		r.Equal(blk.Height()+3, estimateTipHeight(&cfg, &blk, 15*time.Second))
+		r.Equal(blk.Height()+3, estimateTipHeight(&cfg, &blk, 12500*time.Millisecond))
+		r.Equal(blk.Height()+3, estimateTipHeight(&cfg, &blk, 14500*time.Millisecond))
 	})
 	t.Run("before dardanelles", func(t *testing.T) {
 		blk, err := block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.DardanellesBlockHeight - 100).SignAndBuild(sk)
@@ -39,9 +39,9 @@ func TestEstimateTipHeight(t *testing.T) {
 	t.Run("after wake", func(t *testing.T) {
 		blk, err := block.NewBuilder(block.RunnableActions{}).SetHeight(cfg.Genesis.WakeBlockHeight).SignAndBuild(sk)
 		r.NoError(err)
-		r.Equal(blk.Height()+1, estimateTipHeight(&cfg, &blk, 3*time.Second))
-		r.Equal(blk.Height()+1, estimateTipHeight(&cfg, &blk, 5*time.Second))
-		r.Equal(blk.Height()+2, estimateTipHeight(&cfg, &blk, 6*time.Second))
+		r.Equal(blk.Height()+1, estimateTipHeight(&cfg, &blk, 2500*time.Millisecond))
+		r.Equal(blk.Height()+1, estimateTipHeight(&cfg, &blk, 4*time.Second))
+		r.Equal(blk.Height()+2, estimateTipHeight(&cfg, &blk, 5*time.Second))
 	})
 }
 

--- a/consensus/consensusfsm/consensus_ttl.go
+++ b/consensus/consensusfsm/consensus_ttl.go
@@ -25,13 +25,13 @@ var (
 	}
 	// DefaultWakeUpgradeConfig is the default config for wake upgrade
 	DefaultWakeUpgradeConfig = WakeUpgrade{
-		UnmatchedEventTTL:            2 * time.Second,
+		UnmatchedEventTTL:            1500 * time.Millisecond,
 		UnmatchedEventInterval:       100 * time.Millisecond,
-		AcceptBlockTTL:               1 * time.Second,
-		AcceptProposalEndorsementTTL: time.Second,
-		AcceptLockEndorsementTTL:     500 * time.Millisecond,
-		CommitTTL:                    500 * time.Millisecond,
-		BlockInterval:                3 * time.Second,
+		AcceptBlockTTL:               800 * time.Millisecond,
+		AcceptProposalEndorsementTTL: 800 * time.Millisecond,
+		AcceptLockEndorsementTTL:     450 * time.Millisecond,
+		CommitTTL:                    450 * time.Millisecond,
+		BlockInterval:                2500 * time.Millisecond,
 	}
 )
 

--- a/consensus/consensusfsm/consensus_ttl_test.go
+++ b/consensus/consensusfsm/consensus_ttl_test.go
@@ -34,12 +34,12 @@ func TestConsensusConfig_BlockInterval(t *testing.T) {
 		{
 			name:           "At Wake height",
 			height:         cfg.Genesis.WakeBlockHeight,
-			expectedResult: 3 * time.Second,
+			expectedResult: 2500 * time.Millisecond,
 		},
 		{
 			name:           "After Wake height",
 			height:         cfg.Genesis.WakeBlockHeight + 1,
-			expectedResult: 3 * time.Second,
+			expectedResult: 2500 * time.Millisecond,
 		},
 	}
 


### PR DESCRIPTION
Adjust Wake block reward to 4iotx and block interval to 2.5s. Correspondingly, the AcceptBlockTTL and AcceptProposalEndorsementTTL are reduced to 0.8s, AcceptLockEndorsementTTL and CommitTTL are reduced to 0.45s.
	

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
