### PR TITLE
fix(evm): GetCommittedState must not return post-mutation value for prestate-absent keys

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -173,6 +173,13 @@ type (
 		AlwaysWriteCachedContract     bool
 		NoCandidateExitQueue          bool
 		FixInContractTransferLogTopic bool
+		// CorrectPrestateForAbsentKeys, when true, makes contract.GetCommittedState
+		// return the true tx-start prestate value (zero, via trie.ErrNotExist) for
+		// storage slots that were absent in the pre-tx trie. Prior to this gate the
+		// contract-level committed[] cache was populated with post-mutation values
+		// for such slots, causing EIP-2200 SSTORE dynamic gas to misclassify
+		// dirty in-place writes as SSTORE_RESET (100 → 2900 gas overcharge per hit).
+		CorrectPrestateForAbsentKeys bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -348,6 +355,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
 			FixInContractTransferLogTopic:           g.IsToBeEnabled(height),
+			CorrectPrestateForAbsentKeys:            g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/execution/evm/contract.go
+++ b/action/protocol/execution/evm/contract.go
@@ -51,8 +51,15 @@ type (
 		code       protocol.SerializableBytes // contract byte-code
 		root       hash.Hash256
 		committed  map[hash.Hash256][]byte
-		sm         protocol.StateManager
-		trie       trie.Trie // storage trie of the contract
+		// trackAbsent gates the EIP-2200-correct prestate tracking below. When
+		// false (pre-fork), the buggy pre-existing behavior is preserved: keys
+		// observed absent are never recorded, so a later post-mutation GetState
+		// pollutes committed[]. When true (post-fork), absent keys are recorded
+		// in missing[] and GetCommittedState short-circuits them.
+		trackAbsent bool
+		missing     map[hash.Hash256]struct{} // keys observed as absent in the pre-tx trie
+		sm          protocol.StateManager
+		trie        trie.Trie // storage trie of the contract
 	}
 )
 
@@ -65,6 +72,11 @@ func (c *contract) GetCommittedState(key hash.Hash256) ([]byte, error) {
 	if v, ok := c.committed[key]; ok {
 		return v, nil
 	}
+	// If the key was absent in the pre-tx state, do not read the live trie —
+	// it may already hold a post-mutation value written earlier in this tx.
+	if _, ok := c.missing[key]; ok {
+		return nil, trie.ErrNotExist
+	}
 	return c.GetState(key)
 }
 
