### PR TITLE
use relative hardfork timestamp instead of reading from blockchain

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -503,7 +503,7 @@ func getChainConfig(g genesis.Blockchain, height uint64, id uint32, getBlockTime
 // blockHeightToTime returns the block time by height
 // if height is greater than current block height, return nil
 // if height is equal to current block height, return current block time
-// otherwise, return the block time by height from the blockchain
+// otherwise, return a fake time less than current block time
 func blockHeightToTime(ctx context.Context, height uint64) (*time.Time, error) {
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	if height > blkCtx.BlockHeight {
@@ -512,10 +512,7 @@ func blockHeightToTime(ctx context.Context, height uint64) (*time.Time, error) {
 	if height == blkCtx.BlockHeight {
 		return &blkCtx.BlockTimeStamp, nil
 	}
-	t, err := protocol.MustGetBlockchainCtx(ctx).GetBlockTime(height)
-	if err != nil {
-		return nil, err
-	}
+	t := blkCtx.BlockTimeStamp.Add(time.Duration(height-blkCtx.BlockHeight) * time.Second)
 	return &t, nil
 }
 


### PR DESCRIPTION

Since the hardfork timestamp relies on retrieval from the blockchain, it causes the node to depend on the chaindb at the hardfork height. To eliminate this dependency, the hardfork timestamp is changed to a time based on the current block timestamp, as it only requires maintaining the chronological order of the timestamps.

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
