### PR TITLE
refactor: using reflect.TypeFor

### DIFF
--- a/ioctl/cmd/contract/parse.go
+++ b/ioctl/cmd/contract/parse.go
@@ -287,7 +287,7 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 			return nil, ErrInvalidArg
 		}
 
-		bytesType := reflect.ArrayOf(t.Size, reflect.TypeOf(uint8(0)))
+		bytesType := reflect.ArrayOf(t.Size, reflect.TypeFor[uint8]())
 		bytes := reflect.New(bytesType).Elem()
 
 		for i, oneByte := range bytecode {
@@ -352,7 +352,7 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.AddressTy:
-		if reflect.TypeOf(v) == reflect.TypeOf(common.Address{}) {
+		if reflect.TypeOf(v) == reflect.TypeFor[common.Address]() {
 			var ethAddr common.Address
 			ethAddr, ok = v.(common.Address)
 			if ok {
@@ -364,7 +364,7 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.BytesTy:
-		if reflect.TypeOf(v) == reflect.TypeOf([]byte{}) {
+		if reflect.TypeOf(v) == reflect.TypeFor[[]byte]() {
 			var bytes []byte
 			bytes, ok = v.([]byte)
 			if ok {
@@ -373,9 +373,9 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.FixedBytesTy, abi.FunctionTy:
-		if reflect.TypeOf(v).Kind() == reflect.Array && reflect.TypeOf(v).Elem() == reflect.TypeOf(byte(0)) {
+		if reflect.TypeOf(v).Kind() == reflect.Array && reflect.TypeOf(v).Elem() == reflect.TypeFor[byte]() {
 			bytesValue := reflect.ValueOf(v)
-			byteSlice := reflect.MakeSlice(reflect.TypeOf([]byte{}), bytesValue.Len(), bytesValue.Len())
+			byteSlice := reflect.MakeSlice(reflect.TypeFor[[]byte](), bytesValue.Len(), bytesValue.Len())
 			reflect.Copy(byteSlice, bytesValue)
 
 			str = "0x" + hex.EncodeToString(byteSlice.Bytes())

--- a/ioctl/newcmd/contract/parse.go
+++ b/ioctl/newcmd/contract/parse.go
@@ -282,7 +282,7 @@ func parseInputArgument(t *abi.Type, arg interface{}) (interface{}, error) {
 			return nil, ErrInvalidArg
 		}
 
-		bytesType := reflect.ArrayOf(t.Size, reflect.TypeOf(uint8(0)))
+		bytesType := reflect.ArrayOf(t.Size, reflect.TypeFor[uint8]())
 		bytes := reflect.New(bytesType).Elem()
 
 		for i, oneByte := range bytecode {
@@ -349,7 +349,7 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.AddressTy:
-		if reflect.TypeOf(v) == reflect.TypeOf(common.Address{}) {
+		if reflect.TypeOf(v) == reflect.TypeFor[common.Address]() {
 			var ethAddr common.Address
 			ethAddr, ok = v.(common.Address)
 			if ok {
@@ -361,7 +361,7 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.BytesTy:
-		if reflect.TypeOf(v) == reflect.TypeOf([]byte{}) {
+		if reflect.TypeOf(v) == reflect.TypeFor[[]byte]() {
 			var bytes []byte
 			bytes, ok = v.([]byte)
 			if ok {
@@ -370,9 +370,9 @@ func parseOutputArgument(v interface{}, t *abi.Type) (string, bool) {
 		}
 
 	case abi.FixedBytesTy, abi.FunctionTy:
-		if reflect.TypeOf(v).Kind() == reflect.Array && reflect.TypeOf(v).Elem() == reflect.TypeOf(byte(0)) {
+		if reflect.TypeOf(v).Kind() == reflect.Array && reflect.TypeOf(v).Elem() == reflect.TypeFor[byte]() {
 			bytesValue := reflect.ValueOf(v)
-			byteSlice := reflect.MakeSlice(reflect.TypeOf([]byte{}), bytesValue.Len(), bytesValue.Len())
+			byteSlice := reflect.MakeSlice(reflect.TypeFor[[]byte](), bytesValue.Len(), bytesValue.Len())
 			reflect.Copy(byteSlice, bytesValue)
 
 			str = "0x" + hex.EncodeToString(byteSlice.Bytes())


### PR DESCRIPTION
# Description


Try to use better api reflect.TypeFor instead of reflect.TypeOf when we have known the type.
More info https://github.com/golang/go/issues/60088



Fixes #(issue)

## Type of change

- [x] Code refactor or improvement


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
