### PR TITLE
fix(staking): clear DeactivatedAt after confirming candidate exit

### DIFF
--- a/action/protocol/staking/candidate_statemanager.go
+++ b/action/protocol/staking/candidate_statemanager.go
@@ -234,6 +234,11 @@ func (csm *candSM) deactivate(cand *Candidate, bucket *VoteBucket, height uint64
 	}
 	cand.SelfStake = big.NewInt(0)
 	cand.SelfStakeBucketIdx = candidateNoSelfStakeBucketIndex
+	// Clear the exit-queue marker so a subsequent re-stake / activate flow
+	// starts from a clean "no exit in flight" state. Without this the
+	// candidateDeactivation view keeps reporting the previous schedule, and
+	// frontends (iotex-hub) jump straight to "Confirm Exit" again.
+	cand.DeactivatedAt = 0
 	if err := csm.candCenter.Upsert(cand); err != nil {
 		return err
 	}

--- a/action/protocol/staking/ethabi/v4/stake_candidatedeactivation.go
+++ b/action/protocol/staking/ethabi/v4/stake_candidatedeactivation.go
@@ -10,11 +10,11 @@
 //
 // The ABI convention going forward is:
 //
-//   • The big bundled struct getters (candidateByAddress / candidateBy*)
+//   - The big bundled struct getters (candidateByAddress / candidateBy*)
 //     are FROZEN at V4 — new fields will not be appended. New consumers
 //     pair the V4 result with a focused getter via multicall.
 //
-//   • New per-feature state is exposed through its own getter that returns
+//   - New per-feature state is exposed through its own getter that returns
 //     only the fields it owns. The selector lives forever; the bundled
 //     struct ABI doesn't churn.
 //

--- a/action/protocol/staking/ethabi/v4/stake_candidatedeactivation_test.go
+++ b/action/protocol/staking/ethabi/v4/stake_candidatedeactivation_test.go
@@ -56,10 +56,10 @@ func TestBuildReadStateRequestCandidateDeactivation(t *testing.T) {
 func TestCandidateDeactivationToEth(t *testing.T) {
 	r := require.New(t)
 	cases := []struct {
-		name             string
-		deactivatedAt    uint64
-		wantRequested    bool
-		wantScheduledAt  uint64
+		name            string
+		deactivatedAt   uint64
+		wantRequested   bool
+		wantScheduledAt uint64
 	}{
 		{"no exit in flight", 0, false, 0},
 		{"requested, not yet scheduled", uint64(math.MaxUint64), true, 0},

--- a/action/protocol/staking/handler_candidate_endorsement_test.go
+++ b/action/protocol/staking/handler_candidate_endorsement_test.go
@@ -1033,7 +1033,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 			yapHeight:             1, // NoCandidateExitQueue = false
 			blockHeight:           100,
 			initialDeactivatedAt:  90, // Scheduled for height 90
-			expectedDeactivatedAt: 90,
+			expectedDeactivatedAt: 0,  // Cleared on successful deactivate (see f03a4ac16)
 			expectedSelfStakeStr:  "0",
 			expectedErr:           nil,
 		},
@@ -1042,7 +1042,7 @@ func TestProtocol_HandleCandidateEndorsement_RevokeSelfStakeAfterHardfork(t *tes
 			yapHeight:             1, // NoCandidateExitQueue = false
 			blockHeight:           100,
 			initialDeactivatedAt:  90,  // Already scheduled for deactivation at height 90
-			expectedDeactivatedAt: 90,  // DeactivatedAt remains set after deactivate (only self-stake is cleared)
+			expectedDeactivatedAt: 0,   // Cleared after deactivate so the next stake/activate cycle starts clean
 			expectedSelfStakeStr:  "0", // SelfStake is cleared
 			expectedErr:           nil, // Deactivate succeeds
 		},
@@ -1341,7 +1341,7 @@ func TestProtocol_HandleCandidateEndorsement_DeactivatedCandidateEndorsementEdge
 			isSelfStakeBucket:     true,
 			operation:             action.CandidateEndorsementOpRevoke,
 			expectedStatus:        iotextypes.ReceiptStatus_Success,
-			expectedDeactivatedAt: 90, // Should remain unchanged (deactivation was already scheduled)
+			expectedDeactivatedAt: 0, // Cleared on successful deactivate (see f03a4ac16)
 			verifyEndorsement: func(r *require.Assertions, esm *EndorsementStateManager, bucketIdx uint64, blockHeight uint64) {
 				// Endorsement should be deleted after successful revoke
 				_, err := esm.Get(bucketIdx)


### PR DESCRIPTION
## Summary

`csm.deactivate` only zeroed `SelfStake` and `SelfStakeBucketIdx` after a confirm landed, leaving `Candidate.DeactivatedAt` at the previous `scheduledAt` value. The new `candidateDeactivation` view (PR #4829) derives `requested` / `scheduledAtBlock` from this field, so a re-staked candidate looked permanently confirmable to frontends — iotex-hub jumped straight to "Confirm Exit" on the next view even though no new request had been submitted.

This patch resets `DeactivatedAt` to 0 alongside the existing self-stake field resets, so the view reports a clean "no exit in flight" state and the request → schedule → confirm cycle starts fresh on the next round.

## Test plan

- [ ] e2e: register → activate → request-exit → schedule → confirm-exit → re-stake → activate → verify `candidateDeactivation` returns `{requested: false, scheduledAtBlock: 0}` immediately after re-activation
- [ ] confirm UI on iotex-hub renders "No exit in progress" after the re-activation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)