### PR TITLE
docs: add AGENTS.md and CLAUDE.md for AI-agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,122 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and humans) working in this repository.
+
+This file is the single source of truth at the project level; `CLAUDE.md`
+points here. Sub-packages may have their own `CLAUDE.md` for module-specific
+constraints. For build/test setup, see [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+---
+
+## Project context
+
+iotex-core is the reference Go implementation of the IoTeX Layer-1 blockchain.
+The code runs on production mainnet and testnet. Any change that affects state
+transitions, receipts, or consensus is, by default, **breaking**. Treat the
+codebase as production infrastructure, not application code.
+
+---
+
+## Hard rules (red lines)
+
+These apply repo-wide. Crossing them has caused, or would cause, on-chain
+incidents. Do not cross without a maintainer's explicit sign-off in the PR.
+
+### 1. Behavior changes must be gated on a new hardfork height
+
+- Hardfork heights are defined in `blockchain/genesis/genesis.go` and fan out
+  through `FeatureCtx` in `action/protocol/context.go`.
+- An existing hardfork height that is non-zero on mainnet is **immutable**.
+  Never edit, reorder, or delete one. New behavior goes behind a new fork.
+- New feature gates must be checked at every code path that runs the feature.
+  Tests must cover both pre-fork and post-fork branches.
+
+### 2. Determinism — on-chain code is pure with respect to host state
+
+- On-chain time comes from `ctx.BlockCtx.BlockTimeStamp`. Do not call
+  `time.Now()` in `action/protocol/`, `state/`, or `consensus/` execution paths.
+- Do not iterate Go maps in code that produces state or receipts. Sort keys.
+- Do not introduce randomness, file I/O, network calls, or any other source of
+  host-dependent input into action handling or state transitions.
+
+### 3. On-chain schemas are append-only after mainnet deployment
+
+- State and receipt protobuf schemas (e.g. `*.proto` files under
+  `action/protocol/*/pb/`) are immutable once shipped. Never reorder, renumber,
+  or delete fields. Add new fields at the next available number; retire fields
+  by marking them `reserved`.
+- The same rule applies to Go structs serialized to the chain: do not reorder
+  or remove fields without a hardfork-gated migration.
+
+### 4. Deprecated fields stay; never remove them
+
+- Fields marked `// deprecated` (in genesis, state structs, or proto messages)
+  remain in place for node startup and historical replay compatibility. Mark,
+  do not delete.
+
+### 5. Protocol execution order = registration order
+
+- Protocols are registered into `action/protocol/registry.go`. `All()` returns
+  them in registration order, and handlers run in that order. Do not rely on
+  any other ordering, and do not reorder existing registrations without a
+  hardfork plan.
+
+---
+
+## Conventions
+
+Long-standing project practice. Follow unless you have a concrete reason not to.
+
+- **Hardfork naming.** New hardforks are named after places (Hawaii, Iceland,
+  Tsunami, Yap, ...). See `blockchain/genesis/genesis.go` for the running list.
+- **Hardfork tests.** When a fork gates a behavior, test both `height = fork - 1`
+  and `height = fork`.
+- **State versioning across forks.** Prefer a new type or namespace (e.g.
+  `FooV2`, `FooV3`) over mutating an existing on-chain struct.
+- **Linter strictness** (`.golangci.yml`): cyclomatic complexity ≤ 15, function
+  length ≤ 150 lines / 50 statements, line length ≤ 140, goimports with local
+  prefix `github.com/iotexproject/iotex-core`. Run `make fmt` before committing.
+
+---
+
+## Workflow
+
+- Before opening a PR, run:
+  ```
+  make fmt
+  make lint
+  make test
+  ```
+  Do not bypass with `--no-verify` or by skipping lints.
+- Commits follow conventional-commit style with a package scope:
+  `feat(staking): …`, `fix(consensus): …`, `refactor(state): …`,
+  `test(blockchain): …`. Link the relevant issue.
+- One concern per PR. If a refactor and a fix belong together, the refactor
+  goes first as its own commit.
+
+---
+
+## When to ask before acting
+
+Confirm with a maintainer in the issue or PR before:
+
+- choosing a hardfork height,
+- changing any proto schema or on-chain struct layout,
+- modifying anything under `consensus/`,
+- removing or renaming a field in `blockchain/genesis/genesis.go`,
+- altering action serialization or receipt-log emission paths.
+
+---
+
+## Where to look next
+
+| You are working on... | Read first |
+|---|---|
+| Staking / candidates / buckets | `action/protocol/staking/CLAUDE.md` |
+| Block / epoch rewards | `action/protocol/rewarding/CLAUDE.md` |
+| Block production / validation | `blockchain/CLAUDE.md` |
+| Account / state factory / MPT | `state/CLAUDE.md` |
+| RollDPoS / endorsements | `consensus/CLAUDE.md` |
+| Dev setup, local tests | [CONTRIBUTING.md](./CONTRIBUTING.md) |
+| Past architectural decisions | `docs/adr/` |
+| Domain terms | `docs/glossary.md` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](./AGENTS.md). Single source of truth for AI-agent guidance lives there.


### PR DESCRIPTION
## Summary

Adds a project-level `AGENTS.md` (with `CLAUDE.md` as a one-line pointer) that documents the repo-wide invariants and conventions an AI coding agent (or new human contributor) must respect when working in this codebase.

The content is intentionally **project-level only** — module-specific rules (e.g., staking receipt log emission paths, RollDPoS endorsement details, state factory internals) are left to per-package `CLAUDE.md` files, which are tracked as a separate task in the parent issue.

## What's in `AGENTS.md`

- **Hard rules (red lines):**
  1. Behavior changes must be gated on a new hardfork height
  2. Determinism — no `time.Now()`, map iteration, randomness in on-chain code
  3. On-chain schemas are append-only after mainnet deployment
  4. Deprecated fields stay
  5. Protocol execution order = registration order
- **Conventions:** hardfork naming, hardfork test pattern, state versioning, linter strictness
- **Workflow:** `make fmt && make lint && make test` before PR; conventional commits; one concern per PR
- **When to ask before acting:** explicit list of changes that require maintainer sign-off
- **Where to look next:** index pointing to future per-package `CLAUDE.md` files, `CONTRIBUTING.md`, `docs/adr/`, `docs/glossary.md`

## Why two files

`AGENTS.md` is becoming a vendor-neutral convention adopted across several AI coding tools, while `CLAUDE.md` is the convention used by Claude Code specifically. Keeping `AGENTS.md` as the single source of truth and `CLAUDE.md` as a one-line pointer avoids drift and lets multiple agent ecosystems discover the same content.

## Out of scope

- Per-package `CLAUDE.md` files (tracked separately in #4832, P0.2)
- `CONTRIBUTING.md` rewrite (tracked separately in #4832, P0.4)
- `docs/adr/` directory (tracked separately in #4832, P1.3)
- `docs/glossary.md` (tracked separately in #4832, P2.3)

The "Where to look next" table references these intentionally, so as each task lands the index becomes increasingly useful.

## Test plan

- [x] No code change; documentation only
- [x] Markdown renders cleanly on GitHub (preview verified)
- [x] No broken internal links to files that already exist; forward references to files that don't yet exist are flagged in "Out of scope"

Refs #4832