### PR TITLE
feat(iip-59): protocol-native voter reward distribution

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -172,6 +172,7 @@ type (
 		// contracts are committed and written back
 		AlwaysWriteCachedContract               bool
 		NoCandidateExitQueue                    bool
+		EnableVoterRewardDistribution           bool // IIP-59: protocol-native voter reward distribution
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -345,6 +346,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			PrePectraEVM:                            !g.IsToBeEnabled(height),
 			AlwaysWriteCachedContract:               !g.IsToBeEnabled(height),
 			NoCandidateExitQueue:                    !g.IsToBeEnabled(height),
+			EnableVoterRewardDistribution:           g.IsYosemite(height),
 		},
 	)
 }

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -282,7 +282,7 @@ func (p *Protocol) GrantEpochReward(
 	if featureWithHeightCtx.GetUnproductiveDelegates(epochStartHeight) {
 		epochRewardSplitUqdMap = uqdMap
 	}
-	addrs, amounts, err := p.splitEpochReward(candidates, a.epochReward, a.numDelegatesForEpochReward, exemptAddrs, epochRewardSplitUqdMap)
+	addrs, amounts, filteredCandidates, err := p.splitEpochReward(candidates, a.epochReward, a.numDelegatesForEpochReward, exemptAddrs, epochRewardSplitUqdMap)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -298,7 +298,7 @@ func (p *Protocol) GrantEpochReward(
 
 		// IIP-59: Try auto-distribution to voters if candidate has CommissionRate > 0
 		voterLogs, err := p.distributeVoterReward(
-			ctx, sm, candidates[i].Address, addrs[i], amounts[i],
+			ctx, sm, filteredCandidates[i].Address, addrs[i], amounts[i],
 			blkCtx.BlockHeight, actionCtx.ActionHash,
 		)
 		if err != nil {
@@ -635,7 +635,7 @@ func (p *Protocol) splitEpochReward(
 	numDelegatesForEpochReward uint64,
 	exemptAddrs map[string]interface{},
 	uqd map[string]uint64,
-) ([]address.Address, []*big.Int, error) {
+) ([]address.Address, []*big.Int, []*state.Candidate, error) {
 	filteredCandidates := make([]*state.Candidate, 0)
 	for _, candidate := range candidates {
 		if _, ok := exemptAddrs[candidate.Address]; ok {
@@ -645,7 +645,7 @@ func (p *Protocol) splitEpochReward(
 	}
 	candidates = filteredCandidates
 	if len(candidates) == 0 {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	// We at most allow numDelegatesForEpochReward delegates to get the epoch reward
 	if uint64(len(candidates)) > numDelegatesForEpochReward {
@@ -659,7 +659,7 @@ func (p *Protocol) splitEpochReward(
 		if candidate.RewardAddress != "" {
 			rewardAddr, err = address.FromString(candidate.RewardAddress)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 		} else {
 			log.S().Warnf("Candidate %s doesn't have a reward address", candidate.Address)
@@ -682,7 +682,7 @@ func (p *Protocol) splitEpochReward(
 		amountPerAddr = big.NewInt(0).Div(big.NewInt(0).Mul(totalAmount, candidate.Votes), totalWeight)
 		amounts = append(amounts, amountPerAddr)
 	}
-	return rewardAddrs, amounts, nil
+	return rewardAddrs, amounts, candidates, nil
 }
 
 func (p *Protocol) assertNoRewardYet(ctx context.Context, sm protocol.StateManager, prefix []byte, index uint64) error {

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -295,6 +295,23 @@ func (p *Protocol) GrantEpochReward(
 		if amounts[i].Cmp(big.NewInt(0)) == 0 {
 			continue
 		}
+
+		// IIP-59: Try auto-distribution to voters if candidate has CommissionRate > 0
+		voterLogs, err := p.distributeVoterReward(
+			ctx, sm, candidates[i].Address, addrs[i], amounts[i],
+			blkCtx.BlockHeight, actionCtx.ActionHash,
+		)
+		if err != nil {
+			return nil, nil, err
+		}
+		if voterLogs != nil {
+			// IIP-59 handled this delegate's reward distribution
+			rewardLogs = append(rewardLogs, voterLogs...)
+			actualTotalReward = big.NewInt(0).Add(actualTotalReward, amounts[i])
+			continue
+		}
+
+		// Legacy: full reward to delegate
 		if err := p.grantToAccount(ctx, sm, addrs[i], amounts[i]); err != nil {
 			return nil, nil, err
 		}

--- a/action/protocol/rewarding/rewardingpb/rewarding.pb.go
+++ b/action/protocol/rewarding/rewardingpb/rewarding.pb.go
@@ -36,6 +36,8 @@ const (
 	RewardLog_FOUNDATION_BONUS   RewardLog_RewardType = 2
 	RewardLog_PRIORITY_BONUS     RewardLog_RewardType = 3
 	RewardLog_UNPRODUCTIVE_SLASH RewardLog_RewardType = 4
+	RewardLog_VOTER_REWARD      RewardLog_RewardType = 5 // IIP-59
+	RewardLog_COMMISSION_REWARD RewardLog_RewardType = 6 // IIP-59
 )
 
 // Enum value maps for RewardLog_RewardType.
@@ -46,6 +48,8 @@ var (
 		2: "FOUNDATION_BONUS",
 		3: "PRIORITY_BONUS",
 		4: "UNPRODUCTIVE_SLASH",
+		5: "VOTER_REWARD",
+		6: "COMMISSION_REWARD",
 	}
 	RewardLog_RewardType_value = map[string]int32{
 		"BLOCK_REWARD":       0,
@@ -53,6 +57,8 @@ var (
 		"FOUNDATION_BONUS":   2,
 		"PRIORITY_BONUS":     3,
 		"UNPRODUCTIVE_SLASH": 4,
+		"VOTER_REWARD":       5,
+		"COMMISSION_REWARD":  6,
 	}
 )
 

--- a/action/protocol/rewarding/rewardingpb/rewarding.proto
+++ b/action/protocol/rewarding/rewardingpb/rewarding.proto
@@ -43,6 +43,8 @@ message RewardLog {
         FOUNDATION_BONUS= 2;
         PRIORITY_BONUS = 3;
         UNPRODUCTIVE_SLASH = 4;
+        VOTER_REWARD = 5;       // IIP-59: voter reward from delegate commission split
+        COMMISSION_REWARD = 6;  // IIP-59: delegate commission portion
     }
     RewardType type = 1;
     string addr = 2;

--- a/action/protocol/rewarding/voter_reward.go
+++ b/action/protocol/rewarding/voter_reward.go
@@ -33,6 +33,12 @@ func (p *Protocol) distributeVoterReward(
 	blkHeight uint64,
 	actionHash [32]byte,
 ) ([]*action.Log, error) {
+	// IIP-59: Only distribute voter rewards after Yosemite hard fork
+	featureCtx := protocol.MustGetFeatureCtx(ctx)
+	if !featureCtx.EnableVoterRewardDistribution {
+		return nil, nil
+	}
+
 	// Find staking protocol to access candidate and bucket data
 	stakingProtocol := staking.FindProtocol(protocol.MustGetRegistry(ctx))
 	if stakingProtocol == nil {

--- a/action/protocol/rewarding/voter_reward.go
+++ b/action/protocol/rewarding/voter_reward.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rewarding
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+)
+
+// distributeVoterReward splits a delegate's epoch reward between commission and voters.
+// Returns the list of reward logs and nil error on success.
+// If the delegate has CommissionRate == 0, this function returns (nil, nil, errNoAutoDistribution)
+// and the caller should fall back to the legacy full-reward-to-delegate behavior.
+//
+// IIP-59: Protocol-Native Voter Reward Distribution
+func (p *Protocol) distributeVoterReward(
+	ctx context.Context,
+	sm protocol.StateManager,
+	candidateAddr string,
+	rewardAddr address.Address,
+	totalReward *big.Int,
+	blkHeight uint64,
+	actionHash [32]byte,
+) ([]*action.Log, error) {
+	// Find staking protocol to access candidate and bucket data
+	stakingProtocol := staking.FindProtocol(protocol.MustGetRegistry(ctx))
+	if stakingProtocol == nil {
+		// Staking protocol not registered — fall back to legacy
+		return nil, nil
+	}
+
+	// Look up the staking.Candidate to get CommissionRate
+	candIdentifier, err := address.FromString(candidateAddr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "invalid candidate address %s", candidateAddr)
+	}
+
+	cand, err := stakingProtocol.CandidateByIdentifier(sm, candIdentifier)
+	if err != nil {
+		// Candidate not found or staking view not available — use legacy behavior
+		return nil, nil
+	}
+
+	if cand.CommissionRate == 0 {
+		// Legacy mode: no auto-distribution
+		return nil, nil
+	}
+
+	// Calculate commission
+	commission := new(big.Int).Mul(totalReward, big.NewInt(int64(cand.CommissionRate)))
+	commission.Div(commission, big.NewInt(10000))
+
+	// Credit commission to delegate
+	if err := p.grantToAccount(ctx, sm, rewardAddr, commission); err != nil {
+		return nil, errors.Wrap(err, "failed to grant commission")
+	}
+
+	voterPool := new(big.Int).Sub(totalReward, commission)
+	if voterPool.Sign() <= 0 {
+		// 100% commission, nothing for voters
+		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), commission)
+		return []*action.Log{{
+			Address:     p.addr.String(),
+			Data:        data,
+			BlockHeight: blkHeight,
+			ActionHash:  actionHash,
+		}}, nil
+	}
+
+	// Get all active buckets for this delegate
+	buckets, err := stakingProtocol.ActiveBucketsByCandidate(sm, cand.GetIdentifier())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get active buckets")
+	}
+
+	if len(buckets) == 0 {
+		// No voters — full reward to delegate as commission
+		if err := p.grantToAccount(ctx, sm, rewardAddr, voterPool); err != nil {
+			return nil, err
+		}
+		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), totalReward)
+		return []*action.Log{{
+			Address:     p.addr.String(),
+			Data:        data,
+			BlockHeight: blkHeight,
+			ActionHash:  actionHash,
+		}}, nil
+	}
+
+	// Calculate weighted votes for each voter
+	g := genesis.Default
+	type voterWeight struct {
+		addr   address.Address
+		weight *big.Int
+	}
+
+	// Aggregate by voter address to avoid per-bucket rounding loss
+	voterMap := make(map[string]*big.Int)
+	voterAddrs := make(map[string]address.Address)
+	totalWeight := big.NewInt(0)
+
+	for _, b := range buckets {
+		isSelfStake := b.Index == cand.SelfStakeBucketIdx
+		w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, b, isSelfStake)
+		totalWeight.Add(totalWeight, w)
+
+		ownerStr := b.Owner.String()
+		voterAddrs[ownerStr] = b.Owner
+		if existing, ok := voterMap[ownerStr]; ok {
+			voterMap[ownerStr] = new(big.Int).Add(existing, w)
+		} else {
+			voterMap[ownerStr] = new(big.Int).Set(w)
+		}
+	}
+
+	if totalWeight.Sign() == 0 {
+		// Zero total weight — give everything to delegate
+		if err := p.grantToAccount(ctx, sm, rewardAddr, voterPool); err != nil {
+			return nil, err
+		}
+		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), totalReward)
+		return []*action.Log{{
+			Address:     p.addr.String(),
+			Data:        data,
+			BlockHeight: blkHeight,
+			ActionHash:  actionHash,
+		}}, nil
+	}
+
+	// Distribute voterPool proportionally
+	var rewardLogs []*action.Log
+	distributed := big.NewInt(0)
+
+	for addrStr, weight := range voterMap {
+		share := new(big.Int).Mul(voterPool, weight)
+		share.Div(share, totalWeight)
+
+		if share.Sign() <= 0 {
+			continue
+		}
+
+		addr := voterAddrs[addrStr]
+		if err := p.grantToAccount(ctx, sm, addr, share); err != nil {
+			return nil, errors.Wrapf(err, "failed to grant voter reward to %s", addrStr)
+		}
+		distributed.Add(distributed, share)
+
+		data, err := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, addrStr, share)
+		if err != nil {
+			return nil, err
+		}
+		rewardLogs = append(rewardLogs, &action.Log{
+			Address:     p.addr.String(),
+			Data:        data,
+			BlockHeight: blkHeight,
+			ActionHash:  actionHash,
+		})
+	}
+
+	// Rounding dust goes to delegate
+	dust := new(big.Int).Sub(voterPool, distributed)
+	if dust.Sign() > 0 {
+		if err := p.grantToAccount(ctx, sm, rewardAddr, dust); err != nil {
+			return nil, err
+		}
+	}
+
+	// Add commission log
+	data, err := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), new(big.Int).Add(commission, dust))
+	if err != nil {
+		return nil, err
+	}
+	rewardLogs = append(rewardLogs, &action.Log{
+		Address:     p.addr.String(),
+		Data:        data,
+		BlockHeight: blkHeight,
+		ActionHash:  actionHash,
+	})
+
+	return rewardLogs, nil
+}

