### PR TITLE
fix: address four peer-reachable security issues

### DIFF
--- a/actpool/actpool.go
+++ b/actpool/actpool.go
@@ -8,6 +8,7 @@ package actpool
 import (
 	"context"
 	"encoding/hex"
+	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -561,6 +562,65 @@ func (ap *actPool) allocatedWorker(senderAddr address.Address) int {
 	senderBytes := senderAddr.Bytes()
 	var lastByte uint8 = senderBytes[len(senderBytes)-1]
 	return int(lastByte) % _numWorker
+}
+
+// popLowestPriorityAcrossWorkers pops the globally-lowest-priority head action
+// across every worker shard. Evicting only from the sender's shard lets an
+// attacker who fills one shard force honest users in the other ~94% of shards
+// to evict each other; choosing the eviction victim from the union of all
+// shards restores the single-pool fairness implied by MaxNumActsPerPool.
+//
+// We acquire every worker's mu in increasing index order. No other code path
+// holds more than one worker mu at a time, so this cannot deadlock with a
+// concurrent Handle / Reset / PendingActions.
+func (ap *actPool) popLowestPriorityAcrossWorkers() *action.SealedEnvelope {
+	for i := range ap.worker {
+		ap.worker[i].mu.Lock()
+	}
+	defer func() {
+		for i := range ap.worker {
+			ap.worker[i].mu.Unlock()
+		}
+	}()
+	var (
+		bestIdx     = -1
+		bestHasNext bool
+		bestSettled bool
+		bestGP      *big.Int
+	)
+	for i, w := range ap.worker {
+		if len(w.accountActs.accounts) == 0 {
+			continue
+		}
+		settled, gp := w.accountActs.priorityQueue[0].actQueue.NextAction()
+		hasNext := gp != nil
+		if bestIdx < 0 || headLess(hasNext, settled, gp, bestHasNext, bestSettled, bestGP) {
+			bestIdx, bestHasNext, bestSettled, bestGP = i, hasNext, settled, gp
+		}
+	}
+	if bestIdx < 0 {
+		return nil
+	}
+	return ap.worker[bestIdx].accountActs.PopPeek()
+}
+
+// headLess mirrors accountPriorityQueue.Less so that the eviction victim
+// picked across all shards matches what a single unified per-account heap
+// would have evicted.
+func headLess(aHasNext, aSettled bool, aGP *big.Int, bHasNext, bSettled bool, bGP *big.Int) bool {
+	if !bHasNext {
+		return true
+	}
+	if !aHasNext {
+		return false
+	}
+	if !aSettled && bSettled {
+		return true
+	}
+	if !bSettled && aSettled {
+		return false
+	}
+	return aGP.Cmp(bGP) < 0
 }
 
 func (ap *actPool) AddSubscriber(sub Subscriber) {

--- a/actpool/actpool_cross_shard_test.go
+++ b/actpool/actpool_cross_shard_test.go
@@ -1,0 +1,348 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package actpool
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"testing"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_chainmanager"
+)
+
+// TestActPool_popLowestPriorityAcrossWorkers verifies the eviction victim is
+// chosen from the union of every worker shard, not just the sender's shard.
+// Per-shard PopPeek lets an attacker who fills one shard force honest users in
+// every other shard to evict each other (~94% censorship). The fix must pick
+// the globally lowest-priority head action regardless of which shard runs
+// eviction.
+func TestActPool_popLowestPriorityAcrossWorkers(t *testing.T) {
+	r := require.New(t)
+
+	// Find two identityset keys that land in different shards so the test
+	// genuinely exercises cross-shard selection. _numWorker = 16.
+	ap := &actPool{worker: make([]*queueWorker, _numWorker)}
+	for i := range ap.worker {
+		ap.worker[i] = &queueWorker{ap: ap, accountActs: newAccountPool()}
+	}
+	var (
+		idxA, idxB int = -1, -1
+	)
+	for i := 0; i < identityset.Size(); i++ {
+		for j := i + 1; j < identityset.Size(); j++ {
+			if ap.allocatedWorker(identityset.Address(i)) != ap.allocatedWorker(identityset.Address(j)) {
+				idxA, idxB = i, j
+				break
+			}
+		}
+		if idxA >= 0 {
+			break
+		}
+	}
+	r.GreaterOrEqual(idxA, 0, "need two senders in different shards")
+
+	pkA, pkB := identityset.PrivateKey(idxA), identityset.PrivateKey(idxB)
+	addrA, addrB := pkA.PublicKey().Address(), pkB.PublicKey().Address()
+	wA := ap.worker[ap.allocatedWorker(addrA)]
+	wB := ap.worker[ap.allocatedWorker(addrB)]
+	r.NotSame(wA, wB)
+
+	// Shard A holds an expensive action; shard B holds a cheap one. A global
+	// eviction must pop from shard B regardless of which shard is "the
+	// caller". With per-shard PopPeek the attacker (shard A) would never lose
+	// its action; with the fix, B's cheap action is the victim.
+	expensive, err := action.SignedTransfer(addrB.String(), pkA, 1, big.NewInt(1), nil, uint64(0), big.NewInt(10))
+	r.NoError(err)
+	cheap, err := action.SignedTransfer(addrA.String(), pkB, 1, big.NewInt(1), nil, uint64(0), big.NewInt(1))
+	r.NoError(err)
+	r.NoError(wA.accountActs.PutAction(addrA.String(), ap, 1, _balance, _expireTime, expensive))
+	r.NoError(wB.accountActs.PutAction(addrB.String(), ap, 1, _balance, _expireTime, cheap))
+
+	evicted := ap.popLowestPriorityAcrossWorkers()
+	r.Equal(cheap, evicted, "expected globally lowest-priced action to be evicted")
+
+	// Shard A must still hold its expensive action; only shard B's account
+	// was drained. This is the property that prevents cross-shard censorship.
+	queueA := wA.accountActs.Account(addrA.String())
+	r.NotNil(queueA)
+	r.False(queueA.Empty())
+	queueB := wB.accountActs.Account(addrB.String())
+	r.NotNil(queueB)
+	r.True(queueB.Empty())
+}
+
+// TestActPool_popLowestPriorityAcrossWorkers_empty exercises the no-op path:
+// with every shard empty there is nothing to evict and the pop must return
+// nil rather than panic on an empty priorityQueue.
+func TestActPool_popLowestPriorityAcrossWorkers_empty(t *testing.T) {
+	r := require.New(t)
+	ap := &actPool{worker: make([]*queueWorker, _numWorker)}
+	for i := range ap.worker {
+		ap.worker[i] = &queueWorker{ap: ap, accountActs: newAccountPool()}
+	}
+	r.Nil(ap.popLowestPriorityAcrossWorkers())
+}
+
+// TestHeadLess pins the cross-shard eviction ordering against
+// accountPriorityQueue.Less so a future "simplification" of either function
+// can't silently diverge from the global heap semantics.
+func TestHeadLess(t *testing.T) {
+	r := require.New(t)
+	gpLow := big.NewInt(1)
+	gpHigh := big.NewInt(100)
+	cases := []struct {
+		name                                       string
+		aHasNext, aSettled                         bool
+		aGP                                        *big.Int
+		bHasNext, bSettled                         bool
+		bGP                                        *big.Int
+		want                                       bool
+		description                                string
+	}{
+		// nil-next handling mirrors Less: jgp==nil → true; igp==nil (b non-nil) → false.
+		{"b has no next", true, true, gpLow, false, false, nil, true, "b has no next: a wins eviction"},
+		{"a has no next", false, false, nil, true, true, gpHigh, false, "a has no next, b non-nil: b is preferred head"},
+		{"both empty (matches Less asymmetry)", false, false, nil, false, false, nil, true, "both empty: first nil-check fires, a wins"},
+		// settled/unsettled axis (with non-nil gp on both sides)
+		{"a unsettled vs b settled", true, false, gpHigh, true, true, gpLow, true, "unsettled is evicted before settled even at higher gas"},
+		{"a settled vs b unsettled", true, true, gpLow, true, false, gpHigh, false, "settled stays even with lower gas vs unsettled"},
+		// gas axis (both unsettled)
+		{"both unsettled, a cheaper", true, false, gpLow, true, false, gpHigh, true, "lower gas wins eviction among unsettled"},
+		{"both unsettled, a pricier", true, false, gpHigh, true, false, gpLow, false, "higher gas survives among unsettled"},
+		// gas axis (both settled)
+		{"both settled, a cheaper", true, true, gpLow, true, true, gpHigh, true, "lower gas wins eviction among settled"},
+		{"both settled, a pricier", true, true, gpHigh, true, true, gpLow, false, "higher gas survives among settled"},
+		// equal gas: Cmp == 0 → !(<0) → false (not less)
+		{"equal gas same settled state", true, true, gpLow, true, true, big.NewInt(1), false, "ties resolve to false (matches Less strict-less)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r.Equal(tc.want,
+				headLess(tc.aHasNext, tc.aSettled, tc.aGP, tc.bHasNext, tc.bSettled, tc.bGP),
+				tc.description)
+		})
+	}
+}
+
+// TestActPool_crossShardEviction_e2e drives the full Add path: it fills the
+// pool with low-fee actions in shard A and then submits a higher-fee action
+// from shard B. Under the old per-shard PopPeek the shard-B sender would have
+// been forced to evict its own action (cross-shard censorship). With the
+// global eviction the low-fee shard-A action must be the victim.
+func TestActPool_crossShardEviction_e2e(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := require.New(t)
+
+	// Find two identityset keys in different shards.
+	idxA, idxB := -1, -1
+	probe := &actPool{}
+	for i := 0; i < identityset.Size() && idxA < 0; i++ {
+		for j := i + 1; j < identityset.Size(); j++ {
+			if probeShard(probe, identityset.Address(i)) != probeShard(probe, identityset.Address(j)) {
+				idxA, idxB = i, j
+				break
+			}
+		}
+	}
+	r.GreaterOrEqual(idxA, 0)
+	pkA, pkB := identityset.PrivateKey(idxA), identityset.PrivateKey(idxB)
+	addrA, addrB := pkA.PublicKey().Address(), pkB.PublicKey().Address()
+
+	sf := mock_chainmanager.NewMockStateReader(ctrl)
+	sf.EXPECT().Height().Return(uint64(1), nil).AnyTimes()
+	sf.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(func(acc interface{}, opts ...protocol.StateOption) (uint64, error) {
+		acct, ok := acc.(*state.Account)
+		r.True(ok)
+		r.NoError(acct.AddBalance(big.NewInt(1_000_000_000)))
+		return 0, nil
+	}).AnyTimes()
+
+	cfg := getActPoolCfg()
+	cfg.MaxNumActsPerPool = 2 // small so the second add already triggers eviction
+	Ap, err := NewActPool(genesis.TestDefault(), sf, cfg)
+	r.NoError(err)
+	ap := Ap.(*actPool)
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
+
+	// Two low-fee actions in shard A fill the pool.
+	cheap1, err := action.SignedTransfer(addrB.String(), pkA, 1, big.NewInt(1), nil, uint64(100000), big.NewInt(1))
+	r.NoError(err)
+	cheap2, err := action.SignedTransfer(addrB.String(), pkA, 2, big.NewInt(1), nil, uint64(100000), big.NewInt(1))
+	r.NoError(err)
+	r.NoError(ap.Add(ctx, cheap1))
+	r.NoError(ap.Add(ctx, cheap2))
+	r.Equal(uint64(2), ap.GetSize())
+
+	// High-fee shard-B action: the old per-shard eviction would have rejected
+	// it because shard B was empty (PopPeek from B returns nil → no slot freed).
+	// The fix must evict one of the cheap shard-A actions instead and let the
+	// expensive shard-B action in.
+	expensive, err := action.SignedTransfer(addrA.String(), pkB, 1, big.NewInt(1), nil, uint64(100000), big.NewInt(100))
+	r.NoError(err)
+	r.NoError(ap.Add(ctx, expensive))
+
+	// Pool size respected.
+	r.LessOrEqual(ap.GetSize(), uint64(cfg.MaxNumActsPerPool))
+
+	// Expensive action must still be in the pool.
+	xHash, err := expensive.Hash()
+	r.NoError(err)
+	got, err := ap.GetActionByHash(xHash)
+	r.NoError(err)
+	r.Equal(expensive.SenderAddress().String(), got.SenderAddress().String())
+
+	// Exactly one of the cheap actions must have been evicted.
+	c1Hash, _ := cheap1.Hash()
+	c2Hash, _ := cheap2.Hash()
+	_, err1 := ap.GetActionByHash(c1Hash)
+	_, err2 := ap.GetActionByHash(c2Hash)
+	evicted := 0
+	if errors.Is(errors.Cause(err1), action.ErrNotFound) {
+		evicted++
+	}
+	if errors.Is(errors.Cause(err2), action.ErrNotFound) {
+		evicted++
+	}
+	r.Equal(1, evicted, "exactly one shard-A cheap action should have been evicted to make room for the cross-shard expensive one")
+}
+
+// TestActPool_crossShardEviction_rejectsLowerFeeNewcomer covers the
+// ErrTxPoolOverflow branch: when the incoming action is itself the
+// globally-lowest priority, the global pop selects it and the Add must fail
+// with ErrTxPoolOverflow rather than silently evicting an honest user.
+func TestActPool_crossShardEviction_rejectsLowerFeeNewcomer(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	r := require.New(t)
+
+	idxA, idxB := -1, -1
+	probe := &actPool{}
+	for i := 0; i < identityset.Size() && idxA < 0; i++ {
+		for j := i + 1; j < identityset.Size(); j++ {
+			if probeShard(probe, identityset.Address(i)) != probeShard(probe, identityset.Address(j)) {
+				idxA, idxB = i, j
+				break
+			}
+		}
+	}
+	r.GreaterOrEqual(idxA, 0)
+	pkA, pkB := identityset.PrivateKey(idxA), identityset.PrivateKey(idxB)
+	addrA, addrB := pkA.PublicKey().Address(), pkB.PublicKey().Address()
+
+	sf := mock_chainmanager.NewMockStateReader(ctrl)
+	sf.EXPECT().Height().Return(uint64(1), nil).AnyTimes()
+	sf.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(func(acc interface{}, opts ...protocol.StateOption) (uint64, error) {
+		acct, ok := acc.(*state.Account)
+		r.True(ok)
+		r.NoError(acct.AddBalance(big.NewInt(1_000_000_000)))
+		return 0, nil
+	}).AnyTimes()
+
+	cfg := getActPoolCfg()
+	cfg.MaxNumActsPerPool = 2
+	Ap, err := NewActPool(genesis.TestDefault(), sf, cfg)
+	r.NoError(err)
+	ap := Ap.(*actPool)
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
+
+	// Fill with two high-fee actions in shard A.
+	hi1, err := action.SignedTransfer(addrB.String(), pkA, 1, big.NewInt(1), nil, uint64(100000), big.NewInt(100))
+	r.NoError(err)
+	hi2, err := action.SignedTransfer(addrB.String(), pkA, 2, big.NewInt(1), nil, uint64(100000), big.NewInt(100))
+	r.NoError(err)
+	r.NoError(ap.Add(ctx, hi1))
+	r.NoError(ap.Add(ctx, hi2))
+
+	// Newcomer (shard B) tries to enter with a *lower* gas price. It is the
+	// globally lowest priority head, so the global pop should select it and
+	// the Add must fail. Both incumbent actions must survive.
+	lowFee, err := action.SignedTransfer(addrA.String(), pkB, 1, big.NewInt(1), nil, uint64(100000), big.NewInt(1))
+	r.NoError(err)
+	err = ap.Add(ctx, lowFee)
+	r.ErrorIs(errors.Cause(err), action.ErrTxPoolOverflow)
+
+	h1, _ := hi1.Hash()
+	h2, _ := hi2.Hash()
+	_, err = ap.GetActionByHash(h1)
+	r.NoError(err)
+	_, err = ap.GetActionByHash(h2)
+	r.NoError(err)
+}
+
+// TestActPool_crossShardEviction_concurrent stresses the multi-lock global
+// pop under load. It is primarily a deadlock smoke test: many goroutines
+// concurrently exercise Add across all 16 shards. With -race, any lock-order
+// inversion would also surface here.
+func TestActPool_crossShardEviction_concurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("stress test")
+	}
+	ctrl := gomock.NewController(t)
+	r := require.New(t)
+
+	sf := mock_chainmanager.NewMockStateReader(ctrl)
+	sf.EXPECT().Height().Return(uint64(1), nil).AnyTimes()
+	sf.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(func(acc interface{}, opts ...protocol.StateOption) (uint64, error) {
+		acct, ok := acc.(*state.Account)
+		r.True(ok)
+		r.NoError(acct.AddBalance(big.NewInt(1_000_000_000)))
+		return 0, nil
+	}).AnyTimes()
+
+	cfg := getActPoolCfg()
+	cfg.MaxNumActsPerPool = 8 // tight so eviction fires often
+	Ap, err := NewActPool(genesis.TestDefault(), sf, cfg)
+	r.NoError(err)
+	ap := Ap.(*actPool)
+	ap.AddActionEnvelopeValidators(protocol.NewGenericValidator(sf, accountutil.AccountState))
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
+
+	// One sender per identityset entry so the workload spans many shards.
+	const goroutines = 16
+	const perG = 50
+	wg := sync.WaitGroup{}
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for k := 0; k < perG; k++ {
+				pk := identityset.PrivateKey((g*perG + k) % identityset.Size())
+				tsf, err := action.SignedTransfer(pk.PublicKey().Address().String(), pk, uint64(k%4+1), big.NewInt(1), nil, uint64(100000), big.NewInt(int64(k%5+1)))
+				if err != nil {
+					continue
+				}
+				_ = ap.Add(ctx, tsf) // ignore individual outcomes; we only care that the pool doesn't deadlock
+			}
+		}(g)
+	}
+	wg.Wait()
+	// If the test reached this line at all, the global eviction did not
+	// deadlock under concurrent multi-shard load. (Strict capacity equality is
+	// not asserted because the pool's global full-check is read-then-act and
+	// can temporarily overshoot under concurrency — that is pre-existing
+	// behavior unrelated to the cross-shard eviction change.)
+	r.Greater(ap.GetSize(), uint64(0), "pool should hold some actions after the workload")
+}
+
+// probeShard exposes allocatedWorker for test setup (which needs to know the
+// shard of an address before any worker exists).
+func probeShard(_ *actPool, addr address.Address) int {
+	b := addr.Bytes()
+	return int(b[len(b)-1]) % _numWorker
+}