@@ -72,10 +84,18 @@ func (c *contract) GetCommittedState(key hash.Hash256) ([]byte, error) {
 func (c *contract) GetState(key hash.Hash256) ([]byte, error) {
 	v, err := c.trie.Get(key[:])
 	if err != nil {
+		if c.trackAbsent && errors.Cause(err) == trie.ErrNotExist {
+			c.missing[key] = struct{}{}
+		}
 		return nil, err
 	}
-	if _, ok := c.committed[key]; !ok {
-		c.committed[key] = v
+	// Only record the pre-state value if the key has never been seen before.
+	// If it was previously observed absent (missing), any current trie value is
+	// a post-mutation write from this tx and must not overwrite prestate.
+	if _, wasMissing := c.missing[key]; !wasMissing {
+		if _, ok := c.committed[key]; !ok {
+			c.committed[key] = v
+		}
 	}
 	return v, nil
 }
@@ -83,7 +103,9 @@ func (c *contract) GetState(key hash.Hash256) ([]byte, error) {
 // SetState set the value into contract storage
 func (c *contract) SetState(key hash.Hash256, value []byte) error {
 	if _, ok := c.committed[key]; !ok {
-		_, _ = c.GetState(key)
+		if _, ok := c.missing[key]; !ok {
+			_, _ = c.GetState(key)
+		}
 	}
 	c.dirtyState = true
 	if err := c.trie.Upsert(key[:], value); err != nil {
@@ -144,6 +166,8 @@ func (c *contract) Commit() error {
 		// purge the committed value cache
 		c.committed = nil
 		c.committed = make(map[hash.Hash256][]byte)
+		c.missing = nil
+		c.missing = make(map[hash.Hash256]struct{})
 	}
 	if c.dirtyCode {
 		if _, err := c.sm.PutState(c.code, protocol.NamespaceOption(CodeKVNameSpace), protocol.KeyOption(c.Account.CodeHash)); err != nil {
@@ -169,28 +193,37 @@ func (c *contract) Snapshot() Contract {
 		c.Account.Root = hash.BytesToHash256(rh)
 	}
 	return &contract{
-		Account:    c.Account.Clone(),
-		async:      c.async,
-		dirtyCode:  c.dirtyCode,
-		dirtyState: c.dirtyState,
-		code:       c.code,
-		root:       c.Account.Root,
-		committed:  c.committed,
-		sm:         c.sm,
+		Account:     c.Account.Clone(),
+		async:       c.async,
+		dirtyCode:   c.dirtyCode,
+		dirtyState:  c.dirtyState,
+		code:        c.code,
+		root:        c.Account.Root,
+		committed:   c.committed,
+		trackAbsent: c.trackAbsent,
+		missing:     c.missing,
+		sm:          c.sm,
 		// note we simply save the trie (which is an interface/pointer)
 		// later Revert() call needs to reset the saved trie root
 		trie: c.trie,
 	}
 }
 
-// newContract returns a Contract instance
-func newContract(addr hash.Hash160, account *state.Account, sm protocol.StateManager, enableAsync bool) (Contract, error) {
+// newContract returns a Contract instance.
+//
+// trackAbsent enables the EIP-2200-correct prestate tracking (recording of
+// storage slots absent in the pre-tx trie). It should be plumbed from a
+// featureCtx-gated adapter option so pre-fork execution keeps the historical
+// (buggy) behavior and post-fork execution gets the fix.
+func newContract(addr hash.Hash160, account *state.Account, sm protocol.StateManager, enableAsync, trackAbsent bool) (Contract, error) {
 	c := &contract{
-		Account:   account,
-		root:      account.Root,
-		committed: make(map[hash.Hash256][]byte),
-		sm:        sm,
-		async:     enableAsync,
+		Account:     account,
+		root:        account.Root,
+		committed:   make(map[hash.Hash256][]byte),
+		trackAbsent: trackAbsent,
+		missing:     make(map[hash.Hash256]struct{}),
+		sm:          sm,
+		async:       enableAsync,
 	}
 	options := []mptrie.Option{
 		mptrie.KVStoreOption(protocol.NewKVStoreForTrieWithStateManager(ContractKVNameSpace, sm)),

--- a/action/protocol/execution/evm/contract_adapter.go
+++ b/action/protocol/execution/evm/contract_adapter.go
@@ -15,8 +15,8 @@ type contractAdapter struct {
 	erigon Contract
 }
 
-func newContractAdapter(addr hash.Hash160, account *state.Account, sm protocol.StateManager, intra *erigonstate.IntraBlockState, enableAsync bool) (Contract, error) {
-	v1, err := newContract(addr, account, sm, enableAsync)
+func newContractAdapter(addr hash.Hash160, account *state.Account, sm protocol.StateManager, intra *erigonstate.IntraBlockState, enableAsync, trackAbsent bool) (Contract, error) {
+	v1, err := newContract(addr, account, sm, enableAsync, trackAbsent)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create contract")
 	}

--- a/action/protocol/execution/evm/contract_test.go
+++ b/action/protocol/execution/evm/contract_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/v2/db/batch"
+	"github.com/iotexproject/iotex-core/v2/db/trie"
 	"github.com/iotexproject/iotex-core/v2/state"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_chainmanager"
@@ -99,7 +100,7 @@ func TestLoadStoreCommit(t *testing.T) {
 		sm, err := initMockStateManager(ctrl)
 		require.NoError(err)
 		acct := &state.Account{}
-		cntr1, err := newContract(hash.BytesToHash160(_c1[:]), acct, sm, enableAsync)
+		cntr1, err := newContract(hash.BytesToHash160(_c1[:]), acct, sm, enableAsync, true)
 		require.NoError(err)
 
 		tests := []cntrTest{
@@ -222,6 +223,7 @@ func TestSnapshot(t *testing.T) {
 			s,
 			sm,
 			enableAsync,
+			true,
 		)
 		require.NoError(err)
 		require.NoError(_c1.SetState(_k2b, _v2[:]))
@@ -237,4 +239,66 @@ func TestSnapshot(t *testing.T) {
 	t.Run("async mode", func(t *testing.T) {
 		testfunc(true)
 	})
+}
+
+// TestGetCommittedStateAbsentKey guards two aspects of the prestate-absent
+// storage-slot behavior around the CorrectPrestateForAbsentKeys fork gate:
+//
+//   - post-fork (trackAbsent=true, this PR's fix): GetCommittedState must
+//     report the true prestate (ErrNotExist / zero) for a slot that was
+//     absent at tx start, even after an intra-tx SSTORE has landed on it.
+//   - pre-fork (trackAbsent=false): the historical buggy behavior is
+//     preserved so catch-up from mainnet state prior to the fork height
+//     replays byte-identically. GetCommittedState returns the post-mutation
+//     value written earlier in the same tx.
+//
+// Repro pattern (mainnet block 48,900,885, tx 0xfe792b0c...):
+//  1. SLOAD  K  (K absent → trie.ErrNotExist propagated up)
+//  2. SSTORE K, V1  (writes V1 to the live trie)
+//  3. SLOAD  K  (trie now returns V1 without error)
+//  4. GetCommittedState(K)
+//
+// Under the pre-fork code path, step 4 returns V1 (post-mutation), causing
+// EIP-2200 SSTORE gas to be misclassified as SSTORE_RESET on the next write
+// and burning ~2800 extra gas per SSTORE — enough to OOG-revert the ioID
+// device registration flow.
+func TestGetCommittedStateAbsentKey(t *testing.T) {
+	require := require.New(t)
+	run := func(t *testing.T, enableAsync, trackAbsent bool) {
+		ctrl := gomock.NewController(t)
+		sm, err := initMockStateManager(ctrl)
+		require.NoError(err)
+		acct, err := state.NewAccount()
+		require.NoError(err)
+		c, err := newContract(hash.BytesToHash160(_c1[:]), acct, sm, enableAsync, trackAbsent)
+		require.NoError(err)
+
+		// 1. First SLOAD on an absent key surfaces trie.ErrNotExist.
+		v, err := c.GetState(_k1b)
+		require.True(errors.Cause(err) == trie.ErrNotExist)
+		require.Empty(v)
+
+		// 2. Write V1 to the same key.
+		require.NoError(c.SetState(_k1b, _v1b[:]))
+
+		// 3. Second SLOAD now succeeds and returns the just-written value.
+		v, err = c.GetState(_k1b)
+		require.NoError(err)
+		require.Equal(_v1b[:], v)
+
+		// 4. GetCommittedState behaviour depends on the fork gate.
+		v, err = c.GetCommittedState(_k1b)
+		if trackAbsent {
+			require.True(errors.Cause(err) == trie.ErrNotExist,
+				"post-fork: expected trie.ErrNotExist for prestate-absent key, got err=%v v=%x", err, v)
+			require.Empty(v)
+		} else {
+			require.NoError(err, "pre-fork: GetCommittedState must succeed and return polluted value")
+			require.Equal(_v1b[:], v, "pre-fork: expected post-mutation V1 (bug-preserving), got %x", v)
+		}
+	}
+	t.Run("post-fork sync", func(t *testing.T) { run(t, false, true) })
+	t.Run("post-fork async", func(t *testing.T) { run(t, true, true) })
+	t.Run("pre-fork sync (bug preserved)", func(t *testing.T) { run(t, false, false) })
+	t.Run("pre-fork async (bug preserved)", func(t *testing.T) { run(t, true, false) })
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -546,6 +546,9 @@ func prepareStateDBAdapter(ctx context.Context, sm protocol.StateManager) (*Stat
 	if !featureCtx.AlwaysWriteCachedContract {
 		opts = append(opts, SkipWriteCleanContractOption())
 	}
+	if featureCtx.CorrectPrestateForAbsentKeys {
+		opts = append(opts, CorrectPrestateForAbsentKeysOption())
+	}
 	return NewStateDBAdapter(
 		sm,
 		blkCtx.BlockHeight,

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -98,6 +98,14 @@ type (
 		// contracts in CommitContracts; when true, only contracts with dirty state
 		// or code are committed and written back to the state trie
 		skipWriteCleanContract bool
+		// correctPrestateForAbsentKeys, when true, records storage slots observed
+		// absent in the pre-tx trie in a dedicated `missing` map on the contract,
+		// and returns trie.ErrNotExist from GetCommittedState for those slots.
+		// This corrects a long-standing EIP-2200 non-conformance where the
+		// contract-level committed[] cache would be populated with the
+		// post-mutation value from a later intra-tx GetState, causing SSTORE
+		// dynamic gas to be miscomputed as SSTORE_RESET on dirty in-place writes.
+		correctPrestateForAbsentKeys bool
 	}
 )
 
@@ -243,6 +251,16 @@ func SkipWriteCleanContractOption() StateDBAdapterOption {
 	}
 }
 
+// CorrectPrestateForAbsentKeysOption enables recording of prestate-absent
+// storage slots so that GetCommittedState returns the true zero prestate
+// instead of a post-mutation cache-poisoned value. See FeatureCtx doc.
+func CorrectPrestateForAbsentKeysOption() StateDBAdapterOption {
+	return func(adapter *StateDBAdapter) error {
+		adapter.correctPrestateForAbsentKeys = true
+		return nil
+	}
+}
+
 // NewStateDBAdapter creates a new state db with iotex blockchain
 func NewStateDBAdapter(
 	sm protocol.StateManager,
@@ -286,7 +304,7 @@ func NewStateDBAdapter(
 		s.createdAccountSnapshot = make(map[int]createdAccount)
 	}
 	s.newContract = func(addr hash.Hash160, account *state.Account) (Contract, error) {
-		return newContract(addr, account, s.sm, s.asyncContractTrie)
+		return newContract(addr, account, s.sm, s.asyncContractTrie, s.correctPrestateForAbsentKeys)
 	}
 	return s, nil
 }

--- a/action/protocol/execution/evm/evmstatedbadapter_erigon.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_erigon.go
@@ -40,7 +40,7 @@ func NewErigonStateDBAdapter(adapter *StateDBAdapter,
 	intra *erigonstate.IntraBlockState,
 ) *ErigonStateDBAdapter {
 	adapter.newContract = func(addr hash.Hash160, account *state.Account) (Contract, error) {
-		return newContractAdapter(addr, account, adapter.sm, intra, adapter.asyncContractTrie)
+		return newContractAdapter(addr, account, adapter.sm, intra, adapter.asyncContractTrie, adapter.correctPrestateForAbsentKeys)
 	}
 	return &ErigonStateDBAdapter{
 		StateDBAdapter: adapter,


### PR DESCRIPTION
## Summary

`contract.GetState` propagates `trie.ErrNotExist` for a storage key that is absent in the pre-tx trie without recording the observation. If the same key is later written (via `SetState`) and re-read within the same tx, the follow-up `GetState` succeeds and populates `committed[key]` with the **just-written** value. `GetCommittedState` then returns that post-mutation value as if it were the tx-start prestate.

EIP-2200's SSTORE dynamic gas uses `committed` to decide whether a write is a dirty in-place update (SLOAD_GAS, 100) or a full slot reset (SSTORE_RESET, 2900). With the polluted cache, the second write to a previously-absent slot is charged 2800 extra gas per SSTORE. In an ERC-721 mint immediately followed by a transfer within the same tx — for example an ERC-6551 token-bound-account setup that touches `_owners[tokenId]` twice — the accumulated overcharge is large enough to OOG-revert a transaction that would otherwise succeed under the intended gas semantics.

## Fix

Track prestate-absent keys in a new `missing` map alongside `committed`:

- `GetCommittedState` short-circuits missing keys to `trie.ErrNotExist` without touching the live trie.
- `GetState` records `ErrNotExist` observations in `missing`, and does not overwrite `committed` with a live-trie value once a key has been observed missing.
- `SetState` skips the priming `GetState` call for keys already in `missing` (they cannot resolve to a real prestate later in the tx).
- `Snapshot` propagates the shared `missing` map, `Commit` resets it alongside `committed`, and `newContract` initializes it.

## Hardfork gate

Because this changes state-transition semantics for the class of transactions that hit the pattern above, the new behavior is gated on a new feature flag `CorrectPrestateForAbsentKeys`, currently wired to `g.IsToBeEnabled(height)` — staged, no scheduled fork height yet. Pre-fork execution keeps the historical (buggy) code path byte-for-byte so mainnet catch-up from state prior to the fork height replays identically. Post-fork execution gets the fix.

Plumbing follows the existing pattern used by `AsyncContractTrieOption`, `FixSnapshotOrderOption`, etc.:

  - `FeatureCtx.CorrectPrestateForAbsentKeys` in `action/protocol/context.go`
  - `CorrectPrestateForAbsentKeysOption` on `StateDBAdapter`
  - `newContract` / `newContractAdapter` take an explicit `trackAbsent` bool, propagated through `Snapshot`
  - `evm.go` `prepareStateDBAdapter` toggles the option from the feature ctx

## Regression test

`TestGetCommittedStateAbsentKey` covers both fork sides:

  - **post-fork (`trackAbsent=true`)**: the repro pattern must return `trie.ErrNotExist` for `GetCommittedState` on a prestate-absent key.
  - **pre-fork (`trackAbsent=false`)**: the buggy behavior is preserved — `GetCommittedState` returns the post-mutation value. This guards mainnet catch-up determinism.

Both async and sync modes are exercised (4 subtests total).

## Verification against real mainnet state

Applied the post-fork behavior to a debug build of v2.4.2, restarted a full node's mainnet catch-up against a stopped-at-target-1 snapshot, let it execute the block containing failing tx `0xfe792b0c…7ec54a`:

|                       | pre-fork (mainnet reality) | post-fork (with this PR) |
| --------------------- | -------------------------- | ------------------------ |
| SSTORE at `pc=7929 depth=6` | cost `2900` (SSTORE_RESET) | cost **`100`** (dirty in-place) |
| out-of-gas events during tx | ≥1 (`pc=5788 depth=4`)      | **0**                    |
| `ExecuteContract EVM done statusCode` | 106 (revert) | **1** (success)   |
| gas consumed          | 826,574 (reverted)         | 768,498                  |

At the target block's tip, the fixed node's post-execution state digest diverges from the mined block header (which was produced by the still-buggy production build) — this is the expected outcome and confirms the fix is state-affecting, which is precisely why it needs the fork gate.

## Test plan

- [x] `go test ./action/protocol/execution/evm/...` (all tests pass)
- [x] Fork-gated regression test asserts both pre- and post-fork behavior
- [ ] Reviewer input on the target hardfork height once release planning picks one