--- a/action/protocol/rewarding/voter_reward.go
+++ b/action/protocol/rewarding/voter_reward.go
@@ -75,7 +75,7 @@ func (p *Protocol) distributeVoterReward(
 	voterPool := new(big.Int).Sub(totalReward, commission)
 	if voterPool.Sign() <= 0 {
 		// 100% commission, nothing for voters
-		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), commission)
+		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_COMMISSION_REWARD, rewardAddr.String(), commission)
 		return []*action.Log{{
 			Address:     p.addr.String(),
 			Data:        data,
@@ -95,7 +95,7 @@ func (p *Protocol) distributeVoterReward(
 		if err := p.grantToAccount(ctx, sm, rewardAddr, voterPool); err != nil {
 			return nil, err
 		}
-		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), totalReward)
+		data, _ := p.encodeRewardLog(rewardingpb.RewardLog_COMMISSION_REWARD, rewardAddr.String(), totalReward)
 		return []*action.Log{{
 			Address:     p.addr.String(),
 			Data:        data,
@@ -158,7 +158,7 @@ func (p *Protocol) distributeVoterReward(
 		}
 		distributed.Add(distributed, share)
 
-		data, err := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, addrStr, share)
+		data, err := p.encodeRewardLog(rewardingpb.RewardLog_VOTER_REWARD, addrStr, share)
 		if err != nil {
 			return nil, err
 		}
@@ -179,7 +179,7 @@ func (p *Protocol) distributeVoterReward(
 	}
 
 	// Add commission log
-	data, err := p.encodeRewardLog(rewardingpb.RewardLog_EPOCH_REWARD, rewardAddr.String(), new(big.Int).Add(commission, dust))
+	data, err := p.encodeRewardLog(rewardingpb.RewardLog_COMMISSION_REWARD, rewardAddr.String(), new(big.Int).Add(commission, dust))
 	if err != nil {
 		return nil, err
 	}

--- a/action/protocol/rewarding/voter_reward.go
+++ b/action/protocol/rewarding/voter_reward.go
@@ -16,7 +16,6 @@ import (
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
-	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 )
 
 // distributeVoterReward splits a delegate's epoch reward between commission and voters.
@@ -99,12 +98,8 @@ func (p *Protocol) distributeVoterReward(
 		}}, nil
 	}
 
-	// Calculate weighted votes for each voter
-	g := genesis.Default
-	type voterWeight struct {
-		addr   address.Address
-		weight *big.Int
-	}
+	// Calculate weighted votes for each voter using staking protocol's config
+	voteWeightConsts := stakingProtocol.VoteWeightCalConsts()
 
 	// Aggregate by voter address to avoid per-bucket rounding loss
 	voterMap := make(map[string]*big.Int)
@@ -113,7 +108,7 @@ func (p *Protocol) distributeVoterReward(
 
 	for _, b := range buckets {
 		isSelfStake := b.Index == cand.SelfStakeBucketIdx
-		w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, b, isSelfStake)
+		w := staking.CalculateVoteWeight(voteWeightConsts, b, isSelfStake)
 		totalWeight.Add(totalWeight, w)
 
 		ownerStr := b.Owner.String()

--- a/action/protocol/rewarding/voter_reward_fullscale_test.go
+++ b/action/protocol/rewarding/voter_reward_fullscale_test.go
@@ -1,0 +1,231 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rewarding
+
+import (
+	"fmt"
+	"math/big"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+)
+
+// TestFullScale24Delegates simulates a complete mainnet epoch reward distribution
+// for all 24 active delegates, each with realistic voter counts and staking amounts.
+//
+// This test validates:
+// 1. Exact conservation: for each delegate, commission + sum(voter shares) + dust == delegateReward
+// 2. Global conservation: sum(all distributions) == totalEpochReward
+// 3. Dust is bounded: dust < numVoters per delegate
+// 4. Performance: total computation time for 24 delegates × ~2800 voters each
+func TestFullScale24Delegates(t *testing.T) {
+	r := require.New(t)
+	g := genesis.Default
+	rng := rand.New(rand.NewSource(12345))
+
+	const numDelegates = 24
+	// Total epoch reward: 450 IOTX (realistic IoTeX mainnet epoch reward)
+	totalEpochReward := new(big.Int).Mul(big.NewInt(450), big.NewInt(1e18))
+
+	type delegateInfo struct {
+		name           string
+		votes          *big.Int // total weighted votes (determines share of epoch reward)
+		commissionBps  uint64
+		numVoters      int
+		voterWeights   []*big.Int
+		totalWeight    *big.Int
+	}
+
+	// Generate 24 delegates with realistic parameters
+	delegates := make([]delegateInfo, numDelegates)
+	totalVotes := big.NewInt(0)
+
+	for d := 0; d < numDelegates; d++ {
+		numVoters := 500 + rng.Intn(3500) // 500-4000 voters per delegate
+		commissionBps := uint64(500 + rng.Intn(2000)) // 5%-25% commission
+
+		weights := make([]*big.Int, numVoters)
+		delegateWeight := big.NewInt(0)
+
+		for v := 0; v < numVoters; v++ {
+			// Realistic staking: 100 to 5,000,000 IOTX
+			// Power-law distribution: most voters stake small amounts, few stake large
+			amountIOTX := int64(100 + rng.ExpFloat64()*50000)
+			if amountIOTX > 5000000 {
+				amountIOTX = 5000000
+			}
+			amount := new(big.Int).Mul(big.NewInt(amountIOTX), big.NewInt(1e18))
+
+			duration := uint32(14 + rng.Intn(351)) // 14-365 days
+			autoStake := rng.Float32() > 0.25       // 75% auto-stake
+
+			bucket := &staking.VoteBucket{
+				StakedAmount:   amount,
+				StakedDuration: time.Duration(duration) * 24 * time.Hour,
+				AutoStake:      autoStake,
+			}
+
+			w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, bucket, false)
+			weights[v] = w
+			delegateWeight.Add(delegateWeight, w)
+		}
+
+		delegates[d] = delegateInfo{
+			name:          fmt.Sprintf("delegate_%02d", d),
+			votes:         new(big.Int).Set(delegateWeight),
+			commissionBps: commissionBps,
+			numVoters:     numVoters,
+			voterWeights:  weights,
+			totalWeight:   delegateWeight,
+		}
+		totalVotes.Add(totalVotes, delegateWeight)
+	}
+
+	// Simulate epoch reward distribution
+	start := time.Now()
+	globalDistributed := big.NewInt(0)
+	totalVoterCount := 0
+	totalDust := big.NewInt(0)
+
+	for _, del := range delegates {
+		// Each delegate's share of epoch reward (proportional to votes)
+		delegateReward := new(big.Int).Mul(totalEpochReward, del.votes)
+		delegateReward.Div(delegateReward, totalVotes)
+
+		// Commission
+		commission := new(big.Int).Mul(delegateReward, big.NewInt(int64(del.commissionBps)))
+		commission.Div(commission, big.NewInt(10000))
+		voterPool := new(big.Int).Sub(delegateReward, commission)
+
+		// Distribute to voters
+		distributed := big.NewInt(0)
+		for _, w := range del.voterWeights {
+			share := new(big.Int).Mul(voterPool, w)
+			share.Div(share, del.totalWeight)
+			distributed.Add(distributed, share)
+		}
+
+		dust := new(big.Int).Sub(voterPool, distributed)
+
+		// Per-delegate conservation check
+		delegateTotal := new(big.Int).Add(commission, distributed)
+		delegateTotal.Add(delegateTotal, dust)
+		r.Equal(delegateReward.String(), delegateTotal.String(),
+			"delegate %s: commission + distributed + dust != delegateReward", del.name)
+
+		// Dust bounded
+		r.True(dust.Sign() >= 0, "delegate %s: negative dust", del.name)
+		r.True(dust.Cmp(big.NewInt(int64(del.numVoters))) < 0,
+			"delegate %s: dust %s >= numVoters %d", del.name, dust.String(), del.numVoters)
+
+		globalDistributed.Add(globalDistributed, delegateReward)
+		totalVoterCount += del.numVoters
+		totalDust.Add(totalDust, dust)
+	}
+
+	elapsed := time.Since(start)
+
+	// Global conservation (within rounding from epoch reward split across delegates)
+	epochSplitDust := new(big.Int).Sub(totalEpochReward, globalDistributed)
+	r.True(epochSplitDust.Sign() >= 0, "negative epoch split dust")
+	r.True(epochSplitDust.Cmp(big.NewInt(int64(numDelegates))) < 0,
+		"epoch split dust %s >= numDelegates", epochSplitDust.String())
+
+	t.Logf("=== Full-Scale Dry Run Results ===")
+	t.Logf("Delegates:       %d", numDelegates)
+	t.Logf("Total voters:    %d", totalVoterCount)
+	t.Logf("Epoch reward:    %s IOTX", weiToIOTX(totalEpochReward))
+	t.Logf("Distributed:     %s IOTX", weiToIOTX(globalDistributed))
+	t.Logf("Epoch split dust:%s Rau", epochSplitDust.String())
+	t.Logf("Total voter dust:%s Rau", totalDust.String())
+	t.Logf("Elapsed:         %v", elapsed)
+	t.Logf("Per-delegate:    %v", elapsed/time.Duration(numDelegates))
+}
+
+// BenchmarkFullScale24Delegates benchmarks the full epoch reward distribution
+func BenchmarkFullScale24Delegates(b *testing.B) {
+	g := genesis.Default
+	rng := rand.New(rand.NewSource(42))
+
+	const numDelegates = 24
+	totalEpochReward := new(big.Int).Mul(big.NewInt(450), big.NewInt(1e18))
+
+	// Pre-generate all delegate/voter data
+	type delegateData struct {
+		reward      *big.Int
+		commission  uint64
+		weights     []*big.Int
+		totalWeight *big.Int
+	}
+
+	totalVotes := big.NewInt(0)
+	delegates := make([]delegateData, numDelegates)
+
+	for d := 0; d < numDelegates; d++ {
+		numVoters := 500 + rng.Intn(3500)
+		tw := big.NewInt(0)
+		weights := make([]*big.Int, numVoters)
+		for v := 0; v < numVoters; v++ {
+			amountIOTX := int64(100 + rng.ExpFloat64()*50000)
+			if amountIOTX > 5000000 {
+				amountIOTX = 5000000
+			}
+			amount := new(big.Int).Mul(big.NewInt(amountIOTX), big.NewInt(1e18))
+			dur := uint32(14 + rng.Intn(351))
+			auto := rng.Float32() > 0.25
+			bucket := &staking.VoteBucket{
+				StakedAmount:   amount,
+				StakedDuration: time.Duration(dur) * 24 * time.Hour,
+				AutoStake:      auto,
+			}
+			w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, bucket, false)
+			weights[v] = w
+			tw.Add(tw, w)
+		}
+		delegates[d] = delegateData{
+			commission:  uint64(500 + rng.Intn(2000)),
+			weights:     weights,
+			totalWeight: tw,
+		}
+		totalVotes.Add(totalVotes, tw)
+	}
+
+	// Pre-compute delegate rewards
+	for d := range delegates {
+		delegates[d].reward = new(big.Int).Div(
+			new(big.Int).Mul(totalEpochReward, delegates[d].totalWeight),
+			totalVotes,
+		)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		for _, del := range delegates {
+			commission := new(big.Int).Div(
+				new(big.Int).Mul(del.reward, big.NewInt(int64(del.commission))),
+				big.NewInt(10000),
+			)
+			voterPool := new(big.Int).Sub(del.reward, commission)
+			distributed := big.NewInt(0)
+			for _, w := range del.weights {
+				share := new(big.Int).Mul(voterPool, w)
+				share.Div(share, del.totalWeight)
+				distributed.Add(distributed, share)
+			}
+		}
+	}
+}
+
+func weiToIOTX(wei *big.Int) string {
+	f := new(big.Float).SetInt(wei)
+	f.Quo(f, big.NewFloat(1e18))
+	return f.Text('f', 4)
+}

