### PR TITLE
fix(staking): BLS proof-of-possession blocks rogue-key aggregate forgery (CRITICAL)

### DIFF
--- a/action/candidate_register.go
+++ b/action/candidate_register.go
@@ -67,6 +67,11 @@ type CandidateRegister struct {
 	autoStake       bool
 	payload         []byte
 	blsPubKey       []byte
+	// blsPop is the proof-of-possession signature over
+	// BLSPopSigningRoot(blsPubKey, ownerAddress). Required at handler
+	// time once EnforceBLSPoP is active; carried alongside blsPubKey so
+	// it always travels with the registration.
+	blsPop []byte
 }
 
 func init() {
@@ -149,11 +154,15 @@ func NewCandidateRegister(
 }
 
 // NewCandidateRegisterWithBLS creates a CandidateRegister instance with BLS public key
+// and the corresponding proof-of-possession. blsPop must be a 96-byte BLS
+// signature over BLSPopSigningRoot(blsPubKey, ownerAddress); the handler
+// enforces this once EnforceBLSPoP is active.
 func NewCandidateRegisterWithBLS(
 	name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountStr string,
 	duration uint32,
 	autoStake bool,
 	blsPubKey []byte,
+	blsPop []byte,
 	payload []byte,
 ) (*CandidateRegister, error) {
 	cr, err := NewCandidateRegister(name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountStr, duration, autoStake, payload)
@@ -168,6 +177,10 @@ func NewCandidateRegisterWithBLS(
 	cr.amount = nil
 	cr.blsPubKey = make([]byte, len(blsPubKey))
 	copy(cr.blsPubKey, blsPubKey)
+	if len(blsPop) > 0 {
+		cr.blsPop = make([]byte, len(blsPop))
+		copy(cr.blsPop, blsPop)
+	}
 	return cr, nil
 }
 
@@ -215,6 +228,13 @@ func (cr *CandidateRegister) BLSPubKey() []byte {
 	return cr.blsPubKey
 }
 
+// BLSPop returns the BLS proof-of-possession that accompanies the
+// blsPubKey. Empty for legacy registrations and for pre-fork
+// CandidateRegister actions; required once EnforceBLSPoP is active.
+func (cr *CandidateRegister) BLSPop() []byte {
+	return cr.blsPop
+}
+
 // Serialize returns a raw byte stream of the CandidateRegister struct
 func (cr *CandidateRegister) Serialize() []byte {
 	return byteutil.Must(proto.Marshal(cr.Proto()))
@@ -249,6 +269,10 @@ func (cr *CandidateRegister) Proto() *iotextypes.CandidateRegister {
 	case cr.WithBLS():
 		act.Candidate.BlsPubKey = make([]byte, len(cr.blsPubKey))
 		copy(act.Candidate.BlsPubKey, cr.blsPubKey)
+		if len(cr.blsPop) > 0 {
+			act.Candidate.BlsPop = make([]byte, len(cr.blsPop))
+			copy(act.Candidate.BlsPop, cr.blsPop)
+		}
 		if cr.value != nil {
 			act.StakedAmount = cr.value.String()
 		}
@@ -288,6 +312,10 @@ func (cr *CandidateRegister) LoadProto(pbAct *iotextypes.CandidateRegister) erro
 	if withBLS {
 		cr.blsPubKey = make([]byte, len(pbAct.Candidate.GetBlsPubKey()))
 		copy(cr.blsPubKey, pbAct.Candidate.GetBlsPubKey())
+		if pop := pbAct.Candidate.GetBlsPop(); len(pop) > 0 {
+			cr.blsPop = make([]byte, len(pop))
+			copy(cr.blsPop, pop)
+		}
 	}
 	if len(pbAct.GetStakedAmount()) > 0 {
 		amount, ok := new(big.Int).SetString(pbAct.GetStakedAmount(), 10)

--- a/action/candidate_update.go
+++ b/action/candidate_update.go
@@ -41,6 +41,11 @@ type CandidateUpdate struct {
 	operatorAddress address.Address
 	rewardAddress   address.Address
 	blsPubKey       []byte
+	// blsPop is the proof-of-possession for blsPubKey. Required at
+	// handler time once EnforceBLSPoP is active: any update that
+	// introduces or rotates the BLS key must carry a fresh PoP to
+	// prevent rogue-key attacks.
+	blsPop []byte
 }
 
 // CandidateUpdateOption defines the method to customize CandidateUpdate
@@ -99,7 +104,9 @@ func NewCandidateUpdate(name, operatorAddrStr, rewardAddrStr string) (*Candidate
 }
 
 // NewCandidateUpdateWithBLS creates a CandidateUpdate instance with BLS public key
-func NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr string, pubkey []byte) (*CandidateUpdate, error) {
+// and proof-of-possession. blsPop may be empty for pre-fork callers; the
+// handler enforces non-empty PoP once EnforceBLSPoP is active.
+func NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr string, pubkey []byte, pop []byte) (*CandidateUpdate, error) {
 	cu, err := NewCandidateUpdate(name, operatorAddrStr, rewardAddrStr)
 	if err != nil {
 		return nil, err
@@ -110,6 +117,10 @@ func NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr string, pubk
 	}
 	cu.blsPubKey = make([]byte, len(pubkey))
 	copy(cu.blsPubKey, pubkey)
+	if len(pop) > 0 {
+		cu.blsPop = make([]byte, len(pop))
+		copy(cu.blsPop, pop)
+	}
 	return cu, nil
 }
 
@@ -125,6 +136,13 @@ func (cu *CandidateUpdate) RewardAddress() address.Address { return cu.rewardAdd
 // BLSPubKey returns candidate public key to update
 func (cu *CandidateUpdate) BLSPubKey() []byte {
 	return cu.blsPubKey
+}
+
+// BLSPop returns the proof-of-possession for the BLS pubkey carried
+// by this update. Empty for updates that do not rotate the BLS key
+// and for pre-fork updates; required once EnforceBLSPoP is active.
+func (cu *CandidateUpdate) BLSPop() []byte {
+	return cu.blsPop
 }
 
 // WithBLS returns true if the candidate update action is with BLS public key
@@ -159,6 +177,10 @@ func (cu *CandidateUpdate) Proto() *iotextypes.CandidateBasicInfo {
 		act.BlsPubKey = make([]byte, len(cu.blsPubKey))
 		copy(act.BlsPubKey, cu.blsPubKey)
 	}
+	if len(cu.blsPop) > 0 {
+		act.BlsPop = make([]byte, len(cu.blsPop))
+		copy(act.BlsPop, cu.blsPop)
+	}
 	return act
 }
 
@@ -188,6 +210,10 @@ func (cu *CandidateUpdate) LoadProto(pbAct *iotextypes.CandidateBasicInfo) error
 	if len(pbAct.GetBlsPubKey()) > 0 {
 		cu.blsPubKey = make([]byte, len(pbAct.GetBlsPubKey()))
 		copy(cu.blsPubKey, pbAct.GetBlsPubKey())
+		if pop := pbAct.GetBlsPop(); len(pop) > 0 {
+			cu.blsPop = make([]byte, len(pop))
+			copy(cu.blsPop, pop)
+		}
 	}
 	return nil
 }

--- a/action/candidateregister_test.go
+++ b/action/candidateregister_test.go
@@ -140,7 +140,7 @@ func TestCandidateRegister(t *testing.T) {
 	blsPubKey := blsPrivKey.PublicKey().Bytes()
 	for _, test := range candidateRegisterTestParams {
 		test.blsPubKey = blsPubKey
-		cr, err := NewCandidateRegisterWithBLS(test.Name, test.OperatorAddrStr, test.RewardAddrStr, test.OwnerAddrStr, test.AmountStr, test.Duration, test.AutoStake, test.blsPubKey, test.Payload)
+		cr, err := NewCandidateRegisterWithBLS(test.Name, test.OperatorAddrStr, test.RewardAddrStr, test.OwnerAddrStr, test.AmountStr, test.Duration, test.AutoStake, test.blsPubKey, nil, test.Payload)
 		require.Equal(test.Expected, errors.Cause(err))
 		if err != nil {
 			continue
@@ -190,7 +190,7 @@ func TestCandidateRegisterABIEncodeAndDecode(t *testing.T) {
 	t.Run("with public key", func(t *testing.T) {
 		pk, err := crypto.GenerateBLS12381PrivateKey(identityset.PrivateKey(0).Bytes())
 		require.NoError(err)
-		stake, err := NewCandidateRegisterWithBLS(test.Name, test.OperatorAddrStr, test.RewardAddrStr, test.OwnerAddrStr, test.AmountStr, test.Duration, test.AutoStake, pk.PublicKey().Bytes(), test.Payload)
+		stake, err := NewCandidateRegisterWithBLS(test.Name, test.OperatorAddrStr, test.RewardAddrStr, test.OwnerAddrStr, test.AmountStr, test.Duration, test.AutoStake, pk.PublicKey().Bytes(), nil, test.Payload)
 		require.NoError(err)
 		encode(stake)
 	})

--- a/action/candidateupdate_test.go
+++ b/action/candidateupdate_test.go
@@ -29,7 +29,7 @@ func TestCandidateUpdate(t *testing.T) {
 	require := require.New(t)
 	blsPrivKey, err := crypto.GenerateBLS12381PrivateKey(identityset.PrivateKey(0).Bytes())
 	require.NoError(err)
-	cu, err := NewCandidateUpdateWithBLS(_cuName, _cuOperatorAddrStr, _cuRewardAddrStr, blsPrivKey.PublicKey().Bytes())
+	cu, err := NewCandidateUpdateWithBLS(_cuName, _cuOperatorAddrStr, _cuRewardAddrStr, blsPrivKey.PublicKey().Bytes(), nil)
 	require.NoError(err)
 	elp := (&EnvelopeBuilder{}).SetNonce(_cuNonce).SetGasLimit(_cuGasLimit).
 		SetGasPrice(_cuGasPrice).SetAction(cu).Build()

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -173,6 +173,17 @@ type (
 		AlwaysWriteCachedContract bool
 		NoCandidateExitQueue      bool
 		EnableBLSAggregation      bool
+		// EnforceBLSPoP gates the BLS proof-of-possession requirement at
+		// candidate register / update. Without PoP, IIP-52's
+		// FastAggregateVerify path is vulnerable to a rogue-key
+		// aggregate-forgery attack (a registered candidate can publish
+		// pk_rogue = g^x − Σ(other pubkeys) and forge a 2/3+ quorum
+		// certificate with a single signature). Shares the IsToBeEnabled
+		// height with EnableBLSAggregation today but is a semantically
+		// distinct switch — keep them separate so call sites read
+		// self-descriptively and so the two can diverge if a hotfix or
+		// fork-height adjustment is ever needed.
+		EnforceBLSPoP bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -348,6 +359,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
 			EnableBLSAggregation:                    g.IsToBeEnabled(height),
+			EnforceBLSPoP:                           g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -172,6 +172,7 @@ type (
 		// contracts are committed and written back
 		AlwaysWriteCachedContract bool
 		NoCandidateExitQueue      bool
+		EnableBLSAggregation      bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -346,6 +347,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			PrePectraEVM:                            !g.IsYap(height),
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
+			EnableBLSAggregation:                    g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/staking/bls_pop.go
+++ b/action/protocol/staking/bls_pop.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package staking
+
+import (
+	"crypto/sha256"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+)
+
+// blsPopDomain is the iotex-specific domain separator for BLS
+// proof-of-possession signatures at candidate register / update time.
+//
+// Domain separation matters for two reasons:
+//   1. It prevents a PoP signature from being replayed as a consensus
+//      vote signature (or vice versa) — even though both schemes use
+//      the same BLS ciphersuite DST, the message they sign starts with
+//      this iotex-application-level tag and so the resulting signing
+//      root will never collide with a consensus signing root.
+//   2. The version suffix ("v1") reserves room for a future fork to
+//      rotate the PoP scheme without ambiguity.
+const blsPopDomain = "IOTEX_BLS_POP_v1"
+
+// BLSPopSigningRoot returns the bytes that a BLS proof-of-possession
+// must be computed over for the given candidate.
+//
+// Binding three values into the signed message — the domain tag, the BLS
+// public key itself, and the candidate owner address — closes the rogue
+// key attack and two related replays:
+//
+//   - blsPubKey: forces the signer to know the private key for THIS
+//     specific BLS pubkey. A rogue pubkey constructed as
+//     g^x − Σ(other pubkeys) cannot produce a valid PoP because the
+//     attacker does not know its discrete log.
+//   - ownerAddress: prevents two distinct candidates from sharing a
+//     single BLS keypair (and thus a single PoP) without each owner
+//     independently re-attesting; also prevents a PoP submitted for
+//     candidate A from being replayed for candidate B by a man-in-the-
+//     middle who repackages a CandidateRegister tx.
+//   - blsPopDomain: keeps PoP signatures disjoint from consensus
+//     signatures, future PoP schemes, and any other BLS-signed iotex
+//     message that may exist or be added later.
+func BLSPopSigningRoot(blsPubKey []byte, ownerAddress address.Address) []byte {
+	h := sha256.New()
+	h.Write([]byte(blsPopDomain))
+	h.Write(blsPubKey)
+	if ownerAddress != nil {
+		h.Write(ownerAddress.Bytes())
+	}
+	return h.Sum(nil)
+}
+
+// SignBLSPop produces a proof-of-possession for the given BLS private
+// key, binding it to the candidate owner address. Used by tooling
+// (ioctl, SDK) to generate the bls_pop field on CandidateRegister /
+// CandidateUpdate transactions.
+func SignBLSPop(sk *crypto.BLS12381PrivateKey, ownerAddress address.Address) ([]byte, error) {
+	if sk == nil {
+		return nil, errors.New("nil BLS private key")
+	}
+	pk := sk.PublicKey().Bytes()
+	return sk.Sign(BLSPopSigningRoot(pk, ownerAddress))
+}
+
+// VerifyBLSPop verifies the proof-of-possession against the provided
+// pubkey and owner. Returns nil on success.
+func VerifyBLSPop(blsPubKey, blsPop []byte, ownerAddress address.Address) error {
+	if len(blsPubKey) != crypto.BLSPubkeyLength {
+		return errors.Errorf("invalid BLS pubkey length: got %d, want %d", len(blsPubKey), crypto.BLSPubkeyLength)
+	}
+	if len(blsPop) != crypto.BLSAggregateSignatureLength {
+		return errors.Errorf("invalid BLS PoP length: got %d, want %d", len(blsPop), crypto.BLSAggregateSignatureLength)
+	}
+	pk, err := crypto.BLS12381PublicKeyFromBytes(blsPubKey)
+	if err != nil {
+		return errors.Wrap(err, "invalid BLS pubkey")
+	}
+	if !pk.Verify(BLSPopSigningRoot(blsPubKey, ownerAddress), blsPop) {
+		return errors.New("BLS proof-of-possession verification failed")
+	}
+	return nil
+}

--- a/action/protocol/staking/bls_pop_test.go
+++ b/action/protocol/staking/bls_pop_test.go
@@ -1,0 +1,173 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package staking
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/stretchr/testify/require"
+)
+
+// blsKeyForTest deterministically derives a BLS keypair from a seed so
+// the tests are reproducible.
+func blsKeyForTest(t *testing.T, seed string) *crypto.BLS12381PrivateKey {
+	t.Helper()
+	h := sha256.Sum256([]byte(seed))
+	sk, err := crypto.GenerateBLS12381PrivateKey(h[:])
+	require.NoError(t, err)
+	return sk
+}
+
+func addrForTest(t *testing.T, seed string) address.Address {
+	t.Helper()
+	h := sha256.Sum256([]byte(seed))
+	addr, err := address.FromBytes(h[:20])
+	require.NoError(t, err)
+	return addr
+}
+
+func TestBLSPop_RoundTrip(t *testing.T) {
+	require := require.New(t)
+	sk := blsKeyForTest(t, "honest-delegate")
+	owner := addrForTest(t, "owner-address")
+
+	pop, err := SignBLSPop(sk, owner)
+	require.NoError(err)
+	require.Len(pop, crypto.BLSAggregateSignatureLength)
+
+	require.NoError(VerifyBLSPop(sk.PublicKey().Bytes(), pop, owner))
+}
+
+func TestBLSPop_RejectInvalidLength(t *testing.T) {
+	require := require.New(t)
+	sk := blsKeyForTest(t, "x")
+	owner := addrForTest(t, "owner")
+
+	require.Error(VerifyBLSPop([]byte{0x00}, make([]byte, 96), owner),
+		"short BLS pubkey rejected")
+	require.Error(VerifyBLSPop(sk.PublicKey().Bytes(), []byte{0x00}, owner),
+		"short PoP rejected")
+}
+
+func TestBLSPop_RejectWrongOwner(t *testing.T) {
+	// A PoP issued for one candidate owner must not verify under another
+	// owner — closes the replay window where an attacker repackages a
+	// CandidateRegister tx with a different owner address.
+	require := require.New(t)
+	sk := blsKeyForTest(t, "delegate")
+	ownerA := addrForTest(t, "owner-A")
+	ownerB := addrForTest(t, "owner-B")
+
+	pop, err := SignBLSPop(sk, ownerA)
+	require.NoError(err)
+	require.NoError(VerifyBLSPop(sk.PublicKey().Bytes(), pop, ownerA),
+		"sanity: PoP verifies for the owner it was signed for")
+	require.Error(VerifyBLSPop(sk.PublicKey().Bytes(), pop, ownerB),
+		"PoP must NOT verify under a different owner")
+}
+
+func TestBLSPop_RejectWrongPubkey(t *testing.T) {
+	// A PoP for one BLS pubkey must not verify against another — closes
+	// the case where an attacker steals a PoP from someone else's tx and
+	// pairs it with their own pubkey.
+	require := require.New(t)
+	skA := blsKeyForTest(t, "delegate-A")
+	skB := blsKeyForTest(t, "delegate-B")
+	owner := addrForTest(t, "owner")
+
+	popA, err := SignBLSPop(skA, owner)
+	require.NoError(err)
+	require.Error(VerifyBLSPop(skB.PublicKey().Bytes(), popA, owner),
+		"PoP for pubkey A must NOT verify against pubkey B")
+}
+
+// TestBLSPop_RogueKeyAttackBlocked is the security regression guard for
+// the BLS rogue-key aggregate forgery against IIP-52's
+// FastAggregateVerify path.
+//
+// Threat model: an attacker reads N honest delegates' BLS public keys
+// from chain. They pick a private key x they fully control and would
+// like to register
+//
+//	pk_rogue = g^x − Σ(other delegates' pubkeys)
+//
+// in G1. If accepted, the rogue pubkey causes
+// FastAggregateVerify(all_pubkeys, σ, msg) to collapse the aggregated
+// pubkey to g^x, letting one delegate forge a quorum certificate with
+// a single signature.
+//
+// Constructing pk_rogue requires only public information. What does
+// NOT require only public information is knowing its discrete log —
+// pk_rogue's secret key is (x − Σ sk_i), and the attacker does not
+// know any sk_i.
+//
+// The PoP mitigation: registration requires a BLS signature over
+// BLSPopSigningRoot(pk_rogue, owner). Producing this signature
+// requires pk_rogue's secret key. The attacker cannot produce one.
+//
+// The cleanest test of this property is the abstract one: any pubkey
+// for which the actor does not know the secret cannot be the subject
+// of a valid PoP — regardless of how the pubkey was constructed. We
+// model "the attacker tries to register some pubkey they do not own"
+// by using a freshly generated pubkey as pk_rogue and verifying that
+// no PoP signed by any other secret key (whether the attacker's or
+// anyone else's) validates against it.
+func TestBLSPop_RogueKeyAttackBlocked(t *testing.T) {
+	require := require.New(t)
+
+	// 1. N=24 honest delegates' pubkeys, simulating the on-chain active
+	//    set the attacker reads. The exact bytes are not assertion-load-
+	//    bearing — they only need to be distinct, valid BLS pubkeys.
+	const N = 24
+	honestPubKeys := make([][]byte, N)
+	for i := 0; i < N; i++ {
+		buf := make([]byte, 8)
+		binary.BigEndian.PutUint64(buf, uint64(i))
+		sk := blsKeyForTest(t, "honest-"+string(buf))
+		honestPubKeys[i] = sk.PublicKey().Bytes()
+	}
+
+	// 2. The attacker's secret. They can sign anything with this, but
+	//    not under any other key's pubkey.
+	attackerSK := blsKeyForTest(t, "attacker-secret")
+
+	// 3. pk_rogue stand-in: a freshly generated pubkey whose secret the
+	//    attacker does NOT have. (In the wild, this would be the
+	//    explicit g^x − Σ pk_i subtraction; for PoP-verification
+	//    purposes the relevant property is identical — pk for which
+	//    attacker has no sk.)
+	pkRogue := blsKeyForTest(t, "rogue-target-keypair").PublicKey().Bytes()
+	rogueOwner := addrForTest(t, "rogue-owner")
+
+	// 4. Attacker attempts to register pkRogue. The only PoP they can
+	//    produce is one signed with attackerSK — but
+	//    BLSPopSigningRoot(pkRogue, ...) was supposed to be signed under
+	//    pkRogue's secret key, not attackerSK's. Verification must reject.
+	attackerForgedPop, err := attackerSK.Sign(BLSPopSigningRoot(pkRogue, rogueOwner))
+	require.NoError(err)
+	require.Error(VerifyBLSPop(pkRogue, attackerForgedPop, rogueOwner),
+		"PoP signed under attackerSK must NOT validate as possession of pkRogue. "+
+			"This is the exact property that blocks the rogue-key registration")
+
+	// 5. Also reject if the attacker simply pairs the pubkey with a
+	//    blank signature — defensive cover for an actor who skips the
+	//    sign step entirely.
+	require.Error(VerifyBLSPop(pkRogue, make([]byte, crypto.BLSAggregateSignatureLength), rogueOwner),
+		"all-zeros signature must not validate")
+
+	// 6. Control: a delegate that DOES know their key's secret can
+	//    produce a valid PoP — the gate is not blanket-rejecting BLS
+	//    registrations, only those without possession.
+	legitSK := blsKeyForTest(t, "honest-registrant")
+	legitPop, err := SignBLSPop(legitSK, rogueOwner)
+	require.NoError(err)
+	require.NoError(VerifyBLSPop(legitSK.PublicKey().Bytes(), legitPop, rogueOwner),
+		"control: a delegate that knows their own secret can register normally")
+}

--- a/action/protocol/staking/handlers.go
+++ b/action/protocol/staking/handlers.go
@@ -782,6 +782,14 @@ func (p *Protocol) handleCandidateRegister(ctx context.Context, act *action.Cand
 		c.Identifier = candID
 	}
 	if act.WithBLS() {
+		if featureCtx.EnforceBLSPoP {
+			if err := VerifyBLSPop(act.BLSPubKey(), act.BLSPop(), owner); err != nil {
+				return log, nil, &handleError{
+					err:           errors.Wrap(err, "BLS proof-of-possession invalid"),
+					failureStatus: iotextypes.ReceiptStatus_ErrUnauthorizedOperator,
+				}
+			}
+		}
 		c.BLSPubKey = act.BLSPubKey()
 		topics, eventData, err := action.PackCandidateRegisteredEvent(c.GetIdentifier(), c.Operator, c.Owner, c.Name, c.Reward, act.BLSPubKey())
 		if err != nil {
@@ -885,6 +893,14 @@ func (p *Protocol) handleCandidateUpdate(ctx context.Context, act *action.Candid
 	}
 
 	if act.WithBLS() {
+		if featureCtx.EnforceBLSPoP {
+			if err := VerifyBLSPop(act.BLSPubKey(), act.BLSPop(), c.Owner); err != nil {
+				return log, &handleError{
+					err:           errors.Wrap(err, "BLS proof-of-possession invalid"),
+					failureStatus: iotextypes.ReceiptStatus_ErrUnauthorizedOperator,
+				}
+			}
+		}
 		c.BLSPubKey = act.BLSPubKey()
 		topics, eventData, err := action.PackCandidateUpdatedEvent(c.GetIdentifier(), c.Operator, c.Owner, c.Name, c.Reward, act.BLSPubKey())
 		if err != nil {
@@ -930,6 +946,14 @@ func (p *Protocol) handleCandidateUpdateByOperator(ctx context.Context, act *act
 		return log, &handleError{
 			err:           errors.New("candidate reward address cannot be updated by operator"),
 			failureStatus: iotextypes.ReceiptStatus_ErrUnauthorizedOperator,
+		}
+	}
+	if protocol.MustGetFeatureCtx(ctx).EnforceBLSPoP {
+		if err := VerifyBLSPop(act.BLSPubKey(), act.BLSPop(), c.Owner); err != nil {
+			return log, &handleError{
+				err:           errors.Wrap(err, "BLS proof-of-possession invalid"),
+				failureStatus: iotextypes.ReceiptStatus_ErrUnauthorizedOperator,
+			}
 		}
 	}
 	// update BLS public key

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -972,9 +972,17 @@ func (p *Protocol) ActiveCandidates(ctx context.Context, sr protocol.StateReader
 		if err != nil {
 			return nil, err
 		}
-		if active {
-			cand = append(cand, list[i])
+		if !active {
+			continue
 		}
+		// Post-fork (IIP-52): drop candidates without a registered BLS public
+		// key so the per-block aggregate signature has a well-defined signer
+		// set. Pre-fork the BLSPubKey field is empty for every candidate and
+		// this filter is a no-op.
+		if fCtx.EnableBLSAggregation && len(list[i].BLSPubKey) == 0 {
+			continue
+		}
+		cand = append(cand, list[i])
 	}
 	return cand.toStateCandidateList(protocol.MustGetFeatureWithHeightCtx(ctx).CandidateWithoutIdentityStorage(height))
 }

--- a/action/signedaction.go
+++ b/action/signedaction.go
@@ -99,12 +99,15 @@ func SignedCandidateRegister(
 }
 
 // SignedCandidateRegisterWithBLS returns a signed candidate register with BLS public key
+// and proof-of-possession. blsPop may be empty for pre-fork callers and tests; the
+// handler enforces non-empty PoP once EnforceBLSPoP is active.
 func SignedCandidateRegisterWithBLS(
 	nonce uint64,
 	name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountStr string,
 	duration uint32,
 	autoStake bool,
 	blsPubKey []byte,
+	blsPop []byte,
 	payload []byte,
 	gasLimit uint64,
 	gasPrice *big.Int,
@@ -112,7 +115,7 @@ func SignedCandidateRegisterWithBLS(
 	options ...SignedActionOption,
 ) (*SealedEnvelope, error) {
 	cr, err := NewCandidateRegisterWithBLS(name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountStr,
-		duration, autoStake, blsPubKey, payload)
+		duration, autoStake, blsPubKey, blsPop, payload)
 	if err != nil {
 		return nil, err
 	}
@@ -162,16 +165,19 @@ func SignedCandidateUpdate(
 }
 
 // SignedCandidateUpdateWithBLS returns a signed candidate update with BLS public key
+// and the corresponding proof-of-possession. blsPop may be empty for pre-fork
+// callers; the handler enforces non-empty PoP once EnforceBLSPoP is active.
 func SignedCandidateUpdateWithBLS(
 	nonce uint64,
 	name, operatorAddrStr, rewardAddrStr string,
 	blsPubKey []byte,
+	blsPop []byte,
 	gasLimit uint64,
 	gasPrice *big.Int,
 	registererPriKey crypto.PrivateKey,
 	options ...SignedActionOption,
 ) (*SealedEnvelope, error) {
-	cu, err := NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr, blsPubKey)
+	cu, err := NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr, blsPubKey, blsPop)
 	if err != nil {
 		return nil, err
 	}

--- a/api/web3server_integrity_test.go
+++ b/api/web3server_integrity_test.go
@@ -688,6 +688,7 @@ func web3Staking(t *testing.T, handler *hTTPHandler) {
 		"io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza",
 		"io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza",
 		blsPubKey,
+		nil,
 	)
 	require.NoError(err)
 	data9, err := act9.EthData()

--- a/blockchain/block/block.go
+++ b/blockchain/block/block.go
@@ -74,15 +74,47 @@ func (b *Block) RunnableActions() RunnableActions {
 	return RunnableActions{actions: b.Actions, txHash: b.txRoot}
 }
 
-// Finalize creates a footer for the block
+// Finalize creates a footer for the block using the per-delegate endorsements
+// path. Used pre-fork (and as the legacy entry point); post-fork blocks are
+// finalized via FinalizeWithAggregate instead.
 func (b *Block) Finalize(endorsements []*endorsement.Endorsement, ts time.Time) error {
-	if len(b.endorsements) != 0 {
+	if b.isFinalized() {
 		return errors.New("the block has been finalized")
 	}
 	b.endorsements = endorsements
 	b.commitTime = ts
 
 	return nil
+}
+
+// FinalizeWithAggregate creates a footer for the block using the BLS12-381
+// aggregate signature path (IIP-52). The aggregate signature is a single
+// 96-byte BLS sig over the per-block COMMIT vote; signerBitmap identifies
+// which epoch delegates contributed (bit i = delegate i in the epoch's
+// delegate list, LSB-first within each byte).
+//
+// Same one-shot contract as Finalize: a block can only be finalized once.
+func (b *Block) FinalizeWithAggregate(aggregatedSignature, signerBitmap []byte, ts time.Time) error {
+	if b.isFinalized() {
+		return errors.New("the block has been finalized")
+	}
+	if len(aggregatedSignature) == 0 {
+		return errors.New("aggregated signature is empty")
+	}
+	if len(signerBitmap) == 0 {
+		return errors.New("signer bitmap is empty")
+	}
+	b.aggregatedSignature = append([]byte(nil), aggregatedSignature...)
+	b.signerBitmap = append([]byte(nil), signerBitmap...)
+	b.commitTime = ts
+	return nil
+}
+
+// isFinalized reports whether Finalize/FinalizeWithAggregate has already been
+// called for this block. Either path sets commitTime as part of its work, so
+// a non-zero commitTime is a sufficient witness.
+func (b *Block) isFinalized() bool {
+	return len(b.endorsements) != 0 || len(b.aggregatedSignature) != 0 || !b.commitTime.IsZero()
 }
 
 // TransactionLog returns transaction logs in the block

--- a/blockchain/block/footer.go
+++ b/blockchain/block/footer.go
@@ -15,10 +15,16 @@ import (
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 )
 
-// Footer defines a set of proof of this block
+// Footer defines a set of proof of this block. Pre-fork the proof is the
+// per-delegate COMMIT endorsements (endorsements). Once BLS signature
+// aggregation is activated (IIP-52) the proof is the per-block aggregated
+// signature plus a bitmap identifying which epoch delegates contributed; the
+// endorsements slice stays empty.
 type Footer struct {
-	endorsements []*endorsement.Endorsement
-	commitTime   time.Time
+	endorsements        []*endorsement.Endorsement
+	commitTime          time.Time
+	aggregatedSignature []byte
+	signerBitmap        []byte
 }
 
 // Proto converts BlockFooter
@@ -29,6 +35,12 @@ func (f *Footer) Proto() *iotextypes.BlockFooter {
 	pb.Endorsements = []*iotextypes.Endorsement{}
 	for _, en := range f.endorsements {
 		pb.Endorsements = append(pb.Endorsements, en.Proto())
+	}
+	if len(f.aggregatedSignature) > 0 {
+		pb.AggregatedSignature = append([]byte(nil), f.aggregatedSignature...)
+	}
+	if len(f.signerBitmap) > 0 {
+		pb.SignerBitmap = append([]byte(nil), f.signerBitmap...)
 	}
 	return &pb
 }
@@ -43,6 +55,12 @@ func (f *Footer) ConvertFromBlockFooterPb(pb *iotextypes.BlockFooter) error {
 	}
 	commitTime := pb.GetTimestamp().AsTime()
 	f.commitTime = commitTime
+	if aggSig := pb.GetAggregatedSignature(); len(aggSig) > 0 {
+		f.aggregatedSignature = append([]byte(nil), aggSig...)
+	}
+	if bitmap := pb.GetSignerBitmap(); len(bitmap) > 0 {
+		f.signerBitmap = append([]byte(nil), bitmap...)
+	}
 	pbEndorsements := pb.GetEndorsements()
 	if pbEndorsements == nil {
 		return nil
@@ -67,6 +85,27 @@ func (f *Footer) CommitTime() time.Time {
 // Endorsements returns the number of commit endorsements froms delegates
 func (f *Footer) Endorsements() []*endorsement.Endorsement {
 	return f.endorsements
+}
+
+// AggregatedSignature returns the BLS12-381 aggregate signature over the
+// per-block COMMIT vote (96 bytes, G2 compressed) when BLS signature
+// aggregation is activated; empty for pre-fork blocks.
+func (f *Footer) AggregatedSignature() []byte {
+	return append([]byte(nil), f.aggregatedSignature...)
+}
+
+// SignerBitmap returns the bitmap identifying which epoch delegates
+// contributed to AggregatedSignature. Bit i (LSB-first within each byte)
+// corresponds to delegate i in the epoch's delegate list. Empty for
+// pre-fork blocks.
+func (f *Footer) SignerBitmap() []byte {
+	return append([]byte(nil), f.signerBitmap...)
+}
+
+// IsAggregated reports whether this footer carries a BLS aggregate signature
+// rather than the per-delegate endorsements list.
+func (f *Footer) IsAggregated() bool {
+	return len(f.aggregatedSignature) > 0
 }
 
 // Serialize returns the serialized byte stream of the block footer

--- a/blockchain/block/footer_test.go
+++ b/blockchain/block/footer_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestConvertToBlockFooterPb(t *testing.T) {
 	require := require.New(t)
-	footer := &Footer{nil, time.Now()}
+	footer := &Footer{endorsements: nil, commitTime: time.Now()}
 	blockFooter := footer.Proto()
 	require.NotNil(blockFooter)
 	require.Equal(0, len(blockFooter.Endorsements))
@@ -43,7 +43,7 @@ func TestConvertFromBlockFooterPb(t *testing.T) {
 
 func TestSerDesFooter(t *testing.T) {
 	require := require.New(t)
-	footer := &Footer{nil, time.Now()}
+	footer := &Footer{endorsements: nil, commitTime: time.Now()}
 	ser, err := footer.Serialize()
 	require.NoError(err)
 	require.NoError(footer.Deserialize(ser))
@@ -57,10 +57,35 @@ func TestSerDesFooter(t *testing.T) {
 	require.Equal(1, len(footer.endorsements))
 }
 
+func TestFooter_AggregateSerDes(t *testing.T) {
+	require := require.New(t)
+	aggSig := make([]byte, 96)
+	for i := range aggSig {
+		aggSig[i] = byte(i)
+	}
+	bitmap := []byte{0xa5, 0x03}
+	footer := &Footer{
+		commitTime:          time.Unix(1700000000, 0).UTC(),
+		aggregatedSignature: aggSig,
+		signerBitmap:        bitmap,
+	}
+	require.True(footer.IsAggregated())
+
+	ser, err := footer.Serialize()
+	require.NoError(err)
+
+	restored := &Footer{}
+	require.NoError(restored.Deserialize(ser))
+	require.True(restored.IsAggregated())
+	require.Equal(aggSig, restored.AggregatedSignature())
+	require.Equal(bitmap, restored.SignerBitmap())
+	require.Equal(0, len(restored.Endorsements()))
+}
+
 func makeFooter() (f *Footer) {
 	endors := make([]*endorsement.Endorsement, 0)
 	endor := endorsement.NewEndorsement(time.Now(), identityset.PrivateKey(27).PublicKey(), nil)
 	endors = append(endors, endor)
-	f = &Footer{endors, time.Now()}
+	f = &Footer{endorsements: endors, commitTime: time.Now()}
 	return
 }

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -7,6 +7,7 @@ package blockchain
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"os"
 	"slices"
 	"strconv"
@@ -50,6 +51,11 @@ type (
 		ProducerPrivKey            string           `yaml:"producerPrivKey"`
 		ProducerPrivKeySchema      string           `yaml:"producerPrivKeySchema"`
 		ProducerPrivKeyRange       string           `yaml:"producerPrivKeyRange"`
+		// BLSProducerPrivKey is a comma-separated list of hex-encoded BLS12-381
+		// private keys, aligned 1:1 with ProducerPrivKey after applying
+		// ProducerPrivKeyRange. When empty, BLS keys are derived from the
+		// corresponding ECDSA producer keys via crypto.GenerateBLS12381PrivateKey.
+		BLSProducerPrivKey string `yaml:"blsProducerPrivKey"`
 		SignatureScheme            []string         `yaml:"signatureScheme"`
 		EmptyGenesis               bool             `yaml:"emptyGenesis"`
 		GravityChainDB             db.Config        `yaml:"gravityChainDB"`
@@ -206,6 +212,46 @@ func (cfg *Config) ProducerPrivateKeys() []crypto.PrivateKey {
 	}
 
 	return privateKeys[start:end]
+}
+
+// BLSProducerPrivateKeys returns the BLS12-381 producer private keys, aligned
+// 1:1 with ProducerPrivateKeys(). When BLSProducerPrivKey is configured, its
+// entries are parsed and the range/length must match ProducerPrivateKeys();
+// otherwise each BLS key is derived from the corresponding ECDSA key bytes via
+// crypto.GenerateBLS12381PrivateKey.
+func (cfg *Config) BLSProducerPrivateKeys() []*crypto.BLS12381PrivateKey {
+	ecdsa := cfg.ProducerPrivateKeys()
+	blsKeys := make([]*crypto.BLS12381PrivateKey, 0, len(ecdsa))
+	if cfg.BLSProducerPrivKey == "" {
+		for _, sk := range ecdsa {
+			blsSk, err := crypto.GenerateBLS12381PrivateKey(sk.Bytes())
+			if err != nil {
+				log.L().Panic("failed to derive BLS private key from ECDSA producer key", zap.Error(err))
+			}
+			blsKeys = append(blsKeys, blsSk)
+		}
+		return blsKeys
+	}
+	parts := strings.Split(cfg.BLSProducerPrivKey, ",")
+	if len(parts) != len(ecdsa) {
+		log.L().Panic(
+			"BLSProducerPrivKey count does not match ProducerPrivateKeys",
+			zap.Int("bls", len(parts)),
+			zap.Int("ecdsa", len(ecdsa)),
+		)
+	}
+	for i, hexKey := range parts {
+		raw, err := hex.DecodeString(strings.TrimPrefix(strings.TrimSpace(hexKey), "0x"))
+		if err != nil {
+			log.L().Panic("failed to decode BLS producer private key", zap.Int("index", i), zap.Error(err))
+		}
+		blsSk, err := crypto.BLS12381PrivateKeyFromBytes(raw)
+		if err != nil {
+			log.L().Panic("invalid BLS producer private key", zap.Int("index", i), zap.Error(err))
+		}
+		blsKeys = append(blsKeys, blsSk)
+	}
+	return blsKeys
 }
 
 // SetProducerPrivKey set producer privKey by PrivKeyConfigFile info

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/facebookgo/clock"
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/pkg/errors"
@@ -113,7 +114,7 @@ func NewConsensus(
 			return nil, errors.New("block builder factory is not set")
 		}
 		chainMgr := rolldpos.NewChainManager(bc, sf, ops.bbf)
-		delegatesByEpochFunc := func(epochNum uint64, prevHash []byte) ([]string, error) {
+		delegatesByEpochFunc := func(epochNum uint64, prevHash []byte) ([]*rolldpos.Delegate, error) {
 			fork, err := chainMgr.Fork(hash.Hash256(prevHash))
 			if err != nil {
 				return nil, err
@@ -145,53 +146,21 @@ func NewConsensus(
 			if err != nil {
 				return nil, err
 			}
-			addrs := []string{}
+			delegates := make([]*rolldpos.Delegate, 0, len(candidatesList))
 			for _, candidate := range candidatesList {
-				addrs = append(addrs, candidate.Address)
+				d := &rolldpos.Delegate{Address: candidate.Address}
+				if len(candidate.BLSPubKey) > 0 {
+					blsPubKey, err := crypto.BLS12381PublicKeyFromBytes(candidate.BLSPubKey)
+					if err != nil {
+						return nil, errors.Wrapf(err, "invalid BLS pubkey for delegate %s", candidate.Address)
+					}
+					d.BLSPubKey = blsPubKey
+				}
+				delegates = append(delegates, d)
 			}
-			return addrs, nil
+			return delegates, nil
 		}
 		proposersByEpochFunc := delegatesByEpochFunc
-		blsPubKeysByEpochFunc := func(epochNum uint64, prevHash []byte) (map[string][]byte, error) {
-			fork, err := chainMgr.Fork(hash.Hash256(prevHash))
-			if err != nil {
-				return nil, err
-			}
-			forkSF, err := fork.StateReader()
-			if err != nil {
-				return nil, err
-			}
-			re := protocol.NewRegistry()
-			if err := ops.rp.Register(re); err != nil {
-				return nil, err
-			}
-			ctx := genesis.WithGenesisContext(
-				protocol.WithRegistry(context.Background(), re),
-				cfg.Genesis,
-			)
-			ctx = protocol.WithFeatureWithHeightCtx(ctx)
-			tipHeight := fork.TipHeight()
-			tipEpochNum := ops.rp.GetEpochNum(tipHeight)
-			var candidatesList state.CandidateList
-			switch epochNum {
-			case tipEpochNum:
-				candidatesList, err = ops.pp.Delegates(ctx, forkSF)
-			case tipEpochNum + 1:
-				candidatesList, err = ops.pp.NextDelegates(ctx, forkSF)
-			default:
-				err = errors.Errorf("invalid epoch number %d compared to tip epoch number %d", epochNum, tipEpochNum)
-			}
-			if err != nil {
-				return nil, err
-			}
-			out := make(map[string][]byte, len(candidatesList))
-			for _, candidate := range candidatesList {
-				if len(candidate.BLSPubKey) > 0 {
-					out[candidate.Address] = candidate.BLSPubKey
-				}
-			}
-			return out, nil
-		}
 		bd := rolldpos.NewRollDPoSBuilder().
 			SetPriKey(cfg.Chain.ProducerPrivateKeys()...).
 			SetBLSPriKey(cfg.Chain.BLSProducerPrivateKeys()...).
@@ -202,7 +171,6 @@ func NewConsensus(
 			SetBroadcast(ops.broadcastHandler).
 			SetDelegatesByEpochFunc(delegatesByEpochFunc).
 			SetProposersByEpochFunc(proposersByEpochFunc).
-			SetBLSPubKeysByEpochFunc(blsPubKeysByEpochFunc).
 			RegisterProtocol(ops.rp)
 		// TODO: explorer dependency deleted here at #1085, need to revive by migrating to api
 		cs.scheme, err = bd.Build()

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -152,6 +152,46 @@ func NewConsensus(
 			return addrs, nil
 		}
 		proposersByEpochFunc := delegatesByEpochFunc
+		blsPubKeysByEpochFunc := func(epochNum uint64, prevHash []byte) (map[string][]byte, error) {
+			fork, err := chainMgr.Fork(hash.Hash256(prevHash))
+			if err != nil {
+				return nil, err
+			}
+			forkSF, err := fork.StateReader()
+			if err != nil {
+				return nil, err
+			}
+			re := protocol.NewRegistry()
+			if err := ops.rp.Register(re); err != nil {
+				return nil, err
+			}
+			ctx := genesis.WithGenesisContext(
+				protocol.WithRegistry(context.Background(), re),
+				cfg.Genesis,
+			)
+			ctx = protocol.WithFeatureWithHeightCtx(ctx)
+			tipHeight := fork.TipHeight()
+			tipEpochNum := ops.rp.GetEpochNum(tipHeight)
+			var candidatesList state.CandidateList
+			switch epochNum {
+			case tipEpochNum:
+				candidatesList, err = ops.pp.Delegates(ctx, forkSF)
+			case tipEpochNum + 1:
+				candidatesList, err = ops.pp.NextDelegates(ctx, forkSF)
+			default:
+				err = errors.Errorf("invalid epoch number %d compared to tip epoch number %d", epochNum, tipEpochNum)
+			}
+			if err != nil {
+				return nil, err
+			}
+			out := make(map[string][]byte, len(candidatesList))
+			for _, candidate := range candidatesList {
+				if len(candidate.BLSPubKey) > 0 {
+					out[candidate.Address] = candidate.BLSPubKey
+				}
+			}
+			return out, nil
+		}
 		bd := rolldpos.NewRollDPoSBuilder().
 			SetPriKey(cfg.Chain.ProducerPrivateKeys()...).
 			SetBLSPriKey(cfg.Chain.BLSProducerPrivateKeys()...).
@@ -162,6 +202,7 @@ func NewConsensus(
 			SetBroadcast(ops.broadcastHandler).
 			SetDelegatesByEpochFunc(delegatesByEpochFunc).
 			SetProposersByEpochFunc(proposersByEpochFunc).
+			SetBLSPubKeysByEpochFunc(blsPubKeysByEpochFunc).
 			RegisterProtocol(ops.rp)
 		// TODO: explorer dependency deleted here at #1085, need to revive by migrating to api
 		cs.scheme, err = bd.Build()

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -154,6 +154,7 @@ func NewConsensus(
 		proposersByEpochFunc := delegatesByEpochFunc
 		bd := rolldpos.NewRollDPoSBuilder().
 			SetPriKey(cfg.Chain.ProducerPrivateKeys()...).
+			SetBLSPriKey(cfg.Chain.BLSProducerPrivateKeys()...).
 			SetConfig(cfg).
 			SetChainManager(chainMgr).
 			SetBlockDeserializer(block.NewDeserializer(bc.EvmNetworkID())).

--- a/consensus/consensusfsm/consensus_ttl.go
+++ b/consensus/consensusfsm/consensus_ttl.go
@@ -80,6 +80,9 @@ type (
 		CommitTTL(uint64) time.Duration
 		BlockInterval(uint64) time.Duration
 		Delay(uint64) time.Duration
+		// BLSAggregationEnabled reports whether COMMIT-stage BLS signature
+		// aggregation (IIP-52) is active at the given block height.
+		BLSAggregationEnabled(uint64) bool
 	}
 
 	// config implements ConsensusConfig
@@ -92,6 +95,7 @@ type (
 		dardanellesHeight uint64
 		wake              WakeUpgrade
 		wakeHeight        uint64
+		blsAggHeight      uint64
 	}
 )
 
@@ -105,6 +109,7 @@ func NewConsensusConfig(timing ConsensusTiming, dardanelles DardanellesUpgrade, 
 		delay:             delay,
 		wake:              wake,
 		wakeHeight:        g.WakeBlockHeight,
+		blsAggHeight:      g.ToBeEnabledBlockHeight,
 	}
 }
 
@@ -114,6 +119,10 @@ func (c *consensusCfg) isDardanelles(height uint64) bool {
 
 func (c *consensusCfg) isWake(height uint64) bool {
 	return height >= c.wakeHeight
+}
+
+func (c *consensusCfg) BLSAggregationEnabled(height uint64) bool {
+	return height >= c.blsAggHeight
 }
 
 func (c *consensusCfg) EventChanSize() uint {

--- a/consensus/consensusfsm/mock_context_test.go
+++ b/consensus/consensusfsm/mock_context_test.go
@@ -111,6 +111,20 @@ func (mr *MockContextMockRecorder) Active() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Active", reflect.TypeOf((*MockContext)(nil).Active))
 }
 
+// BLSAggregationEnabled mocks base method.
+func (m *MockContext) BLSAggregationEnabled(arg0 uint64) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BLSAggregationEnabled", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BLSAggregationEnabled indicates an expected call of BLSAggregationEnabled.
+func (mr *MockContextMockRecorder) BLSAggregationEnabled(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BLSAggregationEnabled", reflect.TypeOf((*MockContext)(nil).BLSAggregationEnabled), arg0)
+}
+
 // BlockInterval mocks base method.
 func (m *MockContext) BlockInterval(arg0 uint64) time.Duration {
 	m.ctrl.T.Helper()

--- a/consensus/scheme/rolldpos/aggregate.go
+++ b/consensus/scheme/rolldpos/aggregate.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rolldpos
+
+import (
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/endorsement"
+)
+
+// aggregateCommitEndorsements aggregates the per-delegate BLS COMMIT
+// signatures in endorsements into a single BLS12-381 aggregate signature
+// and builds a bitmap identifying which entries of delegates contributed.
+//
+// Bit i (LSB-first within each byte) of the returned bitmap is set when
+// delegates[i] is the endorser of one of the input endorsements. The
+// bitmap length is ceil(len(delegates) / 8).
+//
+// Each endorsement must carry a BLS signature (len(en.Signature()) ==
+// crypto.BLSAggregateSignatureLength) and its endorser address must appear
+// in delegates; otherwise the endorsement is rejected. Callers are
+// responsible for ensuring that all signers signed the same message — that
+// is the case for the COMMIT-vote path since the timestamp is a
+// deterministic function of the round's start time and TTL configuration.
+func aggregateCommitEndorsements(
+	endorsements []*endorsement.Endorsement,
+	delegates []*Delegate,
+) (aggSig []byte, bitmap []byte, err error) {
+	if len(endorsements) == 0 {
+		return nil, nil, errors.New("no COMMIT endorsements to aggregate")
+	}
+	addrIdx := make(map[string]int, len(delegates))
+	for i, d := range delegates {
+		addrIdx[d.Address] = i
+	}
+	bitmap = make([]byte, (len(delegates)+7)/8)
+	sigs := make([][]byte, 0, len(endorsements))
+	for _, en := range endorsements {
+		if len(en.Signature()) != crypto.BLSAggregateSignatureLength {
+			return nil, nil, errors.Errorf(
+				"non-BLS signature in COMMIT endorsement (len=%d, want %d)",
+				len(en.Signature()), crypto.BLSAggregateSignatureLength,
+			)
+		}
+		addr := en.Endorser().Address()
+		if addr == nil {
+			return nil, nil, errors.New("endorser address is nil")
+		}
+		idx, ok := addrIdx[addr.String()]
+		if !ok {
+			return nil, nil, errors.Errorf("endorser %s is not in the round's delegate set", addr.String())
+		}
+		bitmap[idx/8] |= 1 << uint(idx%8)
+		sigs = append(sigs, en.Signature())
+	}
+	agg, err := crypto.NewBLSAggregateSignature(sigs)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to aggregate BLS COMMIT signatures")
+	}
+	return agg.Bytes(), bitmap, nil
+}
+
+// bitmapSigners returns the addresses of the delegates whose bit is set in
+// bitmap, in delegate-index order. Used by the verifier to reconstruct the
+// signer set from a footer's signer_bitmap.
+func bitmapSigners(bitmap []byte, delegates []*Delegate) ([]*Delegate, error) {
+	out := make([]*Delegate, 0, len(delegates))
+	for i, d := range delegates {
+		if i/8 >= len(bitmap) {
+			break
+		}
+		if bitmap[i/8]&(1<<uint(i%8)) != 0 {
+			out = append(out, d)
+		}
+	}
+	// Bits set beyond the delegate-list range are invalid — make sure the
+	// bitmap doesn't claim signers that don't exist in this epoch.
+	for i := len(delegates); i < len(bitmap)*8; i++ {
+		if bitmap[i/8]&(1<<uint(i%8)) != 0 {
+			return nil, errors.Errorf("signer bitmap has bit %d set beyond the delegate count (%d)", i, len(delegates))
+		}
+	}
+	return out, nil
+}

--- a/consensus/scheme/rolldpos/aggregate_test.go
+++ b/consensus/scheme/rolldpos/aggregate_test.go
@@ -1,0 +1,148 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rolldpos
+
+import (
+	"testing"
+	"time"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/endorsement"
+)
+
+// buildDelegateSet returns a slice of n delegates with deterministic ECDSA +
+// BLS key pairs (seeded from i+1). Convenient for aggregation tests.
+func buildDelegateSet(t *testing.T, n int) ([]*Delegate, []crypto.PrivateKey, []*crypto.BLS12381PrivateKey) {
+	t.Helper()
+	delegates := make([]*Delegate, n)
+	ecdsaKeys := make([]crypto.PrivateKey, n)
+	blsKeys := make([]*crypto.BLS12381PrivateKey, n)
+	for i := 0; i < n; i++ {
+		ecdsa, bls := blsTestKeys(t, byte(i+1))
+		delegates[i] = &Delegate{Address: ecdsa.PublicKey().Address().String(), BLSPubKey: bls.PublicKey()}
+		ecdsaKeys[i] = ecdsa
+		blsKeys[i] = bls
+	}
+	return delegates, ecdsaKeys, blsKeys
+}
+
+func TestAggregateCommitEndorsements_RoundTrip(t *testing.T) {
+	require := require.New(t)
+	delegates, ecdsaKeys, blsKeys := buildDelegateSet(t, 4)
+	blkHash := hash.Hash256b([]byte("block"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ts := time.Unix(1700000000, 0).UTC()
+
+	// All four delegates sign the same COMMIT vote at the same timestamp.
+	ens := make([]*endorsement.Endorsement, len(delegates))
+	for i := range delegates {
+		en, err := endorsement.EndorseBLS(vote, ts, ecdsaKeys[i].PublicKey(), blsKeys[i])
+		require.NoError(err)
+		ens[i] = en
+	}
+
+	aggSig, bitmap, err := aggregateCommitEndorsements(ens, delegates)
+	require.NoError(err)
+	require.Equal(crypto.BLSAggregateSignatureLength, len(aggSig))
+	require.Equal(byte(0x0f), bitmap[0], "all four delegates' bits set")
+
+	// Verify: signers from bitmap → BLS pubkeys → FastAggregateVerify.
+	signers, err := bitmapSigners(bitmap, delegates)
+	require.NoError(err)
+	require.Equal(len(delegates), len(signers))
+	pubKeys := make([]*crypto.BLS12381PublicKey, len(signers))
+	for i, d := range signers {
+		pubKeys[i] = d.BLSPubKey
+	}
+	parsed, err := crypto.BLSAggregateSignatureFromBytes(aggSig)
+	require.NoError(err)
+	msg, err := endorsement.SigningHash(vote, ts)
+	require.NoError(err)
+	require.True(parsed.Verify(pubKeys, msg))
+}
+
+func TestAggregateCommitEndorsements_PartialSet(t *testing.T) {
+	require := require.New(t)
+	delegates, ecdsaKeys, blsKeys := buildDelegateSet(t, 5)
+	blkHash := hash.Hash256b([]byte("partial"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ts := time.Unix(1700000001, 0).UTC()
+
+	// Only delegates 0, 2, 4 sign — the other two are absent.
+	signing := []int{0, 2, 4}
+	ens := make([]*endorsement.Endorsement, 0, len(signing))
+	for _, i := range signing {
+		en, err := endorsement.EndorseBLS(vote, ts, ecdsaKeys[i].PublicKey(), blsKeys[i])
+		require.NoError(err)
+		ens = append(ens, en)
+	}
+
+	aggSig, bitmap, err := aggregateCommitEndorsements(ens, delegates)
+	require.NoError(err)
+	require.Equal(byte(0b00010101), bitmap[0], "bits 0, 2, 4 set")
+
+	signers, err := bitmapSigners(bitmap, delegates)
+	require.NoError(err)
+	require.Equal(3, len(signers))
+	require.Equal(delegates[0].Address, signers[0].Address)
+	require.Equal(delegates[2].Address, signers[1].Address)
+	require.Equal(delegates[4].Address, signers[2].Address)
+
+	pubKeys := []*crypto.BLS12381PublicKey{
+		delegates[0].BLSPubKey, delegates[2].BLSPubKey, delegates[4].BLSPubKey,
+	}
+	parsed, err := crypto.BLSAggregateSignatureFromBytes(aggSig)
+	require.NoError(err)
+	msg, err := endorsement.SigningHash(vote, ts)
+	require.NoError(err)
+	require.True(parsed.Verify(pubKeys, msg))
+}
+
+func TestAggregateCommitEndorsements_RejectsNonBLSSig(t *testing.T) {
+	require := require.New(t)
+	delegates, ecdsaKeys, _ := buildDelegateSet(t, 3)
+	blkHash := hash.Hash256b([]byte("ecdsa"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ens, err := endorsement.Endorse(vote, time.Unix(1700000002, 0), ecdsaKeys[0])
+	require.NoError(err)
+	require.Equal(1, len(ens))
+	_, _, err = aggregateCommitEndorsements(ens, delegates)
+	require.Error(err)
+	require.Contains(err.Error(), "non-BLS signature")
+}
+
+func TestAggregateCommitEndorsements_RejectsUnknownEndorser(t *testing.T) {
+	require := require.New(t)
+	delegates, _, _ := buildDelegateSet(t, 3)
+	stranger, strangerBLS := blsTestKeys(t, 0x7f)
+	blkHash := hash.Hash256b([]byte("stranger"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000003, 0), stranger.PublicKey(), strangerBLS)
+	require.NoError(err)
+	_, _, err = aggregateCommitEndorsements([]*endorsement.Endorsement{en}, delegates)
+	require.Error(err)
+	require.Contains(err.Error(), "not in the round's delegate set")
+}
+
+func TestBitmapSigners_BitBeyondDelegateCount(t *testing.T) {
+	require := require.New(t)
+	delegates, _, _ := buildDelegateSet(t, 3)
+	bitmap := []byte{0b00010111} // bit 4 set (no delegate at index 4)
+	_, err := bitmapSigners(bitmap, delegates)
+	require.Error(err)
+	require.Contains(err.Error(), "beyond the delegate count")
+}
+
+func TestBitmapSigners_EmptyBitmap(t *testing.T) {
+	require := require.New(t)
+	delegates, _, _ := buildDelegateSet(t, 3)
+	signers, err := bitmapSigners(nil, delegates)
+	require.NoError(err)
+	require.Equal(0, len(signers))
+}

--- a/consensus/scheme/rolldpos/bls_verify_test.go
+++ b/consensus/scheme/rolldpos/bls_verify_test.go
@@ -37,14 +37,10 @@ func blsTestKeys(t *testing.T, seed byte) (crypto.PrivateKey, *crypto.BLS12381Pr
 // verify dispatch — just enough state for AddVoteEndorsement / verifyEndorsement
 // to find the delegate set and the BLS pubkey index.
 func roundCtxWithBLS(delegateAddr string, blsPubKey *crypto.BLS12381PublicKey) *roundCtx {
-	r := &roundCtx{
-		delegates:      []string{delegateAddr},
+	return &roundCtx{
+		delegates:      []delegate{{address: delegateAddr, blsPubKey: blsPubKey}},
 		numOfDelegates: 1,
 	}
-	if blsPubKey != nil {
-		r.blsPubKeys = map[string]*crypto.BLS12381PublicKey{delegateAddr: blsPubKey}
-	}
-	return r
 }
 
 func TestRoundCtx_VerifyEndorsement_ECDSA(t *testing.T) {
@@ -150,7 +146,7 @@ func TestRollDPoSCtx_VerifyEndorsement_PreForkRejectsBLS(t *testing.T) {
 	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
 	require.NoError(err)
 
-	err = ctx.VerifyEndorsement(1, vote, en)
+	err = ctx.VerifyEndorsement(NewEndorsedConsensusMessage(1, vote, en))
 	require.Error(err)
 	require.Contains(err.Error(), "expected secp256k1")
 }
@@ -167,7 +163,7 @@ func TestRollDPoSCtx_VerifyEndorsement_PostForkRejectsECDSA(t *testing.T) {
 	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
 	require.NoError(err)
 
-	err = ctx.VerifyEndorsement(100, vote, ens[0])
+	err = ctx.VerifyEndorsement(NewEndorsedConsensusMessage(100, vote, ens[0]))
 	require.Error(err)
 	require.Contains(err.Error(), "expected BLS")
 }
@@ -184,7 +180,7 @@ func TestRollDPoSCtx_VerifyEndorsement_PostForkAcceptsBLS(t *testing.T) {
 	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
 	require.NoError(err)
 
-	require.NoError(ctx.VerifyEndorsement(100, vote, en))
+	require.NoError(ctx.VerifyEndorsement(NewEndorsedConsensusMessage(100, vote, en)))
 }
 
 func TestRollDPoSCtx_VerifyEndorsement_PreForkAcceptsECDSA(t *testing.T) {
@@ -199,7 +195,7 @@ func TestRollDPoSCtx_VerifyEndorsement_PreForkAcceptsECDSA(t *testing.T) {
 	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
 	require.NoError(err)
 
-	require.NoError(ctx.VerifyEndorsement(1, vote, ens[0]))
+	require.NoError(ctx.VerifyEndorsement(NewEndorsedConsensusMessage(1, vote, ens[0])))
 }
 
 func TestRollDPoSCtx_NewEndorsement_PostForkProducesBLS(t *testing.T) {

--- a/consensus/scheme/rolldpos/bls_verify_test.go
+++ b/consensus/scheme/rolldpos/bls_verify_test.go
@@ -1,0 +1,265 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rolldpos
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/consensus/consensusfsm"
+	"github.com/iotexproject/iotex-core/v2/endorsement"
+)
+
+// blsTestKeys derives a deterministic (ECDSA, BLS) key pair from a seed byte.
+func blsTestKeys(t *testing.T, seed byte) (crypto.PrivateKey, *crypto.BLS12381PrivateKey) {
+	t.Helper()
+	ikm := make([]byte, 32)
+	for i := range ikm {
+		ikm[i] = seed
+	}
+	ecdsa, err := crypto.BytesToPrivateKey(ikm)
+	require.NoError(t, err)
+	bls, err := crypto.GenerateBLS12381PrivateKey(ikm)
+	require.NoError(t, err)
+	return ecdsa, bls
+}
+
+// roundCtxWithBLS hand-builds a minimal roundCtx for unit tests of the BLS
+// verify dispatch — just enough state for AddVoteEndorsement / verifyEndorsement
+// to find the delegate set and the BLS pubkey index.
+func roundCtxWithBLS(delegateAddr string, blsPubKey *crypto.BLS12381PublicKey) *roundCtx {
+	r := &roundCtx{
+		delegates:      []string{delegateAddr},
+		numOfDelegates: 1,
+	}
+	if blsPubKey != nil {
+		r.blsPubKeys = map[string]*crypto.BLS12381PublicKey{delegateAddr: blsPubKey}
+	}
+	return r
+}
+
+func TestRoundCtx_VerifyEndorsement_ECDSA(t *testing.T) {
+	require := require.New(t)
+	ecdsa, _ := blsTestKeys(t, 0x01)
+	addr := ecdsa.PublicKey().Address().String()
+	ctx := roundCtxWithBLS(addr, nil)
+
+	blkHash := hash.Hash256b([]byte("block-A"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
+	require.NoError(err)
+	require.Equal(1, len(ens))
+	require.Equal(crypto.Secp256k1SigSizeWithRecID, len(ens[0].Signature()),
+		"secp256k1 signature should be 65 bytes")
+
+	require.NoError(ctx.verifyEndorsement(vote, ens[0]),
+		"a valid secp256k1 endorsement on the matching vote must verify")
+}
+
+func TestRoundCtx_VerifyEndorsement_BLS(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x02)
+	addr := ecdsa.PublicKey().Address().String()
+	ctx := roundCtxWithBLS(addr, bls.PublicKey())
+
+	blkHash := hash.Hash256b([]byte("block-B"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
+	require.NoError(err)
+	require.Equal(crypto.BLSAggregateSignatureLength, len(en.Signature()),
+		"BLS signature should be 96 bytes")
+
+	require.NoError(ctx.verifyEndorsement(vote, en),
+		"a valid BLS endorsement with the delegate's registered pubkey must verify")
+}
+
+func TestRoundCtx_VerifyEndorsement_BLS_MissingPubKey(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x03)
+	addr := ecdsa.PublicKey().Address().String()
+	// the round has NO BLS pubkey for this delegate
+	ctx := roundCtxWithBLS(addr, nil)
+
+	blkHash := hash.Hash256b([]byte("block-C"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
+	require.NoError(err)
+
+	err = ctx.verifyEndorsement(vote, en)
+	require.Error(err)
+	require.Contains(err.Error(), "no registered BLS pubkey")
+}
+
+func TestRoundCtx_VerifyEndorsement_BLS_WrongPubKey(t *testing.T) {
+	require := require.New(t)
+	ecdsa, signerBLS := blsTestKeys(t, 0x04)
+	_, otherBLS := blsTestKeys(t, 0x05)
+	addr := ecdsa.PublicKey().Address().String()
+	// the round records a *different* BLS pubkey for this delegate
+	ctx := roundCtxWithBLS(addr, otherBLS.PublicKey())
+
+	blkHash := hash.Hash256b([]byte("block-D"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), signerBLS)
+	require.NoError(err)
+
+	err = ctx.verifyEndorsement(vote, en)
+	require.Error(err)
+	require.Contains(err.Error(), "invalid BLS endorsement signature")
+}
+
+// rollDPoSCtxWithBLSGate hand-builds a minimal rollDPoSCtx for unit tests
+// of the public VerifyEndorsement entry point. blsAggHeight controls the
+// feature gate: 0 means BLS aggregation is on for all heights, MaxUint64
+// means it is off.
+func rollDPoSCtxWithBLSGate(t *testing.T, round *roundCtx, blsAggHeight uint64) *rollDPoSCtx {
+	t.Helper()
+	g := genesis.TestDefault()
+	g.ToBeEnabledBlockHeight = blsAggHeight
+	cfg := consensusfsm.NewConsensusConfig(
+		consensusfsm.ConsensusTiming{},
+		consensusfsm.DefaultDardanellesUpgradeConfig,
+		consensusfsm.DefaultWakeUpgradeConfig,
+		g,
+		0,
+	)
+	return &rollDPoSCtx{
+		ConsensusConfig: cfg,
+		round:           round,
+	}
+}
+
+func TestRollDPoSCtx_VerifyEndorsement_PreForkRejectsBLS(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x10)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, bls.PublicKey())
+	ctx := rollDPoSCtxWithBLSGate(t, round, math.MaxUint64) // BLS off
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
+	require.NoError(err)
+
+	err = ctx.VerifyEndorsement(1, vote, en)
+	require.Error(err)
+	require.Contains(err.Error(), "expected secp256k1")
+}
+
+func TestRollDPoSCtx_VerifyEndorsement_PostForkRejectsECDSA(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x11)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, bls.PublicKey())
+	ctx := rollDPoSCtxWithBLSGate(t, round, 0) // BLS on
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
+	require.NoError(err)
+
+	err = ctx.VerifyEndorsement(100, vote, ens[0])
+	require.Error(err)
+	require.Contains(err.Error(), "expected BLS")
+}
+
+func TestRollDPoSCtx_VerifyEndorsement_PostForkAcceptsBLS(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x12)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, bls.PublicKey())
+	ctx := rollDPoSCtxWithBLSGate(t, round, 0) // BLS on
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	en, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
+	require.NoError(err)
+
+	require.NoError(ctx.VerifyEndorsement(100, vote, en))
+}
+
+func TestRollDPoSCtx_VerifyEndorsement_PreForkAcceptsECDSA(t *testing.T) {
+	require := require.New(t)
+	ecdsa, _ := blsTestKeys(t, 0x13)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, nil)
+	ctx := rollDPoSCtxWithBLSGate(t, round, math.MaxUint64) // BLS off
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
+	require.NoError(err)
+
+	require.NoError(ctx.VerifyEndorsement(1, vote, ens[0]))
+}
+
+func TestRollDPoSCtx_NewEndorsement_PostForkProducesBLS(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x20)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, bls.PublicKey())
+	round.height = 100
+	round.roundStartTime = time.Unix(1700000000, 0)
+	ctx := rollDPoSCtxWithBLSGate(t, round, 0) // BLS on
+	ctx.producerKeys = []producerKey{{address: addr, ecdsa: ecdsa, bls: bls}}
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	msgs, err := ctx.newEndorsement(blkHash[:], COMMIT, ctx.round.StartTime())
+	require.NoError(err)
+	require.Equal(1, len(msgs))
+	sig := msgs[0].Endorsement().Signature()
+	require.Equal(crypto.BLSAggregateSignatureLength, len(sig),
+		"post-fork newEndorsement must emit a 96-byte BLS signature")
+
+	// the resulting endorsement must verify through the same roundCtx
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	require.NoError(round.verifyEndorsement(vote, msgs[0].Endorsement()))
+}
+
+func TestRollDPoSCtx_NewEndorsement_PreForkProducesECDSA(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x21)
+	addr := ecdsa.PublicKey().Address().String()
+	round := roundCtxWithBLS(addr, bls.PublicKey())
+	round.height = 1
+	round.roundStartTime = time.Unix(1700000000, 0)
+	ctx := rollDPoSCtxWithBLSGate(t, round, math.MaxUint64) // BLS off
+	ctx.producerKeys = []producerKey{{address: addr, ecdsa: ecdsa, bls: bls}}
+
+	blkHash := hash.Hash256b([]byte("blk"))
+	msgs, err := ctx.newEndorsement(blkHash[:], COMMIT, ctx.round.StartTime())
+	require.NoError(err)
+	require.Equal(1, len(msgs))
+	sig := msgs[0].Endorsement().Signature()
+	require.Equal(crypto.Secp256k1SigSizeWithRecID, len(sig),
+		"pre-fork newEndorsement must emit a 65-byte secp256k1 signature")
+}
+
+func TestRoundCtx_VerifyEndorsement_LengthDispatch(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x06)
+	addr := ecdsa.PublicKey().Address().String()
+	ctx := roundCtxWithBLS(addr, bls.PublicKey())
+
+	blkHash := hash.Hash256b([]byte("block-E"))
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+
+	// secp256k1 signature uses ECDSA path even though blsPubKeys is populated
+	ens, err := endorsement.Endorse(vote, time.Unix(1700000000, 0), ecdsa)
+	require.NoError(err)
+	require.NoError(ctx.verifyEndorsement(vote, ens[0]))
+
+	// BLS signature uses BLS path
+	blsEn, err := endorsement.EndorseBLS(vote, time.Unix(1700000000, 0), ecdsa.PublicKey(), bls)
+	require.NoError(err)
+	require.NoError(ctx.verifyEndorsement(vote, blsEn))
+}

--- a/consensus/scheme/rolldpos/bls_verify_test.go
+++ b/consensus/scheme/rolldpos/bls_verify_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/iotexproject/iotex-core/v2/endorsement"
 )
 
+// toDelegates wraps a list of operator addresses as Delegates with no BLS
+// pubkey — convenient for tests that exercise pre-fork / address-only paths.
+func toDelegates(addrs []string) []*Delegate {
+	ds := make([]*Delegate, len(addrs))
+	for i, a := range addrs {
+		ds[i] = &Delegate{Address: a}
+	}
+	return ds
+}
+
 // blsTestKeys derives a deterministic (ECDSA, BLS) key pair from a seed byte.
 func blsTestKeys(t *testing.T, seed byte) (crypto.PrivateKey, *crypto.BLS12381PrivateKey) {
 	t.Helper()
@@ -38,7 +48,7 @@ func blsTestKeys(t *testing.T, seed byte) (crypto.PrivateKey, *crypto.BLS12381Pr
 // to find the delegate set and the BLS pubkey index.
 func roundCtxWithBLS(delegateAddr string, blsPubKey *crypto.BLS12381PublicKey) *roundCtx {
 	return &roundCtx{
-		delegates:      []delegate{{address: delegateAddr, blsPubKey: blsPubKey}},
+		delegates:      []*Delegate{{Address: delegateAddr, BLSPubKey: blsPubKey}},
 		numOfDelegates: 1,
 	}
 }

--- a/consensus/scheme/rolldpos/endorsementmanager.go
+++ b/consensus/scheme/rolldpos/endorsementmanager.go
@@ -408,7 +408,7 @@ func (m *endorsementManager) Cleanup(timestamp time.Time) error {
 
 func (m *endorsementManager) Log(
 	logger *zap.Logger,
-	delegates []string,
+	delegates []*Delegate,
 ) *zap.Logger {
 	for encoded, c := range m.collections {
 		proposalEndorsements := c.Endorsements(

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -208,10 +208,15 @@ func (r *RollDPoS) Metrics() (scheme.ConsensusMetrics, error) {
 		return metrics, errors.Wrap(err, "error when calculating round")
 	}
 
+	delegates := round.Delegates()
+	delegateAddrs := make([]string, len(delegates))
+	for i, d := range delegates {
+		delegateAddrs[i] = d.Address
+	}
 	return scheme.ConsensusMetrics{
 		LatestEpoch:         round.EpochNum(),
 		LatestHeight:        height,
-		LatestDelegates:     round.Delegates(),
+		LatestDelegates:     delegateAddrs,
 		LatestBlockProducer: round.proposer,
 	}, nil
 }

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -261,6 +261,7 @@ type (
 		// TODO: we should use keystore in the future
 		encodedAddr       string
 		priKey            []crypto.PrivateKey
+		blsPriKey         []*crypto.BLS12381PrivateKey
 		chain             ChainManager
 		blockDeserializer *block.Deserializer
 		broadcastHandler  scheme.Broadcast
@@ -286,6 +287,13 @@ func (b *Builder) SetConfig(cfg BuilderConfig) *Builder {
 // SetPriKey sets the private key
 func (b *Builder) SetPriKey(priKeys ...crypto.PrivateKey) *Builder {
 	b.priKey = priKeys
+	return b
+}
+
+// SetBLSPriKey sets the BLS12-381 producer private keys, aligned 1:1 with
+// the ECDSA keys set via SetPriKey.
+func (b *Builder) SetBLSPriKey(blsPriKeys ...*crypto.BLS12381PrivateKey) *Builder {
+	b.blsPriKey = blsPriKeys
 	return b
 }
 
@@ -360,6 +368,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.delegatesByEpochFunc,
 		b.proposersByEpochFunc,
 		b.priKey,
+		b.blsPriKey,
 		b.clock,
 		b.cfg.Genesis.BeringBlockHeight,
 	)

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/v2/consensus/scheme"
 	"github.com/iotexproject/iotex-core/v2/db"
+	"github.com/iotexproject/iotex-core/v2/endorsement"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/state/factory"
 )
@@ -184,6 +185,9 @@ func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 		return err
 	}
 	blkHash := blk.HashBlock()
+	if blk.Footer.IsAggregated() {
+		return validateAggregatedFooter(round, blk, blkHash[:])
+	}
 	for _, en := range blk.Endorsements() {
 		if err := round.AddVoteEndorsement(
 			NewConsensusVote(blkHash[:], COMMIT),
@@ -196,6 +200,42 @@ func (r *RollDPoS) ValidateBlockFooter(blk *block.Block) error {
 		return ErrInsufficientEndorsements
 	}
 
+	return nil
+}
+
+// validateAggregatedFooter verifies a BLS-aggregated block footer (IIP-52).
+// The signer_bitmap is decoded against the round's delegate list to recover
+// each contributing delegate's BLS public key. The aggregated signature is
+// then verified against the COMMIT-vote hash that every signer signed —
+// reconstructed via hashDocWithTime over (blockHash, COMMIT, blk.CommitTime).
+// Quorum is checked separately to mirror the per-endorsement majority rule.
+func validateAggregatedFooter(round *roundCtx, blk *block.Block, blkHash []byte) error {
+	signers, err := bitmapSigners(blk.Footer.SignerBitmap(), round.delegates)
+	if err != nil {
+		return errors.Wrap(err, "invalid signer bitmap")
+	}
+	if !round.isMajorityCount(len(signers)) {
+		return ErrInsufficientEndorsements
+	}
+	pubKeys := make([]*crypto.BLS12381PublicKey, 0, len(signers))
+	for _, d := range signers {
+		if d.BLSPubKey == nil {
+			return errors.Errorf("delegate %s has no registered BLS pubkey", d.Address)
+		}
+		pubKeys = append(pubKeys, d.BLSPubKey)
+	}
+	aggSig, err := crypto.BLSAggregateSignatureFromBytes(blk.Footer.AggregatedSignature())
+	if err != nil {
+		return errors.Wrap(err, "invalid aggregated signature")
+	}
+	vote := NewConsensusVote(blkHash, COMMIT)
+	msg, err := endorsement.SigningHash(vote, blk.CommitTime())
+	if err != nil {
+		return errors.Wrap(err, "failed to hash COMMIT vote")
+	}
+	if !aggSig.Verify(pubKeys, msg) {
+		return errors.New("aggregated COMMIT signature verification failed")
+	}
 	return nil
 }
 

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -124,7 +124,7 @@ func (r *RollDPoS) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
 	if err := endorsedMessage.LoadProto(msg, r.ctx.BlockDeserializer()); err != nil {
 		return errors.Wrapf(err, "failed to decode endorsed consensus message")
 	}
-	if err := r.ctx.VerifyEndorsement(endorsedMessage.Height(), endorsedMessage.Document(), endorsedMessage.Endorsement()); err != nil {
+	if err := r.ctx.VerifyEndorsement(endorsedMessage); err != nil {
 		return errors.Wrap(err, "failed to verify signature in endorsement")
 	}
 	en := endorsedMessage.Endorsement()

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -266,10 +266,9 @@ type (
 		broadcastHandler  scheme.Broadcast
 		clock             clock.Clock
 		// TODO: explorer dependency deleted at #1085, need to add api params
-		rp                    *rolldpos.Protocol
-		delegatesByEpochFunc  NodesSelectionByEpochFunc
-		proposersByEpochFunc  NodesSelectionByEpochFunc
-		blsPubKeysByEpochFunc BLSPubKeysByEpochFunc
+		rp                   *rolldpos.Protocol
+		delegatesByEpochFunc NodesSelectionByEpochFunc
+		proposersByEpochFunc NodesSelectionByEpochFunc
 	}
 )
 
@@ -337,16 +336,6 @@ func (b *Builder) SetProposersByEpochFunc(
 	return b
 }
 
-// SetBLSPubKeysByEpochFunc sets the lookup that returns each delegate's
-// registered BLS12-381 public key for a given epoch. Used by the round
-// context to verify BLS-signed endorsements once aggregation is activated.
-func (b *Builder) SetBLSPubKeysByEpochFunc(
-	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc,
-) *Builder {
-	b.blsPubKeysByEpochFunc = blsPubKeysByEpochFunc
-	return b
-}
-
 // RegisterProtocol sets the rolldpos protocol
 func (b *Builder) RegisterProtocol(rp *rolldpos.Protocol) *Builder {
 	b.rp = rp
@@ -377,7 +366,6 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.broadcastHandler,
 		b.delegatesByEpochFunc,
 		b.proposersByEpochFunc,
-		b.blsPubKeysByEpochFunc,
 		b.priKey,
 		b.blsPriKey,
 		b.clock,

--- a/consensus/scheme/rolldpos/rolldpos.go
+++ b/consensus/scheme/rolldpos/rolldpos.go
@@ -23,7 +23,6 @@ import (
 	"github.com/iotexproject/iotex-core/v2/consensus/consensusfsm"
 	"github.com/iotexproject/iotex-core/v2/consensus/scheme"
 	"github.com/iotexproject/iotex-core/v2/db"
-	"github.com/iotexproject/iotex-core/v2/endorsement"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/state/factory"
 )
@@ -125,8 +124,8 @@ func (r *RollDPoS) HandleConsensusMsg(msg *iotextypes.ConsensusMessage) error {
 	if err := endorsedMessage.LoadProto(msg, r.ctx.BlockDeserializer()); err != nil {
 		return errors.Wrapf(err, "failed to decode endorsed consensus message")
 	}
-	if !endorsement.VerifyEndorsedDocument(endorsedMessage) {
-		return errors.New("failed to verify signature in endorsement")
+	if err := r.ctx.VerifyEndorsement(endorsedMessage.Height(), endorsedMessage.Document(), endorsedMessage.Endorsement()); err != nil {
+		return errors.Wrap(err, "failed to verify signature in endorsement")
 	}
 	en := endorsedMessage.Endorsement()
 	switch consensusMessage := endorsedMessage.Document().(type) {
@@ -267,9 +266,10 @@ type (
 		broadcastHandler  scheme.Broadcast
 		clock             clock.Clock
 		// TODO: explorer dependency deleted at #1085, need to add api params
-		rp                   *rolldpos.Protocol
-		delegatesByEpochFunc NodesSelectionByEpochFunc
-		proposersByEpochFunc NodesSelectionByEpochFunc
+		rp                    *rolldpos.Protocol
+		delegatesByEpochFunc  NodesSelectionByEpochFunc
+		proposersByEpochFunc  NodesSelectionByEpochFunc
+		blsPubKeysByEpochFunc BLSPubKeysByEpochFunc
 	}
 )
 
@@ -337,6 +337,16 @@ func (b *Builder) SetProposersByEpochFunc(
 	return b
 }
 
+// SetBLSPubKeysByEpochFunc sets the lookup that returns each delegate's
+// registered BLS12-381 public key for a given epoch. Used by the round
+// context to verify BLS-signed endorsements once aggregation is activated.
+func (b *Builder) SetBLSPubKeysByEpochFunc(
+	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc,
+) *Builder {
+	b.blsPubKeysByEpochFunc = blsPubKeysByEpochFunc
+	return b
+}
+
 // RegisterProtocol sets the rolldpos protocol
 func (b *Builder) RegisterProtocol(rp *rolldpos.Protocol) *Builder {
 	b.rp = rp
@@ -367,6 +377,7 @@ func (b *Builder) Build() (*RollDPoS, error) {
 		b.broadcastHandler,
 		b.delegatesByEpochFunc,
 		b.proposersByEpochFunc,
+		b.blsPubKeysByEpochFunc,
 		b.priKey,
 		b.blsPriKey,
 		b.clock,

--- a/consensus/scheme/rolldpos/rolldpos_test.go
+++ b/consensus/scheme/rolldpos/rolldpos_test.go
@@ -72,7 +72,7 @@ func TestNewRollDPoS(t *testing.T) {
 		g.NumDelegates,
 		g.NumSubEpochs,
 	)
-	delegatesByEpoch := func(uint64, []byte) ([]string, error) { return nil, nil }
+	delegatesByEpoch := func(uint64, []byte) ([]*Delegate, error) { return nil, nil }
 	t.Run("normal", func(t *testing.T) {
 		sk := identityset.PrivateKey(0)
 		chain := mock_blockchain.NewMockBlockchain(ctrl)
@@ -241,13 +241,13 @@ func TestValidateBlockFooter(t *testing.T) {
 		g.NumDelegates,
 		g.NumSubEpochs,
 	)
-	delegatesByEpoch := func(uint64, []byte) ([]string, error) {
-		return []string{
+	delegatesByEpoch := func(uint64, []byte) ([]*Delegate, error) {
+		return toDelegates([]string{
 			candidates[0],
 			candidates[1],
 			candidates[2],
 			candidates[3],
-		}, nil
+		}), nil
 	}
 	r, err := NewRollDPoSBuilder().
 		SetConfig(builderCfg).
@@ -336,13 +336,13 @@ func TestRollDPoS_Metrics(t *testing.T) {
 		g.NumDelegates,
 		g.NumSubEpochs,
 	)
-	delegatesByEpoch := func(uint64, []byte) ([]string, error) {
-		return []string{
+	delegatesByEpoch := func(uint64, []byte) ([]*Delegate, error) {
+		return toDelegates([]string{
 			candidates[0],
 			candidates[1],
 			candidates[2],
 			candidates[3],
-		}, nil
+		}), nil
 	}
 	r, err := NewRollDPoSBuilder().
 		SetConfig(builderCfg).
@@ -455,12 +455,12 @@ func TestRollDPoSConsensus(t *testing.T) {
 			chainAddrs[i] = addressMap[rawAddress]
 		}
 
-		delegatesByEpochFunc := func(_ uint64, _ []byte) ([]string, error) {
+		delegatesByEpochFunc := func(_ uint64, _ []byte) ([]*Delegate, error) {
 			candidates := make([]string, 0, numNodes)
 			for _, addr := range chainAddrs {
 				candidates = append(candidates, addr.encodedAddr)
 			}
-			return candidates, nil
+			return toDelegates(candidates), nil
 		}
 
 		chains := make([]blockchain.Blockchain, 0, numNodes)

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -75,6 +75,12 @@ type (
 	// NodesSelectionByEpochFunc defines a function to select nodes
 	NodesSelectionByEpochFunc func(uint64, []byte) ([]string, error)
 
+	// BLSPubKeysByEpochFunc resolves the registered BLS12-381 public key for
+	// every delegate of the given epoch. The returned map is keyed by the
+	// delegate's operator iotex address; the value is the candidate's raw
+	// 48-byte BLS pubkey (or empty if the candidate hasn't registered one yet).
+	BLSPubKeysByEpochFunc func(uint64, []byte) (map[string][]byte, error)
+
 	// RDPoSCtx is the context of RollDPoS
 	RDPoSCtx interface {
 		consensusfsm.Context
@@ -84,6 +90,12 @@ type (
 		Clock() clock.Clock
 		CheckBlockProposer(uint64, *blockProposal, *endorsement.Endorsement) error
 		CheckVoteEndorser(uint64, *ConsensusVote, *endorsement.Endorsement) error
+		// VerifyEndorsement verifies an endorsement's signature against the
+		// given document, dispatching on signature length: secp256k1 (65 B)
+		// pre-fork or BLS12-381 (96 B) post-fork. Post-fork BLS verify
+		// resolves the verifying public key from the current round's
+		// candidate-state-derived index by endorser iotex address.
+		VerifyEndorsement(uint64, endorsement.Document, *endorsement.Endorsement) error
 	}
 
 	rollDPoSCtx struct {
@@ -129,6 +141,7 @@ func NewRollDPoSCtx(
 	broadcastHandler scheme.Broadcast,
 	delegatesByEpochFunc NodesSelectionByEpochFunc,
 	proposersByEpochFunc NodesSelectionByEpochFunc,
+	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc,
 	priKeys []crypto.PrivateKey,
 	blsPriKeys []*crypto.BLS12381PrivateKey,
 	clock clock.Clock,
@@ -170,12 +183,13 @@ func NewRollDPoSCtx(
 		eManagerDB = db.NewBoltDB(consensusDBConfig)
 	}
 	roundCalc := &roundCalculator{
-		delegatesByEpochFunc: delegatesByEpochFunc,
-		proposersByEpochFunc: proposersByEpochFunc,
-		chain:                chain,
-		rp:                   rp,
-		timeBasedRotation:    timeBasedRotation,
-		beringHeight:         beringHeight,
+		delegatesByEpochFunc:  delegatesByEpochFunc,
+		proposersByEpochFunc:  proposersByEpochFunc,
+		blsPubKeysByEpochFunc: blsPubKeysByEpochFunc,
+		chain:                 chain,
+		rp:                    rp,
+		timeBasedRotation:     timeBasedRotation,
+		beringHeight:          beringHeight,
 	}
 	producerKeys := make([]producerKey, len(priKeys))
 	for i, pk := range priKeys {
@@ -241,6 +255,55 @@ func (ctx *rollDPoSCtx) RoundCalculator() *roundCalculator {
 
 func (ctx *rollDPoSCtx) Clock() clock.Clock {
 	return ctx.clock
+}
+
+// VerifyEndorsement implements RDPoSCtx by branching the signature
+// verification on signature length (secp256k1 65 B pre-fork, BLS 96 B
+// post-fork). Length is matched against the BLSAggregationEnabled feature
+// gate at the message height — a pre-fork message carrying a 96 B signature
+// or a post-fork message carrying a 65 B signature is rejected. For BLS,
+// the verifying pubkey is resolved from the current round's BLS pubkey
+// index by the endorser's iotex address.
+func (ctx *rollDPoSCtx) VerifyEndorsement(
+	height uint64,
+	doc endorsement.Document,
+	en *endorsement.Endorsement,
+) error {
+	ctx.mutex.RLock()
+	defer ctx.mutex.RUnlock()
+	if en == nil {
+		return errors.New("nil endorsement")
+	}
+	sigLen := len(en.Signature())
+	useBLS := ctx.BLSAggregationEnabled(height)
+	switch sigLen {
+	case crypto.Secp256k1SigSizeWithRecID:
+		if useBLS {
+			return errors.Errorf("post-fork message has %d-byte secp256k1 signature, expected BLS", sigLen)
+		}
+		if !endorsement.VerifyEndorsement(doc, en) {
+			return errors.New("invalid secp256k1 endorsement signature")
+		}
+		return nil
+	case crypto.BLSAggregateSignatureLength:
+		if !useBLS {
+			return errors.Errorf("pre-fork message has %d-byte BLS signature, expected secp256k1", sigLen)
+		}
+		endorserAddr := en.Endorser().Address()
+		if endorserAddr == nil {
+			return errors.New("failed to resolve endorser address for BLS endorsement")
+		}
+		pk := ctx.round.BLSPubKey(endorserAddr.String())
+		if pk == nil {
+			return errors.Errorf("delegate %s has no registered BLS pubkey at height %d", endorserAddr, height)
+		}
+		if !endorsement.VerifyBLSEndorsement(doc, en, pk) {
+			return errors.New("invalid BLS endorsement signature")
+		}
+		return nil
+	default:
+		return errors.Errorf("unsupported endorsement signature length %d", sigLen)
+	}
 }
 
 // CheckVoteEndorser checks if the endorsement's endorser is a valid delegate at the given height

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -403,29 +403,29 @@ func (ctx *rollDPoSCtx) HasDelegate() bool {
 func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
-	var privateKey crypto.PrivateKey = nil
+	var key *producerKey
 	proposer := ctx.round.Proposer()
 	// TODO: this is to pass unit tests, remove it after the unit tests are fixed
 	if proposer == "" {
-		privateKey = ctx.producerKeys[0].ecdsa
+		key = &ctx.producerKeys[0]
 	} else {
-		for _, pk := range ctx.producerKeys {
-			if pk.address == proposer {
-				privateKey = pk.ecdsa
+		for i := range ctx.producerKeys {
+			if ctx.producerKeys[i].address == proposer {
+				key = &ctx.producerKeys[i]
 				break
 			}
 		}
 	}
-	if privateKey == nil {
+	if key == nil {
 		return nil, nil
 	}
 	if ctx.round.IsLocked() {
 		return ctx.endorseBlockProposal(newBlockProposal(
 			ctx.round.Block(ctx.round.HashOfBlockInLock()),
 			ctx.round.ProofOfLock(),
-		), privateKey)
+		), key)
 	}
-	return ctx.mintNewBlock(privateKey)
+	return ctx.mintNewBlock(key)
 }
 
 func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Hash256) error {
@@ -733,12 +733,15 @@ func (ctx *rollDPoSCtx) Active() bool {
 // private functions
 ///////////////////////////////////////////
 
-func (ctx *rollDPoSCtx) mintNewBlock(privateKey crypto.PrivateKey) (*EndorsedConsensusMessage, error) {
+func (ctx *rollDPoSCtx) mintNewBlock(key *producerKey) (*EndorsedConsensusMessage, error) {
 	var err error
 	blk := ctx.round.CachedMintedBlock()
 	if blk == nil {
 		// in case that there is no cached block in eManagerDB, it mints a new block.
-		blk, err = ctx.chain.MintNewBlock(ctx.round.StartTime(), privateKey, ctx.round.PrevHash())
+		// Block header signing stays on the ECDSA producer key regardless of
+		// the BLS-aggregation feature flag; the BLS key is only used for the
+		// consensus endorsement wrapping this proposal.
+		blk, err = ctx.chain.MintNewBlock(ctx.round.StartTime(), key.ecdsa, ctx.round.PrevHash())
 		if err != nil {
 			return nil, err
 		}
@@ -751,7 +754,7 @@ func (ctx *rollDPoSCtx) mintNewBlock(privateKey crypto.PrivateKey) (*EndorsedCon
 	if ctx.round.IsUnlocked() {
 		proofOfUnlock = ctx.round.ProofOfLock()
 	}
-	return ctx.endorseBlockProposal(newBlockProposal(blk, proofOfUnlock), privateKey)
+	return ctx.endorseBlockProposal(newBlockProposal(blk, proofOfUnlock), key)
 }
 
 func (ctx *rollDPoSCtx) hasDelegate() bool {
@@ -762,16 +765,13 @@ func (ctx *rollDPoSCtx) hasDelegate() bool {
 	return slices.ContainsFunc(ctx.producerKeys, func(pk producerKey) bool { return ctx.round.IsDelegate(pk.address) })
 }
 
-func (ctx *rollDPoSCtx) endorseBlockProposal(proposal *blockProposal, privateKey crypto.PrivateKey) (*EndorsedConsensusMessage, error) {
-	ens, err := endorsement.Endorse(proposal, ctx.round.StartTime(), privateKey)
+func (ctx *rollDPoSCtx) endorseBlockProposal(proposal *blockProposal, key *producerKey) (*EndorsedConsensusMessage, error) {
+	height := ctx.round.Height()
+	en, err := ctx.signVote(proposal, ctx.round.StartTime(), *key, ctx.BLSAggregationEnabled(height))
 	if err != nil {
 		return nil, err
 	}
-	if len(ens) != 1 {
-		return nil, errors.New("invalid number of endorsements")
-	}
-
-	return NewEndorsedConsensusMessage(ctx.round.Height(), proposal, ens[0]), nil
+	return NewEndorsedConsensusMessage(height, proposal, en), nil
 }
 
 func (ctx *rollDPoSCtx) logger() *zap.Logger {
@@ -868,21 +868,48 @@ func (ctx *rollDPoSCtx) newEndorsement(
 		blkHash,
 		topic,
 	)
-	privKeys := make([]crypto.PrivateKey, 0, len(ctx.producerKeys))
+	height := ctx.round.Height()
+	useBLS := ctx.BLSAggregationEnabled(height)
+	msgs := make([]*EndorsedConsensusMessage, 0, len(ctx.producerKeys))
 	for _, pk := range ctx.producerKeys {
 		if !ctx.round.IsDelegate(pk.address) {
 			continue
 		}
-		privKeys = append(privKeys, pk.ecdsa)
+		en, err := ctx.signVote(vote, timestamp, pk, useBLS)
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, NewEndorsedConsensusMessage(height, vote, en))
 	}
-	ens, err := endorsement.Endorse(vote, timestamp, privKeys...)
+	return msgs, nil
+}
+
+// signVote produces a single endorsement on doc with key, branching on
+// useBLS. Pre-fork it returns a secp256k1-signed Endorsement; post-fork it
+// returns an Endorsement whose signature field carries a BLS12-381 signature
+// (the endorser pubkey is still the secp256k1 producer key so address
+// derivation stays unchanged for receivers).
+func (ctx *rollDPoSCtx) signVote(
+	doc endorsement.Document,
+	timestamp time.Time,
+	pk producerKey,
+	useBLS bool,
+) (*endorsement.Endorsement, error) {
+	if useBLS {
+		if pk.bls == nil {
+			return nil, errors.Errorf(
+				"delegate %s has no BLS private key configured for consensus signing",
+				pk.address,
+			)
+		}
+		return endorsement.EndorseBLS(doc, timestamp, pk.ecdsa.PublicKey(), pk.bls)
+	}
+	ens, err := endorsement.Endorse(doc, timestamp, pk.ecdsa)
 	if err != nil {
 		return nil, err
 	}
-	msgs := make([]*EndorsedConsensusMessage, 0, len(ens))
-	for _, en := range ens {
-		msgs = append(msgs, NewEndorsedConsensusMessage(ctx.round.Height(), vote, en))
+	if len(ens) != 1 {
+		return nil, errors.New("invalid number of endorsements")
 	}
-
-	return msgs, nil
+	return ens[0], nil
 }

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -90,12 +90,12 @@ type (
 		Clock() clock.Clock
 		CheckBlockProposer(uint64, *blockProposal, *endorsement.Endorsement) error
 		CheckVoteEndorser(uint64, *ConsensusVote, *endorsement.Endorsement) error
-		// VerifyEndorsement verifies an endorsement's signature against the
-		// given document, dispatching on signature length: secp256k1 (65 B)
-		// pre-fork or BLS12-381 (96 B) post-fork. Post-fork BLS verify
-		// resolves the verifying public key from the current round's
-		// candidate-state-derived index by endorser iotex address.
-		VerifyEndorsement(uint64, endorsement.Document, *endorsement.Endorsement) error
+		// VerifyEndorsement verifies the endorsement on the given consensus
+		// message, dispatching on signature length: secp256k1 (65 B) pre-fork
+		// or BLS12-381 (96 B) post-fork. Post-fork BLS verify resolves the
+		// verifying public key from the current round's candidate-state-
+		// derived index by endorser iotex address.
+		VerifyEndorsement(*EndorsedConsensusMessage) error
 	}
 
 	rollDPoSCtx struct {
@@ -264,18 +264,27 @@ func (ctx *rollDPoSCtx) Clock() clock.Clock {
 // or a post-fork message carrying a 65 B signature is rejected. For BLS,
 // the verifying pubkey is resolved from the current round's BLS pubkey
 // index by the endorser's iotex address.
-func (ctx *rollDPoSCtx) VerifyEndorsement(
-	height uint64,
-	doc endorsement.Document,
-	en *endorsement.Endorsement,
-) error {
-	ctx.mutex.RLock()
-	defer ctx.mutex.RUnlock()
+//
+// The RLock is released once the round snapshot and feature flag are read;
+// the (potentially slow) signature verification runs without holding it.
+// Reading roundCtx fields after the unlock is safe because a *roundCtx is
+// only ever replaced, never mutated in place.
+func (ctx *rollDPoSCtx) VerifyEndorsement(msg *EndorsedConsensusMessage) error {
+	if msg == nil {
+		return errors.New("nil consensus message")
+	}
+	en := msg.Endorsement()
 	if en == nil {
 		return errors.New("nil endorsement")
 	}
-	sigLen := len(en.Signature())
+	height := msg.Height()
+	ctx.mutex.RLock()
+	round := ctx.round
 	useBLS := ctx.BLSAggregationEnabled(height)
+	ctx.mutex.RUnlock()
+
+	doc := msg.Document()
+	sigLen := len(en.Signature())
 	switch sigLen {
 	case crypto.Secp256k1SigSizeWithRecID:
 		if useBLS {
@@ -293,7 +302,7 @@ func (ctx *rollDPoSCtx) VerifyEndorsement(
 		if endorserAddr == nil {
 			return errors.New("failed to resolve endorser address for BLS endorsement")
 		}
-		pk := ctx.round.BLSPubKey(endorserAddr.String())
+		pk := round.BLSPubKey(endorserAddr.String())
 		if pk == nil {
 			return errors.Errorf("delegate %s has no registered BLS pubkey at height %d", endorserAddr, height)
 		}

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -72,14 +72,10 @@ func init() {
 }
 
 type (
-	// NodesSelectionByEpochFunc defines a function to select nodes
-	NodesSelectionByEpochFunc func(uint64, []byte) ([]string, error)
-
-	// BLSPubKeysByEpochFunc resolves the registered BLS12-381 public key for
-	// every delegate of the given epoch. The returned map is keyed by the
-	// delegate's operator iotex address; the value is the candidate's raw
-	// 48-byte BLS pubkey (or empty if the candidate hasn't registered one yet).
-	BLSPubKeysByEpochFunc func(uint64, []byte) (map[string][]byte, error)
+	// NodesSelectionByEpochFunc defines a function to select nodes for an
+	// epoch. Each returned Delegate pairs the operator iotex address with
+	// the delegate's registered BLS12-381 public key (nil if none).
+	NodesSelectionByEpochFunc func(uint64, []byte) ([]*Delegate, error)
 
 	// RDPoSCtx is the context of RollDPoS
 	RDPoSCtx interface {
@@ -141,7 +137,6 @@ func NewRollDPoSCtx(
 	broadcastHandler scheme.Broadcast,
 	delegatesByEpochFunc NodesSelectionByEpochFunc,
 	proposersByEpochFunc NodesSelectionByEpochFunc,
-	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc,
 	priKeys []crypto.PrivateKey,
 	blsPriKeys []*crypto.BLS12381PrivateKey,
 	clock clock.Clock,
@@ -183,13 +178,12 @@ func NewRollDPoSCtx(
 		eManagerDB = db.NewBoltDB(consensusDBConfig)
 	}
 	roundCalc := &roundCalculator{
-		delegatesByEpochFunc:  delegatesByEpochFunc,
-		proposersByEpochFunc:  proposersByEpochFunc,
-		blsPubKeysByEpochFunc: blsPubKeysByEpochFunc,
-		chain:                 chain,
-		rp:                    rp,
-		timeBasedRotation:     timeBasedRotation,
-		beringHeight:          beringHeight,
+		delegatesByEpochFunc: delegatesByEpochFunc,
+		proposersByEpochFunc: proposersByEpochFunc,
+		chain:                chain,
+		rp:                   rp,
+		timeBasedRotation:    timeBasedRotation,
+		beringHeight:         beringHeight,
 	}
 	producerKeys := make([]producerKey, len(priKeys))
 	for i, pk := range priKeys {

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -672,13 +672,22 @@ func (ctx *rollDPoSCtx) Commit(msg interface{}) (bool, error) {
 	if ctx.round.Height()%100 == 0 {
 		ctx.logger().Info("consensus reached", zap.Uint64("blockHeight", ctx.round.Height()))
 	}
-	if err := pendingBlock.Finalize(
-		ctx.round.Endorsements(blkHash, []ConsensusVoteTopic{COMMIT}),
-		ctx.round.StartTime().Add(
-			ctx.AcceptBlockTTL(ctx.round.height)+ctx.AcceptProposalEndorsementTTL(ctx.round.height)+ctx.AcceptLockEndorsementTTL(ctx.round.height),
-		),
-	); err != nil {
-		return false, errors.Wrap(err, "failed to add endorsements to block")
+	commitEndorsements := ctx.round.Endorsements(blkHash, []ConsensusVoteTopic{COMMIT})
+	commitTime := ctx.round.StartTime().Add(
+		ctx.AcceptBlockTTL(ctx.round.height) + ctx.AcceptProposalEndorsementTTL(ctx.round.height) + ctx.AcceptLockEndorsementTTL(ctx.round.height),
+	)
+	if ctx.BLSAggregationEnabled(ctx.round.height) {
+		aggSig, bitmap, err := aggregateCommitEndorsements(commitEndorsements, ctx.round.delegates)
+		if err != nil {
+			return false, errors.Wrap(err, "failed to aggregate COMMIT signatures")
+		}
+		if err := pendingBlock.FinalizeWithAggregate(aggSig, bitmap, commitTime); err != nil {
+			return false, errors.Wrap(err, "failed to finalize block with aggregate signature")
+		}
+	} else {
+		if err := pendingBlock.Finalize(commitEndorsements, commitTime); err != nil {
+			return false, errors.Wrap(err, "failed to add endorsements to block")
+		}
 	}
 
 	// Commit and broadcast the pending block

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -97,12 +97,22 @@ type (
 		eManagerDB        db.KVStore
 		toleratedOvertime time.Duration
 
-		encodedAddrs []string
-		priKeys      []crypto.PrivateKey
+		producerKeys []producerKey
 		round        *roundCtx
 		clock        clock.Clock
 		active       bool
 		mutex        sync.RWMutex
+	}
+
+	// producerKey binds an ECDSA producer key with its derived iotex address
+	// and, when configured, the matching BLS12-381 key used for COMMIT-stage
+	// signature aggregation. Keeping the three together in a single record is
+	// the single source of truth for the 1:1 alignment required by the
+	// consensus signing paths.
+	producerKey struct {
+		address string
+		ecdsa   crypto.PrivateKey
+		bls     *crypto.BLS12381PrivateKey
 	}
 )
 
@@ -120,6 +130,7 @@ func NewRollDPoSCtx(
 	delegatesByEpochFunc NodesSelectionByEpochFunc,
 	proposersByEpochFunc NodesSelectionByEpochFunc,
 	priKeys []crypto.PrivateKey,
+	blsPriKeys []*crypto.BLS12381PrivateKey,
 	clock clock.Clock,
 	beringHeight uint64,
 ) (RDPoSCtx, error) {
@@ -137,6 +148,12 @@ func NewRollDPoSCtx(
 	}
 	if proposersByEpochFunc == nil {
 		return nil, errors.New("proposers by epoch function cannot be nil")
+	}
+	if len(blsPriKeys) != 0 && len(blsPriKeys) != len(priKeys) {
+		return nil, errors.Errorf(
+			"bls private keys count %d does not match producer private keys count %d",
+			len(blsPriKeys), len(priKeys),
+		)
 	}
 	if cfg.AcceptBlockTTL(0)+cfg.AcceptProposalEndorsementTTL(0)+cfg.AcceptLockEndorsementTTL(0)+cfg.CommitTTL(0) > cfg.BlockInterval(0) {
 		return nil, errors.Errorf(
@@ -160,15 +177,20 @@ func NewRollDPoSCtx(
 		timeBasedRotation:    timeBasedRotation,
 		beringHeight:         beringHeight,
 	}
-	encodedAddrs := make([]string, 0, len(priKeys))
-	for _, pk := range priKeys {
-		encodedAddrs = append(encodedAddrs, pk.PublicKey().Address().String())
+	producerKeys := make([]producerKey, len(priKeys))
+	for i, pk := range priKeys {
+		producerKeys[i] = producerKey{
+			address: pk.PublicKey().Address().String(),
+			ecdsa:   pk,
+		}
+		if i < len(blsPriKeys) {
+			producerKeys[i].bls = blsPriKeys[i]
+		}
 	}
 	return &rollDPoSCtx{
 		ConsensusConfig:   cfg,
 		active:            active,
-		encodedAddrs:      encodedAddrs,
-		priKeys:           priKeys,
+		producerKeys:      producerKeys,
 		chain:             chain,
 		blockDeserializer: blockDeserializer,
 		broadcastHandler:  broadcastHandler,
@@ -385,11 +407,11 @@ func (ctx *rollDPoSCtx) Proposal() (interface{}, error) {
 	proposer := ctx.round.Proposer()
 	// TODO: this is to pass unit tests, remove it after the unit tests are fixed
 	if proposer == "" {
-		privateKey = ctx.priKeys[0]
+		privateKey = ctx.producerKeys[0].ecdsa
 	} else {
-		for i, addr := range ctx.encodedAddrs {
-			if addr == proposer {
-				privateKey = ctx.priKeys[i]
+		for _, pk := range ctx.producerKeys {
+			if pk.address == proposer {
+				privateKey = pk.ecdsa
 				break
 			}
 		}
@@ -420,11 +442,11 @@ func (ctx *rollDPoSCtx) prepareNextProposal(prevHeight uint64, prevHash hash.Has
 	roundCalc := ctx.roundCalc.Fork(fork)
 	// check if the current node is the next proposer
 	nextProposer := roundCalc.Proposer(height, interval, startTime)
-	idx := slices.Index(ctx.encodedAddrs, nextProposer)
+	idx := slices.IndexFunc(ctx.producerKeys, func(pk producerKey) bool { return pk.address == nextProposer })
 	if idx < 0 {
 		return nil
 	}
-	privateKey := ctx.priKeys[idx]
+	privateKey := ctx.producerKeys[idx].ecdsa
 	ctx.logger().Debug("prepare next proposal", log.Hex("prevHash", prevHash[:]), zap.Uint64("height", ctx.round.height+1), zap.Time("timestamp", startTime), zap.String("nextproposer", nextProposer))
 	go func() {
 		blk, err := fork.MintNewBlock(startTime, privateKey, prevHash)
@@ -457,7 +479,11 @@ func (ctx *rollDPoSCtx) WaitUntilRoundStart() time.Duration {
 func (ctx *rollDPoSCtx) PreCommitEndorsement() interface{} {
 	ctx.mutex.RLock()
 	defer ctx.mutex.RUnlock()
-	endorsements := ctx.round.ReadyToCommit(ctx.encodedAddrs)
+	addrs := make([]string, len(ctx.producerKeys))
+	for i, pk := range ctx.producerKeys {
+		addrs[i] = pk.address
+	}
+	endorsements := ctx.round.ReadyToCommit(addrs)
 	if len(endorsements) == 0 {
 		// DON'T CHANGE, this is on purpose, because endorsement as nil won't result in a nil "interface {}"
 		return nil
@@ -733,7 +759,7 @@ func (ctx *rollDPoSCtx) hasDelegate() bool {
 		ctx.logger().Info("current node is in standby mode")
 		return false
 	}
-	return slices.ContainsFunc(ctx.encodedAddrs, ctx.round.IsDelegate)
+	return slices.ContainsFunc(ctx.producerKeys, func(pk producerKey) bool { return ctx.round.IsDelegate(pk.address) })
 }
 
 func (ctx *rollDPoSCtx) endorseBlockProposal(proposal *blockProposal, privateKey crypto.PrivateKey) (*EndorsedConsensusMessage, error) {
@@ -842,12 +868,12 @@ func (ctx *rollDPoSCtx) newEndorsement(
 		blkHash,
 		topic,
 	)
-	privKeys := make([]crypto.PrivateKey, 0, len(ctx.priKeys))
-	for i, addr := range ctx.encodedAddrs {
-		if !ctx.round.IsDelegate(addr) {
+	privKeys := make([]crypto.PrivateKey, 0, len(ctx.producerKeys))
+	for _, pk := range ctx.producerKeys {
+		if !ctx.round.IsDelegate(pk.address) {
 			continue
 		}
-		privKeys = append(privKeys, ctx.priKeys[i])
+		privKeys = append(privKeys, pk.ecdsa)
 	}
 	ens, err := endorsement.Endorse(vote, timestamp, privKeys...)
 	if err != nil {

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 )
 
-var dummyCandidatesByHeightFunc = func(uint64, []byte) ([]string, error) { return nil, nil }
+var dummyCandidatesByHeightFunc = func(uint64, []byte) ([]*Delegate, error) { return nil, nil }
 
 func TestRollDPoSCtx(t *testing.T) {
 	require := require.New(t)
@@ -41,12 +41,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, sf, _, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -56,7 +56,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		g.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -66,19 +66,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	g.Blockchain.BlockInterval = time.Second * 20
 	t.Run("case 5:panic because of nil CandidatesByHeight function", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 6:normal", func(t *testing.T) {
 		bh := g.BeringBlockHeight
-		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, c, bh)
+		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, bh)
 		require.NoError(err)
 		require.Equal(bh, rctx.RoundCalculator().beringHeight)
 		require.NotNil(rctx)
@@ -91,7 +91,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 	c := clock.New()
 	g := genesis.TestDefault()
 	g.Blockchain.BlockInterval = time.Second * 20
-	delegatesByEpochFunc := func(epochnum uint64, _ []byte) ([]string, error) {
+	delegatesByEpochFunc := func(epochnum uint64, _ []byte) ([]*Delegate, error) {
 		re := protocol.NewRegistry()
 		if err := rp.Register(re); err != nil {
 			return nil, err
@@ -124,7 +124,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 		for _, cand := range candidatesList {
 			addrs = append(addrs, cand.Address)
 		}
-		return addrs, nil
+		return toDelegates(addrs), nil
 	}
 	rctx, err := NewRollDPoSCtx(
 		consensusfsm.NewConsensusConfig(DefaultConfig.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, DefaultConfig.Delay),
@@ -138,7 +138,6 @@ func TestCheckVoteEndorser(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
-		nil,
 		nil,
 		nil,
 		c,
@@ -166,7 +165,7 @@ func TestCheckBlockProposer(t *testing.T) {
 	b, sf, ap, rp, pp := makeChain(t)
 	c := clock.New()
 	g.Blockchain.BlockInterval = time.Second * 20
-	delegatesByEpochFunc := func(epochnum uint64, _ []byte) ([]string, error) {
+	delegatesByEpochFunc := func(epochnum uint64, _ []byte) ([]*Delegate, error) {
 		re := protocol.NewRegistry()
 		if err := rp.Register(re); err != nil {
 			return nil, err
@@ -199,7 +198,7 @@ func TestCheckBlockProposer(t *testing.T) {
 		for _, cand := range candidatesList {
 			addrs = append(addrs, cand.Address)
 		}
-		return addrs, nil
+		return toDelegates(addrs), nil
 	}
 	rctx, err := NewRollDPoSCtx(
 		consensusfsm.NewConsensusConfig(DefaultConfig.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, DefaultConfig.Delay),
@@ -213,7 +212,6 @@ func TestCheckBlockProposer(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
-		nil,
 		nil,
 		nil,
 		c,
@@ -281,7 +279,7 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 	c := clock.New()
 	g := genesis.TestDefault()
 	g.Blockchain.BlockInterval = time.Second * 20
-	delegatesByEpoch := func(epochnum uint64, _ []byte) ([]string, error) {
+	delegatesByEpoch := func(epochnum uint64, _ []byte) ([]*Delegate, error) {
 		re := protocol.NewRegistry()
 		if err := rp.Register(re); err != nil {
 			return nil, err
@@ -314,7 +312,7 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		for _, cand := range candidatesList {
 			addrs = append(addrs, cand.Address)
 		}
-		return addrs, nil
+		return toDelegates(addrs), nil
 	}
 	rctx, err := NewRollDPoSCtx(
 		consensusfsm.NewConsensusConfig(DefaultConfig.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, DefaultConfig.Delay),
@@ -328,7 +326,6 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		nil,
 		delegatesByEpoch,
 		delegatesByEpoch,
-		nil,
 		[]crypto.PrivateKey{identityset.PrivateKey(10)},
 		nil,
 		c,

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -41,12 +41,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, sf, _, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -56,7 +56,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		g.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -66,19 +66,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	g.Blockchain.BlockInterval = time.Second * 20
 	t.Run("case 5:panic because of nil CandidatesByHeight function", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 6:normal", func(t *testing.T) {
 		bh := g.BeringBlockHeight
-		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, c, bh)
+		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, bh)
 		require.NoError(err)
 		require.Equal(bh, rctx.RoundCalculator().beringHeight)
 		require.NotNil(rctx)
@@ -138,6 +138,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		c,
 		g.BeringBlockHeight,
@@ -211,6 +212,7 @@ func TestCheckBlockProposer(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		c,
 		g.BeringBlockHeight,
@@ -325,6 +327,7 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		delegatesByEpoch,
 		delegatesByEpoch,
 		[]crypto.PrivateKey{identityset.PrivateKey(10)},
+		nil,
 		c,
 		g.BeringBlockHeight,
 	)

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -41,12 +41,12 @@ func TestRollDPoSCtx(t *testing.T) {
 	b, sf, _, _, _ := makeChain(t)
 
 	t.Run("case 1:panic because of chain is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, nil, block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 2:panic because of rp is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), nil, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -56,7 +56,7 @@ func TestRollDPoSCtx(t *testing.T) {
 		g.NumSubEpochs,
 	)
 	t.Run("case 3:panic because of clock is nil", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, nil, 0)
 		require.Error(err)
 	})
 
@@ -66,19 +66,19 @@ func TestRollDPoSCtx(t *testing.T) {
 	cfg.FSM.AcceptLockEndorsementTTL = time.Second
 	cfg.FSM.CommitTTL = time.Second
 	t.Run("case 4:panic because of fsm time bigger than block interval", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	g.Blockchain.BlockInterval = time.Second * 20
 	t.Run("case 5:panic because of nil CandidatesByHeight function", func(t *testing.T) {
-		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, c, 0)
+		_, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, nil, nil, nil, nil, nil, c, 0)
 		require.Error(err)
 	})
 
 	t.Run("case 6:normal", func(t *testing.T) {
 		bh := g.BeringBlockHeight
-		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, c, bh)
+		rctx, err := NewRollDPoSCtx(consensusfsm.NewConsensusConfig(cfg.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, cfg.Delay), dbConfig, true, time.Second, true, NewChainManager(b, sf, &dummyBlockBuildFactory{}), block.NewDeserializer(0), rp, nil, dummyCandidatesByHeightFunc, dummyCandidatesByHeightFunc, nil, nil, nil, c, bh)
 		require.NoError(err)
 		require.Equal(bh, rctx.RoundCalculator().beringHeight)
 		require.NotNil(rctx)
@@ -138,6 +138,7 @@ func TestCheckVoteEndorser(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		nil,
 		c,
@@ -212,6 +213,7 @@ func TestCheckBlockProposer(t *testing.T) {
 		nil,
 		delegatesByEpochFunc,
 		delegatesByEpochFunc,
+		nil,
 		nil,
 		nil,
 		c,
@@ -326,6 +328,7 @@ func TestNotProducingMultipleBlocks(t *testing.T) {
 		nil,
 		delegatesByEpoch,
 		delegatesByEpoch,
+		nil,
 		[]crypto.PrivateKey{identityset.PrivateKey(10)},
 		nil,
 		c,

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/v2/endorsement"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
@@ -20,12 +21,13 @@ import (
 var errInvalidCurrentTime = errors.New("invalid current time")
 
 type roundCalculator struct {
-	chain                ForkChain
-	timeBasedRotation    bool
-	rp                   *rolldpos.Protocol
-	delegatesByEpochFunc NodesSelectionByEpochFunc
-	proposersByEpochFunc NodesSelectionByEpochFunc
-	beringHeight         uint64
+	chain                 ForkChain
+	timeBasedRotation     bool
+	rp                    *rolldpos.Protocol
+	delegatesByEpochFunc  NodesSelectionByEpochFunc
+	proposersByEpochFunc  NodesSelectionByEpochFunc
+	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc
+	beringHeight          uint64
 }
 
 // UpdateRound updates previous roundCtx
@@ -34,6 +36,7 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 	epochStartHeight := round.EpochStartHeight()
 	delegates := round.Delegates()
 	proposers := round.Proposers()
+	blsPubKeys := round.blsPubKeys
 	switch {
 	case height < round.Height():
 		return nil, errors.New("cannot update to a lower height")
@@ -51,6 +54,9 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 				return nil, err
 			}
 			if proposers, err = c.Proposers(height); err != nil {
+				return nil, err
+			}
+			if blsPubKeys, err = c.blsPubKeysFor(height); err != nil {
 				return nil, err
 			}
 		}
@@ -99,6 +105,7 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 		status:             status,
 		blockInLock:        blockInLock,
 		proofOfLock:        proofOfLock,
+		blsPubKeys:         blsPubKeys,
 	}, nil
 }
 
@@ -227,6 +234,7 @@ func (c *roundCalculator) newRound(
 	var roundNum uint32
 	var proposer string
 	var roundStartTime time.Time
+	var blsPubKeys map[string]*crypto.BLS12381PublicKey
 	if height != 0 {
 		epochNum = c.rp.GetEpochNum(height)
 		epochStartHeight = c.rp.GetEpochHeight(epochNum)
@@ -240,6 +248,9 @@ func (c *roundCalculator) newRound(
 			return
 		}
 		if proposer, err = c.calculateProposer(height, roundNum, proposers); err != nil {
+			return
+		}
+		if blsPubKeys, err = c.blsPubKeysFor(height); err != nil {
 			return
 		}
 	}
@@ -265,6 +276,7 @@ func (c *roundCalculator) newRound(
 		roundStartTime:     roundStartTime,
 		nextRoundStartTime: roundStartTime.Add(blockInterval),
 		status:             _open,
+		blsPubKeys:         blsPubKeys,
 	}
 	eManager.SetIsMarjorityFunc(round.EndorsedByMajority)
 
@@ -293,11 +305,38 @@ func (c *roundCalculator) calculateProposer(
 
 func (c *roundCalculator) Fork(fork ForkChain) *roundCalculator {
 	return &roundCalculator{
-		chain:                fork,
-		timeBasedRotation:    c.timeBasedRotation,
-		rp:                   c.rp,
-		delegatesByEpochFunc: c.delegatesByEpochFunc,
-		proposersByEpochFunc: c.proposersByEpochFunc,
-		beringHeight:         c.beringHeight,
+		chain:                 fork,
+		timeBasedRotation:     c.timeBasedRotation,
+		rp:                    c.rp,
+		delegatesByEpochFunc:  c.delegatesByEpochFunc,
+		proposersByEpochFunc:  c.proposersByEpochFunc,
+		blsPubKeysByEpochFunc: c.blsPubKeysByEpochFunc,
+		beringHeight:          c.beringHeight,
 	}
+}
+
+// blsPubKeysFor resolves the BLS pubkey map for the given height's epoch
+// using the configured callback. Returns nil if no callback was wired (BLS
+// aggregation is off in this configuration) so callers can branch.
+func (c *roundCalculator) blsPubKeysFor(height uint64) (map[string]*crypto.BLS12381PublicKey, error) {
+	if c.blsPubKeysByEpochFunc == nil {
+		return nil, nil
+	}
+	epochNum := c.rp.GetEpochNum(height)
+	raw, err := c.blsPubKeysByEpochFunc(epochNum, nil)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve BLS pubkeys for epoch %d", epochNum)
+	}
+	out := make(map[string]*crypto.BLS12381PublicKey, len(raw))
+	for addr, pkBytes := range raw {
+		if len(pkBytes) == 0 {
+			continue
+		}
+		pk, err := crypto.BLS12381PublicKeyFromBytes(pkBytes)
+		if err != nil {
+			return nil, errors.Wrapf(err, "invalid BLS pubkey for delegate %s", addr)
+		}
+		out[addr] = pk
+	}
+	return out, nil
 }

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
-	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/v2/endorsement"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
@@ -21,13 +20,12 @@ import (
 var errInvalidCurrentTime = errors.New("invalid current time")
 
 type roundCalculator struct {
-	chain                 ForkChain
-	timeBasedRotation     bool
-	rp                    *rolldpos.Protocol
-	delegatesByEpochFunc  NodesSelectionByEpochFunc
-	proposersByEpochFunc  NodesSelectionByEpochFunc
-	blsPubKeysByEpochFunc BLSPubKeysByEpochFunc
-	beringHeight          uint64
+	chain                ForkChain
+	timeBasedRotation    bool
+	rp                   *rolldpos.Protocol
+	delegatesByEpochFunc NodesSelectionByEpochFunc
+	proposersByEpochFunc NodesSelectionByEpochFunc
+	beringHeight         uint64
 }
 
 // UpdateRound updates previous roundCtx
@@ -49,7 +47,7 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 			epochNum = c.rp.GetEpochNum(height)
 			epochStartHeight = c.rp.GetEpochHeight(epochNum)
 			var err error
-			if delegates, err = c.delegatesAt(height); err != nil {
+			if delegates, err = c.Delegates(height); err != nil {
 				return nil, err
 			}
 			if proposers, err = c.Proposers(height); err != nil {
@@ -121,7 +119,7 @@ func (c *roundCalculator) IsDelegate(addr string, height uint64) bool {
 		log.L().Warn("Failed to get delegates", zap.Error(err))
 		return false
 	}
-	return slices.Contains(delegates, addr)
+	return slices.ContainsFunc(delegates, func(d *Delegate) bool { return d.Address == addr })
 }
 
 // RoundInfo returns information of round by the given height and current time
@@ -181,18 +179,28 @@ func (c *roundCalculator) roundInfo(
 	return roundNum, roundStartTime, nil
 }
 
-// Delegates returns list of delegates at given height
-func (c *roundCalculator) Delegates(height uint64) ([]string, error) {
+// Delegates returns the delegate set at the given height, each paired with
+// its registered BLS public key.
+func (c *roundCalculator) Delegates(height uint64) ([]*Delegate, error) {
 	epochNum := c.rp.GetEpochNum(height)
 	prevHash := c.chain.TipHash()
 	return c.delegatesByEpochFunc(epochNum, prevHash[:])
 }
 
-// Proposers returns list of candidate proposers at given height
+// Proposers returns the operator addresses of candidate proposers at the
+// given height.
 func (c *roundCalculator) Proposers(height uint64) ([]string, error) {
 	epochNum := c.rp.GetEpochNum(height)
 	prevHash := c.chain.TipHash()
-	return c.proposersByEpochFunc(epochNum, prevHash[:])
+	proposers, err := c.proposersByEpochFunc(epochNum, prevHash[:])
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]string, len(proposers))
+	for i, p := range proposers {
+		addrs[i] = p.Address
+	}
+	return addrs, nil
 }
 
 // NewRoundWithToleration starts new round with tolerated over time
@@ -225,7 +233,7 @@ func (c *roundCalculator) newRound(
 ) (round *roundCtx, err error) {
 	epochNum := uint64(0)
 	epochStartHeight := uint64(0)
-	var delegates []delegate
+	var delegates []*Delegate
 	var proposers []string
 	var roundNum uint32
 	var proposer string
@@ -233,7 +241,7 @@ func (c *roundCalculator) newRound(
 	if height != 0 {
 		epochNum = c.rp.GetEpochNum(height)
 		epochStartHeight = c.rp.GetEpochHeight(epochNum)
-		if delegates, err = c.delegatesAt(height); err != nil {
+		if delegates, err = c.Delegates(height); err != nil {
 			return
 		}
 		if proposers, err = c.Proposers(height); err != nil {
@@ -296,43 +304,11 @@ func (c *roundCalculator) calculateProposer(
 
 func (c *roundCalculator) Fork(fork ForkChain) *roundCalculator {
 	return &roundCalculator{
-		chain:                 fork,
-		timeBasedRotation:     c.timeBasedRotation,
-		rp:                    c.rp,
-		delegatesByEpochFunc:  c.delegatesByEpochFunc,
-		proposersByEpochFunc:  c.proposersByEpochFunc,
-		blsPubKeysByEpochFunc: c.blsPubKeysByEpochFunc,
-		beringHeight:          c.beringHeight,
+		chain:                fork,
+		timeBasedRotation:    c.timeBasedRotation,
+		rp:                   c.rp,
+		delegatesByEpochFunc: c.delegatesByEpochFunc,
+		proposersByEpochFunc: c.proposersByEpochFunc,
+		beringHeight:         c.beringHeight,
 	}
-}
-
-// delegatesAt returns the delegate set for the given height, pairing each
-// operator iotex address with its registered BLS12-381 public key (nil if
-// the delegate has no BLS key registered, or if the BLS pubkey lookup
-// callback isn't wired in this configuration).
-func (c *roundCalculator) delegatesAt(height uint64) ([]delegate, error) {
-	addrs, err := c.Delegates(height)
-	if err != nil {
-		return nil, err
-	}
-	var pubKeys map[string][]byte
-	if c.blsPubKeysByEpochFunc != nil {
-		epochNum := c.rp.GetEpochNum(height)
-		pubKeys, err = c.blsPubKeysByEpochFunc(epochNum, nil)
-		if err != nil {
-			return nil, errors.Wrapf(err, "failed to resolve BLS pubkeys for epoch %d", epochNum)
-		}
-	}
-	out := make([]delegate, len(addrs))
-	for i, addr := range addrs {
-		out[i] = delegate{address: addr}
-		if pkBytes := pubKeys[addr]; len(pkBytes) > 0 {
-			pk, err := crypto.BLS12381PublicKeyFromBytes(pkBytes)
-			if err != nil {
-				return nil, errors.Wrapf(err, "invalid BLS pubkey for delegate %s", addr)
-			}
-			out[i].blsPubKey = pk
-		}
-	}
-	return out, nil
 }

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -32,7 +32,7 @@ type roundCalculator struct {
 func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInterval time.Duration, now time.Time, toleratedOvertime time.Duration) (*roundCtx, error) {
 	epochNum := round.EpochNum()
 	epochStartHeight := round.EpochStartHeight()
-	delegates := round.delegates
+	delegates := round.Delegates()
 	proposers := round.Proposers()
 	switch {
 	case height < round.Height():

--- a/consensus/scheme/rolldpos/roundcalculator.go
+++ b/consensus/scheme/rolldpos/roundcalculator.go
@@ -34,9 +34,8 @@ type roundCalculator struct {
 func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInterval time.Duration, now time.Time, toleratedOvertime time.Duration) (*roundCtx, error) {
 	epochNum := round.EpochNum()
 	epochStartHeight := round.EpochStartHeight()
-	delegates := round.Delegates()
+	delegates := round.delegates
 	proposers := round.Proposers()
-	blsPubKeys := round.blsPubKeys
 	switch {
 	case height < round.Height():
 		return nil, errors.New("cannot update to a lower height")
@@ -50,13 +49,10 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 			epochNum = c.rp.GetEpochNum(height)
 			epochStartHeight = c.rp.GetEpochHeight(epochNum)
 			var err error
-			if delegates, err = c.Delegates(height); err != nil {
+			if delegates, err = c.delegatesAt(height); err != nil {
 				return nil, err
 			}
 			if proposers, err = c.Proposers(height); err != nil {
-				return nil, err
-			}
-			if blsPubKeys, err = c.blsPubKeysFor(height); err != nil {
 				return nil, err
 			}
 		}
@@ -105,7 +101,6 @@ func (c *roundCalculator) UpdateRound(round *roundCtx, height uint64, blockInter
 		status:             status,
 		blockInLock:        blockInLock,
 		proofOfLock:        proofOfLock,
-		blsPubKeys:         blsPubKeys,
 	}, nil
 }
 
@@ -230,15 +225,15 @@ func (c *roundCalculator) newRound(
 ) (round *roundCtx, err error) {
 	epochNum := uint64(0)
 	epochStartHeight := uint64(0)
-	var delegates, proposers []string
+	var delegates []delegate
+	var proposers []string
 	var roundNum uint32
 	var proposer string
 	var roundStartTime time.Time
-	var blsPubKeys map[string]*crypto.BLS12381PublicKey
 	if height != 0 {
 		epochNum = c.rp.GetEpochNum(height)
 		epochStartHeight = c.rp.GetEpochHeight(epochNum)
-		if delegates, err = c.Delegates(height); err != nil {
+		if delegates, err = c.delegatesAt(height); err != nil {
 			return
 		}
 		if proposers, err = c.Proposers(height); err != nil {
@@ -248,9 +243,6 @@ func (c *roundCalculator) newRound(
 			return
 		}
 		if proposer, err = c.calculateProposer(height, roundNum, proposers); err != nil {
-			return
-		}
-		if blsPubKeys, err = c.blsPubKeysFor(height); err != nil {
 			return
 		}
 	}
@@ -276,7 +268,6 @@ func (c *roundCalculator) newRound(
 		roundStartTime:     roundStartTime,
 		nextRoundStartTime: roundStartTime.Add(blockInterval),
 		status:             _open,
-		blsPubKeys:         blsPubKeys,
 	}
 	eManager.SetIsMarjorityFunc(round.EndorsedByMajority)
 
@@ -315,28 +306,33 @@ func (c *roundCalculator) Fork(fork ForkChain) *roundCalculator {
 	}
 }
 
-// blsPubKeysFor resolves the BLS pubkey map for the given height's epoch
-// using the configured callback. Returns nil if no callback was wired (BLS
-// aggregation is off in this configuration) so callers can branch.
-func (c *roundCalculator) blsPubKeysFor(height uint64) (map[string]*crypto.BLS12381PublicKey, error) {
-	if c.blsPubKeysByEpochFunc == nil {
-		return nil, nil
-	}
-	epochNum := c.rp.GetEpochNum(height)
-	raw, err := c.blsPubKeysByEpochFunc(epochNum, nil)
+// delegatesAt returns the delegate set for the given height, pairing each
+// operator iotex address with its registered BLS12-381 public key (nil if
+// the delegate has no BLS key registered, or if the BLS pubkey lookup
+// callback isn't wired in this configuration).
+func (c *roundCalculator) delegatesAt(height uint64) ([]delegate, error) {
+	addrs, err := c.Delegates(height)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to resolve BLS pubkeys for epoch %d", epochNum)
+		return nil, err
 	}
-	out := make(map[string]*crypto.BLS12381PublicKey, len(raw))
-	for addr, pkBytes := range raw {
-		if len(pkBytes) == 0 {
-			continue
-		}
-		pk, err := crypto.BLS12381PublicKeyFromBytes(pkBytes)
+	var pubKeys map[string][]byte
+	if c.blsPubKeysByEpochFunc != nil {
+		epochNum := c.rp.GetEpochNum(height)
+		pubKeys, err = c.blsPubKeysByEpochFunc(epochNum, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "invalid BLS pubkey for delegate %s", addr)
+			return nil, errors.Wrapf(err, "failed to resolve BLS pubkeys for epoch %d", epochNum)
 		}
-		out[addr] = pk
+	}
+	out := make([]delegate, len(addrs))
+	for i, addr := range addrs {
+		out[i] = delegate{address: addr}
+		if pkBytes := pubKeys[addr]; len(pkBytes) > 0 {
+			pk, err := crypto.BLS12381PublicKeyFromBytes(pkBytes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "invalid BLS pubkey for delegate %s", addr)
+			}
+			out[i].blsPubKey = pk
+		}
 	}
 	return out, nil
 }

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -270,6 +270,7 @@ func makeRoundCalculator(t *testing.T) *roundCalculator {
 		rp,
 		delegatesByEpoch,
 		delegatesByEpoch,
+		nil,
 		0,
 	}
 }

--- a/consensus/scheme/rolldpos/roundcalculator_test.go
+++ b/consensus/scheme/rolldpos/roundcalculator_test.go
@@ -227,7 +227,7 @@ func makeChain(t *testing.T) (blockchain.Blockchain, factory.Factory, actpool.Ac
 
 func makeRoundCalculator(t *testing.T) *roundCalculator {
 	bc, sf, _, rp, pp := makeChain(t)
-	delegatesByEpoch := func(epochNum uint64, _ []byte) ([]string, error) {
+	delegatesByEpoch := func(epochNum uint64, _ []byte) ([]*Delegate, error) {
 		re := protocol.NewRegistry()
 		if err := rp.Register(re); err != nil {
 			return nil, err
@@ -262,7 +262,7 @@ func makeRoundCalculator(t *testing.T) *roundCalculator {
 		for _, cand := range candidatesList {
 			addrs = append(addrs, cand.Address)
 		}
-		return addrs, nil
+		return toDelegates(addrs), nil
 	}
 	return &roundCalculator{
 		NewChainManager(bc, sf, &dummyBlockBuildFactory{}),
@@ -270,7 +270,6 @@ func makeRoundCalculator(t *testing.T) *roundCalculator {
 		rp,
 		delegatesByEpoch,
 		delegatesByEpoch,
-		nil,
 		0,
 	}
 }

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -31,13 +31,23 @@ const (
 	_unlocked
 )
 
+// delegate is one entry of a round's delegate set. It carries the operator
+// iotex address used for proposer/endorser identity, plus the delegate's
+// registered BLS12-381 public key (nil when the delegate has none, e.g.
+// pre-fork). Populated at round construction so verify paths can resolve
+// the pubkey by address without hitting state per message.
+type delegate struct {
+	address   string
+	blsPubKey *crypto.BLS12381PublicKey
+}
+
 // roundCtx keeps the context data for the current round and block.
 type roundCtx struct {
 	epochNum             uint64
 	epochStartHeight     uint64
 	nextEpochStartHeight uint64
 	numOfDelegates       uint64
-	delegates            []string
+	delegates            []delegate
 	proposers            []string
 
 	height             uint64
@@ -51,12 +61,6 @@ type roundCtx struct {
 	proofOfLock []*endorsement.Endorsement
 	status      status
 	eManager    *endorsementManager
-
-	// blsPubKeys maps the epoch delegate's operator iotex address to their
-	// registered BLS12-381 public key. Populated at round construction (via
-	// the BLSPubKeysByEpochFunc callback) so verify paths can resolve the
-	// pubkey by address without hitting state per message.
-	blsPubKeys map[string]*crypto.BLS12381PublicKey
 }
 
 func (ctx *roundCtx) Log(l *zap.Logger) *zap.Logger {
@@ -70,7 +74,7 @@ func (ctx *roundCtx) Log(l *zap.Logger) *zap.Logger {
 }
 
 func (ctx *roundCtx) LogWithStats(l *zap.Logger) *zap.Logger {
-	return ctx.eManager.Log(ctx.Log(l), ctx.delegates)
+	return ctx.eManager.Log(ctx.Log(l), ctx.Delegates())
 }
 
 func (ctx *roundCtx) EpochNum() uint64 {
@@ -110,7 +114,11 @@ func (ctx *roundCtx) Proposer() string {
 }
 
 func (ctx *roundCtx) Delegates() []string {
-	return ctx.delegates
+	addrs := make([]string, len(ctx.delegates))
+	for i, d := range ctx.delegates {
+		addrs[i] = d.address
+	}
+	return addrs
 }
 
 func (ctx *roundCtx) Proposers() []string {
@@ -118,17 +126,19 @@ func (ctx *roundCtx) Proposers() []string {
 }
 
 func (ctx *roundCtx) IsDelegate(addr string) bool {
-	return slices.Contains(ctx.delegates, addr)
+	return slices.ContainsFunc(ctx.delegates, func(d delegate) bool { return d.address == addr })
 }
 
 // BLSPubKey returns the BLS12-381 public key registered for the given
 // delegate operator address at this round's epoch, or nil if the delegate
-// has no registered BLS key or BLS aggregation isn't wired in this config.
+// is not in the round's set or has no registered BLS key.
 func (ctx *roundCtx) BLSPubKey(addr string) *crypto.BLS12381PublicKey {
-	if ctx.blsPubKeys == nil {
-		return nil
+	for _, d := range ctx.delegates {
+		if d.address == addr {
+			return d.blsPubKey
+		}
 	}
-	return ctx.blsPubKeys[addr]
+	return nil
 }
 
 // verifyEndorsement checks the signature on en, dispatching on signature

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -320,7 +320,15 @@ func (ctx *roundCtx) endorsedByMajority(blockHash []byte, topics []ConsensusVote
 }
 
 func (ctx *roundCtx) isMajority(endorsements []*endorsement.Endorsement) bool {
-	return 3*len(endorsements) > 2*int(ctx.numOfDelegates)
+	return ctx.isMajorityCount(len(endorsements))
+}
+
+// isMajorityCount reports whether a vote count satisfies this round's 2/3
+// quorum threshold (3 * count > 2 * numOfDelegates). Single source of truth
+// for both the per-endorsement (pre-fork) and bitmap-count (post-fork)
+// paths, so changes to the quorum rule stay in one place.
+func (ctx *roundCtx) isMajorityCount(count int) bool {
+	return 3*count > 2*int(ctx.numOfDelegates)
 }
 
 func (ctx *roundCtx) block(blkHash []byte) *block.Block {

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -31,14 +31,14 @@ const (
 	_unlocked
 )
 
-// delegate is one entry of a round's delegate set. It carries the operator
+// Delegate is one entry of a round's delegate set. It carries the operator
 // iotex address used for proposer/endorser identity, plus the delegate's
 // registered BLS12-381 public key (nil when the delegate has none, e.g.
-// pre-fork). Populated at round construction so verify paths can resolve
-// the pubkey by address without hitting state per message.
-type delegate struct {
-	address   string
-	blsPubKey *crypto.BLS12381PublicKey
+// pre-fork). Resolved by the NodesSelectionByEpochFunc callback so verify
+// paths can look up the pubkey by address without hitting state per message.
+type Delegate struct {
+	Address   string
+	BLSPubKey *crypto.BLS12381PublicKey
 }
 
 // roundCtx keeps the context data for the current round and block.
@@ -47,7 +47,7 @@ type roundCtx struct {
 	epochStartHeight     uint64
 	nextEpochStartHeight uint64
 	numOfDelegates       uint64
-	delegates            []delegate
+	delegates            []*Delegate
 	proposers            []string
 
 	height             uint64
@@ -116,7 +116,7 @@ func (ctx *roundCtx) Proposer() string {
 func (ctx *roundCtx) Delegates() []string {
 	addrs := make([]string, len(ctx.delegates))
 	for i, d := range ctx.delegates {
-		addrs[i] = d.address
+		addrs[i] = d.Address
 	}
 	return addrs
 }
@@ -126,7 +126,7 @@ func (ctx *roundCtx) Proposers() []string {
 }
 
 func (ctx *roundCtx) IsDelegate(addr string) bool {
-	return slices.ContainsFunc(ctx.delegates, func(d delegate) bool { return d.address == addr })
+	return slices.ContainsFunc(ctx.delegates, func(d *Delegate) bool { return d.Address == addr })
 }
 
 // BLSPubKey returns the BLS12-381 public key registered for the given
@@ -134,8 +134,8 @@ func (ctx *roundCtx) IsDelegate(addr string) bool {
 // is not in the round's set or has no registered BLS key.
 func (ctx *roundCtx) BLSPubKey(addr string) *crypto.BLS12381PublicKey {
 	for _, d := range ctx.delegates {
-		if d.address == addr {
-			return d.blsPubKey
+		if d.Address == addr {
+			return d.BLSPubKey
 		}
 	}
 	return nil

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -74,7 +74,7 @@ func (ctx *roundCtx) Log(l *zap.Logger) *zap.Logger {
 }
 
 func (ctx *roundCtx) LogWithStats(l *zap.Logger) *zap.Logger {
-	return ctx.eManager.Log(ctx.Log(l), ctx.Delegates())
+	return ctx.eManager.Log(ctx.Log(l), ctx.delegates)
 }
 
 func (ctx *roundCtx) EpochNum() uint64 {
@@ -113,12 +113,8 @@ func (ctx *roundCtx) Proposer() string {
 	return ctx.proposer
 }
 
-func (ctx *roundCtx) Delegates() []string {
-	addrs := make([]string, len(ctx.delegates))
-	for i, d := range ctx.delegates {
-		addrs[i] = d.Address
-	}
-	return addrs
+func (ctx *roundCtx) Delegates() []*Delegate {
+	return ctx.delegates
 }
 
 func (ctx *roundCtx) Proposers() []string {

--- a/consensus/scheme/rolldpos/roundctx.go
+++ b/consensus/scheme/rolldpos/roundctx.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
@@ -50,6 +51,12 @@ type roundCtx struct {
 	proofOfLock []*endorsement.Endorsement
 	status      status
 	eManager    *endorsementManager
+
+	// blsPubKeys maps the epoch delegate's operator iotex address to their
+	// registered BLS12-381 public key. Populated at round construction (via
+	// the BLSPubKeysByEpochFunc callback) so verify paths can resolve the
+	// pubkey by address without hitting state per message.
+	blsPubKeys map[string]*crypto.BLS12381PublicKey
 }
 
 func (ctx *roundCtx) Log(l *zap.Logger) *zap.Logger {
@@ -112,6 +119,43 @@ func (ctx *roundCtx) Proposers() []string {
 
 func (ctx *roundCtx) IsDelegate(addr string) bool {
 	return slices.Contains(ctx.delegates, addr)
+}
+
+// BLSPubKey returns the BLS12-381 public key registered for the given
+// delegate operator address at this round's epoch, or nil if the delegate
+// has no registered BLS key or BLS aggregation isn't wired in this config.
+func (ctx *roundCtx) BLSPubKey(addr string) *crypto.BLS12381PublicKey {
+	if ctx.blsPubKeys == nil {
+		return nil
+	}
+	return ctx.blsPubKeys[addr]
+}
+
+// verifyEndorsement checks the signature on en, dispatching on signature
+// length: secp256k1 (65 B) uses the existing endorsement.VerifyEndorsement
+// path; BLS (96 B) resolves the verifying pubkey from this round's BLS
+// pubkey index by the endorser's iotex address. Returns nil on success.
+func (ctx *roundCtx) verifyEndorsement(doc endorsement.Document, en *endorsement.Endorsement) error {
+	switch len(en.Signature()) {
+	case crypto.BLSAggregateSignatureLength:
+		addr := en.Endorser().Address()
+		if addr == nil {
+			return errors.New("failed to resolve endorser address for BLS endorsement")
+		}
+		pk := ctx.BLSPubKey(addr.String())
+		if pk == nil {
+			return errors.Errorf("delegate %s has no registered BLS pubkey in this round", addr)
+		}
+		if !endorsement.VerifyBLSEndorsement(doc, en, pk) {
+			return errors.New("invalid BLS endorsement signature")
+		}
+		return nil
+	default:
+		if !endorsement.VerifyEndorsement(doc, en) {
+			return errors.New("invalid secp256k1 endorsement signature")
+		}
+		return nil
+	}
 }
 
 func (ctx *roundCtx) Block(blkHash []byte) *block.Block {
@@ -208,8 +252,8 @@ func (ctx *roundCtx) AddVoteEndorsement(
 	vote *ConsensusVote,
 	en *endorsement.Endorsement,
 ) error {
-	if !endorsement.VerifyEndorsement(vote, en) {
-		return errors.New("invalid endorsement for the vote")
+	if err := ctx.verifyEndorsement(vote, en); err != nil {
+		return err
 	}
 	if addr := en.Endorser().Address(); addr == nil || !ctx.IsDelegate(addr.String()) {
 		return errors.New("invalid endorser")

--- a/consensus/scheme/rolldpos/roundctx_test.go
+++ b/consensus/scheme/rolldpos/roundctx_test.go
@@ -32,11 +32,11 @@ func TestRoundCtx(t *testing.T) {
 		epochNum:             uint64(1),
 		epochStartHeight:     uint64(1),
 		nextEpochStartHeight: uint64(33),
-		delegates: []string{
-			"delegate1", "delegate2", "delegate3", "delegate4",
-			"delegate5", "delegate6", "delegate7", "delegate8",
-			"delegate9", "delegate0", "delegateA", "delegateB",
-			"delegateC", "delegateD", "delegateE", "delegateF",
+		delegates: []delegate{
+			{address: "delegate1"}, {address: "delegate2"}, {address: "delegate3"}, {address: "delegate4"},
+			{address: "delegate5"}, {address: "delegate6"}, {address: "delegate7"}, {address: "delegate8"},
+			{address: "delegate9"}, {address: "delegate0"}, {address: "delegateA"}, {address: "delegateB"},
+			{address: "delegateC"}, {address: "delegateD"}, {address: "delegateE"}, {address: "delegateF"},
 		},
 	}
 

--- a/consensus/scheme/rolldpos/roundctx_test.go
+++ b/consensus/scheme/rolldpos/roundctx_test.go
@@ -51,7 +51,7 @@ func TestRoundCtx(t *testing.T) {
 	require.Equal("delegateC", round.Proposer())
 	require.False(round.IsDelegate("non-delegate"))
 	for _, d := range round.Delegates() {
-		require.True(round.IsDelegate(d))
+		require.True(round.IsDelegate(d.Address))
 	}
 	t.Run("is-stale", func(t *testing.T) {
 		blkHash := []byte("Some block hash")

--- a/consensus/scheme/rolldpos/roundctx_test.go
+++ b/consensus/scheme/rolldpos/roundctx_test.go
@@ -32,11 +32,11 @@ func TestRoundCtx(t *testing.T) {
 		epochNum:             uint64(1),
 		epochStartHeight:     uint64(1),
 		nextEpochStartHeight: uint64(33),
-		delegates: []delegate{
-			{address: "delegate1"}, {address: "delegate2"}, {address: "delegate3"}, {address: "delegate4"},
-			{address: "delegate5"}, {address: "delegate6"}, {address: "delegate7"}, {address: "delegate8"},
-			{address: "delegate9"}, {address: "delegate0"}, {address: "delegateA"}, {address: "delegateB"},
-			{address: "delegateC"}, {address: "delegateD"}, {address: "delegateE"}, {address: "delegateF"},
+		delegates: []*Delegate{
+			{Address: "delegate1"}, {Address: "delegate2"}, {Address: "delegate3"}, {Address: "delegate4"},
+			{Address: "delegate5"}, {Address: "delegate6"}, {Address: "delegate7"}, {Address: "delegate8"},
+			{Address: "delegate9"}, {Address: "delegate0"}, {Address: "delegateA"}, {Address: "delegateB"},
+			{Address: "delegateC"}, {Address: "delegateD"}, {Address: "delegateE"}, {Address: "delegateF"},
 		},
 	}
 

--- a/e2etest/native_staking_test.go
+++ b/e2etest/native_staking_test.go
@@ -1631,7 +1631,7 @@ func TestCandidateBLSPublicKey(t *testing.T) {
 			name:    "register with bls key",
 			preActs: genTransferActionsWithPrice(int(cfg.Genesis.XinguBlockHeight), gasPrice1559),
 			acts: []*actionWithTime{
-				{mustNoErr(action.SignedCandidateRegisterWithBLS(test.nonceMgr.pop(identityset.Address(candOwnerID2).String()), "cand2", identityset.Address(candOperatorID2).String(), identityset.Address(2).String(), identityset.Address(candOwnerID2).String(), registerAmount.String(), 1, true, blsPubKey, []byte{1, 2, 3}, gasLimit, gasPrice, identityset.PrivateKey(candOwnerID2), action.WithChainID(chainID))), time.Now()},
+				{mustNoErr(action.SignedCandidateRegisterWithBLS(test.nonceMgr.pop(identityset.Address(candOwnerID2).String()), "cand2", identityset.Address(candOperatorID2).String(), identityset.Address(2).String(), identityset.Address(candOwnerID2).String(), registerAmount.String(), 1, true, blsPubKey, nil, []byte{1, 2, 3}, gasLimit, gasPrice, identityset.PrivateKey(candOwnerID2), action.WithChainID(chainID))), time.Now()},
 			},
 			blockExpect: func(test *e2etest, blk *block.Block, err error) {
 				require.NoError(err)
@@ -1657,7 +1657,7 @@ func TestCandidateBLSPublicKey(t *testing.T) {
 			name:    "update bls key by operator",
 			preActs: genTransferActionsWithPrice(jumps, gasPrice1559),
 			acts: []*actionWithTime{
-				{mustNoErr(action.SignedCandidateUpdateWithBLS(test.nonceMgr.pop(identityset.Address(candOperatorID).String()), "cand1", identityset.Address(candOperatorID).String(), "", blsPrivKey2.PublicKey().Bytes(), gasLimit, gasPrice, identityset.PrivateKey(candOperatorID), action.WithChainID(chainID))), time.Now()},
+				{mustNoErr(action.SignedCandidateUpdateWithBLS(test.nonceMgr.pop(identityset.Address(candOperatorID).String()), "cand1", identityset.Address(candOperatorID).String(), "", blsPrivKey2.PublicKey().Bytes(), nil, gasLimit, gasPrice, identityset.PrivateKey(candOperatorID), action.WithChainID(chainID))), time.Now()},
 			},
 			blockExpect: func(test *e2etest, blk *block.Block, err error) {
 				require.NoError(err)

--- a/endorsement/bls_endorsement.go
+++ b/endorsement/bls_endorsement.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package endorsement
+
+import (
+	"time"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+)
+
+// EndorseBLS signs the document with a BLS12-381 private key and returns a
+// standard Endorsement whose signature field carries the 96-byte BLS
+// signature. The endorser public key embedded in the endorsement is the
+// delegate's existing secp256k1 producer key; receivers derive the iotex
+// address from it and resolve the BLS verifying key from candidate state.
+//
+// Used for consensus votes once BLS signature aggregation is activated
+// (IIP-52). The wire format is unchanged from the pre-fork ECDSA path —
+// signature length is the discriminator.
+func EndorseBLS(
+	doc Document,
+	ts time.Time,
+	endorserPubKey crypto.PublicKey,
+	blsSigner *crypto.BLS12381PrivateKey,
+) (*Endorsement, error) {
+	hash, err := hashDocWithTime(doc, ts)
+	if err != nil {
+		return nil, err
+	}
+	sig, err := blsSigner.Sign(hash)
+	if err != nil {
+		return nil, err
+	}
+	return NewEndorsement(ts, endorserPubKey, sig), nil
+}
+
+// VerifyBLSEndorsement checks an Endorsement that carries a BLS12-381
+// signature against the supplied BLS public key. Callers are responsible for
+// resolving pubKey from the endorser's iotex address via candidate state.
+//
+// Use this in place of VerifyEndorsement when the endorsement is known to
+// carry a BLS signature (typically branched on signature length:
+// len(en.Signature()) == crypto.BLSAggregateSignatureLength).
+func VerifyBLSEndorsement(doc Document, en *Endorsement, pubKey *crypto.BLS12381PublicKey) bool {
+	if en == nil || pubKey == nil {
+		return false
+	}
+	hash, err := hashDocWithTime(doc, en.Timestamp())
+	if err != nil {
+		return false
+	}
+	return pubKey.Verify(hash, en.Signature())
+}

--- a/endorsement/bls_endorsement_test.go
+++ b/endorsement/bls_endorsement_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package endorsement
+
+import (
+	"testing"
+	"time"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/stretchr/testify/require"
+)
+
+// stubDocument is a tiny Document implementation for tests: it hashes a
+// fixed payload so two stubDocument values with the same payload produce
+// the same hash.
+type stubDocument struct {
+	payload []byte
+}
+
+func (d *stubDocument) Hash() ([]byte, error) {
+	h := hash.Hash256b(d.payload)
+	return h[:], nil
+}
+
+// blsTestKeys derives a deterministic (ECDSA producer, BLS) key pair from a
+// seed byte. Used in place of identityset to avoid pulling the test package
+// into the endorsement package's tests.
+func blsTestKeys(t *testing.T, seed byte) (crypto.PrivateKey, *crypto.BLS12381PrivateKey) {
+	t.Helper()
+	ikm := make([]byte, 32)
+	for i := range ikm {
+		ikm[i] = seed
+	}
+	ecdsa, err := crypto.BytesToPrivateKey(ikm)
+	require.NoError(t, err)
+	bls, err := crypto.GenerateBLS12381PrivateKey(ikm)
+	require.NoError(t, err)
+	return ecdsa, bls
+}
+
+func TestEndorseBLS_RoundTrip(t *testing.T) {
+	require := require.New(t)
+	ecdsa, bls := blsTestKeys(t, 0x11)
+	doc := &stubDocument{payload: []byte("hello-bls")}
+	ts := time.Unix(1700000000, 0).UTC()
+
+	en, err := EndorseBLS(doc, ts, ecdsa.PublicKey(), bls)
+	require.NoError(err)
+	require.NotNil(en)
+	require.Equal(crypto.BLSAggregateSignatureLength, len(en.Signature()),
+		"BLS signature should be 96 bytes (G2 compressed)")
+	require.True(en.Timestamp().Equal(ts), "timestamp preserved")
+	require.Equal(ecdsa.PublicKey().HexString(), en.Endorser().HexString(),
+		"endorser stays on the secp256k1 pubkey for address derivation")
+
+	require.True(VerifyBLSEndorsement(doc, en, bls.PublicKey()),
+		"verify with the matching BLS pubkey passes")
+}
+
+func TestVerifyBLSEndorsement_WrongPubKey(t *testing.T) {
+	require := require.New(t)
+	ecdsa, signer := blsTestKeys(t, 0x22)
+	_, other := blsTestKeys(t, 0x33)
+	doc := &stubDocument{payload: []byte("doc-a")}
+
+	en, err := EndorseBLS(doc, time.Unix(1700000000, 0), ecdsa.PublicKey(), signer)
+	require.NoError(err)
+	require.False(VerifyBLSEndorsement(doc, en, other.PublicKey()),
+		"a different BLS pubkey must not verify")
+}
+
+func TestVerifyBLSEndorsement_TamperedDoc(t *testing.T) {
+	require := require.New(t)
+	ecdsa, signer := blsTestKeys(t, 0x44)
+	doc := &stubDocument{payload: []byte("original")}
+	other := &stubDocument{payload: []byte("tampered")}
+
+	en, err := EndorseBLS(doc, time.Unix(1700000000, 0), ecdsa.PublicKey(), signer)
+	require.NoError(err)
+	require.False(VerifyBLSEndorsement(other, en, signer.PublicKey()),
+		"verify against a different document must fail")
+}
+
+func TestVerifyBLSEndorsement_TamperedSig(t *testing.T) {
+	require := require.New(t)
+	ecdsa, signer := blsTestKeys(t, 0x55)
+	doc := &stubDocument{payload: []byte("payload")}
+
+	en, err := EndorseBLS(doc, time.Unix(1700000000, 0), ecdsa.PublicKey(), signer)
+	require.NoError(err)
+
+	// flip a bit in the signature and rewrap
+	tamperedSig := en.Signature()
+	tamperedSig[0] ^= 0x01
+	tampered := NewEndorsement(en.Timestamp(), en.Endorser(), tamperedSig)
+	require.False(VerifyBLSEndorsement(doc, tampered, signer.PublicKey()),
+		"a tampered BLS signature must not verify")
+}
+
+func TestVerifyBLSEndorsement_NilInputs(t *testing.T) {
+	require := require.New(t)
+	_, signer := blsTestKeys(t, 0x66)
+	doc := &stubDocument{payload: []byte("payload")}
+
+	require.False(VerifyBLSEndorsement(doc, nil, signer.PublicKey()),
+		"nil endorsement must not verify")
+	require.False(VerifyBLSEndorsement(doc, &Endorsement{}, nil),
+		"nil pubkey must not verify")
+}

--- a/endorsement/endorsement.go
+++ b/endorsement/endorsement.go
@@ -36,6 +36,14 @@ type (
 	}
 )
 
+// SigningHash returns the hash that endorsers sign for the given document
+// at the given timestamp. Use this when verifying a signature whose
+// timestamp comes from outside an Endorsement struct (e.g., reconstructing
+// the COMMIT-vote hash from a BLS-aggregated block footer).
+func SigningHash(doc Document, ts time.Time) ([]byte, error) {
+	return hashDocWithTime(doc, ts)
+}
+
 func hashDocWithTime(doc Document, ts time.Time) ([]byte, error) {
 	h, err := doc.Hash()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -354,4 +354,4 @@ replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/erigontec
 // Fix for go-libutp compatibility with GCC 15+
 replace github.com/anacrolix/go-libutp => github.com/anacrolix/go-libutp v0.0.0-20251121015447-f294e5ed5b4d
 
-replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2
+replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207

--- a/go.mod
+++ b/go.mod
@@ -354,4 +354,4 @@ replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/erigontec
 // Fix for go-libutp compatibility with GCC 15+
 replace github.com/anacrolix/go-libutp => github.com/anacrolix/go-libutp v0.0.0-20251121015447-f294e5ed5b4d
 
-replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207
+replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260610010006-7a486f6a453d

--- a/go.mod
+++ b/go.mod
@@ -353,3 +353,5 @@ replace github.com/ethereum/go-ethereum/crypto/secp256k1 => github.com/erigontec
 
 // Fix for go-libutp compatibility with GCC 15+
 replace github.com/anacrolix/go-libutp => github.com/anacrolix/go-libutp v0.0.0-20251121015447-f294e5ed5b4d
+
+replace github.com/iotexproject/iotex-proto => github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a h1:BE2G
 github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a/go.mod h1:7LneN7BMglt3mEe6/ypXrq64LiXgvGcDvbJgEzZnEpI=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d h1:vPl7sjgea9uQFeGdUr1uhrtT2kDbtRozOC9QnhnrX5E=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d/go.mod h1:CFlPtIrMHxhNuguRY0fdyKPr6hvbFDfUd1q8YcOcoYE=
-github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2 h1:eSdN1g/YxV+Axy0EbT5Fjrejg1K5VHfVk6hnpbTLV9Q=
-github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
+github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207 h1:U3lBAGxGS/C/5G0EU1sJTF8rLKo44DzUPuII26B5Re0=
+github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -299,8 +299,8 @@ github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a h1:BE2G
 github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a/go.mod h1:7LneN7BMglt3mEe6/ypXrq64LiXgvGcDvbJgEzZnEpI=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d h1:vPl7sjgea9uQFeGdUr1uhrtT2kDbtRozOC9QnhnrX5E=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d/go.mod h1:CFlPtIrMHxhNuguRY0fdyKPr6hvbFDfUd1q8YcOcoYE=
-github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207 h1:U3lBAGxGS/C/5G0EU1sJTF8rLKo44DzUPuII26B5Re0=
-github.com/envestcc/iotex-proto v0.0.0-20260528041059-e4439efbb207/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
+github.com/envestcc/iotex-proto v0.0.0-20260610010006-7a486f6a453d h1:t3BKmnxqMQAPoooy6+QojL3eM+4aglbBTF0sHuipWzg=
+github.com/envestcc/iotex-proto v0.0.0-20260610010006-7a486f6a453d/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a h1:BE2G
 github.com/envestcc/erigon/erigon-lib v0.0.0-20251229032433-18f245cc374a/go.mod h1:7LneN7BMglt3mEe6/ypXrq64LiXgvGcDvbJgEzZnEpI=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d h1:vPl7sjgea9uQFeGdUr1uhrtT2kDbtRozOC9QnhnrX5E=
 github.com/envestcc/go-verkle v0.0.0-20251216081422-a9d13963495d/go.mod h1:CFlPtIrMHxhNuguRY0fdyKPr6hvbFDfUd1q8YcOcoYE=
+github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2 h1:eSdN1g/YxV+Axy0EbT5Fjrejg1K5VHfVk6hnpbTLV9Q=
+github.com/envestcc/iotex-proto v0.0.0-20260526105443-52e72a6dedb2/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -598,8 +600,6 @@ github.com/iotexproject/iotex-antenna-go/v2 v2.6.4 h1:7e0VyBDFT+iqwvr/BIk38yf7nC
 github.com/iotexproject/iotex-antenna-go/v2 v2.6.4/go.mod h1:L6AzDHo2TBFDAPA3ly+/PCS4JSX2g3zzhwV8RGQsTDI=
 github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1 h1:jPLni/qKAnxv87HMCutde2tP9JmfWuLZgGpB4OArQGM=
 github.com/iotexproject/iotex-election v0.3.8-0.20251015031218-8df952babca1/go.mod h1:w9HriT1coMRbuknaSD2xqiOqDTnowBDzvFZv8tg1j2M=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16 h1:iaFjQ8QJ3ekZnwPlUX3XJHZ/5uf+FbUltH6o24d4NYA=
-github.com/iotexproject/iotex-proto v0.6.6-0.20260211020747-f26bd969ed16/go.mod h1:OOXZIG6Q9tInog8Y5zzEJQsDv9IaG/xxpDtl4KzdWZs=
 github.com/ipfs/boxo v0.27.2 h1:sGo4KdwBaMjdBjH08lqPJyt27Z4CO6sugne3ryX513s=
 github.com/ipfs/boxo v0.27.2/go.mod h1:qEIRrGNr0bitDedTCzyzBHxzNWqYmyuHgK8LG9Q83EM=
 github.com/ipfs/go-block-format v0.2.0 h1:ZqrkxBA2ICbDRbK8KJs/u0O3dlp6gmAuuXUJNiW1Ycs=

--- a/ioctl/cmd/action/stake2register.go
+++ b/ioctl/cmd/action/stake2register.go
@@ -115,7 +115,11 @@ func register(args []string) error {
 	if err != nil {
 		return output.NewError(0, "failed to get nonce ", err)
 	}
-	cr, err := action.NewCandidateRegisterWithBLS(name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountInRau.String(), duration, _stake2AutoStake, blsPubKeyBytes, payload)
+	// TODO: derive blsPop from a user-supplied BLS private key and pass
+	// it here once the ioctl flow supports it. Pre-fork the PoP is
+	// optional; post-fork (EnforceBLSPoP active) the handler will reject
+	// the registration if blsPop is empty.
+	cr, err := action.NewCandidateRegisterWithBLS(name, operatorAddrStr, rewardAddrStr, ownerAddrStr, amountInRau.String(), duration, _stake2AutoStake, blsPubKeyBytes, nil, payload)
 
 	if err != nil {
 		return output.NewError(output.InstantiationError, "failed to make a candidateRegister instance", err)

--- a/ioctl/cmd/action/stake2update.go
+++ b/ioctl/cmd/action/stake2update.go
@@ -91,7 +91,10 @@ func stake2Update(args []string) error {
 		return output.NewError(0, "failed to get nonce ", err)
 	}
 
-	s2u, err := action.NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr, blsPubKeyBytes)
+	// TODO: derive blsPop from a user-supplied BLS private key. Pre-fork
+	// the PoP is optional; post-fork (EnforceBLSPoP active) the handler
+	// rejects an update that rotates the BLS key without a PoP.
+	s2u, err := action.NewCandidateUpdateWithBLS(name, operatorAddrStr, rewardAddrStr, blsPubKeyBytes, nil)
 	if err != nil {
 		return output.NewError(output.InstantiationError, "failed to make a candidateUpdate instance", err)
 	}


### PR DESCRIPTION
> **Security severity: CRITICAL, latent.** Stacks on iotex-proto#173 and the IIP-52 PR chain (#4841 → #4842 → #4843 → #4847). The diff includes the IIP-52 PRs' changes until they merge; review the last commit (\`fix(staking): require BLS proof-of-possession at candidate register/update\`).
>
> The vulnerability is **gated today** by IIP-52's \`ToBeEnabledBlockHeight = math.MaxUint64\` — no live chain is at risk — but **must be fixed before activation**. IIP-52 PR stack should NOT be allowed to merge + activate without this PR also landing.

## The bug

\`consensus/scheme/rolldpos/rolldpos.go\` \`validateAggregatedFooter\` verifies the IIP-52 COMMIT-vote BLS aggregate signature using:

\`\`\`go
crypto.BLSAggregateSignatureFromBytes(sig).Verify(pubKeys, msg)
// → blst.FastAggregateVerify(true, pubKeys, msg, dst)
\`\`\`

with DST = \`BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_\`. The \`_POP_\` suffix names the IRTF Proof-of-Possession ciphersuite, which is only sound if each registered BLS pubkey arrived with a possession proof at registration.

Today registration validates only key format and subgroup membership:

\`\`\`go
// action/candidate_register.go, action/candidate_update.go
_, err := crypto.BLS12381PublicKeyFromBytes(blsPubKey)
\`\`\`

No PoP is checked. The proto has no PoP field.

## Attack

An attacker with a single active delegate slot:

1. Reads other delegates' BLS pubkeys from chain
2. Picks any secret \`x\` they control
3. Computes \`pk_rogue = g^x − Σ(other pubkeys)\` in G1 (public-information-only)
4. Registers \`pk_rogue\` via \`candidateRegisterWithBLS\` — current handler accepts (no PoP gate)
5. For any block they want to finalize: submits a footer with bitmap set to all delegates and signature \`σ = sign(x, msg)\`
6. \`FastAggregateVerify(Σ pubKeys, σ, msg)\` collapses \`Σ pk_i + pk_rogue\` to \`g^x\`. \`σ\` verifies. \`isMajorityCount\` passes.

**One delegate forges a 2/3+ quorum certificate → finalizes arbitrary blocks → consensus safety break / chain split.**

Reachability gate: requires the attacker's candidate to be in \`round.delegates\` (economic, not cryptographic) AND \`EnableBLSAggregation\` active.

## The fix (Ethereum 2.0 style)

Eth2's mitigation for the same primitive is the \`process_deposit\` PoP: the validator's deposit signature signs a message that includes the pubkey. Adopting the equivalent pattern at \`candidateRegister\` / \`candidateUpdate\`:

\`\`\`go
// action/protocol/staking/bls_pop.go
const blsPopDomain = \"IOTEX_BLS_POP_v1\"

func BLSPopSigningRoot(blsPubKey []byte, ownerAddress address.Address) []byte {
    h := sha256.New()
    h.Write([]byte(blsPopDomain))
    h.Write(blsPubKey)
    h.Write(ownerAddress.Bytes())
    return h.Sum(nil)
}
\`\`\`

Three values bind into the message — closes three replay variants:

| Binding | Closes |
|---|---|
| \`blsPubKey\` | Rogue key — attacker without the secret can't sign over the canonical message at all |
| \`ownerAddress\` | Candidate substitution — PoP for owner A doesn't validate for owner B |
| \`IOTEX_BLS_POP_v1\` prefix | Cross-domain replay — PoP can't be reused as a consensus vote or vice versa; version suffix reserves room for a future fork to rotate |

## Implementation

- **Proto** (iotex-proto#173): \`bytes blsPop = 5\` on \`CandidateBasicInfo\`. go.mod replace updated to envestcc/iotex-proto@7a486f6.

- **FeatureCtx.EnforceBLSPoP**: shares \`IsToBeEnabled\` height with \`EnableBLSAggregation\` today but is a semantically distinct switch — call sites read self-descriptively and the two can diverge if needed.

- **action.CandidateRegister / CandidateUpdate**: carry \`blsPop\` through constructors, Proto/LoadProto, accessors. \`NewCandidateRegisterWithBLS\` and \`NewCandidateUpdateWithBLS\` now accept \`blsPop\`; pre-fork callers may pass nil.

- **handlers.go**: \`handleCandidateRegister\`, \`handleCandidateUpdate\`, and \`handleCandidateUpdateByOperator\` call \`VerifyBLSPop\` before writing \`Candidate.BLSPubKey\` when \`EnforceBLSPoP\` is active. Failure → \`ReceiptStatus_ErrUnauthorizedOperator\`.

- **bls_pop_test.go**: 5 tests including \`TestBLSPop_RogueKeyAttackBlocked\` as the regression guard — models the attacker registering a pubkey they don't own, demonstrates the only PoP they can produce (signed under their own secret) does NOT validate against the target pubkey, plus the control case confirming a legitimate registrant succeeds.

## Out of scope for this PR (follow-ups)

- **ioctl / SDK wiring**: \`stake2register.go\` and \`stake2update.go\` pass nil for \`blsPop\` with TODO markers. They need a flag to ingest a BLS private key and derive the PoP. Pre-fork the empty PoP is accepted; post-fork the same call will fail with the new check, so the tooling MUST be updated before the fork.

- **Migration**: existing pre-fork candidate records have no PoP. Before the fork activates, all active candidates must submit a \`candidateUpdate\` carrying a valid \`blsPop\`; alternative is a fork-block state migration that drops un-attested BLS pubkeys from \`ActiveCandidates\`. IIP draft (separate doc) covers the chosen approach.

- **Receipt status code**: reusing \`ErrUnauthorizedOperator\` (closest semantic match). Adding a dedicated \`ErrInvalidBLSPoP\` is another proto bump and not necessary for the fix.

## Test plan
- [x] Unit tests \`TestBLSPop_*\` — 5 cases, including the rogue-key regression guard
- [x] \`go test ./action/protocol/staking/ ./action/\` — 470 passing locally
- [x] \`go build ./...\` clean
- [ ] CI green on the IIP-52 stack base (#4847) + iotex-proto#173
- [ ] Coordinate migration plan with delegates before flipping fork height

🤖 Generated with [Claude Code](https://claude.com/claude-code)