### PR TITLE
fix(staking): make CandidateDeactivate confirm op callable via Web3

### DIFF
--- a/action/candidate_deactivate.go
+++ b/action/candidate_deactivate.go
@@ -46,6 +46,10 @@ func init() {
 	if !ok {
 		panic("fail to load the cancelCandidateDeactivation method")
 	}
+	confirmCandidateDeactivationMethod, ok = methods["confirmCandidateDeactivation"]
+	if !ok {
+		panic("fail to load the confirmCandidateDeactivation method")
+	}
 }
 
 // NewCandidateDeactivate returns a CandidateDeactivate action
@@ -109,7 +113,7 @@ func NewCandidateDeactivateFromABIBinary(data []byte) (*CandidateDeactivate, err
 	var cd CandidateDeactivate
 	// sanity check
 	switch {
-	case len(data) <= 4:
+	case len(data) < 4:
 		return nil, errDecodeFailure
 	case bytes.Equal(requestCandidateDeactivationMethod.ID, data[:4]):
 		cd.op = CandidateDeactivateOpRequest

--- a/action/candidate_deactivate_test.go
+++ b/action/candidate_deactivate_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// init() in candidate_deactivate.go panics if confirmCandidateDeactivation is
+// missing from the staking ABI; this asserts the method ID is non-zero so a
+// future refactor that drops the JSON entry will fail loudly.
+func TestCandidateDeactivate_ConfirmMethodLoaded(t *testing.T) {
+	r := require.New(t)
+	r.NotEmpty(confirmCandidateDeactivationMethod.ID)
+	r.NotEqual(requestCandidateDeactivationMethod.ID, confirmCandidateDeactivationMethod.ID)
+	r.NotEqual(cancelCandidateDeactivationMethod.ID, confirmCandidateDeactivationMethod.ID)
+}
+
+// EthData(op=Confirm) used to silently produce empty bytes because the method
+// ID was the zero value. With the method loaded we expect a real 4-byte
+// selector that round-trips through the ABI binary parser.
+func TestCandidateDeactivate_ConfirmEthDataRoundTrip(t *testing.T) {
+	r := require.New(t)
+	cd := &CandidateDeactivate{op: CandidateDeactivateOpConfirm}
+	data, err := cd.EthData()
+	r.NoError(err)
+	r.True(len(data) >= 4, "EthData should at least contain the 4-byte selector")
+	r.True(bytes.Equal(data[:4], confirmCandidateDeactivationMethod.ID))
+
+	cd2, err := NewCandidateDeactivateFromABIBinary(data)
+	r.NoError(err)
+	r.Equal(CandidateDeactivateOp(CandidateDeactivateOpConfirm), cd2.op)
+}
+
+// Same round trip for the Request op so this file documents both ABI selectors.
+func TestCandidateDeactivate_RequestEthDataRoundTrip(t *testing.T) {
+	r := require.New(t)
+	cd := &CandidateDeactivate{op: CandidateDeactivateOpRequest}
+	data, err := cd.EthData()
+	r.NoError(err)
+	r.True(bytes.Equal(data[:4], requestCandidateDeactivationMethod.ID))
+
+	cd2, err := NewCandidateDeactivateFromABIBinary(data)
+	r.NoError(err)
+	r.Equal(CandidateDeactivateOp(CandidateDeactivateOpRequest), cd2.op)
+}

--- a/action/native_staking_contract_abi.json
+++ b/action/native_staking_contract_abi.json
@@ -220,6 +220,13 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "confirmCandidateDeactivation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "uint64",


### PR DESCRIPTION
## Summary

- Add `confirmCandidateDeactivation` to `native_staking_contract_abi.json` and load it in `candidate_deactivate.go` init. The Go code declared `confirmCandidateDeactivationMethod` but never loaded it; its `.ID` stayed zero-valued, making the corresponding cases in `NewCandidateDeactivateFromABIBinary` and `EthData` unreachable.
- Loosen the guard in `NewCandidateDeactivateFromABIBinary` from `len(data) <= 4` to `len(data) < 4`. Both `requestCandidateDeactivation` and `confirmCandidateDeactivation` take no arguments, so a valid call is exactly 4 bytes (selector only).

Together these unblock Web3-style submission of the Confirm op — the path external wallets (MetaMask, RainbowKit, etc.) must use because they cannot sign native iotex actions. Submission via gRPC `SendAction` with a proto-encoded `CandidateDeactivate{op=Confirm}` kept working because that path bypasses the ABI parser, which masked the bug during local exit-queue testing.

## Test plan

- [x] `go test ./action/ -count=1` (213 passing, 3 new tests)
  - `TestCandidateDeactivate_ConfirmMethodLoaded` — the new selector loads with a distinct, non-zero ID
  - `TestCandidateDeactivate_ConfirmEthDataRoundTrip` — `EthData(op=Confirm)` round-trips through `NewCandidateDeactivateFromABIBinary`
  - `TestCandidateDeactivate_RequestEthDataRoundTrip` — same round trip for Request (regression for the len guard)
- [ ] End-to-end: submit a Confirm via an external wallet (eth raw tx → STAKING_CONTRACT_ADDRESS) and verify the chain emits `CandidateDeactivated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)