### PR TITLE
fix: harden deserialization and message handlers against panics

### DIFF
--- a/action/envelope.go
+++ b/action/envelope.go
@@ -6,7 +6,6 @@
 package action
 
 import (
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -320,7 +319,7 @@ func (elp *envelope) loadProtoTxCommon(pbAct *iotextypes.ActionCore) error {
 			elp.common = &tx
 		}
 	default:
-		panic(fmt.Sprintf("unsupported action type = %d", pbAct.TxType))
+		return errors.Wrapf(ErrInvalidAct, "unsupported tx type = %d", pbAct.TxType)
 	}
 	return err
 }

--- a/action/envelope_test.go
+++ b/action/envelope_test.go
@@ -140,6 +140,14 @@ func createEnvelope(chainID uint32) (Envelope, *Transfer) {
 	return evlp, tsf
 }
 
+func TestEnvelope_LoadProto_UnsupportedTxType(t *testing.T) {
+	req := require.New(t)
+	evlp := &envelope{}
+	err := evlp.LoadProto(&iotextypes.ActionCore{TxType: 5})
+	req.Error(err)
+	req.ErrorIs(err, ErrInvalidAct)
+}
+
 func TestEnvelope_Hash(t *testing.T) {
 	r := require.New(t)
 	blob := createTestBlobTxData()

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -12,6 +12,7 @@ import (
 	"math"
 	"math/big"
 	"time"
+	"unicode/utf8"
 
 	erigonstate "github.com/erigontech/erigon/core/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -972,9 +973,18 @@ func ExtractRevertMessage(ret []byte) string {
 		return hex.EncodeToString(ret)
 	}
 	data := ret[4:]
+	if len(data) < 64 {
+		return hex.EncodeToString(ret)
+	}
 	msgLength := byteutil.BytesToUint64BigEndian(data[56:64])
-	revertMsg := string(data[64 : 64+msgLength])
-	return revertMsg
+	if msgLength > uint64(len(data)-64) {
+		return hex.EncodeToString(ret)
+	}
+	msg := data[64 : 64+msgLength]
+	if !utf8.Valid(msg) {
+		return hex.EncodeToString(ret)
+	}
+	return string(msg)
 }
 
 func validateAuthorization(evm *vm.EVM, sdb stateDB, auth *types.SetCodeAuthorization, isBlackListed IsBlackListedFunc, blockHeight uint64) (authority common.Address, err error) {

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -8,11 +8,9 @@ package evm
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"math"
 	"math/big"
 	"time"
-	"unicode/utf8"
 
 	erigonstate "github.com/erigontech/erigon/core/state"
 	"github.com/ethereum/go-ethereum/common"
@@ -375,7 +373,11 @@ func ExecuteContract(
 
 	if ps.featureCtx.SetRevertMessageToReceipt && receipt.Status == uint64(iotextypes.ReceiptStatus_ErrExecutionReverted) && len(retval) >= 4 && bytes.Equal(retval[:4], _revertSelector) {
 		// in case of the execution revert error, parse the retVal and add to receipt
-		receipt.SetExecutionRevertMsg(ExtractRevertMessage(retval))
+		msg, err := ExtractRevertMessage(retval)
+		if err != nil {
+			return nil, nil, err
+		}
+		receipt.SetExecutionRevertMsg(msg)
 	}
 	return retval, receipt, nil
 }
@@ -964,27 +966,21 @@ func SimulateAndCollectAccessList(
 	return stateDB.AccessedSlots(), nil
 }
 
-// ExtractRevertMessage extracts the revert message from the return value
-func ExtractRevertMessage(ret []byte) string {
-	if len(ret) < 4 {
-		return hex.EncodeToString(ret)
-	}
-	if !bytes.Equal(ret[:4], _revertSelector) {
-		return hex.EncodeToString(ret)
+// ExtractRevertMessage extracts the revert message from the return value.
+// Returns an error if the payload is not a well-formed Error(string) revert.
+func ExtractRevertMessage(ret []byte) (string, error) {
+	if len(ret) < 4 || !bytes.Equal(ret[:4], _revertSelector) {
+		return "", errors.New("malformed revert payload: missing Error(string) selector")
 	}
 	data := ret[4:]
 	if len(data) < 64 {
-		return hex.EncodeToString(ret)
+		return "", errors.New("malformed revert payload: data shorter than offset+length header")
 	}
 	msgLength := byteutil.BytesToUint64BigEndian(data[56:64])
 	if msgLength > uint64(len(data)-64) {
-		return hex.EncodeToString(ret)
+		return "", errors.New("malformed revert payload: declared length exceeds available data")
 	}
-	msg := data[64 : 64+msgLength]
-	if !utf8.Valid(msg) {
-		return hex.EncodeToString(ret)
-	}
-	return string(msg)
+	return string(data[64 : 64+msgLength]), nil
 }
 
 func validateAuthorization(evm *vm.EVM, sdb stateDB, auth *types.SetCodeAuthorization, isBlackListed IsBlackListedFunc, blockHeight uint64) (authority common.Address, err error) {

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -6,8 +6,11 @@
 package evm
 
 import (
+	"bytes"
 	"context"
 	"crypto/ecdsa"
+	"encoding/binary"
+	"encoding/hex"
 	"errors"
 	"math/big"
 	"testing"
@@ -605,4 +608,82 @@ func TestEIP7702BlacklistLogic(t *testing.T) {
 	convertedAddr, err := address.FromBytes(authority.Bytes())
 	r.NoError(err, "converting authority to io address should succeed")
 	r.Equal(ioAddr.String(), convertedAddr.String(), "converted address should match expected io address")
+}
+
+func TestExtractRevertMessage(t *testing.T) {
+	r := require.New(t)
+
+	// Build a well-formed Error(string) payload for the given message.
+	wellFormed := func(msg string) []byte {
+		out := append([]byte{}, _revertSelector...)
+		offset := make([]byte, 32)
+		offset[31] = 0x20
+		out = append(out, offset...)
+		length := make([]byte, 32)
+		binary.BigEndian.PutUint64(length[24:32], uint64(len(msg)))
+		out = append(out, length...)
+		data := []byte(msg)
+		if pad := len(data) % 32; pad != 0 {
+			data = append(data, make([]byte, 32-pad)...)
+		}
+		return append(out, data...)
+	}
+
+	for _, tc := range []struct {
+		name string
+		in   []byte
+		want string
+	}{
+		{"nil", nil, ""},
+		{"shorter than selector", []byte{0x01, 0x02}, "0102"},
+		{"non-revert prefix", []byte{0x01, 0x02, 0x03, 0x04, 0x05}, "0102030405"},
+		{
+			"selector only, truncated length offset",
+			append(append([]byte{}, _revertSelector...), bytes.Repeat([]byte{0xff}, 50)...),
+			hex.EncodeToString(append(append([]byte{}, _revertSelector...), bytes.Repeat([]byte{0xff}, 50)...)),
+		},
+		{
+			"msgLength exceeds remaining payload",
+			func() []byte {
+				out := append([]byte{}, _revertSelector...)
+				out = append(out, bytes.Repeat([]byte{0x00}, 32)...) // offset
+				length := make([]byte, 32)
+				binary.BigEndian.PutUint64(length[24:32], 1<<20) // claim 1MB message
+				out = append(out, length...)
+				out = append(out, []byte("short")...) // but only provide 5 bytes
+				return out
+			}(),
+			"", // computed below
+		},
+		{
+			"valid length but invalid UTF-8",
+			func() []byte {
+				out := append([]byte{}, _revertSelector...)
+				offset := make([]byte, 32)
+				offset[31] = 0x20
+				out = append(out, offset...)
+				length := make([]byte, 32)
+				length[31] = 0x02
+				out = append(out, length...)
+				out = append(out, 0xff, 0xfe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+				return out
+			}(),
+			"", // computed below
+		},
+		{"well-formed hello", wellFormed("hello"), "hello"},
+		{"well-formed empty", wellFormed(""), ""},
+		{"well-formed with emoji", wellFormed("nope 🚫"), "nope 🚫"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// For the two "fallback to hex" cases we computed at runtime,
+			// expected output is hex of the full input.
+			want := tc.want
+			if tc.name == "msgLength exceeds remaining payload" || tc.name == "valid length but invalid UTF-8" {
+				want = hex.EncodeToString(tc.in)
+			}
+			r.NotPanics(func() {
+				r.Equal(want, ExtractRevertMessage(tc.in))
+			})
+		})
+	}
 }

--- a/action/protocol/execution/evm/evm_test.go
+++ b/action/protocol/execution/evm/evm_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"math/big"
 	"testing"
@@ -630,17 +629,18 @@ func TestExtractRevertMessage(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name string
-		in   []byte
-		want string
+		name    string
+		in      []byte
+		want    string
+		wantErr bool
 	}{
-		{"nil", nil, ""},
-		{"shorter than selector", []byte{0x01, 0x02}, "0102"},
-		{"non-revert prefix", []byte{0x01, 0x02, 0x03, 0x04, 0x05}, "0102030405"},
+		{"nil", nil, "", true},
+		{"shorter than selector", []byte{0x01, 0x02}, "", true},
+		{"non-revert prefix", []byte{0x01, 0x02, 0x03, 0x04, 0x05}, "", true},
 		{
 			"selector only, truncated length offset",
 			append(append([]byte{}, _revertSelector...), bytes.Repeat([]byte{0xff}, 50)...),
-			hex.EncodeToString(append(append([]byte{}, _revertSelector...), bytes.Repeat([]byte{0xff}, 50)...)),
+			"", true,
 		},
 		{
 			"msgLength exceeds remaining payload",
@@ -653,10 +653,15 @@ func TestExtractRevertMessage(t *testing.T) {
 				out = append(out, []byte("short")...) // but only provide 5 bytes
 				return out
 			}(),
-			"", // computed below
+			"", true,
 		},
+		{"well-formed hello", wellFormed("hello"), "hello", false},
+		{"well-formed empty", wellFormed(""), "", false},
+		{"well-formed with emoji", wellFormed("nope 🚫"), "nope 🚫", false},
 		{
-			"valid length but invalid UTF-8",
+			// Regression guard: utf8.Valid check was intentionally removed so
+			// honest-but-non-UTF-8 reverts remain consensus-compatible.
+			"well-formed but non-UTF-8 string",
 			func() []byte {
 				out := append([]byte{}, _revertSelector...)
 				offset := make([]byte, 32)
@@ -665,24 +670,28 @@ func TestExtractRevertMessage(t *testing.T) {
 				length := make([]byte, 32)
 				length[31] = 0x02
 				out = append(out, length...)
-				out = append(out, 0xff, 0xfe, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+				out = append(out, 0xff, 0xfe)
+				out = append(out, make([]byte, 30)...)
 				return out
 			}(),
-			"", // computed below
+			"\xff\xfe", false,
 		},
-		{"well-formed hello", wellFormed("hello"), "hello"},
-		{"well-formed empty", wellFormed(""), ""},
-		{"well-formed with emoji", wellFormed("nope 🚫"), "nope 🚫"},
+		{
+			// Boundary: msgLength exactly equals len(data)-64.
+			"msgLength exactly fills payload",
+			wellFormed("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), // 32 bytes, no padding required
+			"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", false,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			// For the two "fallback to hex" cases we computed at runtime,
-			// expected output is hex of the full input.
-			want := tc.want
-			if tc.name == "msgLength exceeds remaining payload" || tc.name == "valid length but invalid UTF-8" {
-				want = hex.EncodeToString(tc.in)
-			}
 			r.NotPanics(func() {
-				r.Equal(want, ExtractRevertMessage(tc.in))
+				got, err := ExtractRevertMessage(tc.in)
+				if tc.wantErr {
+					r.Error(err)
+				} else {
+					r.NoError(err)
+				}
+				r.Equal(tc.want, got)
 			})
 		})
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -926,7 +926,7 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 		copy(topic[:], evmTopic.Bytes())
 		topics = append(topics, topic)
 	}
-	if topics[0] == _inContractTransfer {
+	if len(topics) > 0 && topics[0] == _inContractTransfer {
 		if len(topics) != 3 {
 			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics")
 		}

--- a/actsync/actionsync.go
+++ b/actsync/actionsync.go
@@ -3,6 +3,7 @@ package actsync
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -33,6 +34,7 @@ type (
 	ActionSync struct {
 		lifecycle.Readiness
 		actions  sync.Map
+		pending  atomic.Int64 // number of live entries in `actions`; bounded by cfg.Size
 		syncChan chan hash.Hash256
 		wg       sync.WaitGroup
 		helper   *Helper
@@ -104,15 +106,24 @@ func (as *ActionSync) RequestAction(_ context.Context, hash hash.Hash256) {
 	if !as.IsReady() {
 		return
 	}
+	// Bound the pending request set: a peer can flood us with forged ACTION_HASH
+	// messages that never resolve, so cap the live map by cfg.Size. Reserve the
+	// slot atomically before touching the map to prevent OOM and unbounded
+	// per-hash unicast amplification by triggerSync.
+	if as.pending.Add(1) > int64(as.cfg.Size) {
+		as.pending.Add(-1)
+		counterMtc.WithLabelValues("capacityExceeded").Inc()
+		log.L().Debug("action sync request capacity exceeded", log.Hex("hash", hash[:]))
+		return
+	}
 	// check if the action is already requested
-	_, ok := as.actions.LoadOrStore(hash, &actionMsg{})
-	if ok {
+	if _, ok := as.actions.LoadOrStore(hash, &actionMsg{}); ok {
+		as.pending.Add(-1)
 		log.L().Debug("Action already requested", log.Hex("hash", hash[:]))
 		return
 	}
 	log.L().Debug("Requesting action", log.Hex("hash", hash[:]))
 	as.trigger(hash)
-	return
 }
 
 // ReceiveAction receives an action
@@ -121,7 +132,9 @@ func (as *ActionSync) ReceiveAction(_ context.Context, hash hash.Hash256) {
 		return
 	}
 	log.L().Debug("received action", log.Hex("hash", hash[:]))
-	as.actions.Delete(hash)
+	if _, loaded := as.actions.LoadAndDelete(hash); loaded {
+		as.pending.Add(-1)
+	}
 }
 
 func (as *ActionSync) sync() {

--- a/actsync/actionsync_test.go
+++ b/actsync/actionsync_test.go
@@ -126,6 +126,102 @@ func TestActionSync(t *testing.T) {
 			r.False(ok, "action should be removed after received")
 		}
 	})
+	t.Run("capacityBound", func(t *testing.T) {
+		// Forged-hash flood: every request is for a unique hash that never
+		// resolves via ReceiveAction. The live map must not grow past cfg.Size.
+		const cap = 8
+		bs := NewActionSync(Config{
+			Size:     cap,
+			Interval: time.Hour, // disable trigger churn for the duration of this test
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		for i := 0; i < cap*4; i++ {
+			bs.RequestAction(context.Background(), hash.Hash256b([]byte{0xff, byte(i), byte(i >> 8)}))
+		}
+		r.Equal(int64(cap), bs.pending.Load(), "pending count must not exceed configured cap")
+		stored := 0
+		bs.actions.Range(func(_, _ any) bool { stored++; return true })
+		r.Equal(cap, stored, "live entries must match the cap")
+		// ReceiveAction on a hash we already stored must drop the counter so a new request can land.
+		var sample hash.Hash256
+		bs.actions.Range(func(k, _ any) bool { sample = k.(hash.Hash256); return false })
+		bs.ReceiveAction(context.Background(), sample)
+		r.Equal(int64(cap-1), bs.pending.Load(), "ReceiveAction must release the slot")
+		bs.RequestAction(context.Background(), hash.Hash256b([]byte("fresh")))
+		r.Equal(int64(cap), bs.pending.Load(), "freed slot can be reused")
+	})
+	t.Run("duplicateRequestDoesNotDoubleCount", func(t *testing.T) {
+		// LoadOrStore must observe an existing entry and refund the slot, otherwise a
+		// peer that repeats the same forged hash would still grow the counter and
+		// eventually wedge the pool at the cap with one real hash.
+		bs := NewActionSync(Config{
+			Size:     4,
+			Interval: time.Hour,
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		dup := hash.Hash256b([]byte("dup"))
+		for i := 0; i < 50; i++ {
+			bs.RequestAction(context.Background(), dup)
+		}
+		r.Equal(int64(1), bs.pending.Load(), "repeated requests for the same hash must collapse to one slot")
+		// ReceiveAction on an unknown hash must not decrement.
+		bs.ReceiveAction(context.Background(), hash.Hash256b([]byte("missing")))
+		r.Equal(int64(1), bs.pending.Load(), "ReceiveAction for an unknown hash must be a no-op for the counter")
+		bs.ReceiveAction(context.Background(), dup)
+		r.Equal(int64(0), bs.pending.Load())
+	})
+	t.Run("concurrentFloodRespectsCap", func(t *testing.T) {
+		// Under contention the atomic reserve+undo must hold the cap exactly;
+		// otherwise a peer can race the check and force the map past the limit.
+		const cap = 16
+		bs := NewActionSync(Config{
+			Size:     cap,
+			Interval: time.Hour,
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		const goroutines = 32
+		const perG = 200
+		wg := sync.WaitGroup{}
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				for k := 0; k < perG; k++ {
+					bs.RequestAction(context.Background(), hash.Hash256b([]byte{byte(g), byte(k), byte(k >> 8)}))
+				}
+			}(g)
+		}
+		wg.Wait()
+		r.LessOrEqual(bs.pending.Load(), int64(cap), "pending must never exceed configured cap, even under contention")
+		stored := 0
+		bs.actions.Range(func(_, _ any) bool { stored++; return true })
+		r.LessOrEqual(stored, cap, "live entries must never exceed the cap")
+		r.EqualValues(stored, bs.pending.Load(), "counter and map size must agree")
+	})
 	t.Run("requestWhenStopping", func(t *testing.T) {
 		count := atomic.Int32{}
 		as := NewActionSync(Config{

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -136,7 +136,7 @@ func (cs *ChainService) Filter(messageType iotexrpc.MessageType, msg proto.Messa
 		return true
 	}
 	blk, ok := msg.(*iotextypes.Block)
-	if !ok || blk == nil {
+	if !ok || blk == nil || blk.Header == nil || blk.Header.Core == nil {
 		return false
 	}
 	if blk.Header.Core.Height > atomic.LoadUint64(&cs.lastReceivedBlockHeight) {
@@ -156,7 +156,7 @@ func (cs *ChainService) ReportFullness(_ context.Context, messageType iotexrpc.M
 	switch messageType {
 	case iotexrpc.MessageType_BLOCK:
 		blk, ok := msg.(*iotextypes.Block)
-		if !ok || blk == nil {
+		if !ok || blk == nil || blk.Header == nil || blk.Header.Core == nil {
 			return
 		}
 		if blk.Header.Core.Height > atomic.LoadUint64(&cs.lastReceivedBlockHeight) {

--- a/chainservice/chainservice_test.go
+++ b/chainservice/chainservice_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package chainservice
+
+import (
+	"testing"
+
+	"github.com/iotexproject/iotex-proto/golang/iotexrpc"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChainService_Filter_NilHeader(t *testing.T) {
+	r := require.New(t)
+	cs := &ChainService{}
+
+	cases := []struct {
+		name string
+		msg  *iotextypes.Block
+	}{
+		{"nil block", nil},
+		{"nil header", &iotextypes.Block{Header: nil}},
+		{"nil header core", &iotextypes.Block{Header: &iotextypes.BlockHeader{Core: nil}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r.NotPanics(func() {
+				r.False(cs.Filter(iotexrpc.MessageType_BLOCK, tc.msg, 10))
+			})
+		})
+	}
+
+	// Non-BLOCK messages always pass without inspecting payload.
+	r.True(cs.Filter(iotexrpc.MessageType_ACTION, nil, 10))
+}
+
+func TestChainService_ReportFullness_NilHeader(t *testing.T) {
+	r := require.New(t)
+	cs := &ChainService{}
+
+	cases := []struct {
+		name string
+		msg  *iotextypes.Block
+	}{
+		{"nil block", nil},
+		{"nil header", &iotextypes.Block{Header: nil}},
+		{"nil header core", &iotextypes.Block{Header: &iotextypes.BlockHeader{Core: nil}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r.NotPanics(func() {
+				cs.ReportFullness(nil, iotexrpc.MessageType_BLOCK, tc.msg, 0.5)
+			})
+		})
+	}
+}

--- a/endorsement/endorsement.go
+++ b/endorsement/endorsement.go
@@ -6,6 +6,7 @@
 package endorsement
 
 import (
+	"errors"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/crypto"
@@ -128,6 +129,9 @@ func (en *Endorsement) Proto() *iotextypes.Endorsement {
 
 // LoadProto converts a protobuf message to endorsement
 func (en *Endorsement) LoadProto(ePb *iotextypes.Endorsement) (err error) {
+	if ePb == nil {
+		return errors.New("nil endorsement")
+	}
 	if err = ePb.Timestamp.CheckValid(); err != nil {
 		return err
 	}

--- a/endorsement/endorsement_test.go
+++ b/endorsement/endorsement_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package endorsement
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+func TestEndorsement_LoadProto_Nil(t *testing.T) {
+	r := require.New(t)
+	en := &Endorsement{}
+	r.NotPanics(func() {
+		err := en.LoadProto(nil)
+		r.Error(err)
+	})
+}
+
+func TestEndorsement_LoadProto_RoundTrip(t *testing.T) {
+	r := require.New(t)
+	priKey := identityset.PrivateKey(0)
+	sig := []byte("signature")
+	now := time.Now()
+
+	original := NewEndorsement(now, priKey.PublicKey(), sig)
+	pb := original.Proto()
+
+	loaded := &Endorsement{}
+	r.NoError(loaded.LoadProto(pb))
+	r.True(now.Equal(loaded.Timestamp()))
+	r.Equal(priKey.PublicKey().HexString(), loaded.Endorser().HexString())
+	r.Equal(0, bytes.Compare(sig, loaded.Signature()))
+}
+
+func TestEndorsement_LoadProto_InvalidEndorser(t *testing.T) {
+	r := require.New(t)
+	en := &Endorsement{}
+	err := en.LoadProto(&iotextypes.Endorsement{
+		// Timestamp left zero is valid (encodes epoch); Endorser bytes are garbage.
+		Endorser: []byte{0x01, 0x02, 0x03},
+	})
+	r.Error(err)
+}

--- a/nodeinfo/manager.go
+++ b/nodeinfo/manager.go
@@ -145,6 +145,11 @@ func (dm *InfoManager) MayHaveBlock(peerID string, start uint64) bool {
 // HandleNodeInfo handle node info message
 func (dm *InfoManager) HandleNodeInfo(ctx context.Context, peerID string, msg *iotextypes.NodeInfo) {
 	log.L().Debug("nodeinfo manager handle node info")
+	// reject malformed messages from peers before dereferencing inner fields
+	if msg == nil || msg.Info == nil {
+		log.L().Warn("nodeinfo manager received malformed node info", zap.String("peerID", peerID))
+		return
+	}
 	// recover pubkey
 	hash := hashNodeInfo(msg.Info)
 	pubKey, err := crypto.RecoverPubkey(hash[:], msg.Signature)

--- a/nodeinfo/manager_test.go
+++ b/nodeinfo/manager_test.go
@@ -123,6 +123,19 @@ func TestDelegateManager_HandleNodeInfo(t *testing.T) {
 		require.Equal(msg.Info.Height, uint64(m.Gauge.GetValue()))
 	})
 
+	t.Run("nil_msg_and_nil_info", func(t *testing.T) {
+		hMock := mock_nodeinfo.NewMockchain(ctrl)
+		tMock := mock_nodeinfo.NewMocktransmitter(ctrl)
+		dm := NewInfoManager(&DefaultConfig, tMock, hMock, 2500*time.Millisecond, privKey)
+		// Both nil msg and msg with nil Info must not panic on field deref / hash.
+		require.NotPanics(func() { dm.HandleNodeInfo(context.Background(), "abc", nil) })
+		require.NotPanics(func() {
+			dm.HandleNodeInfo(context.Background(), "abc", &iotextypes.NodeInfo{Signature: []byte("sig")})
+		})
+		_, ok := dm.nodeMap.Get("abc")
+		require.False(ok)
+	})
+
 	t.Run("verify_fail", func(t *testing.T) {
 		hMock := mock_nodeinfo.NewMockchain(ctrl)
 		tMock := mock_nodeinfo.NewMocktransmitter(ctrl)

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -386,7 +386,11 @@ func StartServer(ctx context.Context, svr *Server, probeSvr *probe.Server, cfg c
 		mux.Handle("/unpause", http.HandlerFunc(svr.pauseMgr.HandleUnPause))
 		mux.Handle("/producer-keys", NewProducerKeysAdmin(svr))
 
-		port := fmt.Sprintf(":%d", cfg.System.HTTPAdminPort)
+		// Bind the admin mux (which exposes /pause, /unpause, /producer-keys and
+		// pprof) to the loopback interface only. Exposing these on an external
+		// address lets any peer that can reach the admin port halt block
+		// production with an unauthenticated POST to /pause.
+		port := fmt.Sprintf("127.0.0.1:%d", cfg.System.HTTPAdminPort)
 		adminserv = httputil.NewServer(port, mux)
 		defer func() {
 			if err := adminserv.Shutdown(ctx); err != nil {

--- a/state/factory/erigonstore/contract_backend.go
+++ b/state/factory/erigonstore/contract_backend.go
@@ -79,7 +79,10 @@ func (backend *contractBackend) Deploy(callMsg *ethereum.CallMsg) (address.Addre
 	ret, addr, leftGas, err := evm.Create(vm.AccountRef(callMsg.From), callMsg.Data, callMsg.Gas, uint256.MustFromBig(callMsg.Value), true)
 	if err != nil {
 		if errors.Is(err, vm.ErrExecutionReverted) {
-			revertMsg := iotexevm.ExtractRevertMessage(ret)
+			revertMsg, msgErr := iotexevm.ExtractRevertMessage(ret)
+			if msgErr != nil {
+				revertMsg = hex.EncodeToString(ret)
+			}
 			log.L().Error("EVM deployment reverted",
 				zap.String("from", callMsg.From.String()),
 				zap.String("data", hex.EncodeToString(callMsg.Data)),
@@ -222,7 +225,10 @@ func (backend *contractBackend) call(callMsg *ethereum.CallMsg, intra evmtypes.I
 	if err != nil {
 		// Check if it's a revert error and extract the revert message
 		if errors.Is(err, vm.ErrExecutionReverted) {
-			revertMsg := iotexevm.ExtractRevertMessage(ret)
+			revertMsg, msgErr := iotexevm.ExtractRevertMessage(ret)
+			if msgErr != nil {
+				revertMsg = hex.EncodeToString(ret)
+			}
 			log.L().Error("EVM call reverted",
 				zap.String("from", callMsg.From.String()),
 				zap.String("to", callMsg.To.String()),


### PR DESCRIPTION
## Summary

Replace panic-prone paths reachable from peer-controlled or otherwise untrusted input with explicit error returns or safe fallbacks, and tighten two unrelated peer-reachable attack vectors discovered in the same audit pass. Each site previously crashed the handling goroutine on malformed input or exposed an unauthenticated control surface; now they surface a recoverable error, bind to loopback, or apply an explicit cap.

### Deserialization / message-handler hardening

- **`action.envelope.LoadProto`** — `pbAct.TxType >= 5` (or any unknown type) hit the `default` branch and panicked. Now returns `errors.Wrapf(ErrInvalidAct, "unsupported tx type = %d", …)`, matching the pattern already used at `action/actctx.go:233`.
- **`evm.ExtractRevertMessage`** — A revert payload starting with the `Error(string)` selector but shorter than 68 bytes, or claiming a `msgLength` larger than the remaining payload, panicked on slice out-of-range. The function now returns `(string, error)`; `ExecuteContract` propagates the error so a tx with a malformed `Error(string)` payload invalidates the action rather than landing with a junk hex string in the receipt. `erigonstore` callers swallow the error with a local hex fallback since they already return `vm.ErrExecutionReverted` to their caller. No UTF-8 gate: honest contracts can revert with non-UTF-8 bytes, so rejecting on that would fork the chain on legitimate input.
- **`evm.StateDBAdapter.AddLog`** — `topics[0]` was accessed without verifying `len(topics) > 0`. Added the `len > 0` guard.
- **`chainservice.ChainService.Filter` and `ReportFullness`** — A `MessageType_BLOCK` whose proto decodes successfully but has `Header == nil` or `Header.Core == nil` (both optional fields) panicked at `blk.Header.Core.Height`. Extended the existing nil-check.
- **`endorsement.Endorsement.LoadProto`** — A nil `*iotextypes.Endorsement` panicked at `ePb.Timestamp.CheckValid()`, which executes *before* `RollDPoS.HandleConsensusMsg`'s signature and delegate-list checks. Now returns an explicit error, fixing both the consensus ingress path and the `endorsementmanager` BoltDB reload path.

### Additional peer-reachable hardening (audit findings #6, #7, #9)

- **`nodeinfo.HandleNodeInfo`** — Dereferenced `msg.Info` without a nil check, so any peer could crash a node by broadcasting `NODE_INFO` with `Info=nil`. Guarded; non-panic test added.
- **`actsync.RequestActionsFromNeighbors`** — No upper bound on in-flight requests, letting a peer drown a node in outbound traffic. Cap added; tests cover cap respected under flood, dedup must not double-count, concurrent flood respects cap.
- **`server/itx` admin mux** — `/pause`, `/unpause`, `/producer-keys`, and pprof were bound to `0.0.0.0`, letting any peer that could reach the admin port halt block production with an unauthenticated `POST /pause`. Now bound to `127.0.0.1`.

### Tests

Each fix has a unit test for the new error / no-panic path, wrapped in `require.NotPanics` so a regression that re-introduces the nil deref or out-of-range slice fails loudly:

- `TestExtractRevertMessage` — cases for nil, short, truncated length offset, oversized declared length, well-formed payloads with ASCII / empty / emoji / non-UTF-8 message; signature-level error propagation.
- `TestEnvelope_LoadProto_UnsupportedTxType` — asserts `TxType=5` returns `ErrInvalidAct`.
- `TestChainService_Filter_NilHeader`, `TestChainService_ReportFullness_NilHeader` — nil block, nil `Header`, nil `Header.Core`, plus non-BLOCK passthrough.
- `TestEndorsement_LoadProto_*` — nil proto, round-trip from a valid endorsement, invalid endorser bytes.
- `nodeinfo` manager: nil-msg + nil-`Info` no-panic case.
- `actsync`: cap respected under flood, dedup must not double-count, concurrent flood respects cap.

## Test plan

- [x] `go build ./action/... ./action/protocol/execution/evm/... ./chainservice/... ./endorsement/... ./actsync/... ./nodeinfo/... ./server/... ./state/...`
- [x] `go test ./action/ -run TestEnvelope_LoadProto_UnsupportedTxType -count=1`
- [x] `go test ./action/protocol/execution/evm/ -run TestExtractRevertMessage -count=1`
- [x] `go test ./chainservice/ -run "TestChainService_(Filter|ReportFullness)_NilHeader" -count=1`
- [x] `go test ./endorsement/... -run TestEndorsement_LoadProto -count=1`
- [x] `go test ./actsync/... -count=1`
- [x] `go test ./nodeinfo/... -count=1`
- [ ] CI: full unit-test suite on the affected packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
