### PR TITLE
disable premint on api nodes

### DIFF
--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -347,6 +347,14 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.clock = clock.New()
 	}
 	b.cfg.DB.DbPath = b.cfg.Consensus.ConsensusDBPath
+	var opts []Option
+	// Premint forks a previous workingset to mint a block ahead of the committed chain tip.
+	// That path needs ws.store.KVStore(), which is nil when a secondary erigon store is wired
+	// (api nodes set HistoryIndexPath). Disable premint there so mint falls back to building
+	// a workingset from scratch.
+	if len(b.cfg.Chain.HistoryIndexPath) > 0 {
+		opts = append(opts, WithPremintDisabled())
+	}
 	ctx, err := NewRollDPoSCtx(
 		consensusfsm.NewConsensusConfig(b.cfg.Consensus.FSM, b.cfg.DardanellesUpgrade, b.cfg.WakeUpgrade, b.cfg.Genesis, b.cfg.Consensus.Delay),
 		b.cfg.DB,
@@ -362,16 +370,10 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.priKey,
 		b.clock,
 		b.cfg.Genesis.BeringBlockHeight,
+		opts...,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing consensus context")
-	}
-	// Premint forks a previous workingset to mint a block ahead of the committed chain tip.
-	// That path needs ws.store.KVStore(), which is nil when a secondary erigon store is wired
-	// (api nodes set HistoryIndexPath). Disable premint there so mint falls back to building
-	// a workingset from scratch.
-	if len(b.cfg.Chain.HistoryIndexPath) > 0 {
-		ctx.DisablePremint(true)
 	}
 	cfsm, err := consensusfsm.NewConsensusFSM(ctx, b.clock)
 	if err != nil {

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -366,6 +366,13 @@ func (b *Builder) Build() (*RollDPoS, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing consensus context")
 	}
+	// Premint forks a previous workingset to mint a block ahead of the committed chain tip.
+	// That path needs ws.store.KVStore(), which is nil when a secondary erigon store is wired
+	// (api nodes set HistoryIndexPath). Disable premint there so mint falls back to building
+	// a workingset from scratch.
+	if len(b.cfg.Chain.HistoryIndexPath) > 0 {
+		ctx.DisablePremint(true)
+	}
 	cfsm, err := consensusfsm.NewConsensusFSM(ctx, b.clock)
 	if err != nil {
 		return nil, errors.Wrap(err, "error when constructing the consensus FSM")

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -153,6 +153,55 @@ func TestNewRollDPoS(t *testing.T) {
 		assert.Error(t, err)
 		assert.Nil(t, r)
 	})
+
+	t.Run("api-node-disables-premint", func(t *testing.T) {
+		sk := identityset.PrivateKey(0)
+		chain := mock_blockchain.NewMockBlockchain(ctrl)
+		chain.EXPECT().AddSubscriber(gomock.Any()).Times(2)
+		chain.EXPECT().ChainID().Return(uint32(1)).AnyTimes()
+		chain.EXPECT().AddSubscriber(gomock.Any()).Return(nil).AnyTimes()
+		apiCfg := builderCfg
+		// Only len(HistoryIndexPath) > 0 matters for the Build-time check; no file is opened.
+		apiCfg.Chain.HistoryIndexPath = "any-non-empty"
+		r, err := NewRollDPoSBuilder().
+			SetConfig(apiCfg).
+			SetPriKey(sk).
+			SetChainManager(NewChainManager(chain, mock_factory.NewMockFactory(ctrl), &dummyBlockBuildFactory{})).
+			SetBroadcast(func(_ proto.Message) error {
+				return nil
+			}).
+			SetDelegatesByEpochFunc(delegatesByEpoch).
+			SetProposersByEpochFunc(delegatesByEpoch).
+			RegisterProtocol(rp).
+			Build()
+		assert.NoError(t, err)
+		assert.NotNil(t, r)
+		assert.True(t, r.ctx.(*rollDPoSCtx).disablePremint)
+	})
+
+	t.Run("non-api-node-keeps-premint", func(t *testing.T) {
+		sk := identityset.PrivateKey(0)
+		chain := mock_blockchain.NewMockBlockchain(ctrl)
+		chain.EXPECT().AddSubscriber(gomock.Any()).Times(2)
+		chain.EXPECT().ChainID().Return(uint32(1)).AnyTimes()
+		chain.EXPECT().AddSubscriber(gomock.Any()).Return(nil).AnyTimes()
+		nonAPICfg := builderCfg
+		nonAPICfg.Chain.HistoryIndexPath = ""
+		r, err := NewRollDPoSBuilder().
+			SetConfig(nonAPICfg).
+			SetPriKey(sk).
+			SetChainManager(NewChainManager(chain, mock_factory.NewMockFactory(ctrl), &dummyBlockBuildFactory{})).
+			SetBroadcast(func(_ proto.Message) error {
+				return nil
+			}).
+			SetDelegatesByEpochFunc(delegatesByEpoch).
+			SetProposersByEpochFunc(delegatesByEpoch).
+			RegisterProtocol(rp).
+			Build()
+		assert.NoError(t, err)
+		assert.NotNil(t, r)
+		assert.False(t, r.ctx.(*rollDPoSCtx).disablePremint)
+	})
 }
 
 func makeBlock(t *testing.T, accountIndex, numOfEndosements int, makeInvalidEndorse bool, height int) *block.Block {

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -84,6 +84,10 @@ type (
 		Clock() clock.Clock
 		CheckBlockProposer(uint64, *blockProposal, *endorsement.Endorsement) error
 		CheckVoteEndorser(uint64, *ConsensusVote, *endorsement.Endorsement) error
+		// DisablePremint turns off the prepareNextProposal pre-mint goroutine.
+		// API nodes (with a secondary erigon store) must call this with true: their workingset
+		// store has no KVStore() for forking, so premint always fails at workingset.NewWorkingSet.
+		DisablePremint(bool)
 	}
 
 	rollDPoSCtx struct {
@@ -97,12 +101,13 @@ type (
 		eManagerDB        db.KVStore
 		toleratedOvertime time.Duration
 
-		encodedAddrs []string
-		priKeys      []crypto.PrivateKey
-		round        *roundCtx
-		clock        clock.Clock
-		active       bool
-		mutex        sync.RWMutex
+		encodedAddrs   []string
+		priKeys        []crypto.PrivateKey
+		round          *roundCtx
+		clock          clock.Clock
+		active         bool
+		disablePremint bool
+		mutex          sync.RWMutex
 	}
 )
 
@@ -219,6 +224,12 @@ func (ctx *rollDPoSCtx) RoundCalculator() *roundCalculator {
 
 func (ctx *rollDPoSCtx) Clock() clock.Clock {
 	return ctx.clock
+}
+
+func (ctx *rollDPoSCtx) DisablePremint(v bool) {
+	ctx.mutex.Lock()
+	defer ctx.mutex.Unlock()
+	ctx.disablePremint = v
 }
 
 // CheckVoteEndorser checks if the endorsement's endorser is a valid delegate at the given height
@@ -407,6 +418,9 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 }
 
 func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Hash256) error {
+	if ctx.disablePremint {
+		return nil
+	}
 	var (
 		height    = prevHeight + 1
 		interval  = ctx.BlockInterval(height)

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -84,11 +84,10 @@ type (
 		Clock() clock.Clock
 		CheckBlockProposer(uint64, *blockProposal, *endorsement.Endorsement) error
 		CheckVoteEndorser(uint64, *ConsensusVote, *endorsement.Endorsement) error
-		// DisablePremint turns off the prepareNextProposal pre-mint goroutine.
-		// API nodes (with a secondary erigon store) must call this with true: their workingset
-		// store has no KVStore() for forking, so premint always fails at workingset.NewWorkingSet.
-		DisablePremint(bool)
 	}
+
+	// Option configures a rollDPoSCtx at construction time.
+	Option func(*rollDPoSCtx)
 
 	rollDPoSCtx struct {
 		consensusfsm.ConsensusConfig
@@ -111,6 +110,15 @@ type (
 	}
 )
 
+// WithPremintDisabled turns off the prepareNextProposal pre-mint goroutine.
+// API nodes (with a secondary erigon store) must pass this: their workingset
+// store has no KVStore() for forking, so premint always fails at workingset.NewWorkingSet.
+func WithPremintDisabled() Option {
+	return func(ctx *rollDPoSCtx) {
+		ctx.disablePremint = true
+	}
+}
+
 // NewRollDPoSCtx returns a context of RollDPoSCtx
 func NewRollDPoSCtx(
 	cfg consensusfsm.ConsensusConfig,
@@ -127,6 +135,7 @@ func NewRollDPoSCtx(
 	priKeys []crypto.PrivateKey,
 	clock clock.Clock,
 	beringHeight uint64,
+	opts ...Option,
 ) (RDPoSCtx, error) {
 	if chain == nil {
 		return nil, errors.New("chain cannot be nil")
@@ -169,7 +178,7 @@ func NewRollDPoSCtx(
 	for _, pk := range priKeys {
 		encodedAddrs = append(encodedAddrs, pk.PublicKey().Address().String())
 	}
-	return &rollDPoSCtx{
+	ctx := &rollDPoSCtx{
 		ConsensusConfig:   cfg,
 		active:            active,
 		encodedAddrs:      encodedAddrs,
@@ -181,7 +190,11 @@ func NewRollDPoSCtx(
 		roundCalc:         roundCalc,
 		eManagerDB:        eManagerDB,
 		toleratedOvertime: toleratedOvertime,
-	}, nil
+	}
+	for _, opt := range opts {
+		opt(ctx)
+	}
+	return ctx, nil
 }
 
 func (ctx *rollDPoSCtx) Start(c context.Context) (err error) {
@@ -224,12 +237,6 @@ func (ctx *rollDPoSCtx) RoundCalculator() *roundCalculator {
 
 func (ctx *rollDPoSCtx) Clock() clock.Clock {
 	return ctx.clock
-}
-
-func (ctx *rollDPoSCtx) DisablePremint(v bool) {
-	ctx.mutex.Lock()
-	defer ctx.mutex.Unlock()
-	ctx.disablePremint = v
 }
 
 // CheckVoteEndorser checks if the endorsement's endorser is a valid delegate at the given height

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -86,7 +86,6 @@ func TestRollDPoSCtx(t *testing.T) {
 }
 
 func TestDisablePremint(t *testing.T) {
-	require := require.New(t)
 	g := genesis.TestDefault()
 	g.Blockchain.BlockInterval = time.Second * 20
 	cfg := DefaultConfig
@@ -94,47 +93,54 @@ func TestDisablePremint(t *testing.T) {
 	cfg.FSM.AcceptProposalEndorsementTTL = time.Second
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
-	b, sf, _, rp, _ := makeChain(t)
-	rctx, err := NewRollDPoSCtx(
-		consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay),
-		db.DefaultConfig,
-		true,
-		time.Second,
-		true,
-		NewChainManager(b, sf, &dummyBlockBuildFactory{}),
-		block.NewDeserializer(0),
-		rp,
-		nil,
-		dummyCandidatesByHeightFunc,
-		dummyCandidatesByHeightFunc,
-		nil,
-		clock.New(),
-		g.BeringBlockHeight,
-	)
-	require.NoError(err)
-	require.NoError(rctx.Start(context.Background()))
-	inner := rctx.(*rollDPoSCtx)
+
+	build := func(t *testing.T, opts ...Option) (*rollDPoSCtx, uint64) {
+		t.Helper()
+		require := require.New(t)
+		b, sf, _, rp, _ := makeChain(t)
+		rctx, err := NewRollDPoSCtx(
+			consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay),
+			db.DefaultConfig,
+			true,
+			time.Second,
+			true,
+			NewChainManager(b, sf, &dummyBlockBuildFactory{}),
+			block.NewDeserializer(0),
+			rp,
+			nil,
+			dummyCandidatesByHeightFunc,
+			dummyCandidatesByHeightFunc,
+			nil,
+			clock.New(),
+			g.BeringBlockHeight,
+			opts...,
+		)
+		require.NoError(err)
+		require.NoError(rctx.Start(context.Background()))
+		return rctx.(*rollDPoSCtx), b.TipHeight()
+	}
+
 	// Production callers reach prepareNextProposal via NewProposalEndorsement, which holds
-	// ctx.mutex.RLock(). The direct calls below bypass that; safe here because all toggles
-	// and reads are sequential in a single goroutine.
+	// ctx.mutex.RLock(). The direct calls below bypass that; safe here because each subtest
+	// constructs its own context and runs sequentially in a single goroutine.
 
-	// default: premint is enabled
-	require.False(inner.disablePremint)
-	// prepareNextProposal hits chain.Fork with a zero hash and returns the wrapped error
-	err = inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256)
-	require.Error(err)
-	require.Contains(err.Error(), "failed to check fork")
+	t.Run("default-premint-enabled", func(t *testing.T) {
+		require := require.New(t)
+		inner, tip := build(t)
+		require.False(inner.disablePremint)
+		// prepareNextProposal hits chain.Fork with a zero hash and returns the wrapped error
+		err := inner.prepareNextProposal(tip, hash.ZeroHash256)
+		require.Error(err)
+		require.Contains(err.Error(), "failed to check fork")
+	})
 
-	// toggle on: prepareNextProposal short-circuits to nil without consulting the chain
-	rctx.DisablePremint(true)
-	require.True(inner.disablePremint)
-	require.NoError(inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256))
-
-	// toggle back off: original behavior restored
-	rctx.DisablePremint(false)
-	require.False(inner.disablePremint)
-	err = inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256)
-	require.Error(err)
+	t.Run("with-premint-disabled", func(t *testing.T) {
+		require := require.New(t)
+		inner, tip := build(t, WithPremintDisabled())
+		require.True(inner.disablePremint)
+		// short-circuits to nil without consulting the chain
+		require.NoError(inner.prepareNextProposal(tip, hash.ZeroHash256))
+	})
 }
 
 func TestCheckVoteEndorser(t *testing.T) {

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -85,6 +85,58 @@ func TestRollDPoSCtx(t *testing.T) {
 	})
 }
 
+func TestDisablePremint(t *testing.T) {
+	require := require.New(t)
+	g := genesis.TestDefault()
+	g.Blockchain.BlockInterval = time.Second * 20
+	cfg := DefaultConfig
+	cfg.FSM.AcceptBlockTTL = time.Second * 10
+	cfg.FSM.AcceptProposalEndorsementTTL = time.Second
+	cfg.FSM.AcceptLockEndorsementTTL = time.Second
+	cfg.FSM.CommitTTL = time.Second
+	b, sf, _, rp, _ := makeChain(t)
+	rctx, err := NewRollDPoSCtx(
+		consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay),
+		db.DefaultConfig,
+		true,
+		time.Second,
+		true,
+		NewChainManager(b, sf, &dummyBlockBuildFactory{}),
+		block.NewDeserializer(0),
+		rp,
+		nil,
+		dummyCandidatesByHeightFunc,
+		dummyCandidatesByHeightFunc,
+		nil,
+		clock.New(),
+		g.BeringBlockHeight,
+	)
+	require.NoError(err)
+	require.NoError(rctx.Start(context.Background()))
+	inner := rctx.(*rollDPoSCtx)
+	// Production callers reach prepareNextProposal via NewProposalEndorsement, which holds
+	// ctx.mutex.RLock(). The direct calls below bypass that; safe here because all toggles
+	// and reads are sequential in a single goroutine.
+
+	// default: premint is enabled
+	require.False(inner.disablePremint)
+	// prepareNextProposal hits chain.Fork with a zero hash and returns the wrapped error
+	err = inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256)
+	require.Error(err)
+	require.Contains(err.Error(), "failed to check fork")
+
+	// toggle on: prepareNextProposal short-circuits to nil without consulting the chain
+	rctx.DisablePremint(true)
+	require.True(inner.disablePremint)
+	require.NoError(inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256))
+
+	// toggle back off: original behavior restored
+	rctx.DisablePremint(false)
+	require.False(inner.disablePremint)
+	err = inner.prepareNextProposal(b.TipHeight(), hash.ZeroHash256)
+	require.Error(err)
+}
+
 func TestCheckVoteEndorser(t *testing.T) {
 	require := require.New(t)
 	b, sf, _, rp, pp := makeChain(t)


### PR DESCRIPTION
## Summary
- API nodes (`cfg.Chain.HistoryIndexPath != ""`) wire a `workingSetStoreWithSecondary` whose `KVStore()` returns nil. The pre-mint path in `prepareNextProposal` forks a previous workingset via `workingSet.NewWorkingSet`, which needs `KVStore()` and errors with `"KVStore() not supported in *workingSetStoreWithSecondary"` — blocking the api node from minting.
- Add `DisablePremint(bool)` to the `RDPoSCtx` interface and gate `prepareNextProposal` on it. `Builder.Build()` turns it on when `HistoryIndexPath` is configured (same condition that creates the secondary erigon store). With pre-mint off, mint goes through the default `newWorkingSet` path, which works correctly for api nodes.
- No new config knob for per-block work limits: existing `MintTimeout` already drives the deadline cutoff in `workingset.go:821-826`. Operators set a tighter `MintTimeout` (or larger `AllowedBlockGasResidue`) on api nodes via existing config.

## Test plan
- [x] `go test ./consensus/scheme/rolldpos/ -count=1` — 48 pass (was 45; +3 new)
- [x] `TestDisablePremint` — default state, setter toggles, `prepareNextProposal` short-circuits to nil without calling `chain.Fork`, and toggling off restores original error behavior
- [x] `TestNewRollDPoS/api-node-disables-premint` — Builder sets the flag when `HistoryIndexPath` is non-empty
- [x] `TestNewRollDPoS/non-api-node-keeps-premint` — flag stays off otherwise
- [ ] Manual: deploy on an api node with a secondary erigon store and confirm it can mint a block (out-of-band)

🤖 Generated with [Claude Code](https://claude.com/claude-code)