### PR TITLE
security: bind agent_id to auth + shadow-based accuracy

### DIFF
--- a/ioswarm/coordinator.go
+++ b/ioswarm/coordinator.go
@@ -385,13 +385,22 @@ func (c *Coordinator) handleResults(result *pb.BatchResult) {
 		c.recentResults.Store(r.TaskID, r)
 	}
 
-	// Feed reward system: count tasks and valid results
+	// Feed reward system: count tasks processed and latency.
+	// When shadow mode is on, accuracy comes from OnBlockExecuted (ground truth),
+	// not from the agent's self-reported Valid flag.
 	var totalLatencyUs uint64
 	correct := uint64(0)
-	for _, r := range result.Results {
-		totalLatencyUs += r.LatencyUs
-		if r.Valid {
-			correct++
+	if !c.cfg.ShadowMode {
+		// Shadow mode off: trust agent's self-reported Valid (legacy behavior)
+		for _, r := range result.Results {
+			totalLatencyUs += r.LatencyUs
+			if r.Valid {
+				correct++
+			}
+		}
+	} else {
+		for _, r := range result.Results {
+			totalLatencyUs += r.LatencyUs
 		}
 	}
 	c.reward.RecordWork(result.AgentID, uint64(len(result.Results)), correct, totalLatencyUs)
@@ -417,11 +426,15 @@ func (c *Coordinator) ShadowStats() ShadowStats {
 func (c *Coordinator) OnBlockExecuted(blockHeight uint64, actualResults map[uint32]bool) {
 	// 1. Compare agent results against actual execution
 	if c.cfg.ShadowMode && len(actualResults) > 0 {
-		mismatches := c.shadow.CompareWithActual(actualResults, blockHeight)
+		mismatches, perAgent := c.shadow.CompareWithActual(actualResults, blockHeight)
 		if len(mismatches) > 0 {
 			c.logger.Warn("shadow mismatches detected",
 				zap.Int("count", len(mismatches)),
 				zap.Uint64("block", blockHeight))
+		}
+		// Feed ground-truth accuracy to reward system
+		for agentID, acc := range perAgent {
+			c.reward.RecordShadowAccuracy(agentID, acc.Matched)
 		}
 	}
 

--- a/ioswarm/grpc_handler.go
+++ b/ioswarm/grpc_handler.go
@@ -233,6 +233,13 @@ func (h *grpcHandler) Register(ctx context.Context, req *pb.RegisterRequest) (*p
 }
 
 func (h *grpcHandler) GetTasks(req *pb.GetTasksRequest, stream IOSwarm_GetTasksServer) error {
+	// If HMAC auth is enabled, enforce that agent_id matches the verified identity
+	if verifiedID := AgentIDFromContext(stream.Context()); verifiedID != "" {
+		if req.AgentID != verifiedID {
+			return status.Errorf(codes.PermissionDenied, "agent_id %q does not match authenticated identity", req.AgentID)
+		}
+	}
+
 	agent, ok := h.coord.registry.GetAgent(req.AgentID)
 	if !ok {
 		return fmt.Errorf("agent %s not registered", req.AgentID)
@@ -387,6 +394,13 @@ func stateDiffToResponse(diff *StateDiff) *pb.StateDiffResponse {
 }
 
 func (h *grpcHandler) Heartbeat(ctx context.Context, req *pb.HeartbeatRequest) (*pb.HeartbeatResponse, error) {
+	// If HMAC auth is enabled, enforce that agent_id matches the verified identity
+	if verifiedID := AgentIDFromContext(ctx); verifiedID != "" {
+		if req.AgentID != verifiedID {
+			return nil, status.Errorf(codes.PermissionDenied, "agent_id %q does not match authenticated identity", req.AgentID)
+		}
+	}
+
 	alive := h.coord.registry.Heartbeat(req)
 	if !alive {
 		return &pb.HeartbeatResponse{

--- a/ioswarm/integration_test.go
+++ b/ioswarm/integration_test.go
@@ -286,7 +286,7 @@ func TestIntegrationE2E(t *testing.T) {
 		actualResults[task.TaskID] = true
 	}
 
-	mismatches := coord.shadow.CompareWithActual(actualResults, 1001)
+	mismatches, _ := coord.shadow.CompareWithActual(actualResults, 1001)
 	if len(mismatches) != 0 {
 		t.Fatalf("expected 0 shadow mismatches, got %d", len(mismatches))
 	}

--- a/ioswarm/reward.go
+++ b/ioswarm/reward.go
@@ -139,6 +139,19 @@ func (r *RewardDistributor) RecordWork(agentID string, tasksProcessed, tasksCorr
 	work.TotalLatencyUs += totalLatencyUs
 }
 
+// RecordShadowAccuracy adds verified correct tasks from shadow comparison.
+// Called from OnBlockExecuted after ground-truth comparison.
+func (r *RewardDistributor) RecordShadowAccuracy(agentID string, matched uint64) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	work, ok := r.agentWork[agentID]
+	if !ok {
+		return // agent not tracked (shouldn't happen)
+	}
+	work.TasksCorrect += matched
+}
+
 // SetAgentWallet sets the payout address for an agent.
 func (r *RewardDistributor) SetAgentWallet(agentID, walletAddress string) {
 	r.mu.Lock()

--- a/ioswarm/shadow.go
+++ b/ioswarm/shadow.go
@@ -63,14 +63,21 @@ func (s *ShadowComparator) RecordAgentResults(agentID string, batch *pb.BatchRes
 	}
 }
 
+// AgentAccuracy holds per-agent shadow match counts for a comparison batch.
+type AgentAccuracy struct {
+	Compared uint64
+	Matched  uint64
+}
+
 // CompareWithActual compares stored agent results against actual execution.
 // actualResults maps task_id → whether the tx was actually valid.
-func (s *ShadowComparator) CompareWithActual(actualResults map[uint32]bool, blockHeight uint64) []ShadowResult {
+// Returns mismatches and per-agent accuracy counts.
+func (s *ShadowComparator) CompareWithActual(actualResults map[uint32]bool, blockHeight uint64) ([]ShadowResult, map[string]*AgentAccuracy) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	var mismatches []ShadowResult
-	var matched []ShadowResult
+	perAgent := make(map[string]*AgentAccuracy)
 
 	for i := range s.results {
 		r := &s.results[i]
@@ -83,10 +90,18 @@ func (s *ShadowComparator) CompareWithActual(actualResults map[uint32]bool, bloc
 		r.BlockHeight = blockHeight
 		r.Match = r.AgentResult.Valid == actual
 
+		// Track per-agent accuracy
+		aa, ok := perAgent[r.AgentID]
+		if !ok {
+			aa = &AgentAccuracy{}
+			perAgent[r.AgentID] = aa
+		}
+		aa.Compared++
+
 		s.stats.TotalCompared++
 		if r.Match {
 			s.stats.TotalMatched++
-			matched = append(matched, *r)
+			aa.Matched++
 		} else {
 			s.stats.TotalMismatched++
 			if r.AgentResult.Valid && !actual {
@@ -119,7 +134,7 @@ func (s *ShadowComparator) CompareWithActual(actualResults map[uint32]bool, bloc
 	// Clear processed results
 	s.results = s.results[:0]
 
-	return mismatches
+	return mismatches, perAgent
 }
 
 // Stats returns current shadow comparison statistics.

--- a/ioswarm/shadow_test.go
+++ b/ioswarm/shadow_test.go
@@ -23,7 +23,7 @@ func TestShadowAllMatch(t *testing.T) {
 
 	// Actual: both valid
 	actual := map[uint32]bool{1: true, 2: true}
-	mismatches := shadow.CompareWithActual(actual, 100)
+	mismatches, perAgent := shadow.CompareWithActual(actual, 100)
 
 	if len(mismatches) != 0 {
 		t.Fatalf("expected 0 mismatches, got %d", len(mismatches))
@@ -32,6 +32,11 @@ func TestShadowAllMatch(t *testing.T) {
 	stats := shadow.Stats()
 	if stats.TotalCompared != 2 || stats.TotalMatched != 2 {
 		t.Fatalf("expected 2/2 matched, got %d/%d", stats.TotalMatched, stats.TotalCompared)
+	}
+
+	// Verify per-agent accuracy
+	if aa, ok := perAgent["ant-1"]; !ok || aa.Compared != 2 || aa.Matched != 2 {
+		t.Fatalf("expected ant-1 accuracy 2/2, got %+v", perAgent["ant-1"])
 	}
 }
 
@@ -49,7 +54,7 @@ func TestShadowMismatch(t *testing.T) {
 
 	// Actual: task 1 invalid (false positive), task 2 valid (false negative)
 	actual := map[uint32]bool{1: false, 2: true}
-	mismatches := shadow.CompareWithActual(actual, 200)
+	mismatches, perAgent := shadow.CompareWithActual(actual, 200)
 
 	if len(mismatches) != 2 {
 		t.Fatalf("expected 2 mismatches, got %d", len(mismatches))
@@ -62,6 +67,11 @@ func TestShadowMismatch(t *testing.T) {
 	if stats.FalseNegatives != 1 {
 		t.Fatalf("expected 1 false negative, got %d", stats.FalseNegatives)
 	}
+
+	// Verify per-agent accuracy: 0 matched out of 2
+	if aa, ok := perAgent["ant-1"]; !ok || aa.Compared != 2 || aa.Matched != 0 {
+		t.Fatalf("expected ant-1 accuracy 0/2, got %+v", perAgent["ant-1"])
+	}
 }
 
 func TestShadowReset(t *testing.T) {
@@ -71,7 +81,7 @@ func TestShadowReset(t *testing.T) {
 	shadow.RecordAgentResults("ant-1", &pb.BatchResult{
 		Results: []*pb.TaskResult{{TaskID: 1, Valid: true}},
 	})
-	shadow.CompareWithActual(map[uint32]bool{1: true}, 1)
+	shadow.CompareWithActual(map[uint32]bool{1: true}, 1) //nolint:dogsled
 
 	shadow.ResetStats()
 	stats := shadow.Stats()


### PR DESCRIPTION
## Summary
- **Fix #1**: `GetTasks` and `Heartbeat` now verify that the `agent_id` in the request matches the HMAC-authenticated identity. `Register` and `SubmitResults` already had this check — this closes the gap where an agent with a valid token could impersonate another agent's task stream or heartbeat.
- **Fix #4**: When shadow mode is on, reward accuracy is now derived from ground-truth block execution (`CompareWithActual`) instead of the agent's self-reported `Valid` flag. This prevents agents from inflating their accuracy score to get the 1.2x bonus. When shadow mode is off, legacy behavior is preserved.

## Files changed
| File | Change |
|------|--------|
| `grpc_handler.go` | Add agent_id binding to `GetTasks` + `Heartbeat` |
| `coordinator.go` | Skip self-reported `correct` when shadow mode is on; feed shadow accuracy from `OnBlockExecuted` |
| `shadow.go` | `CompareWithActual` now returns per-agent accuracy counts |
| `reward.go` | Add `RecordShadowAccuracy` method |
| `shadow_test.go` | Verify per-agent accuracy counts |
| `integration_test.go` | Update `CompareWithActual` call signature |

## Test plan
- [x] `go vet ./ioswarm/...` clean
- [x] `go test -race -run "TestShadow|TestIntegration" ./ioswarm/` passes
- [ ] Deploy to delegate and verify beta agents still connect and earn rewards normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)