### PR TITLE
fix(staking): make *lastExitEpoch compatible with erigon kvListStorage

### DIFF
--- a/action/protocol/staking/lastexitepoch.go
+++ b/action/protocol/staking/lastexitepoch.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package staking
+
+import (
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/systemcontracts"
+)
+
+// Encodes / Decodes implement the kvListContainer interface used by erigon
+// archive storage. lastExitEpoch is a single-valued state kept under the
+// CandsMap namespace alongside the candidate-map kvList, so when archive is
+// enabled it flows through kvListStorage and needs this shape. We collapse
+// the single value into a one-entry list with an empty suffix key.
+//
+// Kept in a dedicated file so adding these methods doesn't shift the
+// compiled layout of protocol.go — gomonkey-based tests there patch by
+// function offset and break when this file changes the offset table.
+func (le *lastExitEpoch) Encodes() ([][]byte, []systemcontracts.GenericValue, error) {
+	data, err := le.Serialize()
+	if err != nil {
+		return nil, nil, err
+	}
+	return [][]byte{nil}, []systemcontracts.GenericValue{{PrimaryData: data}}, nil
+}
+
+// Decodes restores lastExitEpoch from the single-entry list produced by
+// Encodes (or by a previous Store via kvListStorage).
+func (le *lastExitEpoch) Decodes(_ [][]byte, values []systemcontracts.GenericValue) error {
+	if len(values) == 0 {
+		return errors.New("no data to decode last exit epoch")
+	}
+	return le.Deserialize(values[0].PrimaryData)
+}

--- a/action/protocol/staking/lastexitepoch_test.go
+++ b/action/protocol/staking/lastexitepoch_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package staking
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/systemcontracts"
+)
+
+func TestLastExitEpoch_SerializeRoundTrip(t *testing.T) {
+	r := require.New(t)
+	for _, epoch := range []uint64{0, 1, 42, 1 << 20, ^uint64(0)} {
+		in := &lastExitEpoch{epoch: epoch}
+		data, err := in.Serialize()
+		r.NoError(err)
+		out := &lastExitEpoch{}
+		r.NoError(out.Deserialize(data))
+		r.Equal(in.epoch, out.epoch)
+	}
+}
+
+func TestLastExitEpoch_EncodesSingleValueShape(t *testing.T) {
+	r := require.New(t)
+	le := &lastExitEpoch{epoch: 12345}
+	keys, values, err := le.Encodes()
+	r.NoError(err)
+	// kvListStorage stores under `prefix + key` for each entry. lastExitEpoch
+	// is a single-value state, so it must encode to exactly one entry with
+	// an empty suffix key — otherwise the key would shift away from where
+	// PutState/GetState expect it.
+	r.Len(keys, 1)
+	r.Len(values, 1)
+	r.Empty(keys[0])
+	// PrimaryData carries the protobuf-encoded epoch. SecondaryData /
+	// AuxiliaryData stay empty for this state.
+	r.NotEmpty(values[0].PrimaryData)
+	r.Empty(values[0].SecondaryData)
+	r.Empty(values[0].AuxiliaryData)
+}
+
+func TestLastExitEpoch_EncodesDecodesRoundTrip(t *testing.T) {
+	r := require.New(t)
+	for _, epoch := range []uint64{0, 1, 7, 100, 1 << 32, ^uint64(0)} {
+		in := &lastExitEpoch{epoch: epoch}
+		keys, values, err := in.Encodes()
+		r.NoError(err)
+		out := &lastExitEpoch{}
+		r.NoError(out.Decodes(keys, values))
+		r.Equal(in.epoch, out.epoch)
+	}
+}
+
+func TestLastExitEpoch_DecodesEmptyReturnsError(t *testing.T) {
+	r := require.New(t)
+	out := &lastExitEpoch{}
+	err := out.Decodes(nil, nil)
+	r.Error(err)
+	err = out.Decodes([][]byte{}, []systemcontracts.GenericValue{})
+	r.Error(err)
+}
+
+// kvListContainer mirrors the (unexported) interface in
+// state/factory/erigonstore.kvListStorage. *lastExitEpoch must satisfy it so
+// erigon-backed archive state factories can store/load the state — without
+// these methods, handleScheduleCandidateDeactivation panics with
+// "object of type *staking.lastExitEpoch does not supported" when archive is
+// enabled.
+type kvListContainer interface {
+	Encodes() ([][]byte, []systemcontracts.GenericValue, error)
+	Decodes(keys [][]byte, values []systemcontracts.GenericValue) error
+}
+
+func TestLastExitEpoch_ImplementsKVListContainer(t *testing.T) {
+	var _ kvListContainer = (*lastExitEpoch)(nil)
+}


