### PR TITLE
Introduce Yap/YapBeta hardforks with CandidateDeactivate and EVM tracer fixes

### DIFF
--- a/action/builder.go
+++ b/action/builder.go
@@ -293,7 +293,7 @@ func (b *EnvelopeBuilder) BuildRewardingAction(tx *types.Transaction) (Envelope,
 }
 
 func newStakingActionFromABIBinary(data []byte, value *big.Int) (actionPayload, error) {
-	if len(data) <= 4 {
+	if len(data) < 4 {
 		return nil, ErrInvalidABI
 	}
 	if act, err := NewCreateStakeFromABIBinary(data); err == nil {
@@ -324,6 +324,9 @@ func newStakingActionFromABIBinary(data []byte, value *big.Int) (actionPayload, 
 		return act, nil
 	}
 	if act, err := NewCandidateActivateFromABIBinary(data); err == nil {
+		return act, nil
+	}
+	if act, err := NewCandidateDeactivateFromABIBinary(data); err == nil {
 		return act, nil
 	}
 	if act, err := NewCandidateEndorsementFromABIBinary(data); err == nil {

--- a/action/candidate_deactivate.go
+++ b/action/candidate_deactivate.go
@@ -109,7 +109,7 @@ func NewCandidateDeactivateFromABIBinary(data []byte) (*CandidateDeactivate, err
 	var cd CandidateDeactivate
 	// sanity check
 	switch {
-	case len(data) <= 4:
+	case len(data) < 4:
 		return nil, errDecodeFailure
 	case bytes.Equal(requestCandidateDeactivationMethod.ID, data[:4]):
 		cd.op = CandidateDeactivateOpRequest

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -430,6 +430,12 @@ func (elp *envelope) loadProtoActionPayload(pbAct *iotextypes.ActionCore) error 
 			return err
 		}
 		elp.payload = act
+	case pbAct.GetScheduleCandidateDeactivation() != nil:
+		act := &ScheduleCandidateDeactivation{}
+		if err := act.LoadProto(pbAct.GetScheduleCandidateDeactivation()); err != nil {
+			return err
+		}
+		elp.payload = act
 	case pbAct.GetCandidateEndorsement() != nil:
 		act := &CandidateEndorsement{}
 		if err := act.LoadProto(pbAct.GetCandidateEndorsement()); err != nil {

--- a/action/envelope.go
+++ b/action/envelope.go
@@ -424,6 +424,12 @@ func (elp *envelope) loadProtoActionPayload(pbAct *iotextypes.ActionCore) error 
 			return err
 		}
 		elp.payload = act
+	case pbAct.GetCandidateDeactivate() != nil:
+		act := &CandidateDeactivate{}
+		if err := act.LoadProto(pbAct.GetCandidateDeactivate()); err != nil {
+			return err
+		}
+		elp.payload = act
 	case pbAct.GetCandidateEndorsement() != nil:
 		act := &CandidateEndorsement{}
 		if err := act.LoadProto(pbAct.GetCandidateEndorsement()); err != nil {

--- a/action/native_staking_contract_abi.json
+++ b/action/native_staking_contract_abi.json
@@ -28,6 +28,19 @@
         "type": "address"
       }
     ],
+    "name": "CandidateDeactivated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "candidate",
+        "type": "address"
+      }
+    ],
     "name": "CandidateDeactivationRequested",
     "type": "event"
   },
@@ -48,19 +61,6 @@
       }
     ],
     "name": "CandidateDeactivationScheduled",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "candidate",
-        "type": "address"
-      }
-    ],
-    "name": "CandidateDeactivated",
     "type": "event"
   },
   {
@@ -193,6 +193,13 @@
     "type": "event"
   },
   {
+    "inputs": [],
+    "name": "cancelCandidateDeactivation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint64",
@@ -201,20 +208,6 @@
       }
     ],
     "name": "candidateActivate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "requestCandidateDeactivation",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "cancelCandidateDeactivation",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -516,6 +509,13 @@
       }
     ],
     "name": "migrateStake",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "requestCandidateDeactivation",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"

--- a/action/native_staking_contract_interface.sol
+++ b/action/native_staking_contract_interface.sol
@@ -23,6 +23,16 @@ interface INativeStakingContract {
         address indexed candidate,
         uint64 bucketIndex
     );
+    event CandidateDeactivationRequested(
+        address indexed candidate
+    );
+    event CandidateDeactivationScheduled(
+        address indexed candidate,
+        uint64 blockNumber
+    );
+    event CandidateDeactivated(
+        address indexed candidate
+    );
     event CandidateUpdated(
         address indexed candidate,
         address indexed ownerAddress,
@@ -55,6 +65,11 @@ interface INativeStakingContract {
     ) external payable;
 
     function candidateActivate(uint64 bucketIndex) external;
+
+    // Candidate Deactivate methods
+    function requestCandidateDeactivation() external;
+
+    function cancelCandidateDeactivation() external;
 
     // Candidate Endorsement methods
     function candidateEndorsement(uint64 bucketIndex, bool endorse) external;

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -342,10 +342,10 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			StoreVoteOfNFTBucketIntoView:            !g.IsXingu(height),
 			CandidateSlashByOwner:                   !g.IsXinguBeta(height),
 			CandidateBLSPublicKeyNotCopied:          !g.IsXinguBeta(height),
-			OnlyOwnerCanUpdateBLSPublicKey:          !g.IsToBeEnabled(height),
-			PrePectraEVM:                            !g.IsToBeEnabled(height),
-			AlwaysWriteCachedContract:               !g.IsToBeEnabled(height),
-			NoCandidateExitQueue:                    !g.IsToBeEnabled(height),
+			OnlyOwnerCanUpdateBLSPublicKey:          !g.IsYap(height),
+			PrePectraEVM:                            !g.IsYap(height),
+			AlwaysWriteCachedContract:               !g.IsYap(height),
+			NoCandidateExitQueue:                    !g.IsYap(height),
 		},
 	)
 }
