### PR TITLE
fix(staking): emit non-indexed event args on candidate deactivation

### DIFF
--- a/action/protocol/staking/handler_candidate_endorsement.go
+++ b/action/protocol/staking/handler_candidate_endorsement.go
@@ -22,9 +22,9 @@ func (p *Protocol) handleCandidateEndorsement(ctx context.Context, act *action.C
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	var log *receiptLog
 	if featureCtx.EnforceLegacyEndorsement {
-		log = newReceiptLog(p.addr.String(), handleCandidateEndorsement, featureCtx.NewStakingReceiptFormat)
+		log = newReceiptLogLegacy(p.addr.String(), handleCandidateEndorsement, featureCtx.NewStakingReceiptFormat)
 	} else {
-		log = newReceiptLog(p.addr.String(), handleCandidateEndorsementWithOp, featureCtx.NewStakingReceiptFormat)
+		log = newReceiptLogLegacy(p.addr.String(), handleCandidateEndorsementWithOp, featureCtx.NewStakingReceiptFormat)
 	}
 
 	bucket, rErr := p.fetchBucket(csm, act.BucketIndex())

--- a/action/protocol/staking/handler_candidate_selfstake.go
+++ b/action/protocol/staking/handler_candidate_selfstake.go
@@ -111,12 +111,13 @@ func (p *Protocol) handleCandidateDeactivate(ctx context.Context, act *action.Ca
 	if err != nil {
 		return nil, nil, csmErrorToHandleError(actCtx.Caller.String(), err)
 	}
-	return &receiptLog{
-		addr:                  p.addr.String(),
-		postFairbankMigration: true,
-		topics:                topics,
-		data:                  eventData,
-	}, nil, nil
+	// Use AddEvent (not the raw topics/data fields) so receiptLog.Build emits a
+	// log carrying both Topics and Data. The postFairbank single-log path drops
+	// r.data, so a struct literal with topics+data here would silently lose any
+	// non-indexed event args.
+	rLog := &receiptLog{addr: p.addr.String(), postFairbankMigration: true}
+	rLog.AddEvent(topics, eventData)
+	return rLog, nil, nil
 }
 
 func (p *Protocol) handleScheduleCandidateDeactivation(ctx context.Context, act *action.ScheduleCandidateDeactivation, csm CandidateStateManager) (*receiptLog, []*action.TransactionLog, error) {
@@ -146,12 +147,12 @@ func (p *Protocol) handleScheduleCandidateDeactivation(ctx context.Context, act 
 		return nil, nil, err
 	}
 
-	return &receiptLog{
-		addr:                  p.addr.String(),
-		postFairbankMigration: true,
-		topics:                topics,
-		data:                  eventData,
-	}, nil, nil
+	// Use AddEvent so blockNumber (declared non-indexed in the ABI) lands in
+	// the emitted log's Data; raw struct literal with topics+data would be
+	// silently dropped on the postFairbank single-log path in Build.
+	rLog := &receiptLog{addr: p.addr.String(), postFairbankMigration: true}
+	rLog.AddEvent(topics, eventData)
+	return rLog, nil, nil
 }
 
 func (p *Protocol) validateBucketSelfStake(ctx context.Context, csm CandidateStateManager, esm *EndorsementStateManager, bucket *VoteBucket, cand *Candidate) ReceiptError {

--- a/action/protocol/staking/handler_candidate_selfstake.go
+++ b/action/protocol/staking/handler_candidate_selfstake.go
@@ -25,7 +25,7 @@ func (p *Protocol) handleCandidateActivate(ctx context.Context, act *action.Cand
 ) (*receiptLog, []*action.TransactionLog, error) {
 	actCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), handleCandidateActivate, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), handleCandidateActivate, featureCtx.NewStakingReceiptFormat)
 
 	bucket, rErr := p.fetchBucket(csm, act.BucketID())
 	if rErr != nil {
@@ -111,11 +111,7 @@ func (p *Protocol) handleCandidateDeactivate(ctx context.Context, act *action.Ca
 	if err != nil {
 		return nil, nil, csmErrorToHandleError(actCtx.Caller.String(), err)
 	}
-	// Use AddEvent (not the raw topics/data fields) so receiptLog.Build emits a
-	// log carrying both Topics and Data. The postFairbank single-log path drops
-	// r.data, so a struct literal with topics+data here would silently lose any
-	// non-indexed event args.
-	rLog := &receiptLog{addr: p.addr.String(), postFairbankMigration: true}
+	rLog := newReceiptLog(p.addr.String())
 	rLog.AddEvent(topics, eventData)
 	return rLog, nil, nil
 }
@@ -147,10 +143,7 @@ func (p *Protocol) handleScheduleCandidateDeactivation(ctx context.Context, act 
 		return nil, nil, err
 	}
 
-	// Use AddEvent so blockNumber (declared non-indexed in the ABI) lands in
-	// the emitted log's Data; raw struct literal with topics+data would be
-	// silently dropped on the postFairbank single-log path in Build.
-	rLog := &receiptLog{addr: p.addr.String(), postFairbankMigration: true}
+	rLog := newReceiptLog(p.addr.String())
 	rLog.AddEvent(topics, eventData)
 	return rLog, nil, nil
 }

