### PR TITLE
feat(actpool): support removing addresses from blacklist at a future height

### DIFF
--- a/actpool/actpool_test.go
+++ b/actpool/actpool_test.go
@@ -11,6 +11,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/sha256"
 	"encoding/hex"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -1331,5 +1332,37 @@ func TestIsBlackListedFunc(t *testing.T) {
 		// Non-blacklisted address - never enforced
 		require.False(isBlackListed("io1other", 100))
 		require.False(isBlackListed("io1other", 1000))
+	})
+
+	t.Run("removal drops listed addresses from removalHeight onwards", func(t *testing.T) {
+		cfg := Config{
+			BlackList:              []string{"io1abc", "io1xyz"},
+			BlackListActiveHeight:  100,
+			BlackListRemoval:       []string{"io1abc"},
+			BlackListRemovalHeight: 200,
+		}
+		isBlackListed := cfg.IsBlackListedFunc()
+		// Removal entry: enforced in [activeHeight, removalHeight), dropped at removalHeight
+		require.False(isBlackListed("io1abc", 99))
+		require.True(isBlackListed("io1abc", 100))
+		require.True(isBlackListed("io1abc", 199))
+		require.False(isBlackListed("io1abc", 200))
+		require.False(isBlackListed("io1abc", 1000))
+		// Non-removal entry: enforced from activeHeight onwards regardless of removalHeight
+		require.True(isBlackListed("io1xyz", 100))
+		require.True(isBlackListed("io1xyz", 200))
+		require.True(isBlackListed("io1xyz", 1000))
+	})
+
+	t.Run("removalHeight=MaxUint64 keeps everyone blacklisted", func(t *testing.T) {
+		cfg := Config{
+			BlackList:              []string{"io1abc"},
+			BlackListActiveHeight:  100,
+			BlackListRemoval:       []string{"io1abc"},
+			BlackListRemovalHeight: math.MaxUint64,
+		}
+		isBlackListed := cfg.IsBlackListedFunc()
+		require.True(isBlackListed("io1abc", 100))
+		require.True(isBlackListed("io1abc", math.MaxUint64-1))
 	})
 }

