### PR TITLE
fix(ioctl): backlog cleanup — createadd address, ioid panic, bc-info/update/version UX

### DIFF
--- a/ioctl/cmd/account/accountcreateadd.go
+++ b/ioctl/cmd/account/accountcreateadd.go
@@ -15,6 +15,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/ioctl/config"
 	"github.com/iotexproject/iotex-core/v2/ioctl/output"
 	"github.com/iotexproject/iotex-core/v2/ioctl/validator"
+	"github.com/iotexproject/iotex-core/v2/pkg/util/addrutil"
 )
 
 // Multi-language support
@@ -81,7 +82,13 @@ func accountCreateAdd(args []string) error {
 		return output.NewError(output.WriteFileError,
 			fmt.Sprintf("failed to write to config file %s", config.DefaultConfigFile), err)
 	}
+	ethAddr, err := addrutil.IoAddrToEvmAddr(addr)
+	if err != nil {
+		return output.NewError(output.AddressError, "failed to convert to ETH address", err)
+	}
 	output.PrintResult(fmt.Sprintf("New account \"%s\" is created.\n"+
-		"Please Keep your password, or you will lose your private key.", alias))
+		"IO address:  %s\n"+
+		"ETH address: %s\n"+
+		"Please Keep your password, or you will lose your private key.", alias, addr, ethAddr.String()))
 	return nil
 }

--- a/ioctl/cmd/bc/bcinfo.go
+++ b/ioctl/cmd/bc/bcinfo.go
@@ -56,7 +56,9 @@ func (m *infoMessage) String() string {
 func bcInfo() error {
 	chainMeta, err := GetChainMeta()
 	if err != nil {
-		return output.NewError(0, "failed to get chain meta", err)
+		return output.NewError(0, "failed to get chain meta; if you are querying a local node, "+
+			"it may still be syncing or its indexer may not be up to date yet — wait until the node "+
+			"has caught up, or set --endpoint to a fully synced node", err)
 	}
 	message := infoMessage{Node: config.ReadConfig.Endpoint, Info: chainMeta}
 	fmt.Println(message.String())

--- a/ioctl/cmd/ioid/projectregister.go
+++ b/ioctl/cmd/ioid/projectregister.go
@@ -93,7 +93,13 @@ func register(args []string) error {
 		return output.NewError(output.UpdateError, "failed to register project", err)
 	}
 
-	projectId := new(big.Int).SetBytes(receipt.ReceiptInfo.Receipt.Logs[0].Topics[3])
+	logs := receipt.ReceiptInfo.Receipt.Logs
+	if len(logs) == 0 || len(logs[0].Topics) < 4 {
+		return output.NewError(output.APIError,
+			fmt.Sprintf("project registration tx %s was mined but no project-id log was found; "+
+				"the registration may have reverted, please check the receipt on the explorer", tx), nil)
+	}
+	projectId := new(big.Int).SetBytes(logs[0].Topics[3])
 	fmt.Printf("Registered ioID project id is %s\n", projectId.String())
 
 	return nil

--- a/ioctl/cmd/update/update.go
+++ b/ioctl/cmd/update/update.go
@@ -7,6 +7,7 @@ package update
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 
 	"github.com/spf13/cobra"
@@ -66,6 +67,10 @@ func update() error {
 
 	}
 	cmd := exec.Command("bash", "-c", cmdString)
+	// surface the installer's stdout/stderr so failures are diagnosable instead
+	// of being swallowed behind a generic "failed to update ioctl" message.
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
 	output.PrintResult(fmt.Sprintf("Downloading the latest %s version ...\n", _versionType))
 	err := cmd.Run()
 	if err != nil {

--- a/ioctl/cmd/version/version.go
+++ b/ioctl/cmd/version/version.go
@@ -20,8 +20,8 @@ import (
 // Multi-language support
 var (
 	_versionCmdShorts = map[config.Language]string{
-		config.English: "Print the version of ioctl and node",
-		config.Chinese: "打印ioctl和节点的版本",
+		config.English: "Print the version and build info of ioctl",
+		config.Chinese: "打印ioctl的版本与构建信息",
 	}
 	_flagEndpointUsage = map[config.Language]string{
 		config.English: "set endpoint for once",


### PR DESCRIPTION
## Summary
A batch of small, self-contained **`ioctl`** fixes (CLI only — no consensus/chain impact), clearing out long-standing items from the ioctl issue backlog.

| Issue | Fix |
|---|---|
| #4470 | `account createadd` now prints the IO + ETH address on creation (was silent) |
| #4452 | `ioid register` no longer panics (`index out of range [0]`) when the tx emits no matching log; returns a clear error with the tx hash |
| #2828 | `bc info` failure now hints that a local node may still be syncing / indexing, instead of a bare "failed to get chain meta" |
| #4296 | `update` now pipes the installer's stdout/stderr to the terminal so failures (e.g. on macOS) are diagnosable instead of hidden |
| #4004, #3966 | `ioctl version` already prints ioctl version + build info; fixed the stale help text that still claimed "ioctl and node" |

### `account createadd` output now
```
New account "mytest" is created.
IO address:  io1a3n6w5t9qzzplrug4t47s2823ktpha2yh2937e
ETH address: 0xeC67A7516500841f8F88AAEbe828eA8d961BF544
Please Keep your password, or you will lose your private key.
```

## Test plan
- `go build` + `go vet` on all touched packages — OK
- `go test ./ioctl/cmd/account/... ./ioctl/cmd/bc/...` — pass
- Built the `ioctl` binary; verified `account createadd` prints both addresses and `version` help text is correct.

## Not included (need separate handling, not an ioctl code change)
- **#4066** (GLIBC 2.32/2.34 on Ubuntu 20.04): a release/CI toolchain issue — the release binary is CGO-linked against a newer glibc than focal. Fix belongs in the release workflow (build on an older glibc base image or static link), not in ioctl source.
- **#4469** (IIP40 io1 deprecation): a larger address-format policy decision spanning many commands; should be scoped as its own change.

Closes #4470
Closes #4452
Closes #2828
Closes #4296

🤖 Generated with [Claude Code](https://claude.com/claude-code)