--- a/action/protocol/staking/handler_candidate_transfer_ownership.go
+++ b/action/protocol/staking/handler_candidate_transfer_ownership.go
@@ -23,7 +23,7 @@ func (p *Protocol) handleCandidateTransferOwnership(ctx context.Context, act *ac
 	actCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 
-	log := newReceiptLog(p.addr.String(), handleCandidateTransferOwnership, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), handleCandidateTransferOwnership, featureCtx.NewStakingReceiptFormat)
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
 		return log, nil, fetchErr

--- a/action/protocol/staking/handler_stake_migrate.go
+++ b/action/protocol/staking/handler_stake_migrate.go
@@ -154,7 +154,7 @@ func (p *Protocol) withdrawBucket(ctx context.Context, withdrawer *state.Account
 		return nil, nil, errors.Wrapf(err, "failed to store account %s", actionCtx.Caller.String())
 	}
 	// create receipt log
-	actLog := newReceiptLog(p.addr.String(), HandleWithdrawStake, protocol.MustGetFeatureCtx(ctx).NewStakingReceiptFormat)
+	actLog := newReceiptLogLegacy(p.addr.String(), HandleWithdrawStake, protocol.MustGetFeatureCtx(ctx).NewStakingReceiptFormat)
 	actLog.AddTopics(byteutil.Uint64ToBytesBigEndian(bucket.Index), bucket.Candidate.Bytes())
 	actLog.AddAddress(actionCtx.Caller)
 	actLog.SetData(bucket.StakedAmount.Bytes())

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -64,7 +64,7 @@ func (p *Protocol) handleCreateStake(ctx context.Context, act *action.CreateStak
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleCreateStake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleCreateStake, featureCtx.NewStakingReceiptFormat)
 
 	staker, fetchErr := fetchCaller(ctx, csm, act.Amount())
 	if fetchErr != nil {
@@ -134,7 +134,7 @@ func (p *Protocol) handleUnstake(ctx context.Context, act *action.Unstake, csm C
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleUnstake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleUnstake, featureCtx.NewStakingReceiptFormat)
 
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
@@ -233,7 +233,7 @@ func (p *Protocol) handleWithdrawStake(ctx context.Context, act *action.Withdraw
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleWithdrawStake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleWithdrawStake, featureCtx.NewStakingReceiptFormat)
 
 	withdrawer, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
@@ -311,7 +311,7 @@ func (p *Protocol) handleChangeCandidate(ctx context.Context, act *action.Change
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleChangeCandidate, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleChangeCandidate, featureCtx.NewStakingReceiptFormat)
 
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
@@ -405,7 +405,7 @@ func (p *Protocol) handleTransferStake(ctx context.Context, act *action.Transfer
 ) (*receiptLog, error) {
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleTransferStake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleTransferStake, featureCtx.NewStakingReceiptFormat)
 
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
@@ -492,7 +492,7 @@ func (p *Protocol) handleDepositToStake(ctx context.Context, act *action.Deposit
 ) (*receiptLog, []*action.TransactionLog, error) {
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleDepositToStake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleDepositToStake, featureCtx.NewStakingReceiptFormat)
 
 	depositor, fetchErr := fetchCaller(ctx, csm, act.Amount())
 	if fetchErr != nil {
@@ -597,7 +597,7 @@ func (p *Protocol) handleRestake(ctx context.Context, act *action.Restake, csm C
 	actionCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleRestake, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleRestake, featureCtx.NewStakingReceiptFormat)
 
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {
@@ -681,7 +681,7 @@ func (p *Protocol) handleCandidateRegister(ctx context.Context, act *action.Cand
 	actCtx := protocol.MustGetActionCtx(ctx)
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleCandidateRegister, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleCandidateRegister, featureCtx.NewStakingReceiptFormat)
 
 	registrationFee := new(big.Int).Set(p.config.RegistrationConsts.Fee)
 
@@ -852,7 +852,7 @@ func (p *Protocol) handleCandidateUpdate(ctx context.Context, act *action.Candid
 ) (*receiptLog, error) {
 	actCtx := protocol.MustGetActionCtx(ctx)
 	featureCtx := protocol.MustGetFeatureCtx(ctx)
-	log := newReceiptLog(p.addr.String(), HandleCandidateUpdate, featureCtx.NewStakingReceiptFormat)
+	log := newReceiptLogLegacy(p.addr.String(), HandleCandidateUpdate, featureCtx.NewStakingReceiptFormat)
 
 	_, fetchErr := fetchCaller(ctx, csm, big.NewInt(0))
 	if fetchErr != nil {

--- a/action/protocol/staking/receipt_log.go
+++ b/action/protocol/staking/receipt_log.go
@@ -28,7 +28,27 @@ type receiptLog struct {
 	events                []contractEvent
 }
 
-func newReceiptLog(addr, topic string, postFairbankMigration bool) *receiptLog {
+// newReceiptLog builds a receiptLog for the events-based emission path.
+// Callers should populate it via AddEvent; each AddEvent call produces one
+// independent action.Log carrying its own Topics and Data. This is the path
+// new handlers (and all post-Fairbank ABI events) should use.
+//
+// Do NOT mix this with AddTopics / AddAddress / SetData — those mutate the
+// legacy single-log fields (r.topics / r.data) which are only consulted when
+// r.events is empty. If r.events is non-empty, Build returns the per-event
+// logs and the legacy fields are silently discarded.
+func newReceiptLog(addr string) *receiptLog {
+	return &receiptLog{addr: addr}
+}
+
+// newReceiptLogLegacy builds a receiptLog that emits a single log derived from
+// r.topics + r.data. This is the pre-events shape kept for handlers that
+// haven't migrated to AddEvent (CreateStake, Unstake, WithdrawStake, etc.).
+//
+// New code should prefer newReceiptLog + AddEvent. Reach for this only when
+// adding a topic/data tweak to an existing legacy handler — and even then,
+// consider migrating the whole handler to AddEvent instead.
+func newReceiptLogLegacy(addr, topic string, postFairbankMigration bool) *receiptLog {
 	r := receiptLog{
 		addr:                  addr,
 		postFairbankMigration: postFairbankMigration,

--- a/action/protocol/staking/receipt_log_test.go
+++ b/action/protocol/staking/receipt_log_test.go
@@ -126,7 +126,7 @@ func TestReceiptLog(t *testing.T) {
 	}
 
 	for _, v := range logTests {
-		log := newReceiptLog(v.addr, v.name, false)
+		log := newReceiptLogLegacy(v.addr, v.name, false)
 		log.AddTopics(v.topics...)
 		log.AddAddress(v.cand)
 		log.AddAddress(v.voter)
@@ -134,7 +134,7 @@ func TestReceiptLog(t *testing.T) {
 		r.Len(log.Build(ctx, action.ErrInvalidAmount), 0)
 		r.Equal(createLog(ctx, v.name, v.cand, v.voter, v.data), log.Build(ctx, nil)[0])
 
-		log = newReceiptLog(v.addr, v.name, true)
+		log = newReceiptLogLegacy(v.addr, v.name, true)
 		log.AddTopics(v.topics...)
 		log.AddAddress(v.cand)
 		log.AddAddress(v.voter)

--- a/e2etest/exit_queue_test.go
+++ b/e2etest/exit_queue_test.go
@@ -142,6 +142,138 @@ func TestExitQueue(t *testing.T) {
 		})
 	})
 
+	// v2.4.0 added three receipt-log events on the candidate exit-queue flow:
+	//   * CandidateDeactivationRequested(address indexed candidate)
+	//   * CandidateDeactivationScheduled(address indexed candidate, uint64 blockNumber)
+	//   * CandidateDeactivated(address indexed candidate)
+	// Frontends (iotex-hub, explorers) subscribe to these events to drive UI
+	// state, so missing or malformed payloads are a contract-level regression.
+	// This sub-test pins down each event's topics AND data — note the Scheduled
+	// event carries blockNumber as a non-indexed argument, so it must appear in
+	// the log's Data field, not just in topics.
+	t.Run("event logs emitted: requested -> scheduled -> deactivated", func(t *testing.T) {
+		cfg := initExitQueueCfg(r)
+		test := newE2ETest(t, cfg)
+		defer test.teardown()
+		registerEpochProtocols(r, test)
+
+		ownerID := 1
+		chainID := test.cfg.Chain.ID
+		candAddr := identityset.Address(ownerID)
+
+		// Expected (topics, data) for each event — built via the same Pack
+		// helpers the handler uses, so any drift in event signatures is caught
+		// without hard-coding hashes here.
+		reqTopics, reqData, err := action.PackCandidateDeactivationRequestedEvent(candAddr)
+		r.NoError(err)
+		r.Empty(reqData, "Requested event has no non-indexed args; data should be empty")
+		schedTopics, schedData, err := action.PackCandidateDeactivationScheduledEvent(candAddr, uint64(49))
+		r.NoError(err)
+		r.NotEmpty(schedData, "Scheduled event encodes blockNumber as non-indexed arg; data must not be empty")
+		deactTopics, deactData, err := action.PackCandidateDeactivatedEvent(candAddr)
+		r.NoError(err)
+		r.Empty(deactData, "Deactivated event has no non-indexed args; data should be empty")
+
+		test.run([]*testcase{
+			{
+				name:   "register candidate with self-stake",
+				act:    &actionWithTime{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(ownerID).String()), "cand1", identityset.Address(ownerID).String(), identityset.Address(ownerID).String(), identityset.Address(ownerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(ownerID), action.WithChainID(chainID))), time.Now()},
+				expect: []actionExpect{successExpect},
+			},
+			{
+				name: "request exit emits CandidateDeactivationRequested",
+				act:  &actionWithTime{mustNoErr(action.SignedCandidateDeactivate(test.nonceMgr.pop(identityset.Address(ownerID).String()), action.CandidateDeactivateOpRequest, gasLimit, gasPrice, identityset.PrivateKey(ownerID), action.WithChainID(chainID))), time.Now()},
+				expect: []actionExpect{
+					successExpect,
+					&functionExpect{fn: func(test *e2etest, act *action.SealedEnvelope, receipt *action.Receipt, err error) {
+						r := require.New(test.t)
+						logs := receipt.Logs()
+						r.Len(logs, 1, "Request op should emit exactly one log")
+						lg := logs[0]
+						r.Equal(2, len(lg.Topics), "Requested event: topic[0]=sig, topic[1]=candidate")
+						r.Equal(reqTopics[0], lg.Topics[0], "topic[0] must equal CandidateDeactivationRequested signature hash")
+						r.Equal(reqTopics[1], lg.Topics[1], "topic[1] must equal indexed candidate address")
+						r.Empty(lg.Data, "Requested event carries no non-indexed args")
+					}},
+				},
+			},
+			{
+				// Advance past the epoch boundary so the system action
+				// ScheduleCandidateDeactivation runs at block 25 and emits the
+				// CandidateDeactivationScheduled event. The user transfer below
+				// is just a vehicle to commit block 25; the receipt we care
+				// about is the system action's, which we pull from BlockDAO.
+				name: "epoch boundary emits CandidateDeactivationScheduled with blockNumber in Data",
+				preFunc: func(e *e2etest) {
+					bc := e.cs.Blockchain()
+					ap := e.cs.ActionPool()
+					for bc.TipHeight() < 24 {
+						_, err := createAndCommitBlock(bc, ap, time.Now())
+						require.NoError(e.t, err)
+					}
+				},
+				act: &actionWithTime{mustNoErr(action.SignedTransfer(identityset.Address(ownerID).String(), identityset.PrivateKey(ownerID), test.nonceMgr.pop(identityset.Address(ownerID).String()), big.NewInt(1), nil, gasLimit, gasPrice, action.WithChainID(chainID))), time.Now()},
+				expect: []actionExpect{
+					successExpect,
+					&functionExpect{fn: func(test *e2etest, act *action.SealedEnvelope, receipt *action.Receipt, err error) {
+						r := require.New(test.t)
+						// The system action runs in the same block (25) as the
+						// user transfer. Scan all receipts in that block for the
+						// Scheduled event.
+						receipts, err := test.cs.BlockDAO().GetReceipts(25)
+						r.NoError(err)
+						var sched *action.Log
+						for _, rcpt := range receipts {
+							for _, lg := range rcpt.Logs() {
+								if len(lg.Topics) > 0 && lg.Topics[0] == schedTopics[0] {
+									sched = lg
+									break
+								}
+							}
+							if sched != nil {
+								break
+							}
+						}
+						r.NotNil(sched, "CandidateDeactivationScheduled event must be emitted by system action at block 25")
+						r.Equal(2, len(sched.Topics), "Scheduled event: topic[0]=sig, topic[1]=candidate")
+						r.Equal(schedTopics[1], sched.Topics[1], "topic[1] must equal indexed candidate address")
+						// blockNumber is declared non-indexed in the ABI, so it
+						// MUST be serialized into Data. A log with empty Data
+						// here is a regression: frontends would see the event
+						// fire but be unable to read the scheduled exit height.
+						r.Equal(schedData, sched.Data, "Scheduled event's blockNumber (non-indexed) must be in Data")
+					}},
+				},
+			},
+			{
+				// Advance past DeactivatedAt (49) and run Confirm.
+				name: "confirm exit emits CandidateDeactivated",
+				preFunc: func(e *e2etest) {
+					bc := e.cs.Blockchain()
+					ap := e.cs.ActionPool()
+					for bc.TipHeight() < 48 {
+						_, err := createAndCommitBlock(bc, ap, time.Now())
+						require.NoError(e.t, err)
+					}
+				},
+				act: &actionWithTime{mustNoErr(action.SignedCandidateDeactivate(test.nonceMgr.pop(identityset.Address(ownerID).String()), action.CandidateDeactivateOpConfirm, gasLimit, gasPrice, identityset.PrivateKey(ownerID), action.WithChainID(chainID))), time.Now()},
+				expect: []actionExpect{
+					successExpect,
+					&functionExpect{fn: func(test *e2etest, act *action.SealedEnvelope, receipt *action.Receipt, err error) {
+						r := require.New(test.t)
+						logs := receipt.Logs()
+						r.Len(logs, 1, "Confirm op should emit exactly one log")
+						lg := logs[0]
+						r.Equal(2, len(lg.Topics), "Deactivated event: topic[0]=sig, topic[1]=candidate")
+						r.Equal(deactTopics[0], lg.Topics[0], "topic[0] must equal CandidateDeactivated signature hash")
+						r.Equal(deactTopics[1], lg.Topics[1], "topic[1] must equal indexed candidate address")
+						r.Empty(lg.Data, "Deactivated event carries no non-indexed args")
+					}},
+				},
+			},
+		})
+	})
+
 	t.Run("self-stake bucket cannot be directly unstaked", func(t *testing.T) {
 		cfg := initExitQueueCfg(r)
 		test := newE2ETest(t, cfg)


### PR DESCRIPTION
## Summary

- **Fix**: `handleCandidateDeactivate` / `handleScheduleCandidateDeactivation` built their receipt log via a struct literal that set both `r.topics` and `r.data`. `receiptLog.Build`'s postFairbankMigration single-log path only copies `r.topics` onto the emitted `action.Log`, silently dropping `r.data`. Since `CandidateDeactivationScheduled` declares `blockNumber` as non-indexed in the ABI, the encoded value needs to land in `Data` — without this fix, frontends saw the event fire but could not read the scheduled exit height. Both handlers now route through `AddEvent`, matching the pattern `handleCandidateRegister` already uses. Adds an e2e sub-test that verifies all three v2.4 events (Requested / Scheduled / Deactivated).
- **Refactor**: Split `newReceiptLog` into `newReceiptLog` (events-only, for new code) and `newReceiptLogLegacy` (pre-events shape). The single constructor served two emission shapes whose distinction was invisible at the call site — reviewers had no signal which path a handler was on, which is exactly how the bug above slipped in. Doc comments warn against mixing `AddEvent` with legacy `AddTopics` / `SetData`. All 13 production callers + 2 test callers move to `newReceiptLogLegacy`; the deactivate handlers use the new `newReceiptLog`. No behavior change.

## Test plan

- [ ] `make test-unit` passes
- [ ] e2e sub-test in `exit_queue_test.go` verifies Requested / Scheduled / Deactivated events all carry readable `blockNumber` data
- [ ] Manual: trigger `CandidateDeactivate` via Web3 and confirm the `CandidateDeactivationScheduled` log decodes `blockNumber` correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)