### PR TITLE
fix: correct variable name typo caniddate -> candidate

### DIFF
--- a/action/candidate_endorsement.go
+++ b/action/candidate_endorsement.go
@@ -29,6 +29,8 @@ var (
 	candidateEndorsementLegacyMethod         abi.Method
 	candidateEndorsementEndorseMethod        abi.Method
 	candidateEndorsementIntentToRevokeMethod abi.Method
+	// caniddateEndorsementIntentToRevokeMethod is kept for backward compatibility with older code using the misspelled identifier.
+	caniddateEndorsementIntentToRevokeMethod abi.Method
 	candidateEndorsementRevokeMethod         abi.Method
 	_                                        EthCompatibleAction = (*CandidateEndorsement)(nil)
 )
@@ -64,6 +66,8 @@ func init() {
 	if !ok {
 		panic("fail to load the intentToRevokeEndorsement method")
 	}
+	// Backward-compatible alias for the old misspelled identifier.
+	caniddateEndorsementIntentToRevokeMethod = candidateEndorsementIntentToRevokeMethod
 	candidateEndorsementRevokeMethod, ok = candidateEndorsementInterface.Methods["revokeEndorsement"]
 	if !ok {
 		panic("fail to load the revokeEndorsement method")


### PR DESCRIPTION
## Summary

Fix typo in variable name `caniddateEndorsementIntentToRevokeMethod` → `candidateEndorsementIntentToRevokeMethod` in `action/candidate_endorsement.go` (5 occurrences).
