### PR TITLE
fix(evm): derive SELFDESTRUCT transfer logs from actual balance movement

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -172,6 +172,11 @@ type (
 		// contracts are committed and written back
 		AlwaysWriteCachedContract bool
 		NoCandidateExitQueue      bool
+		// CorrectSelfDestructTransferLog derives SELFDESTRUCT IN_CONTRACT_TRANSFER
+		// transaction logs from the actual EVM balance movement (exact beneficiary
+		// and amount; no log when no native token moves) instead of the fragile
+		// "last AddBalance" heuristic.
+		CorrectSelfDestructTransferLog bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -346,6 +351,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			PrePectraEVM:                            !g.IsYap(height),
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
+			CorrectSelfDestructTransferLog:          g.IsZanzibar(height),
 		},
 	)
 }

--- a/action/protocol/context_test.go
+++ b/action/protocol/context_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 )
 
 func TestRegistryCtx(t *testing.T) {
@@ -182,4 +184,21 @@ func TestGetVMConfigCtx(t *testing.T) {
 	ret, ok := GetVMConfigCtx(ctx)
 	require.True(ok)
 	require.True(ret.NoBaseFee)
+}
+
+func TestCorrectSelfDestructTransferLogFeature(t *testing.T) {
+	require := require.New(t)
+	g := genesis.TestDefault()
+	const forkHeight = uint64(1000000)
+	g.ZanzibarBlockHeight = forkHeight
+	featureAt := func(height uint64) FeatureCtx {
+		ctx := genesis.WithGenesisContext(context.Background(), g)
+		ctx = WithBlockCtx(ctx, BlockCtx{BlockHeight: height})
+		return MustGetFeatureCtx(WithFeatureCtx(ctx))
+	}
+	// pre-fork (fork-1): heuristic behavior retained
+	require.False(featureAt(forkHeight - 1).CorrectSelfDestructTransferLog)
+	// at/after fork: corrected derivation enabled
+	require.True(featureAt(forkHeight).CorrectSelfDestructTransferLog)
+	require.True(featureAt(forkHeight + 1).CorrectSelfDestructTransferLog)
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -516,6 +516,9 @@ func prepareStateDBAdapter(ctx context.Context, sm protocol.StateManager) (*Stat
 	if featureCtx.SuicideTxLogMismatchPanic {
 		opts = append(opts, SuicideTxLogMismatchPanicOption())
 	}
+	if featureCtx.CorrectSelfDestructTransferLog {
+		opts = append(opts, CorrectSelfDestructTransferLogOption())
+	}
 	if featureCtx.PanicUnrecoverableError {
 		opts = append(opts, PanicUnrecoverableErrorOption())
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -91,6 +91,18 @@ type (
 		panicUnrecoverableError    bool
 		enableCancun               bool
 		fixRevertSnapshot          bool
+		// correctSelfDestructTransferLog derives SELFDESTRUCT transfer logs from the
+		// actual EVM balance movement instead of the legacy lastAddBalance heuristic
+		correctSelfDestructTransferLog bool
+		// selfDestructBeneficiary / selfDestructTransfer capture the beneficiary and
+		// amount of the native transfer the EVM performs during a SELFDESTRUCT, taken
+		// from the AddBalance call tagged with tracing.BalanceIncreaseSelfdestruct and
+		// consumed by the immediately-following SelfDestruct/SelfDestruct6780 call.
+		// selfDestructTransferSet distinguishes a genuine zero-value transfer from a
+		// stale/absent capture.
+		selfDestructBeneficiary common.Address
+		selfDestructTransfer    *big.Int
+		selfDestructTransferSet bool
 		// ignoreBalanceChangeTouchAccount indicates whether to ignore balance change touch account
 		ignoreBalanceChangeTouchAccount bool
 		// skipWriteCleanContract indicates whether to skip writing back read-only
@@ -174,6 +186,14 @@ func ManualCorrectGasRefundOption() StateDBAdapterOption {
 func SuicideTxLogMismatchPanicOption() StateDBAdapterOption {
 	return func(adapter *StateDBAdapter) error {
 		adapter.suicideTxLogMismatchPanic = true
+		return nil
+	}
+}
+
+// CorrectSelfDestructTransferLogOption sets correctSelfDestructTransferLog as true
+func CorrectSelfDestructTransferLogOption() StateDBAdapterOption {
+	return func(adapter *StateDBAdapter) error {
+		adapter.correctSelfDestructTransferLog = true
 		return nil
 	}
 }
@@ -380,6 +400,14 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, a256 *uint256.
 		return *common.U2560
 	}
 	amount := a256.ToBig()
+	if reason == tracing.BalanceIncreaseSelfdestruct {
+		// Invalidate any previously-captured SELFDESTRUCT transfer up front so that
+		// a failed credit, a zero-value credit (which returns early below), or a
+		// stale capture from an earlier SELFDESTRUCT cannot be reused to emit a
+		// phantom log. The capture is (re)established only after the credit is
+		// successfully persisted (see the success branch below).
+		stateDB.selfDestructTransferSet = false
+	}
 	stateDB.lastAddBalanceAmount.SetUint64(0)
 	if amount.Cmp(big.NewInt(int64(0))) == 0 {
 		org, err := accountutil.Recorded(stateDB.sm, evmAddr)
@@ -422,6 +450,20 @@ func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, a256 *uint256.
 		// keep a record of latest add balance
 		stateDB.lastAddBalanceAddr = addr.String()
 		stateDB.lastAddBalanceAmount.SetBytes(amount.Bytes())
+		if reason == tracing.BalanceIncreaseSelfdestruct {
+			// Capture the exact beneficiary and amount of the native transfer the
+			// EVM performs during a SELFDESTRUCT. go-ethereum's opSelfdestruct[6780]
+			// calls AddBalance(beneficiary, contractBalance, BalanceIncreaseSelfdestruct)
+			// immediately before StateDB.SelfDestruct[6780]; the following SelfDestruct
+			// consumes this to emit an accurate IN_CONTRACT_TRANSFER log (post-fork).
+			// Only set here, on a successfully-persisted non-zero credit.
+			stateDB.selfDestructBeneficiary = evmAddr
+			if stateDB.selfDestructTransfer == nil {
+				stateDB.selfDestructTransfer = new(big.Int)
+			}
+			stateDB.selfDestructTransfer.Set(amount)
+			stateDB.selfDestructTransferSet = true
+		}
 	}
 	return *uint256.MustFromBig(state.Balance)
 }
@@ -560,8 +602,7 @@ func (stateDB *StateDBAdapter) SelfDestruct(evmAddr common.Address) uint256.Int 
 	}
 	// before calling SelfDestruct, EVM will transfer the contract's balance to beneficiary
 	// need to create a transaction log on successful SelfDestruct
-	from, _ := address.FromBytes(evmAddr[:])
-	stateDB.generateSelfDestructTransferLog(from.String(), stateDB.lastAddBalanceAmount.Cmp(actBalance) == 0)
+	stateDB.generateSelfDestructTransferLog(evmAddr, stateDB.lastAddBalanceAmount.Cmp(actBalance) == 0)
 	// mark it as deleted
 	stateDB.selfDestructed[evmAddr] = struct{}{}
 	return prevBalance
@@ -589,8 +630,7 @@ func (stateDB *StateDBAdapter) SelfDestruct6780(evmAddr common.Address) (uint256
 	}
 	// opSelfdestruct6780 has already subtracted the contract's balance
 	// so create a transaction log
-	from, _ := address.FromBytes(evmAddr[:])
-	stateDB.generateSelfDestructTransferLog(from.String(), true)
+	stateDB.generateSelfDestructTransferLog(evmAddr, true)
 	// per EIP-6780, delete the account only if it is created in the same transaction
 	if _, ok := stateDB.createdAccount[evmAddr]; ok {
 		stateDB.selfDestructed[evmAddr] = struct{}{}
@@ -1010,16 +1050,23 @@ func (stateDB *StateDBAdapter) accountState(evmAddr common.Address) (*state.Acco
 	return accountutil.LoadAccountByHash160(stateDB.sm, hash.BytesToHash160(evmAddr[:]), stateDB.accountCreationOpts()...)
 }
 
-func (stateDB *StateDBAdapter) generateSelfDestructTransferLog(sender string, amountMatch bool) {
+func (stateDB *StateDBAdapter) generateSelfDestructTransferLog(contract common.Address, legacyAmountMatch bool) {
+	if stateDB.correctSelfDestructTransferLog {
+		stateDB.generateSelfDestructTransferLogV2(contract)
+		return
+	}
+	// Legacy heuristic (pre-Zanzibar): derive the beneficiary/amount from the last
+	// AddBalance seen before SELFDESTRUCT. Kept byte-identical for historical replay.
 	// To ensure data consistency, generate this log after the hard-fork
 	// a separate patch file will be created later to provide missing logs before the hard-fork
 	// TODO: remove this gating once the hard-fork has passed
+	sender, _ := address.FromBytes(contract[:])
 	if stateDB.suicideTxLogMismatchPanic {
-		if amountMatch {
+		if legacyAmountMatch {
 			if stateDB.lastAddBalanceAmount.Cmp(big.NewInt(0)) > 0 {
 				stateDB.addTransactionLogs(&action.TransactionLog{
 					Type:      iotextypes.TransactionLogType_IN_CONTRACT_TRANSFER,
-					Sender:    sender,
+					Sender:    sender.String(),
 					Recipient: stateDB.lastAddBalanceAddr,
 					Amount:    stateDB.lastAddBalanceAmount,
 				})
@@ -1029,6 +1076,37 @@ func (stateDB *StateDBAdapter) generateSelfDestructTransferLog(sender string, am
 				zap.String("beneficiary", stateDB.lastAddBalanceAmount.String()))
 		}
 	}
+}
+
+// generateSelfDestructTransferLogV2 emits an IN_CONTRACT_TRANSFER log derived from
+// the actual native transfer the EVM performed during SELFDESTRUCT, captured from
+// the AddBalance call tagged tracing.BalanceIncreaseSelfdestruct. A log is emitted
+// if and only if a real transfer of native token between two distinct accounts
+// occurred: it is skipped for zero-value selfdestructs and for the self-beneficiary
+// case (EVM adds then removes the same amount on the same account, so nothing moves
+// between accounts and no funds are transferred out). The capture is consumed so a
+// later SelfDestruct with no preceding transfer cannot reuse stale data.
+func (stateDB *StateDBAdapter) generateSelfDestructTransferLogV2(contract common.Address) {
+	beneficiary := stateDB.selfDestructBeneficiary
+	amount := stateDB.selfDestructTransfer
+	captured := stateDB.selfDestructTransferSet
+	stateDB.selfDestructTransferSet = false
+	if !captured || amount == nil || amount.Sign() <= 0 {
+		// zero-value selfdestruct (or no transfer captured): no native token moved
+		return
+	}
+	if beneficiary == contract {
+		// self-beneficiary: net-zero, no token leaves the account
+		return
+	}
+	from, _ := address.FromBytes(contract[:])
+	to, _ := address.FromBytes(beneficiary[:])
+	stateDB.addTransactionLogs(&action.TransactionLog{
+		Type:      iotextypes.TransactionLogType_IN_CONTRACT_TRANSFER,
+		Sender:    from.String(),
+		Recipient: to.String(),
+		Amount:    new(big.Int).Set(amount),
+	})
 }
 
 func (stateDB *StateDBAdapter) addTransactionLogs(tlog *action.TransactionLog) {
@@ -1293,6 +1371,7 @@ func (stateDB *StateDBAdapter) clear() {
 	stateDB.txLogsSnapshot = make(map[int]int)
 	stateDB.logs = []*action.Log{}
 	stateDB.transactionLogs = []*action.TransactionLog{}
+	stateDB.selfDestructTransferSet = false
 	if stateDB.enableCancun {
 		stateDB.transientStorage = newTransientStorage()
 		stateDB.transientStorageSnapshot = make(map[int]transientStorage)

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/holiman/uint256"
 	"github.com/iotexproject/go-pkgs/hash"
@@ -112,6 +113,136 @@ func TestAddBalance(t *testing.T) {
 	require.Equal(amount, uint256.NewInt(80000))
 	stateDB.AddBalance(addr, common.U2560, 0)
 	require.Zero(len(stateDB.lastAddBalanceAmount.Bytes()))
+}
+
+// TestSelfDestructTransferLog covers the SELFDESTRUCT transaction-log emission
+// under both the legacy "last AddBalance" heuristic (pre-fork) and the corrected
+// derivation from the actual EVM balance movement (post-fork).
+//
+// It faithfully mirrors go-ethereum's opSelfdestruct / opSelfdestruct6780 call
+// sequence into the StateDBAdapter:
+//
+//	opSelfdestruct:     AddBalance(beneficiary, bal, BalanceIncreaseSelfdestruct); SelfDestruct(contract)
+//	opSelfdestruct6780: SubBalance(contract, bal, BalanceDecreaseSelfdestruct);
+//	                    AddBalance(beneficiary, bal, BalanceIncreaseSelfdestruct); SelfDestruct6780(contract)
+func TestSelfDestructTransferLog(t *testing.T) {
+	contract := common.HexToAddress("3fab184622dc19b6109349b94811493bf2a45362")
+	beneficiary := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
+	contractStr := MustNoErrorV(address.FromBytes(contract[:])).String()
+	beneficiaryStr := MustNoErrorV(address.FromBytes(beneficiary[:])).String()
+
+	newDB := func(require *require.Assertions, sm *mock_chainmanager.MockStateManager, correct bool) *StateDBAdapter {
+		opts := []StateDBAdapterOption{
+			NotFixTopicCopyBugOption(),
+			FixSnapshotOrderOption(),
+			SuicideTxLogMismatchPanicOption(),
+			EnableCancunEVMOption(),
+			RevertLogOption(),
+		}
+		if correct {
+			opts = append(opts, CorrectSelfDestructTransferLogOption())
+		}
+		return MustNoErrorV(NewStateDBAdapter(sm, 1, hash.ZeroHash256, opts...))
+	}
+
+	u256 := func(i *big.Int) *uint256.Int { return uint256.MustFromBig(i) }
+
+	// legacySelfDestruct6780 mirrors opSelfdestruct6780
+	do6780 := func(stateDB *StateDBAdapter, c, ben common.Address, bal *big.Int) {
+		stateDB.CreateAccount(c) // mark created-in-tx so 6780 actually deletes
+		stateDB.AddBalance(c, u256(bal), tracing.BalanceChangeUnspecified)
+		stateDB.SubBalance(c, u256(bal), tracing.BalanceDecreaseSelfdestruct)
+		stateDB.AddBalance(ben, u256(bal), tracing.BalanceIncreaseSelfdestruct)
+		stateDB.SelfDestruct6780(c)
+	}
+	// doLegacy mirrors opSelfdestruct
+	doLegacy := func(stateDB *StateDBAdapter, c, ben common.Address, bal *big.Int) {
+		stateDB.AddBalance(c, u256(bal), tracing.BalanceChangeUnspecified)
+		stateDB.AddBalance(ben, u256(stateDB.GetBalance(c).ToBig()), tracing.BalanceIncreaseSelfdestruct)
+		stateDB.SelfDestruct(c)
+	}
+
+	t.Run("pre-fork heuristic emits a bogus self->self log (6780 self-beneficiary)", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, false)
+		do6780(stateDB, contract, contract, big.NewInt(12345))
+		// BUG: current heuristic records the last AddBalance (to the contract itself)
+		// as an IN_CONTRACT_TRANSFER even though no native token moved between accounts.
+		txLogs := stateDB.TransactionLogs()
+		require.Len(txLogs, 1)
+		require.Equal(contractStr, txLogs[0].Sender)
+		require.Equal(contractStr, txLogs[0].Recipient) // phantom: sender == recipient
+		require.Equal("12345", txLogs[0].Amount.String())
+	})
+
+	t.Run("post-fork emits no log for 6780 self-beneficiary", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		do6780(stateDB, contract, contract, big.NewInt(12345))
+		require.Empty(stateDB.TransactionLogs())
+	})
+
+	t.Run("post-fork emits correct log for 6780 external beneficiary", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		do6780(stateDB, contract, beneficiary, big.NewInt(999))
+		txLogs := stateDB.TransactionLogs()
+		require.Len(txLogs, 1)
+		require.Equal(contractStr, txLogs[0].Sender)
+		require.Equal(beneficiaryStr, txLogs[0].Recipient)
+		require.Equal("999", txLogs[0].Amount.String())
+	})
+
+	t.Run("post-fork emits no log for zero-value selfdestruct", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		do6780(stateDB, contract, beneficiary, big.NewInt(0))
+		require.Empty(stateDB.TransactionLogs())
+	})
+
+	t.Run("post-fork legacy selfdestruct to external beneficiary", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		doLegacy(stateDB, contract, beneficiary, big.NewInt(777))
+		txLogs := stateDB.TransactionLogs()
+		require.Len(txLogs, 1)
+		require.Equal(contractStr, txLogs[0].Sender)
+		require.Equal(beneficiaryStr, txLogs[0].Recipient)
+		require.Equal("777", txLogs[0].Amount.String())
+	})
+
+	t.Run("post-fork zero-value credit invalidates a prior capture (no phantom)", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		// a real selfdestruct credit to an external beneficiary is captured...
+		stateDB.AddBalance(beneficiary, u256(big.NewInt(5)), tracing.BalanceIncreaseSelfdestruct)
+		// ...but a following zero-value selfdestruct credit must invalidate it, so the
+		// next SelfDestruct emits nothing (guards against stale-capture phantom logs).
+		stateDB.AddBalance(beneficiary, u256(big.NewInt(0)), tracing.BalanceIncreaseSelfdestruct)
+		stateDB.SelfDestruct(contract)
+		require.Empty(stateDB.TransactionLogs())
+	})
+
+	t.Run("post-fork legacy self-beneficiary emits no log (no panic)", func(t *testing.T) {
+		require := require.New(t)
+		ctrl := gomock.NewController(t)
+		sm := MustNoErrorV(initMockStateManager(ctrl))
+		stateDB := newDB(require, sm, true)
+		doLegacy(stateDB, contract, contract, big.NewInt(555))
+		require.Empty(stateDB.TransactionLogs())
+	})
 }
 
 func TestRefundAPIs(t *testing.T) {

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -82,7 +82,11 @@ func defaultConfig() Genesis {
 			XinguBetaBlockHeight:      41648761,
 			YapBlockHeight:            48985561,
 			YapBetaBlockHeight:        48985561,
-			ToBeEnabledBlockHeight:    math.MaxUint64,
+			// TODO(maintainer): set fork height. PLACEHOLDER sentinel (never
+			// activated) — the real mainnet/testnet Zanzibar height needs
+			// maintainer sign-off before this fork can ship.
+			ZanzibarBlockHeight:    math.MaxUint64,
+			ToBeEnabledBlockHeight: math.MaxUint64,
 		},
 		Account: Account{
 			InitBalanceMap:          map[string]string{},
@@ -390,6 +394,12 @@ type (
 		YapBlockHeight uint64 `yaml:"yapHeight"`
 		// YapBetaBlockHeight is the start height to enable slashing candidate by identity
 		YapBetaBlockHeight uint64 `yaml:"yapBetaHeight"`
+		// ZanzibarBlockHeight is the start height to
+		// 1. derive SELFDESTRUCT IN_CONTRACT_TRANSFER transaction logs from the
+		//    actual EVM balance movement instead of the fragile "last AddBalance"
+		//    heuristic (fixes phantom/incorrect selfdestruct transfer logs).
+		// TODO(maintainer): set fork height before release.
+		ZanzibarBlockHeight uint64 `yaml:"zanzibarHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -790,6 +800,11 @@ func (g *Blockchain) IsYap(height uint64) bool {
 // IsYapBeta checks whether height is equal to or larger than yap beta height
 func (g *Blockchain) IsYapBeta(height uint64) bool {
 	return g.isPost(g.YapBetaBlockHeight, height)
+}
+
+// IsZanzibar checks whether height is equal to or larger than zanzibar height
+func (g *Blockchain) IsZanzibar(height uint64) bool {
+	return g.isPost(g.ZanzibarBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height


### PR DESCRIPTION
## Problem

SELFDESTRUCT `IN_CONTRACT_TRANSFER` transaction logs are derived from a fragile heuristic in `evmstatedbadapter.go`: *"the last `AddBalance` call before `SelfDestruct`"* (`lastAddBalanceAddr` / `lastAddBalanceAmount`). This misrecords the beneficiary/amount in several cases and, in particular, emits a **phantom `self -> self` `IN_CONTRACT_TRANSFER`** for EIP-6780 self-beneficiary selfdestructs where no native token actually moves between accounts.

An internal audit attributed **~753 historical bogus `IN_CONTRACT_TRANSFER` records** (transfers with no corresponding real native-token movement) to this path. This is a separate root cause from the contract-forgery issue.

### Why the heuristic is wrong

go-ethereum's `opSelfdestruct` / `opSelfdestruct6780` call
`AddBalance(beneficiary, contractBalance, tracing.BalanceIncreaseSelfdestruct)`
immediately before `StateDB.SelfDestruct[6780]`. The heuristic reconstructs the transfer *after the fact* and cannot faithfully distinguish:
- **self-beneficiary** (EVM adds then removes the same amount on the same account — net-zero, nothing leaves the account) → phantom `self->self` log;
- **zero-value** selfdestructs;
- **EIP-6780 no-op** (transfer/deletion semantics).

The legacy path additionally **panics** on the self-beneficiary case once `SuicideTxLogMismatchPanic` (Upernavik) is active.

## Fix

Capture the **exact beneficiary and amount at the point the EVM performs the transfer** — the `AddBalance` call tagged `tracing.BalanceIncreaseSelfdestruct`. The capture is established only *after* the credit is successfully persisted, and invalidated on `AddBalance` entry so a failed / zero / stale credit cannot leak a phantom log.

The new derivation emits an `IN_CONTRACT_TRANSFER` **iff a real transfer of native token between two distinct accounts occurred** (`amount > 0` and `beneficiary != contract`). It is skipped for zero-value and self-beneficiary selfdestructs (including the EIP-6780 no-op).

## Hardfork gate — needs maintainer sign-off

The corrected derivation is gated behind a new place-named hardfork, **Zanzibar** (`FeatureCtx.CorrectSelfDestructTransferLog`, `g.IsZanzibar(height)`). The pre-fork heuristic path is preserved **byte-identical** for historical replay.

⚠️ **`ZanzibarBlockHeight` is a PLACEHOLDER sentinel (`math.MaxUint64`)** — the real mainnet/testnet fork height requires maintainer sign-off before release. See `// TODO(maintainer): set fork height` in `blockchain/genesis/genesis.go`.

## Non-consensus rationale

Transaction logs are **not** part of the receipt root or state root (`Receipt.ConvertToReceiptPb` / `Serialize` do not include `transactionLogs`), so this does not affect block validity. But because it changes historical-replay output for a given height, it is still fork-gated for determinism/consistency.

## Historical cleanup (out of scope here)

The ~753 pre-existing bogus records are corrected out of band via the `tools/txlogpatch` generator in **#4870** (extend its input CSV). **This PR is the forward fix only.** The exact fork height and the 753-record CSV require the maintainer / analyser output.

## Tests

- **Reproduction (pre-fork):** the current heuristic emits a phantom `self -> self` `IN_CONTRACT_TRANSFER` for an EIP-6780 self-beneficiary selfdestruct (asserted `Sender == Recipient`).
- **Post-fork:** correct beneficiary/amount for external beneficiary (legacy + 6780); **no log** for EIP-6780 self-beneficiary, zero-value, or legacy self-beneficiary; stale-capture invalidation guard.
- **FeatureCtx boundary:** `CorrectSelfDestructTransferLog` is off at `Zanzibar-1` and on at `Zanzibar` / `Zanzibar+1`.

Verified: `gofmt` clean, `go build ./...`, `go vet` on evm/protocol/e2etest, `go test ./action/protocol/execution/... ./action/protocol/ ./blockchain/genesis/... ./blockchain/integrity/...` green. Reviewed adversarially with Codex to convergence (one finding — capture-before-persist — addressed; Erigon-backend and fork-widening concerns verified as non-issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)