### PR TITLE
feat(metrics): expose on-disk size of each db file

### DIFF
--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -886,10 +886,20 @@ func (builder *Builder) build(forSubChain, forTest bool) (*ChainService, error) 
 	if err := builder.buildActionSyncer(); err != nil {
 		return nil, err
 	}
+	builder.buildDBFileSizeCollector()
 	cs := builder.cs
 	builder.cs = nil
 
 	return cs, nil
+}
+
+// buildDBFileSizeCollector registers a background task that periodically exports the on-disk
+// size of each configured DB file as a Prometheus gauge. It is observability-only and has no
+// consensus/state impact. Skipped when no DB files are configured (e.g. some test builds).
+func (builder *Builder) buildDBFileSizeCollector() {
+	if collector := newDBFileSizeCollector(builder.cfg); collector != nil {
+		builder.cs.lifecycle.Add(collector)
+	}
 }
 
 // estimateTipHeight estimates the height of the block at the given time

--- a/chainservice/dbmetrics.go
+++ b/chainservice/dbmetrics.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package chainservice
+
+import (
+	"io/fs"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
+	"github.com/iotexproject/iotex-core/v2/pkg/routine"
+)
+
+// dbFileSizeUpdateInterval is how often the on-disk size of each DB file is sampled.
+// DB files grow slowly, so a coarse interval keeps the observability overhead negligible.
+const dbFileSizeUpdateInterval = 5 * time.Minute
+
+var dbFileSizeMtc = prometheus.NewGaugeVec(
+	prometheus.GaugeOpts{
+		Name: "iotex_db_file_size_bytes",
+		Help: "On-disk size in bytes of each node database file, labeled by logical db name and path.",
+	},
+	[]string{"db", "path"},
+)
+
+func init() {
+	// Register once per process. Registration in init() avoids duplicate-register
+	// panics when multiple ChainService instances are constructed (e.g. sub-chains, tests).
+	prometheus.MustRegister(dbFileSizeMtc)
+}
+
+// dbFile describes a configured on-disk database and its logical name (used as the metric label).
+type dbFile struct {
+	name string
+	path string
+}
+
+// localChainDBPath resolves the on-disk path of the chain DB. Unlike the other DB paths,
+// ChainDBPath may be a URL: a "file://"/plain path opens a local file, while "grpc://" points at
+// a remote block DAO that has no local file. It mirrors the parsing in buildBlockDAO. It returns
+// an empty string when there is no local file to stat (remote or unparseable), so the caller skips it.
+func localChainDBPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	uri, err := url.Parse(path)
+	if err != nil {
+		// Not a URL; treat as a plain filesystem path (buildBlockDAO would fail earlier otherwise).
+		return path
+	}
+	switch uri.Scheme {
+	case "", "file":
+		return uri.Path
+	default:
+		// e.g. "grpc": remote block DAO, no local file to measure.
+		return ""
+	}
+}
+
+// configuredDBFiles returns the bounded, static set of database files configured for the node.
+// Empty paths are skipped so that disabled components do not create series.
+func configuredDBFiles(cfg config.Config) []dbFile {
+	candidates := []dbFile{
+		{"chain", localChainDBPath(cfg.Chain.ChainDBPath)},
+		{"trie", cfg.Chain.TrieDBPath},
+		{"index", cfg.Chain.IndexDBPath},
+		{"bloomfilter_index", cfg.Chain.BloomfilterIndexDBPath},
+		{"candidate_index", cfg.Chain.CandidateIndexDBPath},
+		{"staking_index", cfg.Chain.StakingIndexDBPath},
+		{"contractstaking_index", cfg.Chain.ContractStakingIndexDBPath},
+		{"blob_store", cfg.Chain.BlobStoreDBPath},
+		{"patch_receipt_index", cfg.Chain.PatchReceiptIndexPath},
+		{"history_index", cfg.Chain.HistoryIndexPath},
+		{"gravity_chain", cfg.Chain.GravityChainDB.DbPath},
+		{"consensus", cfg.Consensus.RollDPoS.ConsensusDBPath},
+	}
+	files := make([]dbFile, 0, len(candidates))
+	for _, c := range candidates {
+		if c.path == "" {
+			continue
+		}
+		files = append(files, c)
+	}
+	return files
+}
+
+// dbFileSizeBytes returns the on-disk size of path. A path may be a single file (boltdb) or a
+// directory (pebbledb), in which case the sizes of all contained files are summed. Any stat/walk
+// error (e.g. a missing or rotated file) is returned so the caller can skip that sample.
+func dbFileSizeBytes(path string) (int64, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	if !info.IsDir() {
+		return info.Size(), nil
+	}
+	var total int64
+	err = filepath.WalkDir(path, func(_ string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		fi, statErr := d.Info()
+		if statErr != nil {
+			// File may have been rotated away mid-walk; skip it rather than aborting.
+			return nil
+		}
+		total += fi.Size()
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return total, nil
+}
+
+// newDBFileSizeCollector builds a lifecycle-managed recurring task that periodically records the
+// on-disk size of each configured DB file into the dbFileSizeMtc gauge. It returns nil when no DB
+// files are configured, so callers should guard the lifecycle registration accordingly.
+func newDBFileSizeCollector(cfg config.Config) *routine.RecurringTask {
+	files := configuredDBFiles(cfg)
+	if len(files) == 0 {
+		return nil
+	}
+	update := func() {
+		for _, f := range files {
+			size, err := dbFileSizeBytes(f.path)
+			if err != nil {
+				// Missing or rotated file: skip this sample, keep the collector alive.
+				log.L().Debug("skip db file size metric", zap.String("db", f.name), zap.String("path", f.path), zap.Error(err))
+				continue
+			}
+			dbFileSizeMtc.WithLabelValues(f.name, f.path).Set(float64(size))
+		}
+	}
+	// Sample once at startup so the metric is populated before the first tick.
+	update()
+	return routine.NewRecurringTask(update, dbFileSizeUpdateInterval)
+}

--- a/chainservice/dbmetrics_test.go
+++ b/chainservice/dbmetrics_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package chainservice
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/config"
+)
+
+func TestDBFileSizeBytes_File(t *testing.T) {
+	r := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chain.db")
+	payload := []byte("hello-iotex")
+	r.NoError(os.WriteFile(path, payload, 0o600))
+
+	size, err := dbFileSizeBytes(path)
+	r.NoError(err)
+	r.Equal(int64(len(payload)), size)
+}
+
+func TestDBFileSizeBytes_Directory(t *testing.T) {
+	r := require.New(t)
+	dir := t.TempDir()
+	// pebbledb-style directory: sum of all contained files, recursively.
+	r.NoError(os.WriteFile(filepath.Join(dir, "a"), []byte("12345"), 0o600))
+	sub := filepath.Join(dir, "sub")
+	r.NoError(os.Mkdir(sub, 0o700))
+	r.NoError(os.WriteFile(filepath.Join(sub, "b"), []byte("6789"), 0o600))
+
+	size, err := dbFileSizeBytes(dir)
+	r.NoError(err)
+	r.Equal(int64(9), size)
+}
+
+func TestDBFileSizeBytes_Missing(t *testing.T) {
+	r := require.New(t)
+	_, err := dbFileSizeBytes(filepath.Join(t.TempDir(), "does-not-exist.db"))
+	r.Error(err)
+}
+
+func TestConfiguredDBFiles_SkipsEmpty(t *testing.T) {
+	r := require.New(t)
+	cfg := config.Config{}
+	cfg.Chain.ChainDBPath = "/data/chain.db"
+	cfg.Chain.TrieDBPath = "/data/trie.db"
+	// leave the rest empty -> they must not produce entries
+
+	files := configuredDBFiles(cfg)
+	r.Len(files, 2)
+	names := map[string]string{}
+	for _, f := range files {
+		names[f.name] = f.path
+	}
+	r.Equal("/data/chain.db", names["chain"])
+	r.Equal("/data/trie.db", names["trie"])
+}
+
+func TestLocalChainDBPath(t *testing.T) {
+	r := require.New(t)
+	r.Equal("", localChainDBPath(""))
+	r.Equal("/var/data/chain.db", localChainDBPath("/var/data/chain.db"))
+	r.Equal("/var/data/chain.db", localChainDBPath("file:///var/data/chain.db"))
+	// grpc (remote block DAO) has no local file to stat
+	r.Equal("", localChainDBPath("grpc://host:1234?insecure=true"))
+}
+
+func TestConfiguredDBFiles_SkipsRemoteChainDB(t *testing.T) {
+	r := require.New(t)
+	cfg := config.Config{}
+	cfg.Chain.ChainDBPath = "grpc://host:1234"
+	cfg.Chain.TrieDBPath = "/data/trie.db"
+
+	files := configuredDBFiles(cfg)
+	for _, f := range files {
+		r.NotEqual("chain", f.name, "remote chain db must not produce a series")
+	}
+}
+
+func TestNewDBFileSizeCollector_NilWhenNoFiles(t *testing.T) {
+	r := require.New(t)
+	r.Nil(newDBFileSizeCollector(config.Config{}))
+}
+
+func TestNewDBFileSizeCollector_PopulatesGauge(t *testing.T) {
+	r := require.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chain.db")
+	r.NoError(os.WriteFile(path, []byte("0123456789"), 0o600))
+
+	cfg := config.Config{}
+	cfg.Chain.ChainDBPath = path
+	collector := newDBFileSizeCollector(cfg)
+	r.NotNil(collector)
+
+	// collector samples once at construction time
+	g, err := dbFileSizeMtc.GetMetricWithLabelValues("chain", path)
+	r.NoError(err)
+	var m dto.Metric
+	r.NoError(g.Write(&m))
+	r.Equal(float64(10), m.GetGauge().GetValue())
+}


### PR DESCRIPTION
## What

Adds a Prometheus gauge exposing the on-disk size of each node database file, so operators can observe DB growth (especially after block gas limit bumps) and estimate disk requirements.

## Details

- New metric `iotex_db_file_size_bytes{db, path}` — one series per configured DB file (bounded cardinality).
- Covers: chain, trie, index, bloomfilter/candidate/staking/contractstaking indexes, blob store, patch receipt index, history index, gravity chain, and consensus DBs. Empty/disabled paths are skipped.
- Populated by a lightweight background `RecurringTask` (5m interval) started/stopped via the existing `ChainService` lifecycle — no goroutine leak.
- Handles pebbledb-style **directory** DBs by recursively summing contained files; single-file boltdb DBs are stat'd directly.
- Missing/rotated files are skipped gracefully (stat error → skip, no crash).
- The `ChainDBPath` URL form is resolved the same way as `buildBlockDAO` (`file://`/plain → local path; `grpc://` remote → skipped).
- Metric is registered once per process via `init()`, avoiding duplicate-register panics when multiple `ChainService` instances are constructed.

Observability-only: no consensus or state-path impact.

## Test

- Unit tests for file/directory/missing stat, empty-path skipping, remote (grpc) chain-db skipping, and gauge population.
- `gofmt` clean, `go build ./...`, `go vet ./chainservice/...`, `go test ./chainservice/` pass.

Closes #4160

🤖 Generated with [Claude Code](https://claude.com/claude-code)