### PR TITLE
allow blockdao indexers to run ahead

### DIFF
--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -317,6 +317,9 @@ func (builder *Builder) buildBlockDAO(forTest bool) error {
 	if err != nil {
 		return err
 	}
+	if _, ok := builder.cfg.Plugins[config.AllowBlockDaoIndexerAheadPlugin]; ok {
+		opts = append(opts, blockdao.WithAllowIndexerAhead())
+	}
 	builder.cs.blockdao = blockdao.NewBlockDAOWithIndexersAndCache(
 		store, indexers, cfg.DB.MaxCacheSize, opts...)
 
@@ -501,7 +504,8 @@ func (builder *Builder) buildBlockchain(forSubChain, forTest bool) error {
 
 	if builder.cs.indexer != nil && builder.cfg.Chain.EnableAsyncIndexWrite {
 		// config asks for a standalone indexer
-		indexBuilder, err := blockindex.NewIndexBuilder(builder.cs.chain.ChainID(), builder.cfg.Genesis, builder.cs.blockdao, builder.cs.indexer)
+		_, allowIndexerAhead := builder.cfg.Plugins[config.AllowBlockDaoIndexerAheadPlugin]
+		indexBuilder, err := blockindex.NewIndexBuilder(builder.cs.chain.ChainID(), builder.cfg.Genesis, builder.cs.blockdao, builder.cs.indexer, allowIndexerAhead)
 		if err != nil {
 			return errors.Wrap(err, "failed to create index builder")
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ const (
 const (
 	// GatewayPlugin is the plugin of accepting user API requests and serving blockchain data to users
 	GatewayPlugin = iota
+	// AllowBlockDaoIndexerAheadPlugin allows the block DAO indexer to be ahead of the DAO tip height
+	AllowBlockDaoIndexerAheadPlugin
 )
 
 type strs []string
@@ -189,6 +191,8 @@ func New(configPaths []string, _plugins []string, validates ...Validate) (Config
 		switch strings.ToLower(plugin) {
 		case "gateway":
 			cfg.Plugins[GatewayPlugin] = nil
+		case "relax":
+			cfg.Plugins[AllowBlockDaoIndexerAheadPlugin] = nil
 		default:
 			return Config{}, errors.Errorf("Plugin %s is not supported", plugin)
 		}


### PR DESCRIPTION
# Description

This PR introduces a "relax" mode that allows BlockDAO indexers to run ahead of the DAO tip height.

When enabled, indexers that are already ahead will skip routine checks and redundant indexing work, avoiding unnecessary stalls.

This mode is especially useful in testing scenarios, where allowing the indexer to progress independently makes it much easier to construct controlled or accelerated chain data for test cases.

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
