### PR TITLE
State candidate with identity

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -179,6 +179,7 @@ type (
 		CalculateProbationList   CheckFunc
 		LoadCandidatesLegacy     CheckFunc
 		CandCenterHasAlias       CheckFunc
+		CandidateWithoutIdentity CheckFunc
 	}
 )
 
@@ -394,6 +395,9 @@ func WithFeatureWithHeightCtx(ctx context.Context) context.Context {
 			},
 			CandCenterHasAlias: func(height uint64) bool {
 				return !g.IsOkhotsk(height)
+			},
+			CandidateWithoutIdentity: func(height uint64) bool {
+				return !g.IsToBeEnabled(height)
 			},
 		},
 	)

--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -341,14 +341,18 @@ func (d *Candidate) toIoTeXTypes() *iotextypes.CandidateV2 {
 	}
 }
 
-func (d *Candidate) toStateCandidate() *state.Candidate {
-	return &state.Candidate{
+func (d *Candidate) toStateCandidate(ignoreIdentity bool) *state.Candidate {
+	c := &state.Candidate{
 		Address:       d.Operator.String(), // state need candidate operator not owner address
 		Votes:         new(big.Int).Set(d.Votes),
 		RewardAddress: d.Reward.String(),
 		CanName:       []byte(d.Name),
 		BLSPubKey:     d.BLSPubKey,
 	}
+	if !ignoreIdentity {
+		c.Identity = d.GetIdentifier().String()
+	}
+	return c
 }
 
 func (l CandidateList) Len() int      { return len(l) }
@@ -457,10 +461,10 @@ func (l *CandidateList) Decode(keys [][]byte, gvs []systemcontracts.GenericValue
 	return nil
 }
 
-func (l CandidateList) toStateCandidateList() (state.CandidateList, error) {
+func (l CandidateList) toStateCandidateList(ignoreIdentity bool) (state.CandidateList, error) {
 	list := make(state.CandidateList, 0, len(l))
 	for _, c := range l {
-		list = append(list, c.toStateCandidate())
+		list = append(list, c.toStateCandidate(ignoreIdentity))
 	}
 	sort.Sort(list)
 	return list, nil

--- a/action/protocol/staking/candidate_center_test.go
+++ b/action/protocol/staking/candidate_center_test.go
@@ -55,7 +55,7 @@ func testEqualAllCommit(r *require.Assertions, m *CandidateCenter, old Candidate
 	list := m.All()
 	r.Equal(size+increase, len(list))
 	r.Equal(size+increase, m.Size())
-	all, err := list.toStateCandidateList()
+	all, err := list.toStateCandidateList(true)
 	r.NoError(err)
 
 	// number of changed cand = change
@@ -76,7 +76,7 @@ func testEqualAllCommit(r *require.Assertions, m *CandidateCenter, old Candidate
 	list = m.All()
 	r.Equal(size+increase, len(list))
 	r.Equal(size+increase, m.Size())
-	all1, err := list.toStateCandidateList()
+	all1, err := list.toStateCandidateList(true)
 	r.NoError(err)
 	r.Equal(all, all1)
 	return list, nil

--- a/action/protocol/staking/candidate_test.go
+++ b/action/protocol/staking/candidate_test.go
@@ -102,7 +102,15 @@ func TestClone(t *testing.T) {
 	d.Identifier = identityset.Address(3)
 	r.Equal(d.Identifier, d.GetIdentifier())
 
-	c := d.toStateCandidate()
+	c := d.toStateCandidate(false)
+	r.Equal(d.GetIdentifier().String(), c.Identity)
+	r.Equal(d.Owner.String(), c.Address)
+	r.Equal(d.Reward.String(), c.RewardAddress)
+	r.Equal(d.Votes, c.Votes)
+	r.Equal(d.Name, string(c.CanName))
+
+	c = d.toStateCandidate(true)
+	r.Equal("", c.Identity)
 	r.Equal(d.Owner.String(), c.Address)
 	r.Equal(d.Reward.String(), c.RewardAddress)
 	r.Equal(d.Votes, c.Votes)

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -866,7 +866,7 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 			cand = append(cand, list[i])
 		}
 	}
-	return cand.toStateCandidateList()
+	return cand.toStateCandidateList(protocol.MustGetFeatureWithHeightCtx(ctx).CandidateWithoutIdentity(height))
 }
 
 // ReadState read the state on blockchain via protocol

--- a/action/protocol/staking/protocol_test.go
+++ b/action/protocol/staking/protocol_test.go
@@ -177,9 +177,9 @@ func TestProtocol(t *testing.T) {
 	}
 
 	// csm's candidate center should be identical to all candidates in stateDB
-	c1, err := all.toStateCandidateList()
+	c1, err := all.toStateCandidateList(true)
 	r.NoError(err)
-	c2, err := csm.DirtyView().candCenter.All().toStateCandidateList()
+	c2, err := csm.DirtyView().candCenter.All().toStateCandidateList(true)
 	r.NoError(err)
 	r.Equal(c1, c2)
 
@@ -669,6 +669,7 @@ func TestSlashCandidate(t *testing.T) {
 		BlockHeight: 100,
 	})
 	ctx = protocol.WithFeatureCtx(ctx)
+	ctx = protocol.WithFeatureWithHeightCtx(ctx)
 
 	t.Run("nil amount", func(t *testing.T) {
 		err := p.SlashCandidate(ctx, sm, owner, nil)

--- a/e2etest/contract_staking_v2_test.go
+++ b/e2etest/contract_staking_v2_test.go
@@ -2078,6 +2078,7 @@ func checkStakingViewInit(test *e2etest, require *require.Assertions) {
 		BlockTimeStamp: tipHeader.Timestamp(),
 	})
 	ctx = protocol.WithFeatureCtx(ctx)
+	ctx = protocol.WithFeatureWithHeightCtx(ctx)
 	cands, err := stk.ActiveCandidates(ctx, test.cs.StateFactory(), 0)
 	require.NoError(err)
 
@@ -2110,6 +2111,7 @@ func checkStakingVoteView(test *e2etest, require *require.Assertions, candName s
 	})
 	ctx = genesis.WithGenesisContext(ctx, test.cfg.Genesis)
 	ctx = protocol.WithFeatureCtx(ctx)
+	ctx = protocol.WithFeatureWithHeightCtx(ctx)
 	cands, err := stkPtl.ActiveCandidates(ctx, test.cs.StateFactory(), 0)
 	require.NoError(err)
 	cand1 := slices.IndexFunc(cands, func(c *state.Candidate) bool {

--- a/go.mod
+++ b/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/iotexproject/go-pkgs v0.1.16-0.20250813090621-fc1c4ebefcb4
 	github.com/iotexproject/iotex-address v0.2.9-0.20251203033311-6e8aa4fd43ef
 	github.com/iotexproject/iotex-antenna-go/v2 v2.6.4
-	github.com/iotexproject/iotex-election v0.3.8
-	github.com/iotexproject/iotex-proto v0.6.6-0.20260209070502-f518cfc1981c
+	github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1
+	github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16
 	github.com/ipfs/go-ipfs-api v0.7.0
 	github.com/libp2p/go-libp2p v0.39.0
 	github.com/libp2p/go-libp2p-pubsub v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -641,10 +641,10 @@ github.com/iotexproject/iotex-address v0.2.9-0.20251203033311-6e8aa4fd43ef h1:mQ
 github.com/iotexproject/iotex-address v0.2.9-0.20251203033311-6e8aa4fd43ef/go.mod h1:K78yPSMB4K7gF/iQ7djT1amph0RBrP3rSkFfH7gNG70=
 github.com/iotexproject/iotex-antenna-go/v2 v2.6.4 h1:7e0VyBDFT+iqwvr/BIk38yf7nCX5a2IEvziI88mlCQs=
 github.com/iotexproject/iotex-antenna-go/v2 v2.6.4/go.mod h1:L6AzDHo2TBFDAPA3ly+/PCS4JSX2g3zzhwV8RGQsTDI=
-github.com/iotexproject/iotex-election v0.3.8 h1:yHUbfqjWtwcYXYv0KLVTaDMjfeMNO0fW9vv+h9eXloc=
-github.com/iotexproject/iotex-election v0.3.8/go.mod h1:w9HriT1coMRbuknaSD2xqiOqDTnowBDzvFZv8tg1j2M=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260209070502-f518cfc1981c h1:S45GWAlNVgPO7BACxWF2Nqmn+HU++yB0+/IL/euuR/4=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260209070502-f518cfc1981c/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
+github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1 h1:jPLni/qKAnxv87HMCutde2tP9JmfWuLZgGpB4OArQGM=
+github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1/go.mod h1:w9HriT1coMRbuknaSD2xqiOqDTnowBDzvFZv8tg1j2M=
+github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16 h1:iaFjQ8QJ3ekZnwPlUX3XJHZ/5uf+FbUltH6o24d4NYA=
+github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/ipfs/boxo v0.27.2 h1:sGo4KdwBaMjdBjH08lqPJyt27Z4CO6sugne3ryX513s=
 github.com/ipfs/boxo v0.27.2/go.mod h1:qEIRrGNr0bitDedTCzyzBHxzNWqYmyuHgK8LG9Q83EM=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=

--- a/state/candidate.go
+++ b/state/candidate.go
@@ -35,7 +35,8 @@ var (
 type (
 	// Candidate indicates the structure of a candidate
 	Candidate struct {
-		Address       string
+		Identity      string // Candidate Identity
+		Address       string // Operator address
 		Votes         *big.Int
 		RewardAddress string
 		CanName       []byte // used as identifier to merge with native staking result, not part of protobuf
@@ -57,7 +58,8 @@ func (c *Candidate) Equal(d *Candidate) bool {
 	if c == nil || d == nil {
 		return false
 	}
-	return strings.Compare(c.Address, d.Address) == 0 &&
+	return strings.Compare(c.Identity, d.Identity) == 0 &&
+		strings.Compare(c.Address, d.Address) == 0 &&
 		c.RewardAddress == d.RewardAddress &&
 		c.Votes.Cmp(d.Votes) == 0 &&
 		bytes.Equal(c.BLSPubKey, d.BLSPubKey)
@@ -76,6 +78,7 @@ func (c *Candidate) Clone() *Candidate {
 		copy(pubkey, c.BLSPubKey)
 	}
 	return &Candidate{
+		Identity:      c.Identity,
 		Address:       c.Address,
 		Votes:         new(big.Int).Set(c.Votes),
 		RewardAddress: c.RewardAddress,
@@ -198,6 +201,7 @@ func (l *CandidateList) Decode(suffixs [][]byte, values []systemcontracts.Generi
 // candidateToPb converts a candidate to protobuf's candidate message
 func candidateToPb(cand *Candidate) *iotextypes.Candidate {
 	candidatePb := &iotextypes.Candidate{
+		Identity:      cand.Identity,
 		Address:       cand.Address,
 		Votes:         cand.Votes.Bytes(),
 		RewardAddress: cand.RewardAddress,
@@ -217,6 +221,7 @@ func pbToCandidate(candPb *iotextypes.Candidate) (*Candidate, error) {
 		return nil, errors.Wrap(ErrCandidatePb, "protobuf's candidate message cannot be nil")
 	}
 	candidate := &Candidate{
+		Identity:      candPb.Identity,
 		Address:       candPb.Address,
 		Votes:         big.NewInt(0).SetBytes(candPb.Votes),
 		RewardAddress: candPb.RewardAddress,


### PR DESCRIPTION
Add identity to state.Candidate. After hard fork, filter candidate with identity, instead of operator address.

Fixes #(issue)

## Type of change
Please delete options that are not relevant.
- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [] My code follows the style guidelines of this project
- [] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
