### PR TITLE
feat(consensus): plumb BLS producer keys + aggregation feature gate (IIP-52)

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -172,6 +172,7 @@ type (
 		// contracts are committed and written back
 		AlwaysWriteCachedContract bool
 		NoCandidateExitQueue      bool
+		EnableBLSAggregation      bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -346,6 +347,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			PrePectraEVM:                            !g.IsYap(height),
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
+			EnableBLSAggregation:                    g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -7,6 +7,7 @@ package blockchain
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"os"
 	"slices"
 	"strconv"
@@ -50,6 +51,11 @@ type (
 		ProducerPrivKey            string           `yaml:"producerPrivKey"`
 		ProducerPrivKeySchema      string           `yaml:"producerPrivKeySchema"`
 		ProducerPrivKeyRange       string           `yaml:"producerPrivKeyRange"`
+		// BLSProducerPrivKey is a comma-separated list of hex-encoded BLS12-381
+		// private keys, aligned 1:1 with ProducerPrivKey after applying
+		// ProducerPrivKeyRange. When empty, BLS keys are derived from the
+		// corresponding ECDSA producer keys via crypto.GenerateBLS12381PrivateKey.
+		BLSProducerPrivKey string `yaml:"blsProducerPrivKey"`
 		SignatureScheme            []string         `yaml:"signatureScheme"`
 		EmptyGenesis               bool             `yaml:"emptyGenesis"`
 		GravityChainDB             db.Config        `yaml:"gravityChainDB"`
@@ -206,6 +212,46 @@ func (cfg *Config) ProducerPrivateKeys() []crypto.PrivateKey {
 	}
 
 	return privateKeys[start:end]
+}
+
+// BLSProducerPrivateKeys returns the BLS12-381 producer private keys, aligned
+// 1:1 with ProducerPrivateKeys(). When BLSProducerPrivKey is configured, its
+// entries are parsed and the range/length must match ProducerPrivateKeys();
+// otherwise each BLS key is derived from the corresponding ECDSA key bytes via
+// crypto.GenerateBLS12381PrivateKey.
+func (cfg *Config) BLSProducerPrivateKeys() []*crypto.BLS12381PrivateKey {
+	ecdsa := cfg.ProducerPrivateKeys()
+	blsKeys := make([]*crypto.BLS12381PrivateKey, 0, len(ecdsa))
+	if cfg.BLSProducerPrivKey == "" {
+		for _, sk := range ecdsa {
+			blsSk, err := crypto.GenerateBLS12381PrivateKey(sk.Bytes())
+			if err != nil {
+				log.L().Panic("failed to derive BLS private key from ECDSA producer key", zap.Error(err))
+			}
+			blsKeys = append(blsKeys, blsSk)
+		}
+		return blsKeys
+	}
+	parts := strings.Split(cfg.BLSProducerPrivKey, ",")
+	if len(parts) != len(ecdsa) {
+		log.L().Panic(
+			"BLSProducerPrivKey count does not match ProducerPrivateKeys",
+			zap.Int("bls", len(parts)),
+			zap.Int("ecdsa", len(ecdsa)),
+		)
+	}
+	for i, hexKey := range parts {
+		raw, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(hexKey), "0x"))
+		if err != nil {
+			log.L().Panic("failed to decode BLS producer private key", zap.Int("index", i), zap.Error(err))
+		}
+		blsSk, err := crypto.BLS12381PrivateKeyFromBytes(raw)
+		if err != nil {
+			log.L().Panic("invalid BLS producer private key", zap.Int("index", i), zap.Error(err))
+		}
+		blsKeys = append(blsKeys, blsSk)
+	}
+	return blsKeys
 }
 
 // SetProducerPrivKey set producer privKey by PrivKeyConfigFile info

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -154,6 +154,7 @@ func NewConsensus(
 		proposersByEpochFunc := delegatesByEpochFunc
 		bd := rolldpos.NewRollDPoSBuilder().
 			SetPriKey(cfg.Chain.ProducerPrivateKeys()...).
+			SetBLSPriKey(cfg.Chain.BLSProducerPrivateKeys()...).
 			SetConfig(cfg).
 			SetChainManager(chainMgr).
 			SetBlockDeserializer(block.NewDeserializer(bc.EvmNetworkID())).

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -261,6 +261,7 @@ type (
 		// TODO: we should use keystore in the future
 		encodedAddr       string
 		priKey            []crypto.PrivateKey
+		blsPriKey         []*crypto.BLS12381PrivateKey
 		chain             ChainManager
 		blockDeserializer *block.Deserializer
 		broadcastHandler  scheme.Broadcast
@@ -286,6 +287,13 @@ func (b *Builder) SetConfig(cfg BuilderConfig) *Builder {
 // SetPriKey sets the private key
 func (b *Builder) SetPriKey(priKeys ...crypto.PrivateKey) *Builder {
 	b.priKey = priKeys
+	return b
+}
+
+// SetBLSPriKey sets the BLS12-381 producer private keys, aligned 1:1 with
+// the ECDSA keys set via SetPriKey.
+func (b *Builder) SetBLSPriKey(blsPriKeys ...*crypto.BLS12381PrivateKey) *Builder {
+	b.blsPriKey = blsPriKeys
 	return b
 }
 
@@ -360,6 +368,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.delegatesByEpochFunc,
 		b.proposersByEpochFunc,
 		b.priKey,
+		b.blsPriKey,
 		b.clock,
 		b.cfg.Genesis.BeringBlockHeight,
 	)

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -97,12 +97,22 @@ type (
 		eManagerDB        db.KVStore
 		toleratedOvertime time.Duration
 
-		encodedAddrs []string
-		priKeys      []crypto.PrivateKey
+		producerKeys []producerKey
 		round        *roundCtx
 		clock        clock.Clock
 		active       bool
 		mutex        sync.RWMutex
+	}
+
+	// producerKey binds an ECDSA producer key with its derived iotex address
+	// and, when configured, the matching BLS12-381 key used for COMMIT-stage
+	// signature aggregation. Keeping the three together in a single record is
+	// the single source of truth for the 1:1 alignment required by the
+	// consensus signing paths.
+	producerKey struct {
+		address string
+		ecdsa   crypto.PrivateKey
+		bls     *crypto.BLS12381PrivateKey
 	}
 )
 
@@ -120,6 +130,7 @@ func NewRollDPoSCtx(
 	delegatesByEpochFunc NodesSelectionByEpochFunc,
 	proposersByEpochFunc NodesSelectionByEpochFunc,
 	priKeys []crypto.PrivateKey,
+	blsPriKeys []*crypto.BLS12381PrivateKey,
 	clock clock.Clock,
 	beringHeight uint64,
 ) (RDPoSCtx, error) {
@@ -137,6 +148,12 @@ func NewRollDPoSCtx(
 	}
 	if proposersByEpochFunc == nil {
 		return nil, errors.New("proposers by epoch function cannot be nil")
+	}
+	if len(blsPriKeys) != 0 && len(blsPriKeys) != len(priKeys) {
+		return nil, errors.Errorf(
+			"bls private keys count %d does not match producer private keys count %d",
+			len(blsPriKeys), len(priKeys),
+		)
 	}
 	if cfg.AcceptBlockTTL(0)+cfg.AcceptProposalEndorsementTTL(0)+cfg.AcceptLockEndorsementTTL(0)+cfg.CommitTTL(0) > cfg.BlockInterval(0) {
 		return nil, errors.Errorf(
@@ -160,15 +177,20 @@ func NewRollDPoSCtx(
 		timeBasedRotation:    timeBasedRotation,
 		beringHeight:         beringHeight,
 	}
-	encodedAddrs := make([]string, 0, len(priKeys))
-	for _, pk := range priKeys {
-		encodedAddrs = append(encodedAddrs, pk.PublicKey().Address().String())
+	producerKeys := make([]producerKey, len(priKeys))
+	for i, pk := range priKeys {
+		producerKeys[i] = producerKey{
+			address: pk.PublicKey().Address().String(),
+			ecdsa:   pk,
+		}
+		if i < len(blsPriKeys) {
+			producerKeys[i].bls = blsPriKeys[i]
+		}
 	}
 	return &rollDPoSCtx{
 		ConsensusConfig:   cfg,
 		active:            active,
-		encodedAddrs:      encodedAddrs,
-		priKeys:           priKeys,
+		producerKeys:      producerKeys,
 		chain:             chain,
 		blockDeserializer: blockDeserializer,
 		broadcastHandler:  broadcastHandler,
@@ -385,11 +407,11 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	proposer := ctx.round.Proposer()
 	// TODO: this is to pass unit tests, remove it after the unit tests are fixed
 	if proposer == "" {
-		privateKey = ctx.priKeys[0]
+		privateKey = ctx.producerKeys[0].ecdsa
 	} else {
-		for i, addr := range ctx.encodedAddrs {
-			if addr == proposer {
-				privateKey = ctx.priKeys[i]
+		for _, pk := range ctx.producerKeys {
+			if pk.address == proposer {
+				privateKey = pk.ecdsa
 				break
 			}
 		}
@@ -420,11 +442,11 @@ func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Has
 	roundCalc := ctx.roundCalc.Fork(fork)
 	// check if the current node is the next proposer
 	nextProposer := roundCalc.Proposer(height, interval, startTime)
-	idx := slices.Index(ctx.encodedAddrs, nextProposer)
+	idx := slices.IndexFunc(ctx.producerKeys, func(pk producerKey) bool { return pk.address == nextProposer })
 	if idx < 0 {
 		return nil
 	}
-	privateKey := ctx.priKeys[idx]
+	privateKey := ctx.producerKeys[idx].ecdsa
 	ctx.logger().Debug("prepare next proposal", log.Hex("prevHash", prevHash[:]), zap.Uint64("height", ctx.round.height+1), zap.Time("timestamp", startTime), zap.String("nextproposer", nextProposer))
 	go func() {
 		blk, err := fork.MintNewBlock(startTime, privateKey, prevHash)
@@ -457,7 +479,11 @@ func (ctx *rollDPoSCtx) WaitUntilRoundStart() time.Duration {
 func (ctx *rollDPoSCtx) PreCommitEndorsement() interface{} {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
-	endorsements := ctx.round.ReadyToCommit(ctx.encodedAddrs)
+	addrs := make([]string, len(ctx.producerKeys))
+	for i, pk := range ctx.producerKeys {
+		addrs[i] = pk.address
+	}
+	endorsements := ctx.round.ReadyToCommit(addrs)
 	if len(endorsements) == 0 {
 		// DON'T CHANGE, this is on purpose, because endorsement as nil won't result in a nil "interface {}"
 		return nil
@@ -733,7 +759,7 @@ func (ctx *rollDPoSCtx) hasDelegate() bool {
 		ctx.logger().Info("current node is in standby mode")
 		return false
 	}
-	return slices.ContainsFunc(ctx.encodedAddrs, ctx.round.IsDelegate)
+	return slices.ContainsFunc(ctx.producerKeys, func(pk producerKey) bool { return ctx.round.IsDelegate(pk.address) })
 }
 
 func (ctx *rollDPoSCtx) endorseBlockProposal(proposal *blockProposal, privateKey crypto.PrivateKey) (*EndorsedConsensusMessage, error) {
@@ -842,12 +868,12 @@ func (ctx *rollDPoSCtx) newEndorsement(
 		blkHash,
 		topic,
 	)
-	privKeys := make([]crypto.PrivateKey, 0, len(ctx.priKeys))
-	for i, addr := range ctx.encodedAddrs {
-		if !ctx.round.IsDelegate(addr) {
+	privKeys := make([]crypto.PrivateKey, 0, len(ctx.producerKeys))
+	for _, pk := range ctx.producerKeys {
+		if !ctx.round.IsDelegate(pk.address) {
 			continue
 		}
-		privKeys = append(privKeys, ctx.priKeys[i])
+		privKeys = append(privKeys, pk.ecdsa)
 	}
 	ens, err := endorsement.Endorse(vote, timestamp, privKeys...)
 	if err != nil {

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -41,12 +41,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, sf, _, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -56,7 +56,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		g.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -66,19 +66,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	g.Blockchain.BlockInterval = time.Second * 20
 	t.Run("case 5:panic because of nil CandidatesByHeight function", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 6:normal", func(t *testing.T) {
 		bh := g.BeringBlockHeight
-		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, c, bh)
+		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, bh)
 		require.NoError(err)
 		require.Equal(bh, rctx.RoundCalculator().beringHeight)
 		require.NotNil(rctx)
@@ -138,6 +138,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		c,
 		g.BeringBlockHeight,
@@ -211,6 +212,7 @@ func TestCheckBlockProposer(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		c,
 		g.BeringBlockHeight,
@@ -325,6 +327,7 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		delegatesByEpoch,
 		delegatesByEpoch,
 		[]crypto.PrivateKey{identityset.PrivateKey(10)},
+		nil,
 		c,
 		g.BeringBlockHeight,
 	)

--- a/go.mod
+++ b/go.mod
@@ -353,3 +353,5 @@ replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/erigontec
 
 // Fix for go-libutp compatibility with GCC 15+
 replace github.com/anacrolix/go-libutp => github.com/anacrolix/go-libutp v0.0.0-20251121015447-f294e5ed5b4d
+
+replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a h1:BE2G
 github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a/go.mod h1:7LneN7BMglt3mEe6/ypXrq64LiXgvGcDvbJgEzZnEpI=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d h1:vPl7sjgea9uQFeGdUr1uhrtT2kDbtRozOC9QnhnrX5E=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d/go.mod h1:CFlPtIrMHxhNuguRY0fdyKPr6hvbFDfUd1q8YcOcoYE=
+github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2 h1:eSdN1g/YxV+Axy0EbT5Fjrejg1K5VHfVk6hnpbTLV9Q=
+github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -598,8 +600,6 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.6.4 h1:7e0VyBDFT+iqwvr/BIk38yf7nC
 github.com/iotexproject/iotex-antenna-go/v2 v2.6.4/go.mod h1:L6AzDHo2TBFDAPA3ly+/PCS4JSX2g3zzhwV8RGQsTDI=
 github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1 h1:jPLni/qKAnxv87HMCutde2tP9JmfWuLZgGpB4OArQGM=
 github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1/go.mod h1:w9HriT1coMRbuknaSD2xqiOqDTnowBDzvFZv8tg1j2M=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16 h1:iaFjQ8QJ3ekZnwPlUX3XJHZ/5uf+FbUltH6o24d4NYA=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/ipfs/boxo v0.27.2 h1:sGo4KdwBaMjdBjH08lqPJyt27Z4CO6sugne3ryX513s=
 github.com/ipfs/boxo v0.27.2/go.mod h1:qEIRrGNr0bitDedTCzyzBHxzNWqYmyuHgK8LG9Q83EM=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=


### PR DESCRIPTION
## Summary

Scaffolding for the BLS signature aggregation work tracked in [IIP-52](https://github.com/iotexproject/iips/blob/master/iip-52.md). **No on-chain behavior change yet** — `EnableBLSAggregation` is gated on `IsToBeEnabled`, and the BLS keys plumbed into `rollDPoSCtx` are not yet used to sign or verify endorsements. Subsequent PRs will add the COMMIT-stage BLS signing path and the BlockFooter aggregation/verification.

- `blockchain/config.go`: add `Chain.BLSProducerPrivKey` (comma-separated hex) and `BLSProducerPrivateKeys()`. Empty value falls back to deriving each BLS key from the corresponding ECDSA producer key via `crypto.GenerateBLS12381PrivateKey` (consistent with the existing `ioctl account blskey` derivation).
- `consensus/scheme/rolldpos`: `Builder.SetBLSPriKey`; `NewRollDPoSCtx` accepts `[]*crypto.BLS12381PrivateKey` aligned 1:1 with the producer ECDSA keys; `rollDPoSCtx.blsPriKeys` is stored for the upcoming signing path.
- `consensus/consensus.go`: wire `SetBLSPriKey(cfg.Chain.BLSProducerPrivateKeys()...)`.
- `action/protocol/context.go`: `FeatureCtx.EnableBLSAggregation` gated on `g.IsToBeEnabled(height)`. Will be flipped to a named hardfork height in a later PR once the rest of Phase 2 lands.
- `go.mod`: bump iotex-proto to envestcc/iotex-proto `bls-aggregate` (52e72a6) for the new `BlockFooter.aggregated_signature` / `signer_bitmap` fields and the `BLSEndorsement` message. Tracking PR: iotexproject/iotex-proto#169.

## Why a separate BLS key field on Chain config

Per IIP-52 there are two equally valid modes for operators: maintain a standalone BLS keystore, or derive deterministically from the producer ECDSA key. The config accepts both — `BLSProducerPrivKey` is the explicit override, empty means derive. Length must match the active producer key range; otherwise the node panics on startup.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] Targeted tests: `TestNewRollDPoSCtx`, `TestCheckVoteEndorser`, `TestCheckBlockProposer` and related (15 tests pass)
- [ ] Two unrelated test failures (`TestRollDPoSConsensus/1-epoch`, `TestBlockIndexerChecker_CheckIndexer`) reproduce on master without this PR — not introduced here.

## Follow-up PRs in this series

1. COMMIT-stage BLS endorsement + p2p dispatch on `ConsensusMessage.bls_endorsement`
2. BlockFooter aggregation in proposer + `ValidateBlockFooter` BLS path
3. `ActiveCandidates` filter excluding delegates without BLS pubkey
4. ioctl / api decoding for the new footer fields
5. Replace `IsToBeEnabled` gate with a named hardfork height

🤖 Generated with [Claude Code](https://claude.com/claude-code)