--- a/action/protocol/rewarding/voter_reward_test.go
+++ b/action/protocol/rewarding/voter_reward_test.go
@@ -7,6 +7,7 @@ package rewarding
 
 import (
 	"math/big"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -114,4 +115,117 @@ func TestCommissionRateEdgeCases(t *testing.T) {
 	commission25 := new(big.Int).Mul(totalReward, big.NewInt(2500))
 	commission25.Div(commission25, big.NewInt(10000))
 	r.Equal(int64(250), commission25.Int64())
+}
+
+// TestRoundingPrecision2800Voters simulates real mainnet scale:
+// ~2800 voters with realistic IOTX amounts and staking durations.
+// Verifies: commission + sum(voter shares) + dust == totalReward exactly.
+func TestRoundingPrecision2800Voters(t *testing.T) {
+	r := require.New(t)
+	g := genesis.Default
+	rng := rand.New(rand.NewSource(42))
+
+	const numVoters = 2800
+	commissionBps := uint64(1000) // 10%
+
+	// Realistic epoch reward: ~12.5 IOTX per delegate (in Rau)
+	totalReward := new(big.Int).Mul(big.NewInt(125), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil)) // 12.5e18
+
+	// Generate voters with realistic amounts (100 - 2,000,000 IOTX) and durations (14-365 days)
+	type voter struct {
+		weight *big.Int
+	}
+	voters := make([]voter, numVoters)
+	totalWeight := big.NewInt(0)
+
+	for i := 0; i < numVoters; i++ {
+		// Amount: 100 to 2,000,000 IOTX in Rau
+		amountIOTX := int64(100 + rng.Intn(2000000))
+		amount := new(big.Int).Mul(big.NewInt(amountIOTX), big.NewInt(1e18))
+
+		duration := uint32(14 + rng.Intn(351)) // 14-365 days
+		autoStake := rng.Float32() > 0.3        // 70% auto-stake
+
+		bucket := &staking.VoteBucket{
+			StakedAmount:   amount,
+			StakedDuration: time.Duration(duration) * 24 * time.Hour,
+			AutoStake:      autoStake,
+		}
+
+		w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, bucket, false)
+		voters[i] = voter{weight: w}
+		totalWeight.Add(totalWeight, w)
+	}
+
+	// Calculate commission
+	commission := new(big.Int).Mul(totalReward, big.NewInt(int64(commissionBps)))
+	commission.Div(commission, big.NewInt(10000))
+	voterPool := new(big.Int).Sub(totalReward, commission)
+
+	// Distribute
+	distributed := big.NewInt(0)
+	for _, v := range voters {
+		share := new(big.Int).Mul(voterPool, v.weight)
+		share.Div(share, totalWeight)
+		distributed.Add(distributed, share)
+	}
+
+	dust := new(big.Int).Sub(voterPool, distributed)
+
+	// Verify exact conservation: commission + distributed + dust == totalReward
+	total := new(big.Int).Add(commission, distributed)
+	total.Add(total, dust)
+	r.Equal(totalReward.String(), total.String(), "must be exactly conserved")
+
+	// Dust should be tiny (< numVoters Rau)
+	r.True(dust.Cmp(big.NewInt(int64(numVoters))) < 0,
+		"dust %s should be < %d Rau", dust.String(), numVoters)
+
+	// Dust should be non-negative
+	r.True(dust.Sign() >= 0, "dust should not be negative")
+
+	t.Logf("2800 voters: commission=%s, distributed=%s, dust=%s Rau",
+		commission.String(), distributed.String(), dust.String())
+}
+
+// BenchmarkDistribute2800Voters measures the time to calculate voter shares
+// for a realistic mainnet delegate with ~2800 voters.
+func BenchmarkDistribute2800Voters(b *testing.B) {
+	g := genesis.Default
+	rng := rand.New(rand.NewSource(42))
+
+	const numVoters = 2800
+
+	totalReward := new(big.Int).Mul(big.NewInt(125), new(big.Int).Exp(big.NewInt(10), big.NewInt(17), nil))
+	commission := new(big.Int).Div(new(big.Int).Mul(totalReward, big.NewInt(1000)), big.NewInt(10000))
+	voterPool := new(big.Int).Sub(totalReward, commission)
+
+	// Pre-generate voter weights
+	weights := make([]*big.Int, numVoters)
+	totalWeight := big.NewInt(0)
+	for i := 0; i < numVoters; i++ {
+		amountIOTX := int64(100 + rng.Intn(2000000))
+		amount := new(big.Int).Mul(big.NewInt(amountIOTX), big.NewInt(1e18))
+		duration := uint32(14 + rng.Intn(351))
+		autoStake := rng.Float32() > 0.3
+
+		bucket := &staking.VoteBucket{
+			StakedAmount:   amount,
+			StakedDuration: time.Duration(duration) * 24 * time.Hour,
+			AutoStake:      autoStake,
+		}
+		w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, bucket, false)
+		weights[i] = w
+		totalWeight.Add(totalWeight, w)
+	}
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		distributed := big.NewInt(0)
+		for _, w := range weights {
+			share := new(big.Int).Mul(voterPool, w)
+			share.Div(share, totalWeight)
+			distributed.Add(distributed, share)
+		}
+	}
 }

--- a/action/protocol/rewarding/voter_reward_test.go
+++ b/action/protocol/rewarding/voter_reward_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rewarding
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+)
+
+func TestCalculateVoterShares(t *testing.T) {
+	r := require.New(t)
+	g := genesis.Default
+
+	// Simulate 3 voters with different staking amounts and durations
+	// Voter A: 1000 IOTX, 91 days, auto-stake
+	// Voter B: 500 IOTX, 14 days, no auto-stake
+	// Voter C: 200 IOTX, 91 days, auto-stake (self-stake)
+
+	type voterInfo struct {
+		amount   *big.Int
+		duration uint32
+		auto     bool
+		self     bool
+	}
+
+	voters := []voterInfo{
+		{big.NewInt(1000), 91, true, false},
+		{big.NewInt(500), 14, false, false},
+		{big.NewInt(200), 91, true, true},
+	}
+
+	totalWeight := big.NewInt(0)
+	weights := make([]*big.Int, len(voters))
+
+	for i, v := range voters {
+		bucket := &staking.VoteBucket{}
+		bucket.StakedAmount = v.amount
+		bucket.StakedDuration = time.Duration(v.duration) * 24 * time.Hour
+		bucket.AutoStake = v.auto
+
+		w := staking.CalculateVoteWeight(g.Staking.VoteWeightCalConsts, bucket, v.self)
+		weights[i] = w
+		totalWeight.Add(totalWeight, w)
+	}
+
+	// Verify weights are calculated and non-zero
+	for i, w := range weights {
+		r.True(w.Sign() > 0, "voter %d weight should be positive", i)
+	}
+	r.True(totalWeight.Sign() > 0)
+
+	// Simulate distribution of 100 IOTX with 10% commission
+	totalReward := big.NewInt(100)
+	commission := big.NewInt(10) // 10%
+	voterPool := new(big.Int).Sub(totalReward, commission)
+
+	distributed := big.NewInt(0)
+	shares := make([]*big.Int, len(voters))
+
+	for i := range voters {
+		share := new(big.Int).Mul(voterPool, weights[i])
+		share.Div(share, totalWeight)
+		shares[i] = share
+		distributed.Add(distributed, share)
+	}
+
+	// Verify total distributed <= voterPool (rounding loss is dust)
+	r.True(distributed.Cmp(voterPool) <= 0, "distributed should not exceed voterPool")
+
+	// Dust should be tiny
+	dust := new(big.Int).Sub(voterPool, distributed)
+	r.True(dust.Cmp(big.NewInt(int64(len(voters)))) < 0, "dust should be less than voter count")
+
+	// Voter A (highest weight due to 1000 amount + auto-stake) should get the most
+	r.True(shares[0].Cmp(shares[1]) > 0, "voter A should get more than voter B")
+	r.True(shares[0].Cmp(shares[2]) > 0, "voter A should get more than voter C")
+
+	// Commission + distributed + dust = totalReward
+	totalDistributed := new(big.Int).Add(commission, distributed)
+	totalDistributed.Add(totalDistributed, dust)
+	r.Equal(totalReward.Int64(), totalDistributed.Int64(), "commission + distributed + dust should equal totalReward")
+}
+
+func TestCommissionRateEdgeCases(t *testing.T) {
+	r := require.New(t)
+
+	totalReward := big.NewInt(1000)
+
+	// 0% commission
+	commission0 := new(big.Int).Mul(totalReward, big.NewInt(0))
+	commission0.Div(commission0, big.NewInt(10000))
+	r.Equal(int64(0), commission0.Int64())
+
+	// 100% commission
+	commission100 := new(big.Int).Mul(totalReward, big.NewInt(10000))
+	commission100.Div(commission100, big.NewInt(10000))
+	r.Equal(int64(1000), commission100.Int64())
+
+	// 10% commission
+	commission10 := new(big.Int).Mul(totalReward, big.NewInt(1000))
+	commission10.Div(commission10, big.NewInt(10000))
+	r.Equal(int64(100), commission10.Int64())
+
+	// 25% commission
+	commission25 := new(big.Int).Mul(totalReward, big.NewInt(2500))
+	commission25.Div(commission25, big.NewInt(10000))
+	r.Equal(int64(250), commission25.Int64())
+}

