### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -903,12 +903,8 @@ func (core *coreService) RawBlocks(startHeight uint64, count uint64, withReceipt
 	if startHeight > tipHeight {
 		return nil, status.Error(codes.InvalidArgument, "start height should not exceed tip height")
 	}
-	endHeight := startHeight + count - 1
-	if endHeight > tipHeight {
-		endHeight = tipHeight
-	}
 	var res []*iotexapi.BlockInfo
-	for height := startHeight; height <= endHeight; height++ {
+	for height := startHeight; height <= min(startHeight+count-1, tipHeight); height++ {
 		blk, err := core.dao.GetBlockByHeight(height)
 		if err != nil {
 			return nil, status.Error(codes.NotFound, err.Error())

--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -709,11 +709,7 @@ func TestProofAndCompareReverseActions(t *testing.T) {
 		if start > size || count == 0 {
 			return nil
 		}
-		end := start + count
-		if end > size {
-			end = size
-		}
-		for i := end; i > start; i-- {
+		for i := min(start+count, size); i > start; i-- {
 			reserved = append(reserved, slice[size-i])
 		}
 		return

--- a/blockindex/bloomfilterindexer.go
+++ b/blockindex/bloomfilterindexer.go
@@ -272,15 +272,7 @@ func (bfx *bloomfilterIndexer) FilterBlocksInRange(l *filter.LogFilter, start, e
 						return err
 					}
 					if l.ExistInBloomFilterv2(br.BloomFilter) {
-						searchStart := br.Start()
-						if start > searchStart {
-							searchStart = start
-						}
-						searchEnd := br.End()
-						if end < searchEnd {
-							searchEnd = end
-						}
-						blkNums[job.idx] = l.SelectBlocksFromRangeBloomFilter(br.BloomFilter, searchStart, searchEnd)
+						blkNums[job.idx] = l.SelectBlocksFromRangeBloomFilter(br.BloomFilter, max(start, br.Start()), min(end, br.End()))
 					}
 					bufPool.Put(br)
 				}

--- a/nodeinfo/manager.go
+++ b/nodeinfo/manager.go
@@ -130,10 +130,7 @@ func (dm *InfoManager) MayHaveBlock(peerID string, start uint64) bool {
 		return false
 	}
 	info := value.(Info)
-	duration := time.Now().Sub(info.Timestamp)
-	if duration < 0 {
-		duration = 0
-	}
+	duration := max(time.Now().Sub(info.Timestamp), 0)
 
 	return int64(info.Height)+duration.Milliseconds()/dm.blockInterval.Milliseconds() > int64(start)
 }


### PR DESCRIPTION
# Description

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

Fixes #(issue)

## Type of change

- [x] Code refactor or improvement


# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] make test
- [] fullsync
- [] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] My changes generate no new warnings
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