@@ -405,7 +405,7 @@ func WithFeatureWithHeightCtx(ctx context.Context) context.Context {
 				return !g.IsOkhotsk(height)
 			},
 			CandidateWithoutIdentity: func(height uint64) bool {
-				return !g.IsToBeEnabled(height)
+				return !g.IsYap(height)
 			},
 			CandidateWithoutIdentityStorage: func(height uint64) bool {
 				return !g.IsToBeEnabled(height)

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -405,10 +405,10 @@ func WithFeatureWithHeightCtx(ctx context.Context) context.Context {
 				return !g.IsOkhotsk(height)
 			},
 			CandidateWithoutIdentity: func(height uint64) bool {
-				return !g.IsYap(height)
+				return !g.IsYapBeta(height)
 			},
 			CandidateWithoutIdentityStorage: func(height uint64) bool {
-				return !g.IsToBeEnabled(height)
+				return !g.IsYap(height)
 			},
 		},
 	)

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -573,7 +573,7 @@ func getChainConfig(g genesis.Blockchain, height uint64, id uint32, getBlockTime
 		chainConfig.CancunTime = &cancunTimestamp
 	}
 	// enable Prague
-	pragueTime, err := getBlockTime(g.ToBeEnabledBlockHeight)
+	pragueTime, err := getBlockTime(g.YapBlockHeight)
 	if err != nil {
 		return nil, err
 	} else if pragueTime != nil {

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -385,8 +385,11 @@ func TestConstantinople(t *testing.T) {
 		require.Equal(isVanuatu, evmChainConfig.IsCancun(big.NewInt(int64(e.height)), evm.Context.Time))
 
 		// Prague and Verkle not yet enabled
-		require.False(chainRules.IsPrague)
-		require.False(evmChainConfig.IsPrague(big.NewInt(int64(e.height)), evm.Context.Time))
+		isYap := g.IsYap(e.height)
+		require.Equal(isYap, chainRules.IsPrague)
+		require.Equal(isYap, evmChainConfig.IsPrague(big.NewInt(int64(e.height)), evm.Context.Time))
+
+		// Verkle not yet enabled
 		require.False(chainRules.IsVerkle)
 		require.False(evmChainConfig.IsVerkle(big.NewInt(int64(e.height)), evm.Context.Time))
 

--- a/action/protocol/execution/evm/tracer.go
+++ b/action/protocol/execution/evm/tracer.go
@@ -54,13 +54,17 @@ func TraceStart(ctx context.Context, ws protocol.StateManager, elp action.TxData
 	default:
 		return errors.New("only eth compatible action is supported for tracing")
 	}
-	vmCtx.Tracer.OnTxStart(evm.GetVMContext(), ethTx, from)
+	if vmCtx.Tracer.OnTxStart != nil {
+		vmCtx.Tracer.OnTxStart(evm.GetVMContext(), ethTx, from)
+	}
 	if _, isExecution := elp.Action().(*action.Execution); isExecution {
 		// CaptureStart will be called in evm
 		return nil
 	}
 
-	vmCtx.Tracer.OnEnter(0, byte(vm.CALL), from, *to, input, elp.Gas(), value)
+	if vmCtx.Tracer.OnEnter != nil {
+		vmCtx.Tracer.OnEnter(0, byte(vm.CALL), from, *to, input, elp.Gas(), value)
+	}
 	return nil
 }
 
@@ -71,9 +75,13 @@ func TraceEnd(ctx context.Context, receipt *action.Receipt) {
 		return
 	}
 	output := receipt.Output
-	vmCtx.Tracer.OnExit(0, output, receipt.GasConsumed, nil, receipt.Status != uint64(iotextypes.ReceiptStatus_Success))
+	if vmCtx.Tracer.OnExit != nil {
+		vmCtx.Tracer.OnExit(0, output, receipt.GasConsumed, nil, receipt.Status != uint64(iotextypes.ReceiptStatus_Success))
+	}
 	ethReceipt := ToEthReceipt(receipt)
-	vmCtx.Tracer.OnTxEnd(ethReceipt, nil)
+	if vmCtx.Tracer.OnTxEnd != nil {
+		vmCtx.Tracer.OnTxEnd(ethReceipt, nil)
+	}
 	if t, ok := GetTracerCtx(ctx); ok {
 		t.CaptureTx(output, receipt)
 	}

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -121,6 +121,12 @@ func (p *Protocol) systemCallContext(ctx context.Context, sm protocol.StateManag
 		GetBlockTime:  bcCtx.GetBlockTime,
 		IsBlackListed: p.isBlackListed,
 	})
+	// Strip the EVM tracer so system-level EVM calls (e.g. setPreviousBlockHash)
+	// don't pollute the tracing callstack used for user transaction traces.
+	if vmCfg, ok := protocol.GetVMConfigCtx(ctx); ok && vmCfg.Tracer != nil {
+		vmCfg.Tracer = nil
+		ctx = protocol.WithVMConfigCtx(ctx, vmCfg)
+	}
 	return ctx, nil
 }
 

--- a/action/protocol/execution/protocol.go
+++ b/action/protocol/execution/protocol.go
@@ -85,7 +85,7 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 		return nil
 	}
 	// deploy the history storage contract at block