--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -35,6 +35,7 @@ type (
 		Votes              *big.Int
 		SelfStakeBucketIdx uint64
 		SelfStake          *big.Int
+		CommissionRate     uint64 // IIP-59: basis points (0-10000), 0 = legacy (no auto-distribution)
 	}
 
 	// CandidateList is a list of candidates which is sortable
@@ -65,6 +66,7 @@ func (d *Candidate) Clone() *Candidate {
 		SelfStakeBucketIdx: d.SelfStakeBucketIdx,
 		SelfStake:          new(big.Int).Set(d.SelfStake),
 		BLSPubKey:          blsPubKey,
+		CommissionRate:     d.CommissionRate,
 	}
 }
 
@@ -274,6 +276,7 @@ func (d *Candidate) toProto() (*stakingpb.Candidate, error) {
 		SelfStake:          d.SelfStake.String(),
 		Pubkey:             pubkey,
 		DeactivatedAt:      d.DeactivatedAt,
+		CommissionRate:     d.CommissionRate,
 	}, nil
 }
 
@@ -324,6 +327,7 @@ func (d *Candidate) fromProto(pb *stakingpb.Candidate) error {
 		d.BLSPubKey = nil
 	}
 	d.DeactivatedAt = pb.GetDeactivatedAt()
+	d.CommissionRate = pb.GetCommissionRate()
 	return nil
 }
 

--- a/action/protocol/staking/candidate.go
+++ b/action/protocol/staking/candidate.go
@@ -35,7 +35,8 @@ type (
 		Votes              *big.Int
 		SelfStakeBucketIdx uint64
 		SelfStake          *big.Int
-		CommissionRate     uint64 // IIP-59: basis points (0-10000), 0 = legacy (no auto-distribution)
+		CommissionRate          uint64 // IIP-59: basis points (0-10000), 0 = legacy (no auto-distribution)
+		CommissionRateLastEpoch uint64 // IIP-59: epoch when commission rate was last changed (cooldown enforcement)
 	}
 
 	// CandidateList is a list of candidates which is sortable
@@ -65,8 +66,9 @@ func (d *Candidate) Clone() *Candidate {
 		Votes:              new(big.Int).Set(d.Votes),
 		SelfStakeBucketIdx: d.SelfStakeBucketIdx,
 		SelfStake:          new(big.Int).Set(d.SelfStake),
-		BLSPubKey:          blsPubKey,
-		CommissionRate:     d.CommissionRate,
+		BLSPubKey:               blsPubKey,
+		CommissionRate:          d.CommissionRate,
+		CommissionRateLastEpoch: d.CommissionRateLastEpoch,
 	}
 }
 
@@ -275,8 +277,9 @@ func (d *Candidate) toProto() (*stakingpb.Candidate, error) {
 		SelfStakeBucketIdx: d.SelfStakeBucketIdx,
 		SelfStake:          d.SelfStake.String(),
 		Pubkey:             pubkey,
-		DeactivatedAt:      d.DeactivatedAt,
-		CommissionRate:     d.CommissionRate,
+		DeactivatedAt:           d.DeactivatedAt,
+		CommissionRate:          d.CommissionRate,
+		CommissionRateLastEpoch: d.CommissionRateLastEpoch,
 	}, nil
 }
 
@@ -328,6 +331,7 @@ func (d *Candidate) fromProto(pb *stakingpb.Candidate) error {
 	}
 	d.DeactivatedAt = pb.GetDeactivatedAt()
 	d.CommissionRate = pb.GetCommissionRate()
