### PR TITLE
fix: return error instead of nil in ethabi EncodeToEth methods

### DIFF
--- a/action/protocol/rewarding/ethabi/availablebalance.go
+++ b/action/protocol/rewarding/ethabi/availablebalance.go
@@ -59,7 +59,7 @@ func (r *AvailableBalanceStateContext) EncodeToEth(resp *iotexapi.ReadStateRespo
 
 	data, err := _availableBalanceMethod.Outputs.Pack(total)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return hex.EncodeToString(data), nil

--- a/action/protocol/rewarding/ethabi/totalbalance.go
+++ b/action/protocol/rewarding/ethabi/totalbalance.go
@@ -59,7 +59,7 @@ func (r *TotalBalanceStateContext) EncodeToEth(resp *iotexapi.ReadStateResponse)
 
 	data, err := _totalBalanceMethod.Outputs.Pack(total)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return hex.EncodeToString(data), nil

--- a/action/protocol/rewarding/ethabi/unclaimedbalance.go
+++ b/action/protocol/rewarding/ethabi/unclaimedbalance.go
@@ -81,7 +81,7 @@ func (r *UnclaimedBalanceStateContext) EncodeToEth(resp *iotexapi.ReadStateRespo
 
 	data, err := _unclaimedBalanceMethod.Outputs.Pack(total)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return hex.EncodeToString(data), nil

--- a/action/protocol/staking/ethabi/common/candidatebyname.go
+++ b/action/protocol/staking/ethabi/common/candidatebyname.go
@@ -79,7 +79,7 @@ func (r *CandidateByNameStateContext) EncodeToEth(resp *iotexapi.ReadStateRespon
 
 	data, err := r.Method.Outputs.Pack(cand)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(data), nil
 }

--- a/action/protocol/staking/ethabi/common/stake_totalstakingamount.go
+++ b/action/protocol/staking/ethabi/common/stake_totalstakingamount.go
@@ -59,7 +59,7 @@ func (r *TotalStakingAmountStateContext) EncodeToEth(resp *iotexapi.ReadStateRes
 
 	data, err := r.Method.Outputs.Pack(total)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(data), nil
 }

--- a/action/protocol/staking/ethabi/common/types.go
+++ b/action/protocol/staking/ethabi/common/types.go
@@ -100,7 +100,7 @@ func EncodeVoteBucketListToEth(outputs abi.Arguments, buckets *iotextypes.VoteBu
 
 	data, err := outputs.Pack(args)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return hex.EncodeToString(data), nil
 }


### PR DESCRIPTION
## Summary

Six ethabi `EncodeToEth` methods incorrectly returned `nil` instead of `err` when `Outputs.Pack()` failed, silently swallowing the error. This fix ensures the actual error is propagated to callers.

### Files fixed
- `action/protocol/rewarding/ethabi/availablebalance.go`
- `action/protocol/rewarding/ethabi/totalbalance.go`
- `action/protocol/rewarding/ethabi/unclaimedbalance.go`
- `action/protocol/staking/ethabi/common/candidatebyname.go`
- `action/protocol/staking/ethabi/common/stake_totalstakingamount.go`
- `action/protocol/staking/ethabi/common/types.go`

### Change
```go
// Before (bug)
data, err := method.Outputs.Pack(value)
if err != nil {
    return "", nil  // error swallowed
}

// After (fix)
data, err := method.Outputs.Pack(value)
if err != nil {
    return "", err  // error properly returned
}
```
