### PR TITLE
fix: include full action hash in GetActionIndex error message

### DIFF
--- a/blockindex/indexer.go
+++ b/blockindex/indexer.go
@@ -198,7 +198,7 @@ func (x *blockIndexer) GetActionIndex(h []byte) (*ActionIndex, error) {
 
 	v, err := x.kvStore.Get(_actionToBlockHashNS, h[_hashOffset:])
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "action hash %x not found", h)
 	}
 	a := &ActionIndex{}
 	if err := a.Deserialize(v); err != nil {


### PR DESCRIPTION
## Summary
  - When `GetActionIndex` fails to find an action, the error message now includes the complete action hash instead of only showing the truncated 20-byte key suffix
  - This prevents users from confusing the truncated key (40 hex chars, similar to an Ethereum address) with an actual address

  ## Before
  key = 63a01aa3a9afcb318f9c282a45fe07f267366146 doesn't exist...

  ## After
  action hash  not found: key = 63a01aa3a9afcb318f9c282a45fe07f267366146 doesn't exist...

  ## Test Plan
  - [x] All related tests pass
  - [x] Lint passes