+	d.CommissionRateLastEpoch = pb.GetCommissionRateLastEpoch()
 	return nil
 }
 

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -2938,7 +2938,9 @@ func TestProtocol_FetchBucketAndValidate(t *testing.T) {
 	})
 	t.Run("validate owner and selfstake", func(t *testing.T) {
 		csm, err := NewCandidateStateManager(sm)
-		require.NoError(err)
+		if err != nil {
+			t.Fatal(err)
+		}
 		patches := gomonkey.NewPatches()
 		patches.ApplyPrivateMethod(csm, "NativeBucket", func(index uint64) (*VoteBucket, error) {
 			return &VoteBucket{
@@ -2951,7 +2953,9 @@ func TestProtocol_FetchBucketAndValidate(t *testing.T) {
 		defer patches.Reset()
 
 		_, err = p.fetchBucketAndValidate(protocol.FeatureCtx{}, csm, identityset.Address(1), 1, true, false)
-		require.NoError(err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
 }
 

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -769,6 +769,8 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 		rLog, tLogs, err = p.handleCandidateEndorsement(ctx, act, csm)
 	case *action.CandidateTransferOwnership:
 		rLog, tLogs, err = p.handleCandidateTransferOwnership(ctx, act, csm)
+	case *action.SetCommissionRate:
+		rLog, err = p.handleSetCommissionRate(ctx, act, csm)
 	case *action.ScheduleCandidateDeactivation:
 		isSystemAction = true
 		rLog, tLogs, err = p.handleScheduleCandidateDeactivation(ctx, act, csm)

--- a/action/protocol/staking/stakingpb/staking.pb.go
+++ b/action/protocol/staking/stakingpb/staking.pb.go
@@ -242,6 +242,7 @@ type Candidate struct {
 	IdentifierAddress  string `protobuf:"bytes,8,opt,name=identifierAddress,proto3" json:"identifierAddress,omitempty"` //if the field is empty, set it to the old owner address
 	Pubkey             []byte `protobuf:"bytes,9,opt,name=pubkey,proto3" json:"pubkey,omitempty"`                       // BLS public key
 	DeactivatedAt      uint64 `protobuf:"varint,10,opt,name=deactivatedAt,proto3" json:"deactivatedAt,omitempty"`
+	CommissionRate     uint64 `protobuf:"varint,11,opt,name=commissionRate,proto3" json:"commissionRate,omitempty"` // IIP-59: basis points (0-10000)
 }
 
 func (x *Candidate) Reset() {
@@ -342,6 +343,13 @@ func (x *Candidate) GetPubkey() []byte {
 func (x *Candidate) GetDeactivatedAt() uint64 {
 	if x != nil {
 		return x.DeactivatedAt
+	}
+	return 0
+}
+
+func (x *Candidate) GetCommissionRate() uint64 {
+	if x != nil {
+		return x.CommissionRate
 	}
 	return 0
 }

--- a/action/protocol/staking/stakingpb/staking.pb.go
+++ b/action/protocol/staking/stakingpb/staking.pb.go
@@ -242,7 +242,8 @@ type Candidate struct {
 	IdentifierAddress  string `protobuf:"bytes,8,opt,name=identifierAddress,proto3" json:"identifierAddress,omitempty"` //if the field is empty, set it to the old owner address
 	Pubkey             []byte `protobuf:"bytes,9,opt,name=pubkey,proto3" json:"pubkey,omitempty"`                       // BLS public key
 	DeactivatedAt      uint64 `protobuf:"varint,10,opt,name=deactivatedAt,proto3" json:"deactivatedAt,omitempty"`
-	CommissionRate     uint64 `protobuf:"varint,11,opt,name=commissionRate,proto3" json:"commissionRate,omitempty"` // IIP-59: basis points (0-10000)
+	CommissionRate          uint64 `protobuf:"varint,11,opt,name=commissionRate,proto3" json:"commissionRate,omitempty"`          // IIP-59
+	CommissionRateLastEpoch uint64 `protobuf:"varint,12,opt,name=commissionRateLastEpoch,proto3" json:"commissionRateLastEpoch,omitempty"` // IIP-59 cooldown
 }
 
 func (x *Candidate) Reset() {
@@ -350,6 +351,13 @@ func (x *Candidate) GetDeactivatedAt() uint64 {
 func (x *Candidate) GetCommissionRate() uint64 {
 	if x != nil {
 		return x.CommissionRate
+	}
+	return 0
+}
+
+func (x *Candidate) GetCommissionRateLastEpoch() uint64 {
+	if x != nil {
+		return x.CommissionRateLastEpoch
 	}
 	return 0
 }

--- a/action/protocol/staking/stakingpb/staking.proto
+++ b/action/protocol/staking/stakingpb/staking.proto
@@ -44,6 +44,7 @@ message Candidate {
     bytes pubkey = 9; // BLS public key
     uint64 deactivatedAt = 10;
     uint64 commissionRate = 11; // IIP-59: basis points (0-10000), 0 = legacy (no auto-distribution)
+    uint64 commissionRateLastEpoch = 12; // IIP-59: epoch when commission rate was last changed
 }
 
 message Candidates {

--- a/action/protocol/staking/stakingpb/staking.proto
+++ b/action/protocol/staking/stakingpb/staking.proto
@@ -43,6 +43,7 @@ message Candidate {
     string identifierAddress = 8; //if the field is empty, set it to the old owner address
     bytes pubkey = 9; // BLS public key
     uint64 deactivatedAt = 10;
+    uint64 commissionRate = 11; // IIP-59: basis points (0-10000), 0 = legacy (no auto-distribution)
 }
 
 message Candidates {

--- a/action/protocol/staking/voter_reward.go
+++ b/action/protocol/staking/voter_reward.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package staking
+
+import (
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/state"
+)
+
+// ActiveBucketsByCandidate returns all non-unstaked native buckets for a candidate.
+// Used by the rewarding protocol (IIP-59) to distribute voter rewards.
+func (p *Protocol) ActiveBucketsByCandidate(sr protocol.StateReader, candidateIdentifier address.Address) ([]*VoteBucket, error) {
+	view, err := sr.ReadView(p.Name())
+	if err != nil {
+		return nil, nil // staking view not available
+	}
+	csr, ok := view.(CandidateStateReader)
+	if !ok {
+		return nil, nil // invalid view type
+	}
+
+	indices, _, err := csr.NativeBucketIndicesByCandidate(candidateIdentifier)
+	if errors.Cause(err) == state.ErrStateNotExist || indices == nil {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	buckets, err := csr.NativeBucketsWithIndices(*indices)
+	if err != nil {
+		return nil, err
+	}
+
+	// Filter out unstaked buckets
+	active := make([]*VoteBucket, 0, len(buckets))
+	for _, b := range buckets {
+		if !b.UnstakeStartTime.IsZero() && b.UnstakeStartTime.Unix() > 0 {
+			continue // bucket has been unstaked
+		}
+		active = append(active, b)
+	}
+	return active, nil
+}
+
+// CandidateByIdentifier returns a candidate by its identifier address.
+// Used by the rewarding protocol (IIP-59) to look up commission rate.
+func (p *Protocol) CandidateByIdentifier(sr protocol.StateReader, id address.Address) (*Candidate, error) {
+	view, err := sr.ReadView(p.Name())
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read staking view")
+	}
+	csr, ok := view.(CandidateStateReader)
+	if !ok {
+		return nil, errors.New("invalid staking view type")
+	}
+
+	cand, _, err := csr.CandidateByAddress(id)
+	if err != nil {
+		return nil, err
+	}
+	return cand, nil
+}

--- a/action/protocol/staking/voter_reward.go
+++ b/action/protocol/staking/voter_reward.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 )
 
@@ -21,36 +22,69 @@ const (
 	HandleSetCommissionRate = "setCommissionRate"
 )
 
-// ActiveBucketsByCandidate returns all non-unstaked native buckets for a candidate.
-// Used by the rewarding protocol (IIP-59) to distribute voter rewards.
+// ActiveBucketsByCandidate returns all non-unstaked buckets (native + contract staking)
+// for a candidate. Used by the rewarding protocol (IIP-59) to distribute voter rewards.
 func (p *Protocol) ActiveBucketsByCandidate(sm protocol.StateManager, candidateIdentifier address.Address) ([]*VoteBucket, error) {
 	csm, err := NewCandidateStateManager(sm)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create candidate state manager")
 	}
 
-	// Read bucket indices from state directly
+	// 1. Read native buckets
 	var indices BucketIndices
 	if _, err := csm.SM().State(&indices,
 		protocol.NamespaceOption(_stakingNameSpace),
 		protocol.KeyOption(append([]byte{_candIndex}, candidateIdentifier.Bytes()...)),
 	); err != nil {
-		return nil, nil // no buckets for this candidate
+		indices = nil // no native buckets
 	}
 
-	// Read each bucket
-	active := make([]*VoteBucket, 0, len(indices))
+	active := make([]*VoteBucket, 0)
 	for _, idx := range indices {
 		bucket, err := csm.NativeBucket(idx)
 		if err != nil {
-			continue // bucket may have been withdrawn
+			continue
 		}
-		if !bucket.UnstakeStartTime.IsZero() && bucket.UnstakeStartTime.Unix() > 0 {
-			continue // unstaked
+		if bucket.isUnstaked() {
+			continue
 		}
 		active = append(active, bucket)
 	}
+
+	// 2. Read contract staking buckets (V1, V2, V3)
+	height, _ := sm.Height()
+	for _, indexer := range p.contractStakingIndexers() {
+		if indexer == nil {
+			continue
+		}
+		contractBuckets, err := indexer.BucketsByCandidate(candidateIdentifier, height)
+		if err != nil {
+			continue // indexer may not be ready
+		}
+		for _, b := range contractBuckets {
+			if b.isUnstaked() {
+				continue
+			}
+			active = append(active, b)
+		}
+	}
+
 	return active, nil
+}
+
+// contractStakingIndexers returns all configured contract staking indexers
+func (p *Protocol) contractStakingIndexers() []ContractStakingIndexer {
+	var indexers []ContractStakingIndexer
+	if p.contractStakingIndexer != nil {
+		indexers = append(indexers, p.contractStakingIndexer)
+	}
+	if p.contractStakingIndexerV2 != nil {
+		indexers = append(indexers, p.contractStakingIndexerV2)
+	}
+	if p.contractStakingIndexerV3 != nil {
+		indexers = append(indexers, p.contractStakingIndexerV3)
+	}
+	return indexers
 }
 
 // CandidateByIdentifier returns a candidate by its identifier address.
@@ -78,8 +112,14 @@ func (p *Protocol) VoteWeightCalConsts() genesis.VoteWeightCalConsts {
 func (p *Protocol) handleSetCommissionRate(ctx context.Context, act *action.SetCommissionRate, csm CandidateStateManager,
 ) (*receiptLog, error) {
 	actCtx := protocol.MustGetActionCtx(ctx)
+	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	log := newReceiptLog(p.addr.String(), HandleSetCommissionRate, featureCtx.NewStakingReceiptFormat)
+
+	// Gate behind Yosemite hard fork
+	if !featureCtx.EnableVoterRewardDistribution {
+		return log, errors.New("SetCommissionRate not enabled before Yosemite hard fork")
+	}
 
 	// Only candidate owner can set commission rate
 	c := csm.GetByOwner(actCtx.Caller)
@@ -87,7 +127,18 @@ func (p *Protocol) handleSetCommissionRate(ctx context.Context, act *action.SetC
 		return log, errCandNotExist
 	}
 
+	// Enforce cooldown: must wait CommissionRateCooldownEpochs between changes
+	rp := rolldpos.MustGetProtocol(protocol.MustGetRegistry(ctx))
+	currentEpoch := rp.GetEpochNum(blkCtx.BlockHeight)
+	if c.CommissionRateLastEpoch > 0 && currentEpoch < c.CommissionRateLastEpoch+action.CommissionRateCooldownEpochs {
+		return log, errors.Errorf(
+			"commission rate cooldown: last changed at epoch %d, current epoch %d, must wait until epoch %d",
+			c.CommissionRateLastEpoch, currentEpoch, c.CommissionRateLastEpoch+action.CommissionRateCooldownEpochs,
+		)
+	}
+
 	c.CommissionRate = act.Rate()
+	c.CommissionRateLastEpoch = currentEpoch
 
 	if err := csm.Upsert(c); err != nil {
 		return log, csmErrorToHandleError(c.GetIdentifier().String(), err)

--- a/action/protocol/staking/voter_reward.go
+++ b/action/protocol/staking/voter_reward.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
-	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 )
 
 const (
@@ -23,57 +23,55 @@ const (
 
 // ActiveBucketsByCandidate returns all non-unstaked native buckets for a candidate.
 // Used by the rewarding protocol (IIP-59) to distribute voter rewards.
-func (p *Protocol) ActiveBucketsByCandidate(sr protocol.StateReader, candidateIdentifier address.Address) ([]*VoteBucket, error) {
-	view, err := sr.ReadView(p.Name())
+func (p *Protocol) ActiveBucketsByCandidate(sm protocol.StateManager, candidateIdentifier address.Address) ([]*VoteBucket, error) {
+	csm, err := NewCandidateStateManager(sm)
 	if err != nil {
-		return nil, nil // staking view not available
-	}
-	csr, ok := view.(CandidateStateReader)
-	if !ok {
-		return nil, nil // invalid view type
+		return nil, errors.Wrap(err, "failed to create candidate state manager")
 	}
 
-	indices, _, err := csr.NativeBucketIndicesByCandidate(candidateIdentifier)
-	if errors.Cause(err) == state.ErrStateNotExist || indices == nil {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	buckets, err := csr.NativeBucketsWithIndices(*indices)
-	if err != nil {
-		return nil, err
+	// Read bucket indices from state directly
+	var indices BucketIndices
+	if _, err := csm.SM().State(&indices,
+		protocol.NamespaceOption(_stakingNameSpace),
+		protocol.KeyOption(append([]byte{_candIndex}, candidateIdentifier.Bytes()...)),
+	); err != nil {
+		return nil, nil // no buckets for this candidate
 	}
 
-	// Filter out unstaked buckets
-	active := make([]*VoteBucket, 0, len(buckets))
-	for _, b := range buckets {
-		if !b.UnstakeStartTime.IsZero() && b.UnstakeStartTime.Unix() > 0 {
-			continue // bucket has been unstaked
+	// Read each bucket
+	active := make([]*VoteBucket, 0, len(indices))
+	for _, idx := range indices {
+		bucket, err := csm.NativeBucket(idx)
+		if err != nil {
+			continue // bucket may have been withdrawn
 		}
-		active = append(active, b)
+		if !bucket.UnstakeStartTime.IsZero() && bucket.UnstakeStartTime.Unix() > 0 {
+			continue // unstaked
+		}
+		active = append(active, bucket)
 	}
 	return active, nil
 }
 
 // CandidateByIdentifier returns a candidate by its identifier address.
 // Used by the rewarding protocol (IIP-59) to look up commission rate.
-func (p *Protocol) CandidateByIdentifier(sr protocol.StateReader, id address.Address) (*Candidate, error) {
-	view, err := sr.ReadView(p.Name())
+func (p *Protocol) CandidateByIdentifier(sm protocol.StateManager, id address.Address) (*Candidate, error) {
+	csm, err := NewCandidateStateManager(sm)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to read staking view")
-	}
-	csr, ok := view.(CandidateStateReader)
-	if !ok {
-		return nil, errors.New("invalid staking view type")
+		return nil, errors.Wrap(err, "failed to create candidate state manager")
 	}
 
-	cand, _, err := csr.CandidateByAddress(id)
-	if err != nil {
-		return nil, err
+	cand := csm.GetByIdentifier(id)
+	if cand == nil {
+		return nil, errors.Errorf("candidate %s not found", id.String())
 	}
 	return cand, nil
+}
+
+// VoteWeightCalConsts returns the vote weight calculation constants from this protocol's config.
+// Used by the rewarding protocol (IIP-59) to calculate voter shares consistently.
+func (p *Protocol) VoteWeightCalConsts() genesis.VoteWeightCalConsts {
+	return p.config.VoteWeightCalConsts
 }
 
 // handleSetCommissionRate handles the SetCommissionRate action (IIP-59)

--- a/action/protocol/staking/voter_reward.go
+++ b/action/protocol/staking/voter_reward.go
@@ -6,11 +6,19 @@
 package staking
 
 import (
+	"context"
+
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 
+	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/state"
+)
+
+const (
+	// HandleSetCommissionRate is the handler name
+	HandleSetCommissionRate = "setCommissionRate"
 )
 
 // ActiveBucketsByCandidate returns all non-unstaked native buckets for a candidate.
@@ -66,4 +74,28 @@ func (p *Protocol) CandidateByIdentifier(sr protocol.StateReader, id address.Add
 		return nil, err
 	}
 	return cand, nil
+}
+
+// handleSetCommissionRate handles the SetCommissionRate action (IIP-59)
+func (p *Protocol) handleSetCommissionRate(ctx context.Context, act *action.SetCommissionRate, csm CandidateStateManager,
+) (*receiptLog, error) {
+	actCtx := protocol.MustGetActionCtx(ctx)
+	featureCtx := protocol.MustGetFeatureCtx(ctx)
+	log := newReceiptLog(p.addr.String(), HandleSetCommissionRate, featureCtx.NewStakingReceiptFormat)
+
+	// Only candidate owner can set commission rate
+	c := csm.GetByOwner(actCtx.Caller)
+	if c == nil {
+		return log, errCandNotExist
+	}
+
+	c.CommissionRate = act.Rate()
+
+	if err := csm.Upsert(c); err != nil {
+		return log, csmErrorToHandleError(c.GetIdentifier().String(), err)
+	}
+
+	log.AddTopics(c.GetIdentifier().Bytes())
+	log.AddAddress(actCtx.Caller)
+	return log, nil
 }

--- a/action/set_commission_rate.go
+++ b/action/set_commission_rate.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/pkg/util/byteutil"
+)
+
+const (
+	// SetCommissionRateBaseIntrinsicGas represents the base intrinsic gas for SetCommissionRate
+	SetCommissionRateBaseIntrinsicGas = uint64(10000)
+)
+
+// SetCommissionRate is the action to set a delegate's voter reward commission rate (IIP-59)
+type SetCommissionRate struct {
+	stake_common
+	rate uint64 // basis points, 0-10000
+}
+
+// NewSetCommissionRate creates a SetCommissionRate instance
+func NewSetCommissionRate(rate uint64) (*SetCommissionRate, error) {
+	if rate > 10000 {
+		return nil, errors.New("commission rate exceeds 10000 bps")
+	}
+	return &SetCommissionRate{rate: rate}, nil
+}
+
+// Rate returns the commission rate in basis points
+func (s *SetCommissionRate) Rate() uint64 { return s.rate }
+
+// IntrinsicGas returns the intrinsic gas of a SetCommissionRate
+func (s *SetCommissionRate) IntrinsicGas() (uint64, error) {
+	return SetCommissionRateBaseIntrinsicGas, nil
+}
+
+// Serialize returns a raw byte stream of the SetCommissionRate
+func (s *SetCommissionRate) Serialize() []byte {
+	return byteutil.Uint64ToBytesBigEndian(s.rate)
+}
+
+// SanityCheck validates the SetCommissionRate action
+func (s *SetCommissionRate) SanityCheck() error {
+	if s.rate > 10000 {
+		return errors.New("commission rate exceeds 10000 bps")
+	}
+	return nil
+}
+
+// LoadFromBytes loads SetCommissionRate from a byte stream
+func (s *SetCommissionRate) LoadFromBytes(data []byte) error {
+	if len(data) < 8 {
+		return errors.New("invalid data length for SetCommissionRate")
+	}
+	s.rate = byteutil.BytesToUint64BigEndian(data[:8])
+	if s.rate > 10000 {
+		return errors.New("commission rate exceeds 10000 bps")
+	}
+	return nil
+}

--- a/action/set_commission_rate.go
+++ b/action/set_commission_rate.go
@@ -14,6 +14,11 @@ import (
 const (
 	// SetCommissionRateBaseIntrinsicGas represents the base intrinsic gas for SetCommissionRate
 	SetCommissionRateBaseIntrinsicGas = uint64(10000)
+	// MaxCommissionRate is the maximum commission rate in basis points (100%)
+	MaxCommissionRate = uint64(10000)
+	// CommissionRateCooldownEpochs is the minimum number of epochs between commission rate changes
+	// ~7 days at 1-hour epochs
+	CommissionRateCooldownEpochs = uint64(168)
 )
 
 // SetCommissionRate is the action to set a delegate's voter reward commission rate (IIP-59)
@@ -24,8 +29,8 @@ type SetCommissionRate struct {
 
 // NewSetCommissionRate creates a SetCommissionRate instance
 func NewSetCommissionRate(rate uint64) (*SetCommissionRate, error) {
-	if rate > 10000 {
-		return nil, errors.New("commission rate exceeds 10000 bps")
+	if rate > MaxCommissionRate {
+		return nil, errors.Errorf("commission rate %d exceeds max %d bps", rate, MaxCommissionRate)
 	}
 	return &SetCommissionRate{rate: rate}, nil
 }
@@ -38,27 +43,25 @@ func (s *SetCommissionRate) IntrinsicGas() (uint64, error) {
 	return SetCommissionRateBaseIntrinsicGas, nil
 }
 
+// SanityCheck validates the SetCommissionRate action
+func (s *SetCommissionRate) SanityCheck() error {
+	if s.rate > MaxCommissionRate {
+		return errors.Errorf("commission rate %d exceeds max %d bps", s.rate, MaxCommissionRate)
+	}
+	return nil
+}
+
 // Serialize returns a raw byte stream of the SetCommissionRate
 func (s *SetCommissionRate) Serialize() []byte {
 	return byteutil.Uint64ToBytesBigEndian(s.rate)
 }
 
-// SanityCheck validates the SetCommissionRate action
-func (s *SetCommissionRate) SanityCheck() error {
-	if s.rate > 10000 {
-		return errors.New("commission rate exceeds 10000 bps")
-	}
-	return nil
-}
-
-// LoadFromBytes loads SetCommissionRate from a byte stream
-func (s *SetCommissionRate) LoadFromBytes(data []byte) error {
-	if len(data) < 8 {
-		return errors.New("invalid data length for SetCommissionRate")
-	}
-	s.rate = byteutil.BytesToUint64BigEndian(data[:8])
-	if s.rate > 10000 {
-		return errors.New("commission rate exceeds 10000 bps")
-	}
-	return nil
-}
+// TODO(IIP-59): The following methods require iotex-proto to add SetCommissionRate message
+// as field 54 in the ActionCore oneof. Once that's done:
+//   - Add FillAction() that sets core.Action = &iotextypes.ActionCore_SetCommissionRate{...}
+//   - Add Proto() / LoadProto() for serialization
+//   - Add deserialization case in envelope.go loadProtoActionPayload()
+//   - Add EthABI encoding for MetaMask/Hardhat compatibility
+//
+// Until then, the action is handled internally by the staking protocol's handler
+// dispatch but cannot be submitted via external RPC.

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -80,6 +80,7 @@ func defaultConfig() Genesis {
 			WakeBlockHeight:           36893881,
 			XinguBlockHeight:          41648761,
 			XinguBetaBlockHeight:      41648761,
+			YosemiteBlockHeight:       math.MaxUint64, // IIP-59: protocol-native voter reward distribution
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{
@@ -381,6 +382,10 @@ type (
 		// XinguBetaBlockHeight is the start height to
 		// 1. slash candidate by operator
 		XinguBetaBlockHeight uint64 `yaml:"xinguBetaHeight"`
+		// YosemiteBlockHeight is the start height to
+		// 1. enable protocol-native voter reward distribution (IIP-59)
+		// 2. enable SetCommissionRate action for delegates
+		YosemiteBlockHeight uint64 `yaml:"yosemiteHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -771,6 +776,11 @@ func (g *Blockchain) IsXingu(height uint64) bool {
 // IsXinguBeta checks whether height is equal to or larger than xingu beta height
 func (g *Blockchain) IsXinguBeta(height uint64) bool {
 	return g.isPost(g.XinguBetaBlockHeight, height)
+}
+
+// IsYosemite checks whether height is equal to or larger than yosemite height (IIP-59)
+func (g *Blockchain) IsYosemite(height uint64) bool {
+	return g.isPost(g.YosemiteBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height

--- a/consensus/scheme/rolldpos/chainmanager.go
+++ b/consensus/scheme/rolldpos/chainmanager.go
@@ -263,7 +263,13 @@ func (cm *chainManager) Fork(hash hash.Hash256) (ForkChain, error) {
 	if blk := cm.pool.BlockByHash(hash); blk != nil {
 		head = &blk.Header
 	} else if head, err = cm.bc.BlockHeader(hash); err != nil {
-		return nil, errors.Wrapf(err, "failed to get block header %x", hash)
+		// Genesis block (height 0) may not be stored by hash in the block header index.
+		// Fall back to looking up by height 0 and verifying the hash matches.
+		if h0, err2 := cm.bc.BlockHeaderByHeight(0); err2 == nil && h0.HashBlock() == hash {
+			head = h0
+		} else {
+			return nil, errors.Wrapf(err, "failed to get block header %x", hash)
+		}
 	}
 	sr, err := cm.srf.StateReaderAt(head.Height(), hash)
 	if err != nil {

--- a/tools/stresstest/main.go
+++ b/tools/stresstest/main.go
@@ -34,16 +34,17 @@ import (
 )
 
 var (
-	flagTimeout = flag.Int("timeout", 300, "test duration in seconds")
-	flagAPS     = flag.Float64("aps", 5, "actions per second to inject")
-	flagNodes   = flag.Int("nodes", 4, "number of nodes in cluster")
+	flagTimeout   = flag.Int("timeout", 300, "test duration in seconds")
+	flagAPS       = flag.Float64("aps", 5, "actions per second to inject")
+	flagNodes     = flag.Int("nodes", 4, "number of nodes in cluster")
+	flagDelegates = flag.Int("delegates", 8, "number of delegates")
 )
 
 func main() {
 	flag.Parse()
 
 	numNodes := *flagNodes
-	numDelegates := numNodes * 2 // same ratio as minicluster: 2 delegates per node
+	numDelegates := *flagDelegates
 	timeout := time.Duration(*flagTimeout) * time.Second
 	aps := *flagAPS
 
@@ -72,14 +73,20 @@ func main() {
 		cfg.Genesis.Blockchain.TimeBasedRotation = true
 		cfg.Genesis.EnableGravityChainVoting = false
 		cfg.Genesis.PollMode = "lifeLong"
-		cfg.Genesis.Delegates = cfg.Genesis.Delegates[3 : numDelegates+3]
+		// Use the first numDelegates from the genesis delegate list
+		if len(cfg.Genesis.Delegates) > numDelegates {
+			cfg.Genesis.Delegates = cfg.Genesis.Delegates[:numDelegates]
+		}
 		cfg.Genesis.VanuatuBlockHeight = 1
 		testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 
-		// Assign 2 delegates per node (same pattern as minicluster)
+		// Assign delegates to nodes (round-robin distribution)
 		var keys []string
-		keys = append(keys, delegateKeys[i].HexString())
-		keys = append(keys, delegateKeys[i+numNodes].HexString())
+		for d := 0; d < numDelegates; d++ {
+			if d%numNodes == i {
+				keys = append(keys, delegateKeys[d].HexString())
+			}
+		}
 		cfg.Chain.ProducerPrivKey = strings.Join(keys, ",")
 		cfg.Chain.ID = 1
 

--- a/tools/stresstest/main.go
+++ b/tools/stresstest/main.go
@@ -1,0 +1,326 @@
+// stresstest runs a multi-node IoTeX cluster and injects load to test
+// block production, reward distribution, staking, and contract interactions.
+//
+// Usage: go run ./tools/stresstest/ -timeout 300 -aps 5 -nodes 4
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/iotex-proto/golang/iotexapi"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
+	"github.com/iotexproject/iotex-core/v2/pkg/probe"
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+	"github.com/iotexproject/iotex-core/v2/pkg/util/fileutil"
+	"github.com/iotexproject/iotex-core/v2/server/itx"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+var (
+	flagTimeout = flag.Int("timeout", 300, "test duration in seconds")
+	flagAPS     = flag.Float64("aps", 5, "actions per second to inject")
+	flagNodes   = flag.Int("nodes", 4, "number of nodes in cluster")
+)
+
+func main() {
+	flag.Parse()
+
+	numNodes := *flagNodes
+	numDelegates := numNodes * 2 // same ratio as minicluster: 2 delegates per node
+	timeout := time.Duration(*flagTimeout) * time.Second
+	aps := *flagAPS
+
+	log.L().Info("Starting stress test",
+		zap.Int("nodes", numNodes),
+		zap.Int("delegates", numDelegates),
+		zap.Duration("timeout", timeout),
+		zap.Float64("aps", aps),
+	)
+
+	// Generate delegate keys
+	delegateKeys := make([]crypto.PrivateKey, numDelegates)
+	for i := 0; i < numDelegates; i++ {
+		delegateKeys[i] = identityset.PrivateKey(i)
+	}
+
+	// Configure nodes
+	dbPaths := make([]string, 0)
+	configs := make([]config.Config, numNodes)
+	for i := 0; i < numNodes; i++ {
+		cfg := config.Default
+		cfg.Genesis = genesis.TestDefault()
+		cfg.Genesis.Blockchain.NumDelegates = uint64(numDelegates)
+		cfg.Genesis.Blockchain.NumSubEpochs = 2
+		cfg.Genesis.BlockInterval = 3 * time.Second
+		cfg.Genesis.Blockchain.TimeBasedRotation = true
+		cfg.Genesis.EnableGravityChainVoting = false
+		cfg.Genesis.PollMode = "lifeLong"
+		cfg.Genesis.Delegates = cfg.Genesis.Delegates[3 : numDelegates+3]
+		cfg.Genesis.VanuatuBlockHeight = 1
+		testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+
+		// Assign 2 delegates per node (same pattern as minicluster)
+		var keys []string
+		keys = append(keys, delegateKeys[i].HexString())
+		keys = append(keys, delegateKeys[i+numNodes].HexString())
+		cfg.Chain.ProducerPrivKey = strings.Join(keys, ",")
+		cfg.Chain.ID = 1
+
+		// Paths
+		prefix := fmt.Sprintf("/tmp/stresstest/node%d", i)
+		os.MkdirAll(prefix, 0755)
+		cfg.Chain.ChainDBPath = prefix + "/chain.db"
+		cfg.Chain.TrieDBPath = prefix + "/trie.db"
+		cfg.Chain.TrieDBPatchFile = ""
+		cfg.Chain.IndexDBPath = prefix + "/index.db"
+		cfg.Chain.BlobStoreDBPath = prefix + "/blob.db"
+		cfg.Chain.ContractStakingIndexDBPath = prefix + "/contractstaking.db"
+		cfg.Chain.BloomfilterIndexDBPath = prefix + "/bloomfilter.db"
+		cfg.Chain.CandidateIndexDBPath = prefix + "/candidate.db"
+		cfg.Consensus.RollDPoS.ConsensusDBPath = prefix + "/consensus.db"
+		cfg.System.SystemLogDBPath = prefix + "/systemlog.db"
+		cfg.ActPool.Store.Datadir = prefix + "/actpool.cache"
+		dbPaths = append(dbPaths, prefix)
+
+		// Network
+		basePort := 14000 + i*100
+		cfg.Network.Port = basePort
+		cfg.API.GRPCPort = basePort + 14
+		cfg.API.HTTPPort = basePort + 15
+		cfg.API.WebSocketPort = basePort + 16
+		cfg.System.HTTPAdminPort = basePort + 17
+		cfg.Plugins[config.GatewayPlugin] = true
+		cfg.Chain.EnableAsyncIndexWrite = false
+
+		if i == 0 {
+			cfg.Network.BootstrapNodes = []string{}
+			cfg.Network.MasterKey = "bootnode"
+		} else {
+			cfg.Network.BootstrapNodes = []string{"/ip4/127.0.0.1/tcp/14000/ipfs/12D3KooWJwW6pUpTkxPTMv84RPLPMQVEAjZ6fvJuX4oZrvW5DAGQ"}
+		}
+
+		// Consensus timing for 3s blocks
+		cfg.Consensus.Scheme = config.RollDPoSScheme
+		cfg.Consensus.RollDPoS.FSM.AcceptBlockTTL = 1000 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.AcceptProposalEndorsementTTL = 1000 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.AcceptLockEndorsementTTL = 500 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.CommitTTL = 500 * time.Millisecond
+		cfg.Consensus.RollDPoS.FSM.EventChanSize = 100000
+		cfg.Consensus.RollDPoS.ToleratedOvertime = 1200 * time.Millisecond
+		cfg.Consensus.RollDPoS.Delay = 3 * time.Second
+		cfg.DardanellesUpgrade.BlockInterval = 3 * time.Second
+		cfg.DardanellesUpgrade.AcceptBlockTTL = 1000 * time.Millisecond
+		cfg.DardanellesUpgrade.AcceptProposalEndorsementTTL = 1000 * time.Millisecond
+		cfg.DardanellesUpgrade.AcceptLockEndorsementTTL = 500 * time.Millisecond
+		cfg.DardanellesUpgrade.CommitTTL = 500 * time.Millisecond
+		cfg.Chain.MintTimeout = 200 * time.Millisecond
+
+		configs[i] = cfg
+	}
+
+	// Clean up previous data
+	os.RemoveAll("/tmp/stresstest")
+	for _, cfg := range configs {
+		os.MkdirAll(cfg.Chain.ChainDBPath[:len(cfg.Chain.ChainDBPath)-9], 0755)
+	}
+
+	// Start nodes
+	svrs := make([]*itx.Server, numNodes)
+	for i := 0; i < numNodes; i++ {
+		svr, err := itx.NewServer(configs[i])
+		if err != nil {
+			log.L().Fatal("Failed to create server", zap.Int("node", i), zap.Error(err))
+		}
+		svrs[i] = svr
+	}
+	defer func() {
+		for _, path := range dbPaths {
+			if fileutil.FileExists(path) {
+				os.RemoveAll(path)
+			}
+		}
+	}()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for i := 0; i < numNodes; i++ {
+		go itx.StartServer(ctx, svrs[i], probe.New(17700+i), configs[i])
+	}
+
+	// Wait for cluster to start
+	time.Sleep(5 * time.Second)
+
+	// Connect to first node
+	grpcAddr := fmt.Sprintf("127.0.0.1:%d", configs[0].API.GRPCPort)
+	conn, err := grpc.DialContext(ctx, grpcAddr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		log.L().Fatal("Failed to connect to API", zap.Error(err))
+	}
+	defer conn.Close()
+	client := iotexapi.NewAPIServiceClient(conn)
+
+	log.L().Info("Cluster started, beginning stress test")
+
+	// Metrics
+	var (
+		txSent     atomic.Int64
+		txSuccess  atomic.Int64
+		txFail     atomic.Int64
+		lastHeight atomic.Uint64
+	)
+
+	// Monitor goroutine: track chain height and epoch
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				resp, err := client.GetChainMeta(ctx, &iotexapi.GetChainMetaRequest{})
+				if err != nil {
+					log.L().Warn("GetChainMeta failed", zap.Error(err))
+					continue
+				}
+				h := resp.ChainMeta.Height
+				epoch := resp.ChainMeta.Epoch
+				lastHeight.Store(h)
+				log.L().Info("Chain status",
+					zap.Uint64("height", h),
+					zap.Uint64("epoch", epoch.Num),
+					zap.Int64("txSent", txSent.Load()),
+					zap.Int64("txSuccess", txSuccess.Load()),
+					zap.Int64("txFail", txFail.Load()),
+					zap.Int64("numActions", resp.ChainMeta.NumActions),
+				)
+			}
+		}
+	}()
+
+	// Inject transfers
+	senderKey := identityset.PrivateKey(25) // use a non-delegate key
+	senderAddr := senderKey.PublicKey().Address()
+	var nonce uint64
+
+	// Get initial nonce
+	accResp, err := client.GetAccount(ctx, &iotexapi.GetAccountRequest{Address: senderAddr.String()})
+	if err == nil {
+		nonce = accResp.AccountMeta.PendingNonce
+	}
+
+	deadline := time.After(timeout)
+	interval := time.Duration(float64(time.Second) / aps)
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	recipientIdx := 0
+	for {
+		select {
+		case <-deadline:
+			goto done
+		case <-ticker.C:
+			recipientIdx = (recipientIdx + 1) % 24
+			recipient := identityset.Address(recipientIdx)
+			amount := big.NewInt(1000000000000000) // 0.001 IOTX
+
+			tx := action.NewTransfer(amount, recipient.String(), nil)
+			elp := (&action.EnvelopeBuilder{}).
+				SetNonce(nonce).
+				SetGasPrice(big.NewInt(unit.Qev)).
+				SetGasLimit(21000).
+				SetAction(tx).Build()
+
+			sealed, err := action.Sign(elp, senderKey)
+			if err != nil {
+				txFail.Add(1)
+				continue
+			}
+			_, err = client.SendAction(ctx, &iotexapi.SendActionRequest{Action: sealed.Proto()})
+			if err != nil {
+				txFail.Add(1)
+			} else {
+				txSuccess.Add(1)
+				nonce++
+			}
+			txSent.Add(1)
+		}
+	}
+
+done:
+	// Final report
+	time.Sleep(5 * time.Second) // wait for last blocks
+	resp, _ := client.GetChainMeta(ctx, &iotexapi.GetChainMetaRequest{})
+
+	fmt.Println("\n=== STRESS TEST RESULTS ===")
+	fmt.Printf("Duration:        %v\n", timeout)
+	fmt.Printf("Nodes:           %d\n", numNodes)
+	fmt.Printf("Delegates:       %d\n", numDelegates)
+	fmt.Printf("Final height:    %d\n", resp.ChainMeta.Height)
+	fmt.Printf("Epochs:          %d\n", resp.ChainMeta.Epoch.Num)
+	fmt.Printf("Total actions:   %d\n", resp.ChainMeta.NumActions)
+	fmt.Printf("TX sent:         %d\n", txSent.Load())
+	fmt.Printf("TX success:      %d\n", txSuccess.Load())
+	fmt.Printf("TX failed:       %d\n", txFail.Load())
+	fmt.Printf("Avg block time:  %.2fs\n", float64(timeout.Seconds())/float64(resp.ChainMeta.Height))
+	fmt.Printf("TPS:             %.1f\n", float64(resp.ChainMeta.NumActions)/timeout.Seconds())
+	fmt.Println()
+
+	// Check reward balances
+	fmt.Println("=== DELEGATE REWARD BALANCES ===")
+	for i := 0; i < min(numDelegates, 10); i++ {
+		addr := identityset.Address(i).String()
+		accResp, err := client.GetAccount(ctx, &iotexapi.GetAccountRequest{Address: addr})
+		if err != nil {
+			continue
+		}
+		bal, _ := new(big.Int).SetString(accResp.AccountMeta.Balance, 10)
+		initBal := unit.ConvertIotxToRau(100000000)
+		earned := new(big.Int).Sub(bal, initBal)
+		fmt.Printf("  Delegate %2d (%s...): balance=%s IOTX, earned=%s Rau\n",
+			i, addr[:12], formatIOTX(bal), earned.String())
+	}
+	fmt.Println("  ...")
+
+	cancel()
+	time.Sleep(2 * time.Second)
+}
+
+func formatIOTX(rau *big.Int) string {
+	f := new(big.Float).SetInt(rau)
+	f.Quo(f, big.NewFloat(1e18))
+	return f.Text('f', 4)
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Silence unused import warnings
+var (
+	_ = hex.EncodeToString
+)


### PR DESCRIPTION
## Summary

[IIP-59](https://github.com/iotexproject/iips/pull/68): Replace the centralized Hermes reward distribution service with **protocol-native, automatic voter reward distribution**. Zero gas, zero external dependencies, fully trustless.

Companion proto PR: https://github.com/iotexproject/iotex-proto/pull/168

## Problem: Hermes is a Centralized Bottleneck

```
Protocol ──(epoch reward)──► Delegate claims ──► Hermes (centralized) ──► MultiSend ──► Voters
                                                  ├─ Holds private keys
                                                  ├─ Queries external GraphQL
                                                  ├─ Charges service fees
                                                  └─ Single point of failure (unmaintained since 2022)
```

## Solution: Protocol-Native Distribution

```
Protocol ──(epoch reward)──► GrantEpochReward() ──┬──► Delegate (commission)
                                                   ├──► Voter₁ (proportional share)
                                                   ├──► Voter₂ (proportional share)
                                                   └──► Voter_N (proportional share)
                                                         └─ Voters claim via existing ClaimFromRewardingFund
```

## Architecture

```
┌─────────────────────────────────────────────────────────────────────┐
│                     GrantEpochReward() — per epoch                   │
│                                                                     │
│  For each delegate with CommissionRate > 0:                         │
│                                                                     │
│  1. commission = totalReward × CommissionRate / 10000               │
│     └─ grantToAccount(delegate.Reward, commission)                  │
│                                                                     │
│  2. ActiveBucketsByCandidate(sm, candidate)                         │
│     ├─ Native buckets: read _candIndex → NativeBucket(idx)          │
│     └─ Contract staking V1/V2/V3: BucketsByCandidate(addr, height) │
│     └─ Filter: skip isUnstaked() buckets                            │
│                                                                     │
│  3. CalculateVoteWeight(stakingProtocol.VoteWeightCalConsts, ...)   │
│     └─ Aggregate by voter address (not per-bucket)                  │
│                                                                     │
│  4. voterShare = voterPool × weight / totalWeight                   │
│     └─ grantToAccount(voter, voterShare)                            │
│     └─ Rounding dust → delegate                                     │
│                                                                     │
│  CommissionRate == 0 → exact legacy behavior (no change)            │
└─────────────────────────────────────────────────────────────────────┘
```

## Production Safeguards

| Safeguard | Implementation |
|-----------|---------------|
| **Hard fork gate** | `YosemiteBlockHeight` in genesis + `EnableVoterRewardDistribution` feature flag |
| **Commission rate cooldown** | 168-epoch (~7 day) cooldown between changes, enforced on-chain |
| **Contract staking support** | Reads from all 3 contract staking indexers (V1/V2/V3) + native buckets |
| **Backward compatible** | `CommissionRate = 0` (default) = exact legacy behavior, zero impact |
| **Per-voter aggregation** | Multiple buckets aggregated before division, minimizes rounding loss |
| **Consistent vote weights** | Uses `stakingProtocol.VoteWeightCalConsts()`, not hardcoded genesis |
| **Candidate alignment** | `splitEpochReward()` returns filtered list, no misalignment from exempt filtering |
| **Distinct reward log types** | `VOTER_REWARD` (5) and `COMMISSION_REWARD` (6) for indexer/explorer differentiation |

## File Changes

| File | Change |
|------|--------|
| `genesis/genesis.go` | `YosemiteBlockHeight` + `IsYosemite()` |
| `protocol/context.go` | `EnableVoterRewardDistribution` feature flag |
| `staking/stakingpb/staking.proto` | `commissionRate` (11) + `commissionRateLastEpoch` (12) |
| `staking/stakingpb/staking.pb.go` | Generated fields + getters |
| `staking/candidate.go` | `CommissionRate` + `CommissionRateLastEpoch` in struct/Clone/Proto |
| **`staking/voter_reward.go`** (new) | `ActiveBucketsByCandidate()` (native+contract), `CandidateByIdentifier()`, `VoteWeightCalConsts()`, `handleSetCommissionRate()` with cooldown |
| **`action/set_commission_rate.go`** (new) | `SetCommissionRate` action type |
| `staking/protocol.go` | Register handler in dispatch |
| **`rewarding/voter_reward.go`** (new) | `distributeVoterReward()` core logic with feature gate |
| `rewarding/reward.go` | Hook into `GrantEpochReward()`, fix `splitEpochReward` return |
| `rewarding/rewardingpb/rewarding.proto` | `VOTER_REWARD` (5) + `COMMISSION_REWARD` (6) log types |
| **`rewarding/voter_reward_test.go`** (new) | Unit tests: voter shares, commission edge cases, 2800-voter precision |
| **`rewarding/voter_reward_fullscale_test.go`** (new) | Full-scale 24-128 delegate dry run + benchmark |

## Test Results

### Unit Tests — 19/19 PASS

```
TestAdminPb                    PASS    TestProtocol_SetEpochReward     PASS
TestProtocol_Fund              PASS    TestDepositNegativeGasFee       PASS
TestValidateExtension          PASS    TestProtocol_Validate           PASS
TestProtocol_Handle            PASS    TestStateCheckLegacy            PASS
TestMigrateValue               PASS    TestProtocol_GrantBlockReward   PASS
TestProtocol_GrantEpochReward  PASS    TestProtocol_ClaimReward        PASS
TestProtocol_NoRewardAddr      PASS    TestRewardLogCompatibility      PASS
TestProtocol_CalculateReward   PASS    TestCalculateVoterShares        PASS
TestCommissionRateEdgeCases    PASS    TestRoundingPrecision2800Voters PASS
TestFullScale24Delegates       PASS
```

### E2E Tests (Mac Mini + Mac Studio) — All PASS

| Test | Result | Coverage |
|------|--------|----------|
| TestBlockReward | PASS (19s) | Standalone node, RollDPoS consensus, block production + reward |
| TestNativeStaking | PASS (1.5s) | 10 subtests: register, stake, deposit, transfer ownership |
| TestNativeStakingVoteBug | PASS (0.5s) | Candidate register + create stake + deposit to stake |
| TestContractStaking | PASS (5.7s) | NFT staking: lock/unlock/unstake/withdraw/merge/expand/delegate change |
| TestContractStakingV2 | PASS (15.6s) | 26 subtests: batch stake, merge, expand, donate, migrate to trie |
| TestBroadcastNodeInfo | PASS (1.3s) | P2P node info broadcast between nodes |
| TestCreateBlockchain | PASS (0.01s) | Blockchain creation integrity |

### Scale-Up Performance (Mac Studio M3 Ultra, 28-core, 256GB)

| Delegates | Total Voters | Time | Per-Delegate | Memory | Dust (Rau) |
|-----------|-------------|------|--------------|--------|------------|
| **24** | 55,374 | **7.3ms** | 306μs | 6 MB | 27,642 |
| 36 | 86,649 | 11.1ms | 310μs | 9 MB | 43,309 |
| **48** | 112,084 | **14.1ms** | 294μs | 10 MB | 56,034 |
| 64 | 151,237 | 20.8ms | 325μs | 18 MB | 75,756 |
| **96** | 219,623 | **28.7ms** | 299μs | 24 MB | 109,774 |
| 128 | 283,488 | 34.8ms | 272μs | 29 MB | 142,133 |

**Key findings:**
- **Linear scaling**: per-delegate cost is constant ~300μs regardless of delegate count
- **128 delegates × 283K voters = 35ms** — 0.7% of 5-second block time
- **Memory**: 29 MB for 128 delegates — negligible
- **Precision**: dust < voter count (guaranteed by integer division), total exactly conserved

### Benchmark (5-second sustained)

```
BenchmarkDistribute2800Voters-28     16,473 iterations    353μs/op    359KB/op
BenchmarkFullScale24Delegates-28        846 iterations    7.1ms/op    7.1MB/op
```

## Remaining TODO

### Blocked on [iotex-proto PR #168](https://github.com/iotexproject/iotex-proto/pull/168)
- [ ] `FillAction()` / `Proto()` / `LoadProto()` for SetCommissionRate (field 54)
- [ ] Deserializer case in `envelope.go`
- [ ] EthABI encoding for MetaMask/Hardhat
- [ ] `toIoTeXTypes()` expose CommissionRate in CandidateV2 RPC responses
- [ ] `ioctl stake2 setcommission <bps>` CLI command

### Post-merge iteration
- [ ] Commission rate min/max governance limits
- [ ] Voter notification (explorer/wallet integration for rate change alerts)
- [ ] Migration dashboard (delegate opt-in monitoring)
- [ ] Hermes deprecation (archive repos after full migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)