### PR TITLE
feat(ioctl): expose Yap candidate exit queue

### DIFF
--- a/action/candidate_deactivate.go
+++ b/action/candidate_deactivate.go
@@ -53,8 +53,8 @@ func init() {
 }
 
 // NewCandidateDeactivate returns a CandidateDeactivate action
-func NewCandidateDeactivate() *CandidateDeactivate {
-	return &CandidateDeactivate{}
+func NewCandidateDeactivate(op CandidateDeactivateOp) *CandidateDeactivate {
+	return &CandidateDeactivate{op: op}
 }
 
 // IntrinsicGas returns the intrinsic gas of a CandidateDeactivate

--- a/action/signedaction.go
+++ b/action/signedaction.go
@@ -522,8 +522,7 @@ func SignedCandidateDeactivate(
 	senderPriKey crypto.PrivateKey,
 	options ...SignedActionOption,
 ) (*SealedEnvelope, error) {
-	cd := NewCandidateDeactivate()
-	cd.op = op
+	cd := NewCandidateDeactivate(op)
 	bd := &EnvelopeBuilder{}
 	bd = bd.SetNonce(nonce).
 		SetGasPrice(gasPrice).

--- a/ioctl/cmd/action/stake2.go
+++ b/ioctl/cmd/action/stake2.go
@@ -58,6 +58,8 @@ func init() {
 	Stake2Cmd.AddCommand(_stake2IntentToRevokeCmd)
 	Stake2Cmd.AddCommand(_stake2RevokeCmd)
 	Stake2Cmd.AddCommand(_stake2ActivateCmd)
+	Stake2Cmd.AddCommand(_stake2DeactivateRequestCmd)
+	Stake2Cmd.AddCommand(_stake2DeactivateConfirmCmd)
 	Stake2Cmd.AddCommand(_stake2TransferOwnershipCmd)
 	Stake2Cmd.AddCommand(_stake2MigrateCmd)
 	Stake2Cmd.PersistentFlags().StringVar(&config.ReadConfig.Endpoint, "endpoint", config.ReadConfig.Endpoint, config.TranslateInLang(_stake2FlagEndpointUsages, config.UILanguage))

--- a/ioctl/cmd/action/stake2deactivate.go
+++ b/ioctl/cmd/action/stake2deactivate.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/ioctl/output"
+)
+
+// sendStake2Deactivate builds and submits a CandidateDeactivate action for
+// the signer's own candidate. Used by both deactivate-request and
+// deactivate-confirm; the only difference is the op code.
+func sendStake2Deactivate(op action.CandidateDeactivateOp) error {
+	sender, err := Signer()
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to get signer address", err)
+	}
+
+	gasLimit := _gasLimitFlag.Value().(uint64)
+	if gasLimit == 0 {
+		gasLimit = action.CandidateDeactivateBaseIntrinsicGas
+	}
+	gasPriceRau, err := gasPriceInRau()
+	if err != nil {
+		return output.NewError(0, "failed to get gas price", err)
+	}
+	nonce, err := nonce(sender)
+	if err != nil {
+		return output.NewError(0, "failed to get nonce", err)
+	}
+
+	return SendAction(
+		(&action.EnvelopeBuilder{}).
+			SetNonce(nonce).
+			SetGasPrice(gasPriceRau).
+			SetGasLimit(gasLimit).
+			SetAction(action.NewCandidateDeactivate(op)).
+			Build(),
+		sender)
+}

--- a/ioctl/cmd/action/stake2deactivate_confirm.go
+++ b/ioctl/cmd/action/stake2deactivate_confirm.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/ioctl/config"
+	"github.com/iotexproject/iotex-core/v2/ioctl/output"
+)
+
+var (
+	_stake2DeactivateConfirmCmdUses = map[config.Language]string{
+		config.English: "deactivate-confirm" +
+			" [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "deactivate-confirm" +
+			" [-s 签署人] [-n NONCE] [-l GAS 限制] [-p GAS 价格] [-P 密码] [-y]",
+	}
+
+	_stake2DeactivateConfirmCmdShorts = map[config.Language]string{
+		config.English: "Confirm deactivation after the scheduled block has been reached",
+		config.Chinese: "在退出调度区块到达后, 确认完成退出",
+	}
+)
+
+var _stake2DeactivateConfirmCmd = &cobra.Command{
+	Use:   config.TranslateInLang(_stake2DeactivateConfirmCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(_stake2DeactivateConfirmCmdShorts, config.UILanguage),
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return output.PrintError(stake2DeactivateConfirm())
+	},
+}
+
+func init() {
+	RegisterWriteCommand(_stake2DeactivateConfirmCmd)
+}
+
+func stake2DeactivateConfirm() error {
+	return sendStake2Deactivate(action.CandidateDeactivateOpConfirm)
+}