--- a/actpool/queueworker.go
+++ b/actpool/queueworker.go
@@ -121,22 +121,28 @@ func (worker *queueWorker) Handle(job workerJob) error {
 
 	atomic.AddUint64(&worker.ap.gasInPool, intrinsicGas)
 
-	worker.mu.Lock()
-	defer worker.mu.Unlock()
 	if replace {
-		// TODO: early return if sender is the account to pop and nonce is larger than largest in the queue
-		actToReplace := worker.accountActs.PopPeek()
+		// Pick the eviction victim across *all* shards, not just this sender's
+		// shard. Per-shard PopPeek lets an attacker who saturates one shard
+		// force honest senders in every other shard to evict each other.
+		// popLowestPriorityAcrossWorkers locks all workers in index order, so
+		// we must release no other worker mu before calling it. Handle's other
+		// state mutations happen via putAction / accountActs which take the
+		// lock internally, so it's safe to call here without holding mu.
+		actToReplace := worker.ap.popLowestPriorityAcrossWorkers()
 		if actToReplace == nil {
 			log.L().Warn("UNEXPECTED ERROR: action pool is full, but no action to drop")
-			return nil
-		}
-		worker.ap.removeInvalidActs([]*action.SealedEnvelope{actToReplace})
-		if actToReplace.SenderAddress().String() == sender && actToReplace.Nonce() == nonce {
-			err = action.ErrTxPoolOverflow
-			_actpoolMtc.WithLabelValues("overMaxNumActsPerPool").Inc()
+		} else {
+			worker.ap.removeInvalidActs([]*action.SealedEnvelope{actToReplace})
+			if actToReplace.SenderAddress().String() == sender && actToReplace.Nonce() == nonce {
+				err = action.ErrTxPoolOverflow
+				_actpoolMtc.WithLabelValues("overMaxNumActsPerPool").Inc()
+			}
 		}
 	}
 
+	worker.mu.Lock()
+	defer worker.mu.Unlock()
 	worker.removeEmptyAccounts()
 
 	return err

--- a/actsync/actionsync.go
+++ b/actsync/actionsync.go
@@ -3,6 +3,7 @@ package actsync
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -33,6 +34,7 @@ type (
 	ActionSync struct {
 		lifecycle.Readiness
 		actions  sync.Map
+		pending  atomic.Int64 // number of live entries in `actions`; bounded by cfg.Size
 		syncChan chan hash.Hash256
 		wg       sync.WaitGroup
 		helper   *Helper
@@ -104,15 +106,24 @@ func (as *ActionSync) RequestAction(_ context.Context, hash hash.Hash256) {
 	if !as.IsReady() {
 		return
 	}
+	// Bound the pending request set: a peer can flood us with forged ACTION_HASH
+	// messages that never resolve, so cap the live map by cfg.Size. Reserve the
+	// slot atomically before touching the map to prevent OOM and unbounded
+	// per-hash unicast amplification by triggerSync.
+	if as.pending.Add(1) > int64(as.cfg.Size) {
+		as.pending.Add(-1)
+		counterMtc.WithLabelValues("capacityExceeded").Inc()
+		log.L().Debug("action sync request capacity exceeded", log.Hex("hash", hash[:]))
+		return
+	}
 	// check if the action is already requested
-	_, ok := as.actions.LoadOrStore(hash, &actionMsg{})
-	if ok {
+	if _, ok := as.actions.LoadOrStore(hash, &actionMsg{}); ok {
+		as.pending.Add(-1)
 		log.L().Debug("Action already requested", log.Hex("hash", hash[:]))
 		return
 	}
 	log.L().Debug("Requesting action", log.Hex("hash", hash[:]))
 	as.trigger(hash)
-	return
 }
 
 // ReceiveAction receives an action
@@ -121,7 +132,9 @@ func (as *ActionSync) ReceiveAction(_ context.Context, hash hash.Hash256) {
 		return
 	}
 	log.L().Debug("received action", log.Hex("hash", hash[:]))
-	as.actions.Delete(hash)
+	if _, loaded := as.actions.LoadAndDelete(hash); loaded {
+		as.pending.Add(-1)
+	}
 }
 
 func (as *ActionSync) sync() {

--- a/actsync/actionsync_test.go
+++ b/actsync/actionsync_test.go
@@ -126,6 +126,102 @@ func TestActionSync(t *testing.T) {
 			r.False(ok, "action should be removed after received")
 		}
 	})
+	t.Run("capacityBound", func(t *testing.T) {
+		// Forged-hash flood: every request is for a unique hash that never
+		// resolves via ReceiveAction. The live map must not grow past cfg.Size.
+		const cap = 8
+		bs := NewActionSync(Config{
+			Size:     cap,
+			Interval: time.Hour, // disable trigger churn for the duration of this test
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		for i := 0; i < cap*4; i++ {
+			bs.RequestAction(context.Background(), hash.Hash256b([]byte{0xff, byte(i), byte(i >> 8)}))
+		}
+		r.Equal(int64(cap), bs.pending.Load(), "pending count must not exceed configured cap")
+		stored := 0
+		bs.actions.Range(func(_, _ any) bool { stored++; return true })
+		r.Equal(cap, stored, "live entries must match the cap")
+		// ReceiveAction on a hash we already stored must drop the counter so a new request can land.
+		var sample hash.Hash256
+		bs.actions.Range(func(k, _ any) bool { sample = k.(hash.Hash256); return false })
+		bs.ReceiveAction(context.Background(), sample)
+		r.Equal(int64(cap-1), bs.pending.Load(), "ReceiveAction must release the slot")
+		bs.RequestAction(context.Background(), hash.Hash256b([]byte("fresh")))
+		r.Equal(int64(cap), bs.pending.Load(), "freed slot can be reused")
+	})
+	t.Run("duplicateRequestDoesNotDoubleCount", func(t *testing.T) {
+		// LoadOrStore must observe an existing entry and refund the slot, otherwise a
+		// peer that repeats the same forged hash would still grow the counter and
+		// eventually wedge the pool at the cap with one real hash.
+		bs := NewActionSync(Config{
+			Size:     4,
+			Interval: time.Hour,
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		dup := hash.Hash256b([]byte("dup"))
+		for i := 0; i < 50; i++ {
+			bs.RequestAction(context.Background(), dup)
+		}
+		r.Equal(int64(1), bs.pending.Load(), "repeated requests for the same hash must collapse to one slot")
+		// ReceiveAction on an unknown hash must not decrement.
+		bs.ReceiveAction(context.Background(), hash.Hash256b([]byte("missing")))
+		r.Equal(int64(1), bs.pending.Load(), "ReceiveAction for an unknown hash must be a no-op for the counter")
+		bs.ReceiveAction(context.Background(), dup)
+		r.Equal(int64(0), bs.pending.Load())
+	})
+	t.Run("concurrentFloodRespectsCap", func(t *testing.T) {
+		// Under contention the atomic reserve+undo must hold the cap exactly;
+		// otherwise a peer can race the check and force the map past the limit.
+		const cap = 16
+		bs := NewActionSync(Config{
+			Size:     cap,
+			Interval: time.Hour,
+		}, &Helper{
+			P2PNeighbor: func() ([]peer.AddrInfo, error) {
+				return neighbors, nil
+			},
+			UnicastOutbound: func(_ context.Context, _ peer.AddrInfo, _ proto.Message) error {
+				return nil
+			},
+		})
+		r.NoError(bs.Start(context.Background()))
+		defer func() { r.NoError(bs.Stop(context.Background())) }()
+		const goroutines = 32
+		const perG = 200
+		wg := sync.WaitGroup{}
+		for g := 0; g < goroutines; g++ {
+			wg.Add(1)
+			go func(g int) {
+				defer wg.Done()
+				for k := 0; k < perG; k++ {
+					bs.RequestAction(context.Background(), hash.Hash256b([]byte{byte(g), byte(k), byte(k >> 8)}))
+				}
+			}(g)
+		}
+		wg.Wait()
+		r.LessOrEqual(bs.pending.Load(), int64(cap), "pending must never exceed configured cap, even under contention")
+		stored := 0
+		bs.actions.Range(func(_, _ any) bool { stored++; return true })
+		r.LessOrEqual(stored, cap, "live entries must never exceed the cap")
+		r.EqualValues(stored, bs.pending.Load(), "counter and map size must agree")
+	})
 	t.Run("requestWhenStopping", func(t *testing.T) {
 		count := atomic.Int32{}
 		as := NewActionSync(Config{

--- a/nodeinfo/manager.go
+++ b/nodeinfo/manager.go
@@ -145,6 +145,11 @@ func (dm *InfoManager) MayHaveBlock(peerID string, start uint64) bool {
 // HandleNodeInfo handle node info message
 func (dm *InfoManager) HandleNodeInfo(ctx context.Context, peerID string, msg *iotextypes.NodeInfo) {
 	log.L().Debug("nodeinfo manager handle node info")
+	// reject malformed messages from peers before dereferencing inner fields
+	if msg == nil || msg.Info == nil {
+		log.L().Warn("nodeinfo manager received malformed node info", zap.String("peerID", peerID))
+		return
+	}
 	// recover pubkey
 	hash := hashNodeInfo(msg.Info)
 	pubKey, err := crypto.RecoverPubkey(hash[:], msg.Signature)

--- a/nodeinfo/manager_test.go
+++ b/nodeinfo/manager_test.go
@@ -123,6 +123,19 @@ func TestDelegateManager_HandleNodeInfo(t *testing.T) {
 		require.Equal(msg.Info.Height, uint64(m.Gauge.GetValue()))
 	})
 
+	t.Run("nil_msg_and_nil_info", func(t *testing.T) {
+		hMock := mock_nodeinfo.NewMockchain(ctrl)
+		tMock := mock_nodeinfo.NewMocktransmitter(ctrl)
+		dm := NewInfoManager(&DefaultConfig, tMock, hMock, 2500*time.Millisecond, privKey)
+		// Both nil msg and msg with nil Info must not panic on field deref / hash.
+		require.NotPanics(func() { dm.HandleNodeInfo(context.Background(), "abc", nil) })
+		require.NotPanics(func() {
+			dm.HandleNodeInfo(context.Background(), "abc", &iotextypes.NodeInfo{Signature: []byte("sig")})
+		})
+		_, ok := dm.nodeMap.Get("abc")
+		require.False(ok)
+	})
+
 	t.Run("verify_fail", func(t *testing.T) {
 		hMock := mock_nodeinfo.NewMockchain(ctrl)
 		tMock := mock_nodeinfo.NewMocktransmitter(ctrl)

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -386,7 +386,11 @@ func StartServer(ctx context.Context, svr *Server, probeSvr *probe.Server, cfg c
 		mux.Handle("/unpause", http.HandlerFunc(svr.pauseMgr.HandleUnPause))
 		mux.Handle("/producer-keys", NewProducerKeysAdmin(svr))
 
-		port := fmt.Sprintf(":%d", cfg.System.HTTPAdminPort)
+		// Bind the admin mux (which exposes /pause, /unpause, /producer-keys and
+		// pprof) to the loopback interface only. Exposing these on an external
+		// address lets any peer that can reach the admin port halt block
+		// production with an unauthenticated POST to /pause.
+		port := fmt.Sprintf("127.0.0.1:%d", cfg.System.HTTPAdminPort)
 		adminserv = httputil.NewServer(port, mux)
 		defer func() {
 			if err := adminserv.Shutdown(ctx); err != nil {


### PR DESCRIPTION
## Summary

Four independent HIGH-severity issues reachable by any peer, fixed
together because they all live on the unauthenticated network surface:

- **nodeinfo**: `HandleNodeInfo` dereferenced `msg.Info` without a nil
  check, so any peer broadcasting `NODE_INFO` with `Info=nil` crashed
  the receiving node. Guard `msg` / `msg.Info` up front.
- **actsync**: `ActionSync.actions` was an unbounded `sync.Map` keyed by
  hash. Flooding forged `ACTION_HASH` messages drove the map to OOM,
  and the periodic `triggerSync` amplified the flood into per-hash
  unicast requests to neighbors. Cap live entries at `cfg.Size` via an
  atomic counter; `LoadOrStore` / `LoadAndDelete` refund the slot on
  dedup and on receipt.
- **server/itx**: the admin mux (`/pause`, `/unpause`, `/producer-keys`,
  pprof) bound to all interfaces on `:HTTPAdminPort`. Any host reachable
  on that port could halt block production with an unauthenticated
  `POST /pause`. Bind to `127.0.0.1` only.
- **actpool**: the pool is sharded into 16 workers by
  `addr.Bytes()[last]%16`. The `MaxNumActsPerPool` full-check was global
  but the eviction (`worker.accountActs.PopPeek`) ran on the receiving
  worker's local shard. Filling one shard with gapped future-nonce
  min-fee spam from grinded same-shard accounts forced honest senders
  in the other 15 shards to evict their own actions while the attacker
  paid nothing. Add `popLowestPriorityAcrossWorkers`, which locks all
  workers in index order and evicts the globally-lowest-priority head,
  matching `accountPriorityQueue.Less`.

### Why grouped

Each fix is small, but separating them creates four parallel branches
on the same hardening pass. They were all surfaced together as
peer-reachable HIGH-severity findings. None of them depend on each
other; bisecting is straightforward (each fix is isolated to its own
file/package).

### Deadlock analysis (actpool)

`popLowestPriorityAcrossWorkers` is the only multi-`worker.mu` site in
the package. It acquires all 16 worker mutexes in a fixed index order;
every other call site holds at most a single worker's mutex. Therefore
no cycle can form. `removeInvalidActs` (which fires subscriber
`onRemoved` callbacks) now runs **outside** the worker-mu region; the
prior code held the local worker mutex while firing those callbacks,
so this change is strictly safer for subscriber re-entrancy.

## Test plan

- [x] `go test ./actpool/ ./actsync/ ./nodeinfo/ -race` — 107 pass
- [x] `go build ./...` — clean
- [x] **nodeinfo** — `nil_msg_and_nil_info` no-panic case
- [x] **actsync** — flood capacity, duplicate dedup, concurrent flood
      respects cap under `-race`
- [x] **actpool** — direct global-pop unit, `headLess` truth table
      mirroring `accountPriorityQueue.Less`, end-to-end Add cross-shard
      eviction, `ErrTxPoolOverflow` when newcomer is globally lowest,
      concurrent multi-shard stress for deadlock detection (`-race`)
- [ ] CI green

## Notes for reviewers

- The admin-mux change drops external reachability of the admin
  endpoints. Anyone using `/ha`, `/producer-keys`, or pprof over the
  network will need an SSH tunnel or a sidecar proxy instead. Default
  config disables the admin port (`HTTPAdminPort: 0`), so production
  nodes that haven't opted in are unaffected.
- Under sustained pool overflow the global eviction briefly serializes
  all 16 workers. Overflow is the rare path; the alternative (per-shard)
  is the bug being fixed.
- The actpool global full-check is read-then-act and can transiently
  overshoot `MaxNumActsPerPool` under concurrency. This is pre-existing
  behavior and not introduced by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