### PR DESCRIPTION
## Summary

Archive-enabled nodes (\`chain.historyIndexPath\` set) crash and enter a restart loop when processing the Yap-hardfork \`ScheduleCandidateDeactivation\` action:

\`\`\`
height N: object of type *staking.lastExitEpoch does not supported
  at state/factory/erigonstore.(*kvListStorage).Store (kvliststorage.go:30)
  at state/factory/erigonstore.(*ErigonWorkingSetStore).PutObject (workingsetstore_erigon.go:331)
  at state/factory.(*workingSet).PutState (workingset.go:415)
  at action/protocol/staking.(*Protocol).handleScheduleCandidateDeactivation (handler_candidate_selfstake.go:141)
\`\`\`

### Cause

The CandsMap namespace is registered with \`WithKVListOption()\` in \`state/factory/erigonstore/registry.go:90\`, which routes every object stored under it through \`kvListStorage\`. \`kvListStorage.Store\` type-asserts the object to \`kvListContainer\` (\`Encodes\` / \`Decodes\` methods), but \`*lastExitEpoch\` — which sits in the same namespace under the fixed key \`_lastExitEpoch\` alongside the candidate map — only implements the legacy \`Serialize\` / \`Deserialize\` pair. Type assertion fails, \`Store\` returns the "not supported" error, block validation fails, and the node restarts.

### Fix

Add \`Encodes\` / \`Decodes\` methods to \`*lastExitEpoch\` that collapse the single value into a one-entry kv list: empty suffix key, \`PrimaryData\` carries the existing proto-encoded epoch. The on-disk shape under the prefix \`_lastExitEpoch\` is identical to what the non-archive path produces, so existing chains aren't disturbed.

Kept in a dedicated file (\`lastexitepoch.go\`) instead of next to \`Serialize\`/\`Deserialize\` in \`protocol.go\`. Reason: adding code to \`protocol.go\` shifts its compiled function offsets, which makes \`gomonkey\`-based tests in \`handlers_test.go\` flake on darwin/arm64 (\`TestProtocol_FetchBucketAndValidate/validate_owner_and_selfstake\`). Putting the new methods in a separate file leaves \`protocol.go\` byte-for-byte unchanged. The flake doesn't reproduce on linux/amd64 (verified by running the test on \`golang:1.24-alpine\` linux/amd64).

### How this was hit in practice

Reproduced on a local-dev chain after enabling archive on api-node only:

1. Candidate \`newcand\` registered + sends \`CandidateDeactivateRequest\` at block 4960
2. At the next epoch boundary the chain proposes \`ScheduleCandidateDeactivation\` in block 4961
3. api-node \`Validate\`s that block, hits the type-assert, panics, restarts
4. Delegates (no archive) keep producing blocks, api-node never catches up

After this fix, api-node validates 4961 successfully, the schedule lands, and the full \`request → schedule → confirm\` cycle completes.

## Test plan

- [x] \`go build ./action/protocol/staking/...\`
- [x] \`go test -run TestLastExitEpoch -v ./action/protocol/staking/\` — 5 new tests cover Serialize/Deserialize round-trip, Encodes single-value shape, Encodes/Decodes round-trip, Decodes-on-empty error, and a static assert that \`*lastExitEpoch\` satisfies the kvListContainer interface
- [x] End-to-end on a local-dev archive-enabled chain: request → schedule → confirm cycle completes; \`candidate_exit_queue\` table populates all three phase columns
- [x] \`TestProtocol_FetchBucketAndValidate\` passes on linux/amd64 (darwin/arm64 flake is gomonkey-related and pre-existing — see "Fix" above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)