### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/api/logfilter/logfilter.go
+++ b/api/logfilter/logfilter.go
@@ -2,6 +2,7 @@ package logfilter
 
 import (
 	"bytes"
+	"slices"
 
 	"github.com/iotexproject/go-pkgs/bloom"
 	"github.com/iotexproject/iotex-proto/golang/iotexapi"
@@ -57,11 +58,8 @@ func (l *LogFilter) MatchLogs(receipts []*action.Receipt) []*action.Log {
 func (l *LogFilter) match(log *iotextypes.Log) bool {
 	addrMatch := len(l.pbFilter.Address) == 0
 	if !addrMatch {
-		for _, e := range l.pbFilter.Address {
-			if e == log.ContractAddress {
-				addrMatch = true
-				break
-			}
+		if slices.Contains(l.pbFilter.Address, log.ContractAddress) {
+			addrMatch = true
 		}
 	}
 	if !addrMatch {
@@ -105,10 +103,8 @@ func (l *LogFilter) ExistInBloomFilter(bf bloom.BloomFilter) bool {
 			continue
 		}
 
-		for _, v := range e.Topic {
-			if bf.Exist(v) {
-				return true
-			}
+		if slices.ContainsFunc(e.Topic, bf.Exist) {
+			return true
 		}
 	}
 	// {} or nil matches any address or topic list

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -8,6 +8,7 @@ package blockchain
 import (
 	"crypto/ecdsa"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -263,11 +264,5 @@ func (cfg *Config) whitelistSignatureScheme(sk crypto.PrivateKey) bool {
 	if sigScheme == "" {
 		return false
 	}
-	for _, e := range cfg.SignatureScheme {
-		if sigScheme == e {
-			// signature scheme is whitelisted
-			return true
-		}
-	}
-	return false
+	return slices.Contains(cfg.SignatureScheme, sigScheme)
 }

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -6,6 +6,7 @@
 package rolldpos
 
 import (
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -118,13 +119,7 @@ func (c *roundCalculator) IsDelegate(addr string, height uint64) bool {
 		log.L().Warn("Failed to get delegates", zap.Error(err))
 		return false
 	}
-	for _, d := range delegates {
-		if addr == d {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(delegates, addr)
 }
 
 // RoundInfo returns information of round by the given height and current time

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -6,6 +6,7 @@
 package rolldpos
 
 import (
+	"slices"
 	"time"
 
 	"github.com/pkg/errors"
@@ -110,13 +111,7 @@ func (ctx *roundCtx) Proposers() []string {
 }
 
 func (ctx *roundCtx) IsDelegate(addr string) bool {
-	for _, d := range ctx.delegates {
-		if addr == d {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ctx.delegates, addr)
 }
 
 func (ctx *roundCtx) Block(blkHash []byte) *block.Block {

--- a/ioctl/config/configsetget.go
+++ b/ioctl/config/configsetget.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -226,12 +227,7 @@ func isValidEndpoint(endpoint string) bool {
 
 // isValidExplorer checks if the explorer is a valid option
 func isValidExplorer(arg string) bool {
-	for _, exp := range _validExpl {
-		if arg == exp {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(_validExpl, arg)
 }
 
 // isSupportedLanguage checks if the language is a supported option and returns index when supported

--- a/ioctl/newcmd/config/config.go
+++ b/ioctl/newcmd/config/config.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -352,12 +353,7 @@ func isValidEndpoint(endpoint string) bool {
 
 // isValidExplorer checks if the explorer is a valid option
 func isValidExplorer(arg string) bool {
-	for _, exp := range _validExpl {
-		if arg == exp {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(_validExpl, arg)
 }
 
 // writeConfig writes to config file

--- a/ioctl/util/util.go
+++ b/ioctl/util/util.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"syscall"
@@ -189,10 +190,8 @@ func JwtAuth() (jwt metadata.MD, err error) {
 // CheckArgs used for check ioctl cmd arg(s)'s num
 func CheckArgs(validNum ...int) cobra.PositionalArgs {
 	return func(cmd *cobra.Command, args []string) error {
-		for _, n := range validNum {
-			if len(args) == n {
-				return nil
-			}
+		if slices.Contains(validNum, len(args)) {
+			return nil
 		}
 		nums := strings.Replace(strings.Trim(fmt.Sprint(validNum), "[]"), " ", " or ", -1)
 		return fmt.Errorf("accepts "+nums+" arg(s), received %d", len(args))


### PR DESCRIPTION
# Description


There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.




Fixes #(issue)

## Type of change

- [x] Code refactor or improvement


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
