### PR TITLE
fix(evm): only treat 3-topic logs as in-contract transfers (follow-up to #4844)

### DIFF
--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -926,10 +926,12 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 		copy(topic[:], evmTopic.Bytes())
 		topics = append(topics, topic)
 	}
-	if len(topics) > 0 && topics[0] == _inContractTransfer {
-		if len(topics) != 3 {
-			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics")
-		}
+	// A genuine in-contract transfer is emitted by the protocol with exactly
+	// three topics (type, from, to). Log topics are EVM-controlled, so only
+	// treat the log as an in-contract transfer when the shape matches exactly;
+	// any other shape (including a forged sentinel topic on a 1- or 2-topic
+	// log) falls through to the normal log append below.
+	if len(topics) == 3 && topics[0] == _inContractTransfer {
 		if amount, zero := new(big.Int).SetBytes(evmLog.Data), big.NewInt(0); amount.Cmp(zero) == 1 {
 			from, _ := address.FromBytes(topics[1][12:])
 			to, _ := address.FromBytes(topics[2][12:])

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -1077,3 +1077,57 @@ func TestSelfdestruct6780(t *testing.T) {
 	r.Equal(createdAccount{
 		_c1: struct{}{}}, state.createdAccount)
 }
+
+// TestAddLogInContractTransferTopicShape verifies that AddLog only treats a log
+// as an in-contract transfer when it carries exactly three topics, and that any
+// other topic shape bearing the in-contract-transfer sentinel is recorded as an
+// ordinary log rather than triggering a panic. Log topics are EVM-controlled, so
+// a malformed shape must never be fatal.
+func TestAddLogInContractTransferTopicShape(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	sm, err := initMockStateManager(ctrl)
+	require.NoError(err)
+
+	newAdapter := func() *StateDBAdapter {
+		stateDB, err := NewStateDBAdapter(
+			sm,
+			1,
+			hash.ZeroHash256,
+			NotFixTopicCopyBugOption(),
+			FixSnapshotOrderOption(),
+		)
+		require.NoError(err)
+		return stateDB
+	}
+	sentinel := common.BytesToHash(_inContractTransfer[:])
+	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
+
+	t.Run("malformed sentinel topic is recorded as a normal log", func(t *testing.T) {
+		stateDB := newAdapter()
+		require.NotPanics(func() {
+			stateDB.AddLog(&types.Log{
+				Address: addr,
+				Topics:  []common.Hash{sentinel}, // 1 topic: not a valid in-contract transfer
+				Data:    []byte{0x01},
+			})
+		})
+		require.Len(stateDB.logs, 1)
+		require.Empty(stateDB.transactionLogs)
+	})
+
+	t.Run("well-formed in-contract transfer is still recorded", func(t *testing.T) {
+		stateDB := newAdapter()
+		from := common.BytesToHash(identityset.Address(1).Bytes())
+		to := common.BytesToHash(identityset.Address(2).Bytes())
+		stateDB.AddLog(&types.Log{
+			Address: addr,
+			Topics:  []common.Hash{sentinel, from, to},
+			Data:    big.NewInt(100).Bytes(),
+		})
+		require.Empty(stateDB.logs)
+		require.Len(stateDB.transactionLogs, 1)
+		require.Equal(identityset.Address(1).String(), stateDB.transactionLogs[0].Sender)
+		require.Equal(identityset.Address(2).String(), stateDB.transactionLogs[0].Recipient)
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up hardening to #4844. `StateDBAdapter.AddLog` still calls
`log.Panic("Invalid in contract transfer topics")` when a log's first topic
equals the in-contract-transfer sentinel but the topic count is not exactly 3.

`_inContractTransfer` is `hash.BytesToHash256([]byte{byte(IN_CONTRACT_TRANSFER)})`,
i.e. the all-zero topic, and log topics are EVM-controlled. #4844 added a
`len(topics) > 0` guard that removed the empty-topic (LOG0) index-out-of-range,
but a 1- or 2-topic log whose first topic is all-zero still enters the branch and
hits the `len != 3` panic.

Genuine in-contract transfers are always emitted by the protocol with exactly
three topics (type, from, to), so the correct guard is to enter the special
handling only when `len(topics) == 3`. Any other shape is an ordinary log and is
appended as such. This removes the remaining panic without changing behavior for
real in-contract-transfer logs or for any normal log (real event signatures are
non-zero keccak hashes, so honest traffic never carries an all-zero first topic).

## Change

- `AddLog`: gate the in-contract-transfer handling on
  `len(topics) == 3 && topics[0] == _inContractTransfer`; drop the now-dead
  `len != 3` panic. Malformed shapes fall through to the normal log append.

## Test

- Added `TestAddLogInContractTransferTopicShape`: asserts `AddLog` does not panic
  on a 1-topic log whose topic0 is the sentinel (recorded as a normal log), and
  that a well-formed 3-topic in-contract transfer is still recorded as a
  transaction log with the correct sender/recipient.
- `go test ./action/protocol/execution/evm/ -race` — full package passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)