### PR TITLE
Fix archive simulate bugs

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -657,7 +657,7 @@ func (core *coreService) readContract(
 	}
 	var (
 		g             = core.bc.Genesis()
-		blockGasLimit = g.BlockGasLimitByHeight(height)
+		blockGasLimit = g.BlockGasLimitByHeight(height + 1)
 	)
 	if elp.Gas() == 0 || blockGasLimit < elp.Gas() {
 		elp.SetGas(blockGasLimit)
@@ -2004,7 +2004,7 @@ func (core *coreService) SimulateExecution(ctx context.Context, addr address.Add
 	var (
 		g             = core.bc.Genesis()
 		tipHeight     = core.bc.TipHeight()
-		blockGasLimit = g.BlockGasLimitByHeight(tipHeight)
+		blockGasLimit = g.BlockGasLimitByHeight(tipHeight + 1)
 	)
 	elp.SetGas(blockGasLimit)
 	return core.simulateExecution(ctx, tipHeight, false, addr, elp)
@@ -2108,7 +2108,7 @@ func (core *coreService) TraceCall(ctx context.Context,
 	}
 	var (
 		g             = core.bc.Genesis()
-		blockGasLimit = g.BlockGasLimitByHeight(height)
+		blockGasLimit = g.BlockGasLimitByHeight(height + 1)
 	)
 	if gasLimit == 0 {
 		gasLimit = blockGasLimit

--- a/api/coreservice_with_height.go
+++ b/api/coreservice_with_height.go
@@ -32,6 +32,9 @@ type (
 )
 
 func newCoreServiceWithHeight(cs *coreService, height uint64) *coreServiceReaderWithHeight {
+	if height == 0 {
+		height = cs.TipHeight()
+	}
 	return &coreServiceReaderWithHeight{
 		cs:     cs,
 		height: height,


### PR DESCRIPTION
# Description

fix these two bugs:
1. `eth_call` on latest return nothing
```
curl  https://archive-mainnet.iotex.io \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_call","params":[{"from": null,"to":"0x8114746e4308a4d3ff2a74b66414ff35657fa0e2","data":"0x8da5cb5b"}, "latest"
  ],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"result":"0x"}
```
2. `eth_call` error on block WakeBlockHeight-1
```
curl  https://archive-mainnet.iotex.io \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"method":"eth_call","params":[{"from": null,"to":"0x8114746e4308a4d3ff2a74b66414ff35657fa0e2","data":"0x8da5cb5b"}, "0x232F4B8"
  ],"id":1,"jsonrpc":"2.0"}'
{"jsonrpc":"2.0","id":1,"error":{"code":13,"message":"exceeds block gas limit"}}
```

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