--- a/actpool/config.go
+++ b/actpool/config.go
@@ -1,6 +1,7 @@
 package actpool
 
 import (
+	"math"
 	"math/big"
 	"time"
 
@@ -51,6 +52,22 @@ var (
 			"io1zh88jlem8vvzp9z6t73rs4qd72jnzpm8pv8ndu",
 		},
 		BlackListActiveHeight: 45404174,
+		BlackListRemoval: []string{
+			"io10epxv6w4he9pgx0qtagm7lc78aw9jsm7s8t0tw",
+			"io10jr2hh4xcm3s3yhq98zudxh08e9uume6e0ekee",
+			"io126e8lcld9ucl6nxm55s6hxmq9velxw9u9t8ps5",
+			"io13pgqh3dhd63sen5clvt2cvqflshf0swxzq4utt",
+			"io19rw6y85rh4d78az0s7w5dknp6j06cst5wtwnt3",
+			"io1aj8u2a0tr2mjumcxy4zrnecszr8mh6wkrmjrxq",
+			"io1fp748ue6tsssn3z9q5cxcpyewjvcptkrtryju3",
+			"io1fqv56nlmr2fnuex66j09k0qn5962yeezkp688n",
+			"io1frcfdlrtrk0kk354sl703e2v7qwd3rclajhg5r",
+			"io1fseuvqpg8gchcnc4sz3e2z73h8q837ult8yjv6",
+			"io1fsrrc02mldtwhjjncngvf58yxw2emmgsz9gk0p",
+			"io1ft54ueh2qn0nfep6xf92nm60n5sqlj0d9uzksg",
+			"io1ftl20mky24k43yp06zcjx653ktas9xmvzvtasz",
+		},
+		BlackListRemovalHeight: math.MaxUint64,
 		Store: &StoreConfig{
 			Datadir: "/var/data/actpool.cache",
 		},
@@ -75,6 +92,10 @@ type Config struct {
 	BlackList []string `yaml:"blackList"`
 	// BlackListActiveHeight is the height from which the blacklist is enforced (0 means always enforced)
 	BlackListActiveHeight uint64 `yaml:"blackListActiveHeight"`
+	// BlackListRemoval lists the account addresses that are removed from the blacklist at BlackListRemovalHeight
+	BlackListRemoval []string `yaml:"blackListRemoval"`
+	// BlackListRemovalHeight is the height from which BlackListRemoval entries are no longer treated as blacklisted
+	BlackListRemovalHeight uint64 `yaml:"blackListRemovalHeight"`
 	// Store defines the config for persistent cache
 	Store *StoreConfig `yaml:"store"`
 	// MaxNumBlobsPerAcct defines the maximum number of blob txs an account can have
@@ -94,7 +115,7 @@ func (ap Config) MinGasPrice() *big.Int {
 
 // IsBlackListedFunc returns a function that checks if an address is blacklisted at a given height
 func (ap Config) IsBlackListedFunc() func(addr string, height uint64) bool {
-	return IsBlackListedFunc(ap.BlackList, ap.BlackListActiveHeight)
+	return IsBlackListedFunc(ap.BlackList, ap.BlackListActiveHeight, ap.BlackListRemoval, ap.BlackListRemovalHeight)
 }
 
 // StoreConfig is the configuration for the blob store

--- a/actpool/util.go
+++ b/actpool/util.go
@@ -1,23 +1,31 @@
 package actpool
 
-// IsBlackListedFunc creates a function that checks if an address is blacklisted at a given height
-func IsBlackListedFunc(blackList []string, activeHeight uint64) func(addr string, height uint64) bool {
-	// Create blacklist map
+// IsBlackListedFunc creates a function that checks if an address is blacklisted at a given height.
+// Addresses in removal are still treated as blacklisted in [activeHeight, removalHeight); from
+// removalHeight onwards they are no longer considered blacklisted.
+func IsBlackListedFunc(blackList []string, activeHeight uint64, removal []string, removalHeight uint64) func(addr string, height uint64) bool {
 	bl := make(map[string]bool, len(blackList))
 	for _, addr := range blackList {
 		bl[addr] = true
 	}
+	rm := make(map[string]bool, len(removal))
+	for _, addr := range removal {
+		rm[addr] = true
+	}
 
 	return func(addr string, height uint64) bool {
-		if bl == nil || len(bl) == 0 {
+		if len(bl) == 0 {
 			return false
 		}
 		if _, ok := bl[addr]; !ok {
 			return false
 		}
-		if activeHeight == 0 {
-			return true
+		if activeHeight != 0 && height < activeHeight {
+			return false
 		}
-		return height >= activeHeight
+		if rm[addr] && height >= removalHeight {
+			return false
+		}
+		return true
 	}
 }


### PR DESCRIPTION
## Summary
- Add `BlackListRemoval` + `BlackListRemovalHeight` to `actpool.Config` so specific addresses can be dropped from the blacklist at a designated height without mutating the original `BlackList` (preserves historical SetCode authorization validation in EVM).
- Populate `BlackListRemoval` with the 13 mainnet addresses queued for removal at the next hardfork; `BlackListRemovalHeight` is left at `math.MaxUint64` as a feature gate — flip it to the real height in a follow-up once the next hardfork height is finalized.
- `IsBlackListedFunc` now enforces removal: in `[activeHeight, removalHeight)` the address still hits the blacklist; from `removalHeight` onward the listed addresses are no longer blacklisted.

## Test plan
- [x] `go test ./actpool/...`
- [x] `go test ./action/protocol/execution/... ./blocksync/... ./e2etest/...`
- [x] New unit tests cover: address still blacklisted at `removalHeight-1`, dropped at `removalHeight`, non-removal addresses unaffected, and `removalHeight=MaxUint64` behaves identically to current production config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)