### PR TITLE
refactor: use maps.Copy to simplify the code

### DIFF
--- a/db/batch/kv_cache.go
+++ b/db/batch/kv_cache.go
@@ -5,6 +5,8 @@
 
 package batch
 
+import "maps"
+
 type (
 	// KVStoreCache is a local cache of batched <k, v> for fast query
 	KVStoreCache interface {
@@ -145,9 +147,7 @@ func (c *kvCache) Append(caches ...KVStoreCache) error {
 			if _, ok := c.cache[key1]; !ok {
 				c.cache[key1] = make(map[string]*node)
 			}
-			for key2, node := range ns {
-				c.cache[key1][key2] = node
-			}
+			maps.Copy(c.cache[key1], ns)
 		}
 	}
 	return nil

--- a/db/trie/mptrie/branchnode.go
+++ b/db/trie/mptrie/branchnode.go
@@ -6,6 +6,8 @@
 package mptrie
 
 import (
+	"maps"
+
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
@@ -248,9 +250,7 @@ func (b *branchNode) updateChild(cli client, key byte, child node) (node, error)
 	var indices *SortedList
 	// update branchnode with new child
 	children := make(map[byte]node, len(b.children))
-	for k, v := range b.children {
-		children[k] = v
-	}
+	maps.Copy(children, b.children)
 	if child == nil {
 		delete(children, key)
 		if b.indices.sorted {
@@ -277,9 +277,7 @@ func (b *branchNode) updateChild(cli client, key byte, child node) (node, error)
 
 func (b *branchNode) Clone() (branch, error) {
 	children := make(map[byte]node, len(b.children))
-	for key, child := range b.children {
-		children[key] = child
-	}
+	maps.Copy(children, b.children)
 	hashVal := make([]byte, len(b.hashVal))
 	copy(hashVal, b.hashVal)
 	ser := make([]byte, len(b.ser))


### PR DESCRIPTION
# Description

Inspired by https://github.com/iotexproject/iotex-core/pull/4741 and replace all case.

There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

Fixes #(issue)

## Type of change

- [x] Code refactor or improvement


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
