### PR TITLE
feat(bundle): harden BundlePool with size/lookahead limits

### DIFF
--- a/action/bundle.go
+++ b/action/bundle.go
@@ -20,7 +20,7 @@ func NewBundle() *Bundle {
 }
 
 func (b *Bundle) validateItem(item *SealedEnvelope) error {
-	if item == nil {
+	if item == nil || item.Envelope == nil {
 		return ErrNilAction
 	}
 	switch item.Action().(type) {

--- a/action/bundle.go
+++ b/action/bundle.go
@@ -23,6 +23,12 @@ func (b *Bundle) validateItem(item *SealedEnvelope) error {
 	if item == nil {
 		return ErrNilAction
 	}
+	switch item.Action().(type) {
+	case *Transfer, *Execution, *txContainer:
+		// Transfer, Execution, and txContainer actions are allowed in bundles
+	default:
+		return ErrInvalidAct
+	}
 	return nil
 }
 

--- a/action/bundle_test.go
+++ b/action/bundle_test.go
@@ -1,0 +1,121 @@
+package action
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+func signedTransfer(t *testing.T, nonce uint64) *SealedEnvelope {
+	t.Helper()
+	se, err := SignedTransfer(
+		identityset.Address(1).String(),
+		identityset.PrivateKey(2),
+		nonce,
+		big.NewInt(1),
+		nil,
+		21000,
+		big.NewInt(1),
+	)
+	require.NoError(t, err)
+	return se
+}
+
+func signedClaim(t *testing.T) *SealedEnvelope {
+	t.Helper()
+	act := NewClaimFromRewardingFund(big.NewInt(1), nil, nil)
+	elp := (&EnvelopeBuilder{}).SetNonce(0).SetGasLimit(ClaimFromRewardingFundBaseGas).SetGasPrice(big.NewInt(1)).SetAction(act).Build()
+	selp, err := Sign(elp, identityset.PrivateKey(0))
+	require.NoError(t, err)
+	return selp
+}
+
+func TestBundle_ValidateItem(t *testing.T) {
+	t.Run("Transfer allowed", func(t *testing.T) {
+		b := NewBundle()
+		require.NoError(t, b.Add(signedTransfer(t, 0)))
+	})
+	t.Run("Execution allowed", func(t *testing.T) {
+		se, err := SignedExecution("", identityset.PrivateKey(2), 0, big.NewInt(0), 100000, big.NewInt(1), nil)
+		require.NoError(t, err)
+		b := NewBundle()
+		require.NoError(t, b.Add(se))
+	})
+	t.Run("ClaimFromRewardingFund rejected", func(t *testing.T) {
+		b := NewBundle()
+		require.ErrorIs(t, b.Add(signedClaim(t)), ErrInvalidAct)
+	})
+	t.Run("nil item rejected", func(t *testing.T) {
+		b := NewBundle()
+		require.ErrorIs(t, b.Add(nil), ErrNilAction)
+	})
+}
+
+func TestBundle_Hash(t *testing.T) {
+	t.Run("nil bundle returns zero hash", func(t *testing.T) {
+		var b *Bundle
+		require.Equal(t, hash.ZeroHash256, b.Hash())
+	})
+	t.Run("empty bundle returns zero hash", func(t *testing.T) {
+		require.Equal(t, hash.ZeroHash256, NewBundle().Hash())
+	})
+	t.Run("same contents produce same hash", func(t *testing.T) {
+		se := signedTransfer(t, 0)
+		b1, b2 := NewBundle(), NewBundle()
+		require.NoError(t, b1.Add(se))
+		require.NoError(t, b2.Add(se))
+		b1.SetTargetBlockHeight(10)
+		b2.SetTargetBlockHeight(10)
+		require.Equal(t, b1.Hash(), b2.Hash())
+	})
+	t.Run("different target height produces different hash", func(t *testing.T) {
+		se := signedTransfer(t, 0)
+		b1, b2 := NewBundle(), NewBundle()
+		require.NoError(t, b1.Add(se))
+		require.NoError(t, b2.Add(se))
+		b1.SetTargetBlockHeight(10)
+		b2.SetTargetBlockHeight(20)
+		require.NotEqual(t, b1.Hash(), b2.Hash())
+	})
+}
+
+func TestBundle_Gas(t *testing.T) {
+	t.Run("nil bundle returns 0", func(t *testing.T) {
+		var b *Bundle
+		require.Zero(t, b.Gas())
+	})
+	t.Run("empty bundle returns 0", func(t *testing.T) {
+		require.Zero(t, NewBundle().Gas())
+	})
+	t.Run("sums gas of all items", func(t *testing.T) {
+		se1 := signedTransfer(t, 0) // gas 21000
+		se2 := signedTransfer(t, 1) // gas 21000
+		b := NewBundle()
+		require.NoError(t, b.Add(se1, se2))
+		require.Equal(t, se1.Gas()+se2.Gas(), b.Gas())
+	})
+}
+
+func TestBundle_ProtoRoundTrip(t *testing.T) {
+	se1 := signedTransfer(t, 0)
+	se2 := signedTransfer(t, 1)
+	orig := NewBundle()
+	require.NoError(t, orig.Add(se1, se2))
+	orig.SetTargetBlockHeight(42)
+
+	pb := orig.Proto()
+	require.NotNil(t, pb)
+	require.Equal(t, uint64(42), pb.TargetBlockNumber)
+	require.Equal(t, 2, len(pb.Actions))
+
+	restored := NewBundle()
+	require.NoError(t, restored.LoadProto(pb, (&Deserializer{}).SetEvmNetworkID(1)))
+	require.Equal(t, orig.Len(), restored.Len())
+	require.Equal(t, orig.TargetBlockHeight(), restored.TargetBlockHeight())
+	require.Equal(t, orig.Gas(), restored.Gas())
+	require.Equal(t, orig.Hash(), restored.Hash())
+}

--- a/action/bundle_test.go
+++ b/action/bundle_test.go
@@ -53,6 +53,10 @@ func TestBundle_ValidateItem(t *testing.T) {
 		b := NewBundle()
 		require.ErrorIs(t, b.Add(nil), ErrNilAction)
 	})
+	t.Run("nil Envelope rejected without panic", func(t *testing.T) {
+		b := NewBundle()
+		require.ErrorIs(t, b.Add(&SealedEnvelope{}), ErrNilAction)
+	})
 }
 
 func TestBundle_Hash(t *testing.T) {

--- a/actpool/bundlepool.go
+++ b/actpool/bundlepool.go
@@ -17,6 +17,13 @@ import (
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 )
 
+const (
+	// DefaultMaxBundleLookahead is the default maximum number of blocks ahead a bundle can target.
+	DefaultMaxBundleLookahead = uint64(100)
+	// DefaultMaxBundlePoolSize is the default maximum number of bundles in the pool.
+	DefaultMaxBundlePoolSize = 1000
+)
+
 var (
 	ErrNoBundlesForHeight = errors.New("no bundles for the height")
 	ErrNilBundle          = errors.New("bundle is nil")
@@ -25,8 +32,8 @@ var (
 	ErrBundleUUIDExists   = errors.New("bundle with UUID already exists")
 	ErrEmptyBundle        = errors.New("bundle is empty")
 	ErrBundleNotFound     = errors.New("bundle not found")
+	ErrBundlePoolFull     = errors.New("bundle pool is full")
 	ErrNilBlock           = errors.New("block is nil")
-	ErrInvalidCaller      = errors.New("invalid caller")
 	ErrBlockHeightTooLow  = errors.New("block height is too low")
 )
 
@@ -46,6 +53,8 @@ type (
 		mu                    sync.RWMutex
 		height                uint64
 		genesis               genesis.Genesis
+		maxLookahead          uint64 // max blocks ahead a bundle can target
+		maxSize               int    // max total bundles in the pool
 		metas                 map[hash.Hash256]*meta
 		uuids                 map[string]hash.Hash256   // UUID to bundle hash mapping
 		targetHeightToBundles map[uint64][]hash.Hash256 // Target block height to bundles mapping
@@ -60,12 +69,28 @@ func NewBundlePool(g genesis.Genesis) *BundlePool {
 		mu:                    sync.RWMutex{},
 		height:                0,
 		genesis:               g,
+		maxLookahead:          DefaultMaxBundleLookahead,
+		maxSize:               DefaultMaxBundlePoolSize,
 		metas:                 make(map[hash.Hash256]*meta),
 		uuids:                 make(map[string]hash.Hash256),
 		targetHeightToBundles: make(map[uint64][]hash.Hash256),
 		broadcast:             nil,
 		validate:              nil,
 	}
+}
+
+// SetMaxLookahead sets the maximum number of blocks ahead a bundle can target.
+func (bp *BundlePool) SetMaxLookahead(n uint64) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	bp.maxLookahead = n
+}
+
+// SetMaxSize sets the maximum number of bundles allowed in the pool.
+func (bp *BundlePool) SetMaxSize(n int) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	bp.maxSize = n
 }
 
 func (bp *BundlePool) SetValidator(validateFunc ValidateActionFunc) {
@@ -94,6 +119,12 @@ func (bp *BundlePool) AddBundle(ctx context.Context, sender address.Address, uui
 	defer bp.mu.Unlock()
 	if height <= bp.height {
 		return errors.Wrapf(ErrBundleTargetHeight, "bundle target block height %d is less than current height %d", height, bp.height)
+	}
+	if height > bp.height+bp.maxLookahead {
+		return errors.Wrapf(ErrBundleTargetHeight, "bundle target block height %d exceeds max lookahead of %d blocks (current height %d)", height, bp.maxLookahead, bp.height)
+	}
+	if len(bp.metas) >= bp.maxSize {
+		return errors.Wrapf(ErrBundlePoolFull, "bundle pool has reached its maximum size of %d", bp.maxSize)
 	}
 	if _, ok := bp.metas[h]; ok {
 		return errors.Wrapf(ErrBundleExists, "bundle with hash %x already exists", h)
@@ -156,7 +187,8 @@ func (bp *BundlePool) Size() int {
 }
 
 // DeleteBundle deletes a bundle from the pool by its UUID.
-func (bp *BundlePool) DeleteBundle(caller address.Address, uuid string) error {
+// The UUID itself is the ownership token — only the original submitter knows it.
+func (bp *BundlePool) DeleteBundle(uuid string) error {
 	bp.mu.Lock()
 	defer bp.mu.Unlock()
 	h, ok := bp.uuids[uuid]
@@ -164,9 +196,6 @@ func (bp *BundlePool) DeleteBundle(caller address.Address, uuid string) error {
 		return errors.Wrapf(ErrBundleNotFound, "bundle with UUID %s not found", uuid)
 	}
 	m := bp.metas[h]
-	if m.sender != caller {
-		return errors.Wrapf(ErrInvalidCaller, "caller %s is not the sender of the bundle with hash %x", caller.String(), h)
-	}
 	height := m.bundle.TargetBlockHeight()
 	// Remove from targetHeightToBundles
 	hashes := bp.targetHeightToBundles[height]

--- a/actpool/bundlepool.go
+++ b/actpool/bundlepool.go
@@ -87,7 +87,11 @@ func (bp *BundlePool) SetMaxLookahead(n uint64) {
 }
 
 // SetMaxSize sets the maximum number of bundles allowed in the pool.
+// n must be > 0; invalid values are ignored.
 func (bp *BundlePool) SetMaxSize(n int) {
+	if n <= 0 {
+		return
+	}
 	bp.mu.Lock()
 	defer bp.mu.Unlock()
 	bp.maxSize = n
@@ -120,7 +124,7 @@ func (bp *BundlePool) AddBundle(ctx context.Context, sender address.Address, uui
 	if height <= bp.height {
 		return errors.Wrapf(ErrBundleTargetHeight, "bundle target block height %d is less than current height %d", height, bp.height)
 	}
-	if height > bp.height+bp.maxLookahead {
+	if height-bp.height > bp.maxLookahead {
 		return errors.Wrapf(ErrBundleTargetHeight, "bundle target block height %d exceeds max lookahead of %d blocks (current height %d)", height, bp.maxLookahead, bp.height)
 	}
 	if len(bp.metas) >= bp.maxSize {

--- a/actpool/bundlepool_test.go
+++ b/actpool/bundlepool_test.go
@@ -210,8 +210,8 @@ func TestBundlePool_AddAndGetBundles(t *testing.T) {
 
 	t.Run("non-empty bundle", func(t *testing.T) {
 		bundle := action.NewBundle()
-		bundle.Add(se)
-		bundle.Add(se2)
+		require.NoError(bundle.Add(se))
+		require.NoError(bundle.Add(se2))
 		bundle.SetTargetBlockHeight(102)
 		require.Equal(0, bp.Size())
 		require.NoError(bp.AddBundle(ctx, sender, "uuid-valid", bundle))
@@ -240,7 +240,7 @@ func TestBundlePool_AddAndGetBundles(t *testing.T) {
 		t.Run("pool size limit", func(t *testing.T) {
 			bp.SetMaxSize(1) // pool already has 1 bundle
 			bundle2 := action.NewBundle()
-			bundle2.Add(se)
+			require.NoError(bundle2.Add(se))
 			bundle2.SetTargetBlockHeight(103)
 			require.ErrorIs(bp.AddBundle(ctx, sender, "uuid-overflow", bundle2), ErrBundlePoolFull)
 			bp.SetMaxSize(DefaultMaxBundlePoolSize) // restore

--- a/actpool/bundlepool_test.go
+++ b/actpool/bundlepool_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/v2/action"
@@ -12,6 +13,165 @@ import (
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 )
+
+func newTestBundle(t *testing.T, nonce uint64, targetHeight uint64) *action.Bundle {
+	t.Helper()
+	se, err := action.SignedTransfer(
+		identityset.Address(1).String(),
+		identityset.PrivateKey(2),
+		nonce,
+		big.NewInt(1),
+		nil,
+		21000,
+		big.NewInt(1),
+	)
+	require.NoError(t, err)
+	b := action.NewBundle()
+	require.NoError(t, b.Add(se))
+	b.SetTargetBlockHeight(targetHeight)
+	return b
+}
+
+func newTestBlock(t *testing.T, height uint64) block.Block {
+	t.Helper()
+	blk, err := block.NewTestingBuilder().SetHeight(height).SignAndBuild(identityset.PrivateKey(0))
+	require.NoError(t, err)
+	return blk
+}
+
+func TestBundlePool_ReceiveBlock(t *testing.T) {
+	ctx := context.Background()
+	sender := identityset.Address(2)
+
+	t.Run("nil block", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		require.ErrorIs(t, bp.ReceiveBlock(nil), ErrNilBlock)
+	})
+
+	t.Run("height too low", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		blk100 := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk100))
+		// same height
+		blk100again := newTestBlock(t, 100)
+		require.ErrorIs(t, bp.ReceiveBlock(&blk100again), ErrBlockHeightTooLow)
+		// lower height
+		blk99 := newTestBlock(t, 99)
+		require.ErrorIs(t, bp.ReceiveBlock(&blk99), ErrBlockHeightTooLow)
+	})
+
+	t.Run("removes bundles at target height only", func(t *testing.T) {
+		// After the first block is received (height > 0), only bundles whose
+		// targetHeight == received block height are removed; future bundles survive.
+		bp := NewBundlePool(genesis.Default)
+		blk100 := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk100))
+
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-101", newTestBundle(t, 1, 101)))
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-102", newTestBundle(t, 2, 102)))
+		require.Equal(t, 2, bp.Size())
+
+		blk101 := newTestBlock(t, 101)
+		require.NoError(t, bp.ReceiveBlock(&blk101))
+
+		require.Equal(t, 1, bp.Size())
+		_, _, bundles, err := bp.BundlesAtHeight(102)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(bundles))
+		_, _, _, err = bp.BundlesAtHeight(101)
+		require.ErrorIs(t, err, ErrNoBundlesForHeight)
+	})
+
+	t.Run("initial state prunes stale bundles on first block", func(t *testing.T) {
+		// When height == 0 (pool just created / after Reset), the first ReceiveBlock
+		// prunes all bundles whose targetHeight <= received block height.
+		bp := NewBundlePool(genesis.Default)
+
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-50", newTestBundle(t, 1, 50)))
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-90", newTestBundle(t, 2, 90)))
+		require.Equal(t, 2, bp.Size())
+
+		blk60 := newTestBlock(t, 60)
+		require.NoError(t, bp.ReceiveBlock(&blk60))
+
+		// height=50 bundle pruned (50 <= 60); height=90 bundle survives (90 > 60)
+		require.Equal(t, 1, bp.Size())
+		_, _, _, err := bp.BundlesAtHeight(50)
+		require.ErrorIs(t, err, ErrNoBundlesForHeight)
+		_, _, bundles, err := bp.BundlesAtHeight(90)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(bundles))
+	})
+
+	t.Run("Reset clears pool and resets height", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		blk100 := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk100))
+
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-101", newTestBundle(t, 1, 101)))
+		require.Equal(t, 1, bp.Size())
+
+		bp.Reset()
+		require.Equal(t, 0, bp.Size())
+
+		// After Reset height is 0; bundles for any height 1..maxLookahead are accepted again.
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-50-after-reset", newTestBundle(t, 2, 50)))
+		require.Equal(t, 1, bp.Size())
+	})
+}
+
+func TestBundlePool_Validator(t *testing.T) {
+	ctx := context.Background()
+	sender := identityset.Address(2)
+
+	t.Run("validator rejects bundle", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		bp.SetValidator(func(_ context.Context, _ *action.SealedEnvelope) error {
+			return errors.New("rejected by validator")
+		})
+		blk := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk))
+
+		err := bp.AddBundle(ctx, sender, "uuid-1", newTestBundle(t, 1, 101))
+		require.Error(t, err)
+		require.Equal(t, 0, bp.Size())
+	})
+
+	t.Run("validator passes bundle", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		bp.SetValidator(func(_ context.Context, _ *action.SealedEnvelope) error {
+			return nil
+		})
+		blk := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk))
+
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-1", newTestBundle(t, 1, 101)))
+		require.Equal(t, 1, bp.Size())
+	})
+
+	t.Run("validator called for each action in bundle", func(t *testing.T) {
+		bp := NewBundlePool(genesis.Default)
+		callCount := 0
+		bp.SetValidator(func(_ context.Context, _ *action.SealedEnvelope) error {
+			callCount++
+			return nil
+		})
+		blk := newTestBlock(t, 100)
+		require.NoError(t, bp.ReceiveBlock(&blk))
+
+		// Bundle with 2 actions
+		se1 := newTestBundle(t, 1, 101)
+		se2, err := action.SignedTransfer(
+			identityset.Address(1).String(), identityset.PrivateKey(3),
+			2, big.NewInt(1), nil, 21000, big.NewInt(1),
+		)
+		require.NoError(t, err)
+		require.NoError(t, se1.Add(se2))
+
+		require.NoError(t, bp.AddBundle(ctx, sender, "uuid-1", se1))
+		require.Equal(t, 2, callCount)
+	})
+}
 
 func TestBundlePool_AddAndGetBundles(t *testing.T) {
 	require := require.New(t)
@@ -72,6 +232,18 @@ func TestBundlePool_AddAndGetBundles(t *testing.T) {
 			require.Error(bp.AddBundle(ctx, sender, "uuid-less", bundle))
 			bundle.SetTargetBlockHeight(100)
 			require.Error(bp.AddBundle(ctx, sender, "uuid-equal", bundle))
+			// beyond max lookahead
+			bundle.SetTargetBlockHeight(100 + DefaultMaxBundleLookahead + 1)
+			require.ErrorIs(bp.AddBundle(ctx, sender, "uuid-far-future", bundle), ErrBundleTargetHeight)
+			bundle.SetTargetBlockHeight(102)
+		})
+		t.Run("pool size limit", func(t *testing.T) {
+			bp.SetMaxSize(1) // pool already has 1 bundle
+			bundle2 := action.NewBundle()
+			bundle2.Add(se)
+			bundle2.SetTargetBlockHeight(103)
+			require.ErrorIs(bp.AddBundle(ctx, sender, "uuid-overflow", bundle2), ErrBundlePoolFull)
+			bp.SetMaxSize(DefaultMaxBundlePoolSize) // restore
 		})
 		t.Run("add dup bundle", func(t *testing.T) {
 			require.Error(bp.AddBundle(ctx, sender, "uuid-dup-hash", bundle))
@@ -81,7 +253,7 @@ func TestBundlePool_AddAndGetBundles(t *testing.T) {
 			bundle.SetTargetBlockHeight(102)
 		})
 		t.Run("Delete bundle", func(t *testing.T) {
-			require.NoError(bp.DeleteBundle(sender, "uuid-valid"))
+			require.NoError(bp.DeleteBundle("uuid-valid"))
 			require.Equal(0, bp.Size())
 			_, _, _, err := bp.BundlesAtHeight(102)
 			require.Error(err)

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -586,11 +586,17 @@ func (core *coreService) SendBundle(ctx context.Context, in *iotextypes.Bundle, 
 // DeleteBundle deletes a bundle from the bundle pool.
 func (core *coreService) DeleteBundle(ctx context.Context, id string) error {
 	log.T(ctx).Debug("receive delete bundle request")
+	if id == "" {
+		return status.Error(codes.InvalidArgument, "bundle UUID must not be empty")
+	}
 	bp := core.ap.BundlePool()
 	if bp == nil {
 		return status.Error(codes.Unavailable, "bundle pool is not available")
 	}
 	if err := bp.DeleteBundle(id); err != nil {
+		if errors.Is(err, actpool.ErrBundleNotFound) {
+			return status.Error(codes.NotFound, err.Error())
+		}
 		return status.Error(codes.Internal, fmt.Sprintf("failed to delete bundle: %v", err))
 	}
 	return nil

--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -92,7 +92,7 @@ type (
 		// SendBundle is the API to send a bundle to blockchain.
 		SendBundle(ctx context.Context, in *iotextypes.Bundle, sender address.Address, id string) (string, error)
 		// DeleteBundle deletes a bundle from the bundle pool.
-		DeleteBundle(ctx context.Context, sender address.Address, uuid string) error
+		DeleteBundle(ctx context.Context, uuid string) error
 		// SendAction is the API to send an action to blockchain.
 		SendAction(ctx context.Context, in *iotextypes.Action) (string, error)
 		// ReadContract reads the state in a contract address specified by the slot
@@ -584,13 +584,13 @@ func (core *coreService) SendBundle(ctx context.Context, in *iotextypes.Bundle, 
 }
 
 // DeleteBundle deletes a bundle from the bundle pool.
-func (core *coreService) DeleteBundle(ctx context.Context, sender address.Address, id string) error {
+func (core *coreService) DeleteBundle(ctx context.Context, id string) error {
 	log.T(ctx).Debug("receive delete bundle request")
 	bp := core.ap.BundlePool()
 	if bp == nil {
 		return status.Error(codes.Unavailable, "bundle pool is not available")
 	}
-	if err := bp.DeleteBundle(sender, id); err != nil {
+	if err := bp.DeleteBundle(id); err != nil {
 		return status.Error(codes.Internal, fmt.Sprintf("failed to delete bundle: %v", err))
 	}
 	return nil

--- a/api/mock_apicoreservice.go
+++ b/api/mock_apicoreservice.go
@@ -296,17 +296,17 @@ func (mr *MockCoreServiceMockRecorder) CodeAt(ctx, addr, height any) *gomock.Cal
 }
 
 // DeleteBundle mocks base method.
-func (m *MockCoreService) DeleteBundle(ctx context.Context, sender address.Address, uuid string) error {
+func (m *MockCoreService) DeleteBundle(ctx context.Context, uuid string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBundle", ctx, sender, uuid)
+	ret := m.ctrl.Call(m, "DeleteBundle", ctx, uuid)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteBundle indicates an expected call of DeleteBundle.
-func (mr *MockCoreServiceMockRecorder) DeleteBundle(ctx, sender, uuid any) *gomock.Call {
+func (mr *MockCoreServiceMockRecorder) DeleteBundle(ctx, uuid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBundle", reflect.TypeOf((*MockCoreService)(nil).DeleteBundle), ctx, sender, uuid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBundle", reflect.TypeOf((*MockCoreService)(nil).DeleteBundle), ctx, uuid)
 }
 
 // EVMNetworkID mocks base method.


### PR DESCRIPTION

Security hardening on top of the bundle pool introduced in #4733:
- Remove broken sender-based DeleteBundle authorization; use UUID as ownership token
- Add maxLookahead (100 blocks) to prevent memory DoS from far-future target heights
- Add maxSize (1000) to cap total bundles and prevent memory exhaustion
- Restrict bundle contents to Transfer/Execution/txContainer action types