--- a/ioctl/cmd/action/stake2deactivate_request.go
+++ b/ioctl/cmd/action/stake2deactivate_request.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package action
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/ioctl/config"
+	"github.com/iotexproject/iotex-core/v2/ioctl/output"
+)
+
+var (
+	_stake2DeactivateRequestCmdUses = map[config.Language]string{
+		config.English: "deactivate-request" +
+			" [-s SIGNER] [-n NONCE] [-l GAS_LIMIT] [-p GAS_PRICE] [-P PASSWORD] [-y]",
+		config.Chinese: "deactivate-request" +
+			" [-s 签署人] [-n NONCE] [-l GAS 限制] [-p GAS 价格] [-P 密码] [-y]",
+	}
+
+	_stake2DeactivateRequestCmdShorts = map[config.Language]string{
+		config.English: "Request to deactivate the signer's candidate (start the exit queue)",
+		config.Chinese: "申请退出: 将签署人对应的候选人加入退出队列",
+	}
+)
+
+var _stake2DeactivateRequestCmd = &cobra.Command{
+	Use:   config.TranslateInLang(_stake2DeactivateRequestCmdUses, config.UILanguage),
+	Short: config.TranslateInLang(_stake2DeactivateRequestCmdShorts, config.UILanguage),
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cmd.SilenceUsage = true
+		return output.PrintError(stake2DeactivateRequest())
+	},
+}
+
+func init() {
+	RegisterWriteCommand(_stake2DeactivateRequestCmd)
+}
+
+func stake2DeactivateRequest() error {
+	return sendStake2Deactivate(action.CandidateDeactivateOpRequest)
+}

--- a/ioctl/cmd/bc/bcdelegate.go
+++ b/ioctl/cmd/bc/bcdelegate.go
@@ -8,6 +8,7 @@ package bc
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"slices"
 	"strings"
@@ -24,6 +25,10 @@ import (
 	"github.com/iotexproject/iotex-core/v2/ioctl/output"
 	"github.com/iotexproject/iotex-core/v2/ioctl/util"
 )
+
+// candidateExitRequestedSentinel mirrors the chain-side sentinel that encodes
+// "Request received, schedule pending" in CandidateV2.DeactivatedAt.
+const candidateExitRequestedSentinel = uint64(math.MaxUint64)
 
 // Multi-language support
 var (
@@ -70,6 +75,14 @@ func (m *delegateMessage) delegateString() string {
 	lines = append(lines, fmt.Sprintf("	totalWeightedVotes: %s", util.RauToString(vote, util.IotxDecimalNum)))
 	lines = append(lines, fmt.Sprintf("	selfStakeBucketIdx: %d", d.SelfStakeBucketIdx))
 	lines = append(lines, fmt.Sprintf("	selfStakingTokens: %s IOTX", util.RauToString(token, util.IotxDecimalNum)))
+	switch d.DeactivatedAt {
+	case 0:
+		// active candidate; no exit in flight — omit the line entirely
+	case candidateExitRequestedSentinel:
+		lines = append(lines, "	deactivation: requested (schedule pending)")
+	default:
+		lines = append(lines, fmt.Sprintf("	deactivation: scheduled at block %d", d.DeactivatedAt))
+	}
 	lines = append(lines, "}")
 	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
## Summary

Adds CLI surface for the candidate exit queue introduced by Yap (v2.4.0) and finalized in v2.4.1. Before this change, ioctl could trigger \`CandidateActivate\` (resume) but had no way to request or confirm an exit — operators had to fall back to crafting raw Web3 calls.

**Write-side:**
- \`ioctl stake2 deactivate-request\` — submits \`CandidateDeactivate(OpRequest)\` for the signer's own candidate
- \`ioctl stake2 deactivate-confirm\` — submits \`CandidateDeactivate(OpConfirm)\` once the scheduled block has been reached

**Read-side:**
- \`ioctl bc delegate <name|addr>\` now prints the exit-queue state, decoding the chain-side \`MaxUint64\` sentinel into a human-readable \`"requested (schedule pending)"\` and a numeric height into \`"scheduled at block N"\`. Active candidates (\`DeactivatedAt == 0\`) keep their current output unchanged.

**Plumbing:**
- \`action.NewCandidateDeactivate()\` now takes the op parameter, matching the \`NewCandidateActivate(bucketID)\` constructor style. The single existing caller in \`signedaction.go\` is updated; the unexported \`op\` field is no longer set by callers reaching past the constructor.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./action/ -run TestCandidateDeactivate\` (3 cases pass)
- [x] Built ioctl binary; \`stake2 deactivate-request --help\` and \`deactivate-confirm --help\` render correctly with the standard signer/nonce/gas/password/wait flags
- [ ] Live test against a candidate that has called Request (verify \`bc delegate\` renders \`"requested (schedule pending)"\`)
- [ ] Live test against a candidate that has been Scheduled (verify \`bc delegate\` renders \`"scheduled at block N"\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)