-	if blkCtx.BlockHeight == g.ToBeEnabledBlockHeight {
+	if blkCtx.BlockHeight == g.YapBlockHeight {
 		if err := p.deployHistoryBlockStorageContract(ctx, sm); err != nil {
 			return err
 		}

--- a/action/protocol/execution/protocol_test.go
+++ b/action/protocol/execution/protocol_test.go
@@ -494,7 +494,7 @@ func (sct *SmartContractTest) prepareBlockchain(
 		cfg.Genesis.Blockchain.VanuatuBlockHeight = 1
 	}
 	if sct.InitGenesis.IsPrague {
-		cfg.Genesis.Blockchain.ToBeEnabledBlockHeight = 1
+		cfg.Genesis.Blockchain.YapBlockHeight = 1
 		testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	}
 	for _, expectedBalance := range sct.InitBalances {

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -1011,7 +1011,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 
 	tests := []struct {
 		name                  string
-		toBeEnabledHeight     uint64 // Controls NoCandidateExitQueue flag
+		yapHeight             uint64 // Controls NoCandidateExitQueue flag
 		blockHeight           uint64
 		initialDeactivatedAt  uint64
 		expectedDeactivatedAt uint64
@@ -1021,7 +1021,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 	}{
 		{
 			name:                  "revoke self-stake after hardfork with no prior request - requests deactivation",
-			toBeEnabledHeight:     1, // NoCandidateExitQueue = false
+			yapHeight:             1, // NoCandidateExitQueue = false
 			blockHeight:           10,
 			initialDeactivatedAt:  0,
 			expectedDeactivatedAt: candidateExitRequested,
@@ -1030,7 +1030,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 		},
 		{
 			name:                  "revoke self-stake after hardfork with scheduled deactivation ready - deactivates",
-			toBeEnabledHeight:     1, // NoCandidateExitQueue = false
+			yapHeight:             1, // NoCandidateExitQueue = false
 			blockHeight:           100,
 			initialDeactivatedAt:  90, // Scheduled for height 90
 			expectedDeactivatedAt: 90,
@@ -1039,7 +1039,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 		},
 		{
 			name:                  "revoke self-stake after hardfork with exit requested - fails with not scheduled",
-			toBeEnabledHeight:     1, // NoCandidateExitQueue = false
+			yapHeight:             1, // NoCandidateExitQueue = false
 			blockHeight:           100,
 			initialDeactivatedAt:  90,  // Already scheduled for deactivation at height 90
 			expectedDeactivatedAt: 90,  // DeactivatedAt remains set after deactivate (only self-stake is cleared)
@@ -1048,7 +1048,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 		},
 		{
 			name:                  "revoke self-stake before hardfork - clears self-stake directly",
-			toBeEnabledHeight:     1<<64 - 1, // NoCandidateExitQueue = true
+			yapHeight:             1<<64 - 1, // NoCandidateExitQueue = true
 			blockHeight:           10,
 			initialDeactivatedAt:  0,
 			expectedDeactivatedAt: 0,
@@ -1116,7 +1116,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 			cfg.GreenlandBlockHeight = 1
 			cfg.TsunamiBlockHeight = 1
 			cfg.UpernavikBlockHeight = 1
-			cfg.ToBeEnabledBlockHeight = tt.toBeEnabledHeight
+			cfg.YapBlockHeight = tt.yapHeight
 			ctx = genesis.WithGenesisContext(ctx, cfg)
 			ctx = protocol.WithFeatureCtx(ctx)
 
@@ -1207,7 +1207,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeNonSelfStakeAfterHardfork(t *
 		cfg.GreenlandBlockHeight = 1
 		cfg.TsunamiBlockHeight = 1
 		cfg.UpernavikBlockHeight = 1
-		cfg.ToBeEnabledBlockHeight = 1 // NoCandidateExitQueue = false
+		cfg.YapBlockHeight = 1 // NoCandidateExitQueue = false
 		ctx = genesis.WithGenesisContext(ctx, cfg)
 		ctx = protocol.WithFeatureCtx(ctx)
 
@@ -1436,7 +1436,7 @@ func TestProtocol_HandleCandidateEndorsement_DeactivatedCandidateEndorsementEdge
 			cfg.GreenlandBlockHeight = 1
 			cfg.TsunamiBlockHeight = 1
 			cfg.UpernavikBlockHeight = 1
-			cfg.ToBeEnabledBlockHeight = 1 // NoCandidateExitQueue = false
+			cfg.YapBlockHeight = 1 // NoCandidateExitQueue = false
 			ctx = genesis.WithGenesisContext(ctx, cfg)
 			ctx = protocol.WithFeatureCtx(ctx)
 

--- a/action/protocol/staking/handler_candidate_selfstake.go
+++ b/action/protocol/staking/handler_candidate_selfstake.go
@@ -99,7 +99,7 @@ func (p *Protocol) handleCandidateDeactivate(ctx context.Context, act *action.Ca
 		if rErr != nil {
 			return nil, nil, rErr
 		}
-		if err := csm.deactivate(cand, bucket, protocol.MustGetBlockCtx(ctx).BlockHeight, p.calculateVoteWeight); err == nil {
+		if err = csm.deactivate(cand, bucket, protocol.MustGetBlockCtx(ctx).BlockHeight, p.calculateVoteWeight); err == nil {
 			topics, eventData, err = action.PackCandidateDeactivatedEvent(id)
 		}
 	default:

--- a/action/rlp_tx_test.go
+++ b/action/rlp_tx_test.go
@@ -691,6 +691,18 @@ func TestEthTxDecodeVerifyV2(t *testing.T) {
 			builder: elpbuilder.BuildStakingAction,
 		},
 		{
+			// requestCandidateDeactivation() takes no parameters — calldata is exactly 4 bytes.
+			// This is the case that was missing from newStakingActionFromABIBinary, causing
+			// CandidateDeactivate to silently fail via eth_sendRawTransaction.
+			name:     "CandidateDeactivateRequest",
+			encoding: iotextypes.Encoding_ETHEREUM_EIP155,
+			txto:     MustNoErrorV(address.FromBytes(address.StakingProtocolAddrHash[:])).String(),
+			txamount: big.NewInt(0),
+			txdata:   requestCandidateDeactivationMethod.ID,
+			action:   &CandidateDeactivate{op: CandidateDeactivateOpRequest},
+			builder:  elpbuilder.BuildStakingAction,
+		},
+		{
 			name:     "StakeCandidateEndorsement",
 			encoding: iotextypes.Encoding_ETHEREUM_EIP155,
 			txto:     MustNoErrorV(address.FromBytes(address.StakingProtocolAddrHash[:])).String(),

--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -857,7 +857,6 @@ func TestReverseActionsInBlock(t *testing.T) {
 }
 
 func TestActions(t *testing.T) {
-	require := require.New(t)
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -868,81 +867,35 @@ func TestActions(t *testing.T) {
 	}
 
 	t.Run("FailedToCheckActionIndex", func(t *testing.T) {
-		p := NewPatches()
-		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return errors.New(t.Name())
-			},
-		)
+		require := require.New(t)
+		orig := cs.indexer
+		cs.indexer = nil
+		defer func() { cs.indexer = orig }()
 		_, err := cs.Actions(0, 0)
-		require.EqualError(err, t.Name())
+		require.EqualError(err, "no action index")
 	})
 
 	t.Run("CountIsZero", func(t *testing.T) {
-		p := NewPatches()
-		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return nil
-			},
-		)
-
+		require := require.New(t)
 		_, err := cs.Actions(0, 0)
 		require.ErrorContains(err, "count must be greater than zero")
 	})
 
 	t.Run("CountIsGreaterThanRange", func(t *testing.T) {
-		p := NewPatches()
-		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return nil
-			},
-		)
-
+		require := require.New(t)
 		_, err := cs.Actions(0, 2001)
 		require.ErrorContains(err, "range exceeds the limit")
 	})
 
 	t.Run("FailedToGetTotalActions", func(t *testing.T) {
-		p := NewPatches()
-		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return nil
-			},
-		)
-
+		require := require.New(t)
 		indexer.EXPECT().GetTotalActions().Return(uint64(0), errors.New(t.Name())).Times(1)
 		_, err := cs.Actions(0, 1)
 		require.ErrorContains(err, t.Name())
 	})
 
 	t.Run("StartGreaterThanTotalActions", func(t *testing.T) {
-		p := NewPatches()
-		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return nil
-			},
-		)
-
+		require := require.New(t)
 		// greater than totalActions
 		indexer.EXPECT().GetTotalActions().Return(uint64(0), nil).Times(1)
 		_, err := cs.Actions(1, 1)
@@ -955,16 +908,9 @@ func TestActions(t *testing.T) {
 	})
 
 	t.Run("GetActionsFromIndexer", func(t *testing.T) {
+		require := require.New(t)
 		p := NewPatches()
 		defer p.Reset()
-
-		p = p.ApplyPrivateMethod(
-			cs,
-			"checkActionIndex",
-			func() error {
-				return nil
-			},
-		)
 
 		indexer.EXPECT().GetTotalActions().Return(uint64(1), nil).Times(1)
 		p = p.ApplyPrivateMethod(

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -81,6 +81,7 @@ func defaultConfig() Genesis {
 			XinguBlockHeight:          41648761,
 			XinguBetaBlockHeight:      41648761,
 			YapBlockHeight:            51648761,
+			YapBetaBlockHeight:        51648761,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{
@@ -383,7 +384,12 @@ type (
 		// 1. slash candidate by operator
 		XinguBetaBlockHeight uint64 `yaml:"xinguBetaHeight"`
 		// YapBlockHeight is the start height of Yap hardfork
+		// 1. enable evm Prague upgrade
+		// 2. enable state candidate with identity
+		// 3. enable candidate exit queue
 		YapBlockHeight uint64 `yaml:"yapHeight"`
+		// YapBetaBlockHeight is the start height to enable slashing candidate by identity
+		YapBetaBlockHeight uint64 `yaml:"yapBetaHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -779,6 +785,11 @@ func (g *Blockchain) IsXinguBeta(height uint64) bool {
 // IsYap checks whether height is equal to or larger than yap height
 func (g *Blockchain) IsYap(height uint64) bool {
 	return g.isPost(g.YapBlockHeight, height)
+}
+
+// IsYapBeta checks whether height is equal to or larger than yap beta height
+func (g *Blockchain) IsYapBeta(height uint64) bool {
+	return g.isPost(g.YapBetaBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -80,6 +80,7 @@ func defaultConfig() Genesis {
 			WakeBlockHeight:           36893881,
 			XinguBlockHeight:          41648761,
 			XinguBetaBlockHeight:      41648761,
+			YapBlockHeight:            51648761,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{
@@ -381,6 +382,8 @@ type (
 		// XinguBetaBlockHeight is the start height to
 		// 1. slash candidate by operator
 		XinguBetaBlockHeight uint64 `yaml:"xinguBetaHeight"`
+		// YapBlockHeight is the start height of Yap hardfork
+		YapBlockHeight uint64 `yaml:"yapHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -771,6 +774,11 @@ func (g *Blockchain) IsXingu(height uint64) bool {
 // IsXinguBeta checks whether height is equal to or larger than xingu beta height
 func (g *Blockchain) IsXinguBeta(height uint64) bool {
 	return g.isPost(g.XinguBetaBlockHeight, height)
+}
+
+// IsYap checks whether height is equal to or larger than yap height
+func (g *Blockchain) IsYap(height uint64) bool {
+	return g.isPost(g.YapBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -80,8 +80,8 @@ func defaultConfig() Genesis {
 			WakeBlockHeight:           36893881,
 			XinguBlockHeight:          41648761,
 			XinguBetaBlockHeight:      41648761,
-			YapBlockHeight:            51648761,
-			YapBetaBlockHeight:        51648761,
+			YapBlockHeight:            48985561,
+			YapBetaBlockHeight:        48985561,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{

--- a/config/config.go
+++ b/config/config.go
@@ -346,6 +346,8 @@ func ValidateForkHeights(cfg Config) error {
 		return errors.Wrap(ErrInvalidCfg, "Wake is heigher than Xingu")
 	case hu.XinguBlockHeight > hu.XinguBetaBlockHeight:
 		return errors.Wrap(ErrInvalidCfg, "Xingu is heigher than XinguBeta")
+	case hu.XinguBetaBlockHeight > hu.YapBlockHeight:
+		return errors.Wrap(ErrInvalidCfg, "XinguBeta is heigher than Yap")
 	}
 	return nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -348,6 +348,8 @@ func ValidateForkHeights(cfg Config) error {
 		return errors.Wrap(ErrInvalidCfg, "Xingu is heigher than XinguBeta")
 	case hu.XinguBetaBlockHeight > hu.YapBlockHeight:
 		return errors.Wrap(ErrInvalidCfg, "XinguBeta is heigher than Yap")
+	case hu.YapBlockHeight > hu.YapBetaBlockHeight:
+		return errors.Wrap(ErrInvalidCfg, "Yap is heigher than YapBeta")
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -391,6 +391,9 @@ func TestValidateForkHeights(t *testing.T) {
 			"XinguBeta", ErrInvalidCfg, "XinguBeta is heigher than Yap",
 		},
 		{
+			"Yap", ErrInvalidCfg, "Yap is heigher than YapBeta",
+		},
+		{
 			"", nil, "",
 		},
 	}
@@ -462,6 +465,8 @@ func newTestCfg(fork string) Config {
 		cfg.Genesis.XinguBlockHeight = cfg.Genesis.XinguBetaBlockHeight + 1
 	case "XinguBeta":
 		cfg.Genesis.XinguBetaBlockHeight = cfg.Genesis.YapBlockHeight + 1
+	case "Yap":
+		cfg.Genesis.YapBlockHeight = cfg.Genesis.YapBetaBlockHeight + 1
 	}
 	return cfg
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -388,6 +388,9 @@ func TestValidateForkHeights(t *testing.T) {
 			"Xingu", ErrInvalidCfg, "Xingu is heigher than XinguBeta",
 		},
 		{
+			"XinguBeta", ErrInvalidCfg, "XinguBeta is heigher than Yap",
+		},
+		{
 			"", nil, "",
 		},
 	}
@@ -457,6 +460,8 @@ func newTestCfg(fork string) Config {
 		cfg.Genesis.WakeBlockHeight = cfg.Genesis.XinguBlockHeight + 1
 	case "Xingu":
 		cfg.Genesis.XinguBlockHeight = cfg.Genesis.XinguBetaBlockHeight + 1
+	case "XinguBeta":
+		cfg.Genesis.XinguBetaBlockHeight = cfg.Genesis.YapBlockHeight + 1
 	}
 	return cfg
 }

--- a/e2etest/exit_queue_test.go
+++ b/e2etest/exit_queue_test.go
@@ -21,7 +21,7 @@ import (
 func initExitQueueCfg(r *require.Assertions) config.Config {
 	cfg := initCfg(r)
 	cfg.Genesis.VanuatuBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 2
+	cfg.Genesis.YapBlockHeight = 2
 	cfg.Genesis.ExitAdmissionInterval = 1
 	// Use small epoch size for faster epoch transitions
 	cfg.Genesis.DardanellesNumSubEpochs = 1

--- a/e2etest/native_staking_test.go
+++ b/e2etest/native_staking_test.go
@@ -1582,7 +1582,7 @@ func TestCandidateBLSPublicKey(t *testing.T) {
 	cfg.Genesis.WakeBlockHeight = 1
 	cfg.Genesis.XinguBlockHeight = 10 // enable CandidateBLSPublicKey feature
 	cfg.Genesis.XinguBetaBlockHeight = 11
-	cfg.Genesis.ToBeEnabledBlockHeight = 20 // enable candidate BLS key update by operator feature
+	cfg.Genesis.YapBlockHeight = 20 // enable candidate BLS key update by operator feature
 	cfg.Genesis.SystemStakingContractAddress = ""
 	cfg.Genesis.SystemStakingContractV2Address = ""
 	cfg.Genesis.SystemStakingContractV3Address = ""
@@ -1646,7 +1646,7 @@ func TestCandidateBLSPublicKey(t *testing.T) {
 	})
 	height, err := test.cs.BlockDAO().Height()
 	require.NoError(err)
-	jumps := int(cfg.Genesis.ToBeEnabledBlockHeight - height)
+	jumps := int(cfg.Genesis.YapBlockHeight - height)
 	if jumps <= 0 {
 		jumps = 1
 	}

--- a/e2etest/setcodetx_test.go
+++ b/e2etest/setcodetx_test.go
@@ -38,13 +38,13 @@ func TestSetCodeTx_E2E(t *testing.T) {
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.XinguBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 5 // enable setcode tx
+	cfg.Genesis.YapBlockHeight = 5 // enable setcode tx
 	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
 	// Configure blacklist for testing EIP-7702 blacklist enforcement
 	blacklistedAccount := 28
 	cfg.Genesis.InitBalanceMap[identityset.Address(blacklistedAccount).String()] = unit.ConvertIotxToRau(1000000).String()
 	cfg.ActPool.BlackList = []string{identityset.Address(blacklistedAccount).String()}
-	cfg.ActPool.BlackListActiveHeight = cfg.Genesis.ToBeEnabledBlockHeight + 1
+	cfg.ActPool.BlackListActiveHeight = cfg.Genesis.YapBlockHeight + 1
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	test := newE2ETest(t, cfg)
 	chainID := cfg.Chain.ID
@@ -173,7 +173,7 @@ func TestSetCodeTx_E2E(t *testing.T) {
 		},
 	})
 	var (
-		skipBlocks           = cfg.Genesis.ToBeEnabledBlockHeight - test.cs.Blockchain().TipHeight()
+		skipBlocks           = cfg.Genesis.YapBlockHeight - test.cs.Blockchain().TipHeight()
 		accountContract      = 7
 		candOwnerID          = 3
 		stakeAmount          = unit.ConvertIotxToRau(10000)
@@ -328,7 +328,7 @@ func TestSetCodeTx_BatchTransfer(t *testing.T) {
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.XinguBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 1 // enable setcode tx from the start
+	cfg.Genesis.YapBlockHeight = 1 // enable setcode tx from the start
 	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	test := newE2ETest(t, cfg)
@@ -493,7 +493,7 @@ func TestSetCodeTx_ERC20ApproveAndTransfer(t *testing.T) {
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.XinguBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 1 // enable setcode tx from the start
+	cfg.Genesis.YapBlockHeight = 1 // enable setcode tx from the start
 	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	test := newE2ETest(t, cfg)
@@ -722,7 +722,7 @@ func TestSetCodeTx_GasSponsorship(t *testing.T) {
 	cfg.Plugins[config.GatewayPlugin] = true
 	cfg.Chain.EnableAsyncIndexWrite = false
 	cfg.Genesis.XinguBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 1 // enable setcode tx from the start
+	cfg.Genesis.YapBlockHeight = 1 // enable setcode tx from the start
 
 	// Sponsor has native tokens to pay for gas
 	sponsor := identityset.Address(10)
@@ -955,7 +955,7 @@ func TestEstimateGas(t *testing.T) {
 	r.NoError(err)
 	cfg.Chain.HistoryIndexPath = historyIndexPath
 	cfg.Genesis.XinguBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = 5 // enable setcode tx
+	cfg.Genesis.YapBlockHeight = 5 // enable setcode tx
 	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	test := newE2ETest(t, cfg)
@@ -999,7 +999,7 @@ func TestEstimateGas(t *testing.T) {
 	test.run([]*testcase{
 		{
 			name:    "deploy_contract_v3",
-			preActs: genTransfers(int(cfg.Genesis.ToBeEnabledBlockHeight)),
+			preActs: genTransfers(int(cfg.Genesis.YapBlockHeight)),
 			acts: []*actionWithTime{
 				{mustNoErr(action.SignedExecution("", identityset.PrivateKey(contractCreator), test.nonceMgr.pop(identityset.Address(contractCreator).String()), big.NewInt(0), 2*gasLimit, gasPrice, append(bytecodeV3, mustCallDataV3("", minAmount, contractV2AddressEth)...), action.WithChainID(chainID))), time.Now()},
 				{mustNoErr(action.SignedExecution(contractV3Address, identityset.PrivateKey(contractCreator), test.nonceMgr.pop(identityset.Address(contractCreator).String()), big.NewInt(0), gasLimit, gasPrice, mustCallDataV3("setBeneficiary(address)", common.BytesToAddress(identityset.Address(beneficiaryID).Bytes())), action.WithChainID(chainID))), time.Now()},
@@ -1078,7 +1078,7 @@ func TestEstimateGas(t *testing.T) {
 		},
 		// big calldata before prague
 		{
-			blockNumber: big.NewInt(int64(cfg.Genesis.ToBeEnabledBlockHeight - 2)),
+			blockNumber: big.NewInt(int64(cfg.Genesis.YapBlockHeight - 2)),
 			call: ethereum.CallMsg{
 				From:     common.BytesToAddress(assertions.MustNoErrorV(address.FromString(sender)).Bytes()),
 				To:       &contractV2AddressEth,
@@ -1090,7 +1090,7 @@ func TestEstimateGas(t *testing.T) {
 		},
 		// big calldata after prague
 		{
-			blockNumber: big.NewInt(int64(cfg.Genesis.ToBeEnabledBlockHeight)),
+			blockNumber: big.NewInt(int64(cfg.Genesis.YapBlockHeight)),
 			call: ethereum.CallMsg{
 				From:     common.BytesToAddress(assertions.MustNoErrorV(address.FromString(sender)).Bytes()),
 				To:       &contractV2AddressEth,

--- a/e2etest/trace_block_test.go
+++ b/e2etest/trace_block_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-resty/resty/v2"
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/v2/action"
@@ -20,13 +21,13 @@ import (
 	"github.com/iotexproject/iotex-core/v2/testutil"
 )
 
-func TestTraceBlockByNumber(t *testing.T) {
+func traceBlockSetup(t *testing.T) (cfg config.Config, sender string, senderSK crypto.PrivateKey, receiver string) {
 	r := require.New(t)
-	sender := identityset.Address(10).String()
-	senderSK := identityset.PrivateKey(10)
-	receiver := identityset.Address(11).String()
+	sender = identityset.Address(10).String()
+	senderSK = identityset.PrivateKey(10)
+	receiver = identityset.Address(11).String()
 
-	cfg := initCfg(r)
+	cfg = initCfg(r)
 	historyIndexPath, err := os.MkdirTemp("", "historyindex")
 	r.NoError(err)
 	cfg.Chain.HistoryIndexPath = historyIndexPath
@@ -38,35 +39,41 @@ func TestTraceBlockByNumber(t *testing.T) {
 	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
 	cfg.Genesis.YapBetaBlockHeight = 1
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+	return
+}
+
+func rpcTraceBlock(t *testing.T, port int, height uint64, tracerName string) (json.RawMessage, error) {
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","params":["0x%x",{"tracer":%q}],"id":1}`, height, tracerName)
+	url := fmt.Sprintf("http://localhost:%d", port)
+	type web3Response struct {
+		Result json.RawMessage `json:"result"`
+		Error  *struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	result := &web3Response{}
+	resp, err := resty.New().R().SetBody(body).Post(url)
+	if err != nil {
+		return nil, err
+	}
+	if err := json.Unmarshal(resp.Body(), result); err != nil {
+		return nil, err
+	}
+	if result.Error != nil {
+		return nil, fmt.Errorf("rpc error %d: %s", result.Error.Code, result.Error.Message)
+	}
+	return result.Result, nil
+}
+
+func TestTraceBlockByNumber(t *testing.T) {
+	r := require.New(t)
+	cfg, sender, senderSK, receiver := traceBlockSetup(t)
 
 	test := newE2ETest(t, cfg)
 	chainID := cfg.Chain.ID
 	gasPrice := big.NewInt(unit.Qev)
 	ctx := context.Background()
-
-	rpcCall := func(height uint64) (json.RawMessage, error) {
-		body := fmt.Sprintf(`{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","params":["0x%x",{"tracer":"callTracer"}],"id":1}`, height)
-		url := fmt.Sprintf("http://localhost:%d", cfg.API.HTTPPort)
-		type web3Response struct {
-			Result json.RawMessage `json:"result"`
-			Error  *struct {
-				Code    int    `json:"code"`
-				Message string `json:"message"`
-			} `json:"error"`
-		}
-		result := &web3Response{}
-		resp, err := resty.New().R().SetBody(body).Post(url)
-		if err != nil {
-			return nil, err
-		}
-		if err := json.Unmarshal(resp.Body(), result); err != nil {
-			return nil, err
-		}
-		if result.Error != nil {
-			return nil, fmt.Errorf("rpc error %d: %s", result.Error.Code, result.Error.Message)
-		}
-		return result.Result, nil
-	}
 
 	// deploy a simple contract so the traced block has EVM execution
 	var contractAddr string
@@ -77,7 +84,7 @@ func TestTraceBlockByNumber(t *testing.T) {
 			mustNoErr(action.Sign(
 				action.NewEnvelope(
 					action.NewLegacyTx(chainID, test.nonceMgr.pop(sender), gasLimit, gasPrice),
-					// minimal bytecode: PUSH1 0x00 PUSH1 0x00 RETURN (6000600000) — deploys empty contract
+					// minimal bytecode: PUSH1 0x00 PUSH1 0x00 RETURN — deploys empty contract
 					action.NewExecution("", big.NewInt(0), []byte{0x60, 0x00, 0x60, 0x00, 0xf3}),
 				),
 				senderSK,
@@ -110,12 +117,72 @@ func TestTraceBlockByNumber(t *testing.T) {
 
 	// trace the block containing the contract deployment
 	t.Logf("calling debug_traceBlockByNumber for height %d", deployBlkHeight)
-	result, err := rpcCall(deployBlkHeight)
-	r.NoError(err, "debug_traceBlockByNumber should succeed for historical block with EVM tx")
-	t.Logf("trace result: %s", string(result))
+	result, err := rpcTraceBlock(t, cfg.API.HTTPPort, deployBlkHeight, "callTracer")
+	r.NoError(err, "callTracer should succeed for historical block with EVM tx")
+	t.Logf("callTracer result: %s", string(result))
 	r.NotNil(result)
 
-	// also verify the result array contains one entry per tx
+	var entries []json.RawMessage
+	r.NoError(json.Unmarshal(result, &entries))
+	r.Len(entries, 1, "should have one trace entry for the single tx in the block")
+
+	_ = contractAddr
+}
+
+func TestTraceBlockByNumberPrestateTracer(t *testing.T) {
+	r := require.New(t)
+	cfg, sender, senderSK, receiver := traceBlockSetup(t)
+
+	test := newE2ETest(t, cfg)
+	chainID := cfg.Chain.ID
+	gasPrice := big.NewInt(unit.Qev)
+	ctx := context.Background()
+
+	// deploy a simple contract so the traced block has EVM execution
+	var deployBlkHeight uint64
+	test.runCase(ctx, &testcase{
+		name: "deploy contract",
+		act: &actionWithTime{
+			mustNoErr(action.Sign(
+				action.NewEnvelope(
+					action.NewLegacyTx(chainID, test.nonceMgr.pop(sender), gasLimit, gasPrice),
+					// minimal bytecode: PUSH1 0x00 PUSH1 0x00 RETURN — deploys empty contract
+					action.NewExecution("", big.NewInt(0), []byte{0x60, 0x00, 0x60, 0x00, 0xf3}),
+				),
+				senderSK,
+			)),
+			time.Now(),
+		},
+		blockExpect: func(test *e2etest, blk *block.Block, err error) {
+			r.NoError(err)
+			r.EqualValues(1, blk.Receipts[0].Status)
+			deployBlkHeight = blk.Height()
+			t.Log("contract deployed at block height:", deployBlkHeight)
+		},
+	})
+
+	// produce one more block so deployBlkHeight is historical
+	test.runCase(ctx, &testcase{
+		name: "another tx",
+		act: &actionWithTime{
+			mustNoErr(action.Sign(
+				action.NewEnvelope(
+					action.NewLegacyTx(chainID, test.nonceMgr.pop(sender), gasLimit, gasPrice),
+					action.NewTransfer(big.NewInt(1), receiver, nil),
+				),
+				senderSK,
+			)),
+			time.Now(),
+		},
+	})
+
+	// trace with prestateTracer
+	t.Logf("calling debug_traceBlockByNumber with prestateTracer for height %d", deployBlkHeight)
+	result, err := rpcTraceBlock(t, cfg.API.HTTPPort, deployBlkHeight, "prestateTracer")
+	r.NoError(err, "prestateTracer should succeed for historical block with EVM tx")
+	t.Logf("prestateTracer result: %s", string(result))
+	r.NotNil(result)
+
 	var entries []json.RawMessage
 	r.NoError(json.Unmarshal(result, &entries))
 	r.Len(entries, 1, "should have one trace entry for the single tx in the block")

--- a/e2etest/trace_block_test.go
+++ b/e2etest/trace_block_test.go
@@ -1,0 +1,122 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+func TestTraceBlockByNumber(t *testing.T) {
+	r := require.New(t)
+	sender := identityset.Address(10).String()
+	senderSK := identityset.PrivateKey(10)
+	receiver := identityset.Address(11).String()
+
+	cfg := initCfg(r)
+	historyIndexPath, err := os.MkdirTemp("", "historyindex")
+	r.NoError(err)
+	cfg.Chain.HistoryIndexPath = historyIndexPath
+	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.API.HTTPPort = testutil.RandomPort()
+	cfg.API.WebSocketPort = 0
+	cfg.Plugins[config.GatewayPlugin] = true
+	cfg.Chain.EnableAsyncIndexWrite = false
+	cfg.Genesis.InitBalanceMap[sender] = unit.ConvertIotxToRau(1000000).String()
+	cfg.Genesis.YapBetaBlockHeight = 1
+	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+
+	test := newE2ETest(t, cfg)
+	chainID := cfg.Chain.ID
+	gasPrice := big.NewInt(unit.Qev)
+	ctx := context.Background()
+
+	rpcCall := func(height uint64) (json.RawMessage, error) {
+		body := fmt.Sprintf(`{"jsonrpc":"2.0","method":"debug_traceBlockByNumber","params":["0x%x",{"tracer":"callTracer"}],"id":1}`, height)
+		url := fmt.Sprintf("http://localhost:%d", cfg.API.HTTPPort)
+		type web3Response struct {
+			Result json.RawMessage `json:"result"`
+			Error  *struct {
+				Code    int    `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		}
+		result := &web3Response{}
+		resp, err := resty.New().R().SetBody(body).Post(url)
+		if err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(resp.Body(), result); err != nil {
+			return nil, err
+		}
+		if result.Error != nil {
+			return nil, fmt.Errorf("rpc error %d: %s", result.Error.Code, result.Error.Message)
+		}
+		return result.Result, nil
+	}
+
+	// deploy a simple contract so the traced block has EVM execution
+	var contractAddr string
+	var deployBlkHeight uint64
+	test.runCase(ctx, &testcase{
+		name: "deploy contract",
+		act: &actionWithTime{
+			mustNoErr(action.Sign(
+				action.NewEnvelope(
+					action.NewLegacyTx(chainID, test.nonceMgr.pop(sender), gasLimit, gasPrice),
+					// minimal bytecode: PUSH1 0x00 PUSH1 0x00 RETURN (6000600000) — deploys empty contract
+					action.NewExecution("", big.NewInt(0), []byte{0x60, 0x00, 0x60, 0x00, 0xf3}),
+				),
+				senderSK,
+			)),
+			time.Now(),
+		},
+		blockExpect: func(test *e2etest, blk *block.Block, err error) {
+			r.NoError(err)
+			r.EqualValues(1, blk.Receipts[0].Status)
+			contractAddr = blk.Receipts[0].ContractAddress
+			deployBlkHeight = blk.Height()
+			t.Log("contract deployed at block height:", deployBlkHeight, "addr:", contractAddr)
+		},
+	})
+
+	// produce one more block so deployBlkHeight is historical
+	test.runCase(ctx, &testcase{
+		name: "another tx",
+		act: &actionWithTime{
+			mustNoErr(action.Sign(
+				action.NewEnvelope(
+					action.NewLegacyTx(chainID, test.nonceMgr.pop(sender), gasLimit, gasPrice),
+					action.NewTransfer(big.NewInt(1), receiver, nil),
+				),
+				senderSK,
+			)),
+			time.Now(),
+		},
+	})
+
+	// trace the block containing the contract deployment
+	t.Logf("calling debug_traceBlockByNumber for height %d", deployBlkHeight)
+	result, err := rpcCall(deployBlkHeight)
+	r.NoError(err, "debug_traceBlockByNumber should succeed for historical block with EVM tx")
+	t.Logf("trace result: %s", string(result))
+	r.NotNil(result)
+
+	// also verify the result array contains one entry per tx
+	var entries []json.RawMessage
+	r.NoError(json.Unmarshal(result, &entries))
+	r.Len(entries, 1, "should have one trace entry for the single tx in the block")
+}

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -193,9 +193,16 @@ func (ws *workingSet) runAction(
 	}
 	fCtx := protocol.MustGetFeatureCtx(ctx)
 	var receipt *action.Receipt
-	traceErr := evm.TraceStart(ctx, ws, selp.Envelope)
-	if traceErr != nil {
-		log.L().Error("failed to start tracing EVM execution", zap.Error(traceErr))
+	// System actions (e.g. GrantReward) are implementation details and must not
+	// appear in block-level traces (debug_traceBlock*). Skip TraceStart/TraceEnd
+	// for them so CaptureTx is never called on their behalf.
+	isSystemAct := action.IsSystemAction(selp)
+	var traceErr error
+	if !isSystemAct {
+		traceErr = evm.TraceStart(ctx, ws, selp.Envelope)
+		if traceErr != nil {
+			log.L().Error("failed to start tracing EVM execution", zap.Error(traceErr))
+		}
 	}
 	for _, actionHandler := range reg.All() {
 		receipt, err = actionHandler.Handle(ctx, selp.Envelope, ws)
@@ -213,7 +220,7 @@ func (ws *workingSet) runAction(
 	if receipt == nil {
 		return nil, errors.New("receipt is empty")
 	}
-	if traceErr == nil {
+	if !isSystemAct && traceErr == nil {
 		evm.TraceEnd(ctx, receipt)
 	}
 	if fCtx.EnableBlobTransaction && len(selp.BlobHashes()) > 0 {

--- a/testutil/genesis.go
+++ b/testutil/genesis.go
@@ -34,6 +34,7 @@ func NormalizeGenesisHeights(g *genesis.Blockchain) {
 		&g.WakeBlockHeight,
 		&g.XinguBlockHeight,
 		&g.XinguBetaBlockHeight,
+		&g.YapBlockHeight,
 		&g.ToBeEnabledBlockHeight,
 	}
 	for i := len(heights) - 2; i >= 0; i-- {

--- a/testutil/genesis.go
+++ b/testutil/genesis.go
@@ -35,6 +35,7 @@ func NormalizeGenesisHeights(g *genesis.Blockchain) {
 		&g.XinguBlockHeight,
 		&g.XinguBetaBlockHeight,
 		&g.YapBlockHeight,
+		&g.YapBetaBlockHeight,
 		&g.ToBeEnabledBlockHeight,
 	}
 	for i := len(heights) - 2; i >= 0; i-- {


### PR DESCRIPTION
# Description

Bundles the Yap/YapBeta hardfork wiring with a set of fixes that ride the same activation. The PR has three logical parts:

## 1. Yap and YapBeta hardforks

- `blockchain/genesis/genesis.go`, `config/config.go`, `testutil/genesis.go`: register `Yap` and `YapBeta` block heights and plumb them through config.
- Mainnet activation height set to **48985561** (epoch 62162, est. 2026-06-08 07:52 CST) for both Yap and YapBeta.
- `action/protocol/context.go`: replace placeholder `IsToBeEnabled` gating with explicit `IsYap` / `IsYapBeta` checks for `OnlyOwnerCanUpdateBLSPublicKey`, `PrePectraEVM`, `AlwaysWriteCachedContract`, `NoCandidateExitQueue`, etc.
- Tests updated in `e2etest/`, `api/coreservice_test.go`, `action/protocol/staking/`, `action/protocol/execution/` to use the new feature flags.

## 2. CandidateDeactivate usable via Web3 / gRPC

- `action/builder.go`: register `NewCandidateDeactivateFromABIBinary` in the staking action parser list.
- `action/candidate_deactivate.go`: fix `len <= 4` guard to `< 4` so no-arg ABI methods are accepted.
- `action/envelope.go`: add the missing `GetCandidateDeactivate()` (and `ScheduleCandidateDeactivation`) cases in the proto deserializer.
- `action/native_staking_contract_interface.sol` + regenerated `native_staking_contract_abi.json`: expose `requestCandidateDeactivation` / `cancelCandidateDeactivation` and the three deactivation events.
- `action/rlp_tx_test.go`: add a `CandidateDeactivateRequest` round-trip test.
- `action/protocol/staking/handler_candidate_selfstake.go`: fix `:=` shadowing that swallowed deactivate errors in `CandidateDeactivateOpConfirm`.

## 3. EVM tracer fixes for `debug_traceBlock*`

- `action/protocol/execution/protocol.go`: strip `Tracer` from `VMConfigCtx` in `systemCallContext` so system EVM calls (e.g. `setPreviousBlockHash`, `deployHistoryBlockStorageContract`) don't leak frames into the user transaction trace.
- `action/protocol/execution/evm/tracer.go` (`TraceStart` / `TraceEnd`): nil-guard hook fields (`OnExit`, `OnTxStart`, `OnTxEnd`, `OnEnter`) so tracers that don't register every hook (e.g. `prestateTracer`) no longer panic.
- `state/factory/workingset.go`: skip `TraceStart`/`TraceEnd` for system actions so `GrantReward` & co. don't show up as spurious entries in `debug_traceBlock` output (matches geth behavior).
- `e2etest/trace_block_test.go`: new regression tests covering the callstack-pollution case and `prestateTracer` over `debug_traceBlockByNumber`.

Refs: #4825

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (hardfork — changes consensus behavior at activation height)

# How Has This Been Tested?

- [x] `make test`
- [x] New e2e tests: `e2etest/trace_block_test.go` (tracer fixes), `action/rlp_tx_test.go` (CandidateDeactivate round-trip)
- [x] Existing e2e suites updated for the new feature flags pass
