### PR TITLE
fix(api): use a fresh tracer per transaction in debug_traceBlock*

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/eth/tracers"
@@ -2348,26 +2349,68 @@ func (core *coreService) traceBlock(ctx context.Context, blk *block.Block, confi
 	})
 	ctx = protocol.WithRegistry(ctx, core.registry)
 	ctx = protocol.WithFeatureCtx(ctx)
+	bcCtx := protocol.MustGetBlockchainCtx(ctx)
+	ctx = evm.WithHelperCtx(ctx, evm.HelperContext{
+		GetBlockHash:   bcCtx.GetBlockHash,
+		GetBlockTime:   bcCtx.GetBlockTime,
+		DepositGasFunc: rewarding.DepositGas,
+	})
 	retvals := make([][]byte, 0)
 	receipts := make([]*action.Receipt, 0)
 	results := make([]*blockTraceResult, 0)
-	ctx, tracer, err := core.traceContext(ctx, new(tracers.Context), config)
-	if err != nil {
+
+	// Every transaction in the block must be traced with a fresh tracer, exactly
+	// like geth's traceBlock (which calls DefaultDirectory.New per tx). Sharing a
+	// single tracer across the whole block leaks state between transactions:
+	// prestateTracer accumulates touched accounts and callTracer never resets its
+	// callstack, dropping later txs with "incorrect number of top-level calls".
+	//
+	// The block is processed in a single pass over a working set that must carry
+	// state forward from one tx to the next, so we cannot simply re-invoke the
+	// tracing entrypoint per tx. Instead we wire a stable *tracing.Hooks into the
+	// EVM (via VMConfigCtx) and swap in a freshly instantiated tracer's hooks
+	// between transactions. CaptureTx (invoked once per traced user tx, after its
+	// hooks have fired) collects the current tracer's result and then rearms a new
+	// tracer for the next tx.
+	sharedHooks := new(tracing.Hooks)
+	var curTracer *tracers.Tracer
+	newTracer := func() error {
+		t, err := parseTracer(ctx, new(tracers.Context), config)
+		if err != nil {
+			return err
+		}
+		curTracer = t
+		if t.Hooks != nil {
+			*sharedHooks = *t.Hooks
+		} else {
+			*sharedHooks = tracing.Hooks{}
+		}
+		return nil
+	}
+	if err := newTracer(); err != nil {
 		return nil, nil, nil, err
 	}
+	ctx = protocol.WithVMConfigCtx(ctx, vm.Config{
+		Tracer:    sharedHooks,
+		NoBaseFee: true,
+	})
 	ctx = evm.WithTracerCtx(ctx, evm.TracerContext{
 		CaptureTx: func(retval []byte, receipt *action.Receipt) {
-			res, err := tracer.GetResult()
+			res, err := curTracer.GetResult()
 			if err != nil {
 				log.L().Error("failed to get tracer result", zap.Error(err))
-				return
+			} else {
+				results = append(results, &blockTraceResult{
+					TxHash: receipt.ActionHash,
+					Result: res,
+				})
+				retvals = append(retvals, retval)
+				receipts = append(receipts, receipt)
 			}
-			results = append(results, &blockTraceResult{
-				TxHash: receipt.ActionHash,
-				Result: res,
-			})
-			retvals = append(retvals, retval)
-			receipts = append(receipts, receipt)
+			// rearm a fresh tracer for the next transaction in the block
+			if err := newTracer(); err != nil {
+				log.L().Error("failed to create tracer for next transaction", zap.Error(err))
+			}
 		},
 	})
 	ws, err := core.sf.WorkingSetAtTransaction(ctx, blk.Height(), blk.Actions...)

--- a/e2etest/trace_block_test.go
+++ b/e2etest/trace_block_test.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/go-resty/resty/v2"
 	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/stretchr/testify/require"
@@ -186,4 +188,135 @@ func TestTraceBlockByNumberPrestateTracer(t *testing.T) {
 	var entries []json.RawMessage
 	r.NoError(json.Unmarshal(result, &entries))
 	r.Len(entries, 1, "should have one trace entry for the single tx in the block")
+}
+
+// TestTraceBlockPerTxIsolation traces a block containing two independent
+// transactions (two distinct senders, two distinct receivers) and asserts that
+// each transaction's trace is isolated from the others. This is the regression
+// test for issue #4825: a single tracer shared across all transactions in the
+// block causes prestate to accumulate and the callTracer callstack to never
+// reset, silently dropping the second tx's result.
+func TestTraceBlockPerTxIsolation(t *testing.T) {
+	r := require.New(t)
+	cfg, senderA, senderASK, receiverA := traceBlockSetup(t)
+	// fund a second, independent sender so the two txs touch disjoint accounts
+	senderB := identityset.Address(12).String()
+	senderBSK := identityset.PrivateKey(12)
+	receiverB := identityset.Address(13).String()
+	cfg.Genesis.InitBalanceMap[senderB] = unit.ConvertIotxToRau(1000000).String()
+
+	test := newE2ETest(t, cfg)
+	chainID := cfg.Chain.ID
+	gasPrice := big.NewInt(unit.Qev)
+	ctx := context.Background()
+
+	// eth-hex forms of the two senders (prestateTracer keys accounts by address)
+	senderAHex := strings.ToLower(common.BytesToAddress(identityset.Address(10).Bytes()).Hex())
+	senderBHex := strings.ToLower(common.BytesToAddress(identityset.Address(12).Bytes()).Hex())
+
+	// mine one block containing two independent transfers
+	var traceBlkHeight uint64
+	test.runCase(ctx, &testcase{
+		name: "two independent transfers",
+		acts: []*actionWithTime{
+			{
+				mustNoErr(action.Sign(
+					action.NewEnvelope(
+						action.NewLegacyTx(chainID, test.nonceMgr.pop(senderA), gasLimit, gasPrice),
+						action.NewTransfer(big.NewInt(1), receiverA, nil),
+					),
+					senderASK,
+				)),
+				time.Now(),
+			},
+			{
+				mustNoErr(action.Sign(
+					action.NewEnvelope(
+						action.NewLegacyTx(chainID, test.nonceMgr.pop(senderB), gasLimit, gasPrice),
+						action.NewTransfer(big.NewInt(1), receiverB, nil),
+					),
+					senderBSK,
+				)),
+				time.Now(),
+			},
+		},
+		blockExpect: func(test *e2etest, blk *block.Block, err error) {
+			r.NoError(err)
+			// block also carries a system GrantReward action besides the 2 user txs
+			r.GreaterOrEqual(len(blk.Actions), 2, "block should contain the two user txs")
+			traceBlkHeight = blk.Height()
+			t.Log("two-tx block at height:", traceBlkHeight)
+		},
+	})
+
+	// produce one more block so traceBlkHeight is historical
+	test.runCase(ctx, &testcase{
+		name: "another tx",
+		act: &actionWithTime{
+			mustNoErr(action.Sign(
+				action.NewEnvelope(
+					action.NewLegacyTx(chainID, test.nonceMgr.pop(senderA), gasLimit, gasPrice),
+					action.NewTransfer(big.NewInt(1), receiverA, nil),
+				),
+				senderASK,
+			)),
+			time.Now(),
+		},
+	})
+
+	// callTracer: both txs must yield a valid top-level call result; none dropped.
+	callResult, err := rpcTraceBlock(t, cfg.API.HTTPPort, traceBlkHeight, "callTracer")
+	r.NoError(err, "callTracer should succeed")
+	t.Logf("callTracer result: %s", string(callResult))
+	var callEntries []struct {
+		TxHash string          `json:"txHash"`
+		Result json.RawMessage `json:"result"`
+	}
+	r.NoError(json.Unmarshal(callResult, &callEntries))
+	r.Len(callEntries, 2, "callTracer must return one result per tx; none may be dropped")
+	seenTx := map[string]bool{}
+	for i, e := range callEntries {
+		r.NotEmpty(e.TxHash, "entry %d must carry a tx hash", i)
+		r.False(seenTx[e.TxHash], "entry %d duplicates tx hash %s", i, e.TxHash)
+		seenTx[e.TxHash] = true
+		var frame struct {
+			Type  string `json:"type"`
+			From  string `json:"from"`
+			Error string `json:"error"`
+		}
+		r.NoError(json.Unmarshal(e.Result, &frame), "entry %d must be a valid call frame", i)
+		r.NotEmpty(frame.Type, "entry %d must have a call type", i)
+		r.NotEmpty(frame.From, "entry %d must have a from address", i)
+	}
+
+	// prestateTracer: each tx's prestate must contain only its own touched
+	// accounts. No single entry may contain both senders' accounts.
+	preResult, err := rpcTraceBlock(t, cfg.API.HTTPPort, traceBlkHeight, "prestateTracer")
+	r.NoError(err, "prestateTracer should succeed")
+	t.Logf("prestateTracer result: %s", string(preResult))
+	var preEntries []struct {
+		TxHash string          `json:"txHash"`
+		Result json.RawMessage `json:"result"`
+	}
+	r.NoError(json.Unmarshal(preResult, &preEntries))
+	r.Len(preEntries, 2, "prestateTracer must return one result per tx")
+	sawA, sawB := false, false
+	for i, e := range preEntries {
+		var pre map[string]json.RawMessage
+		r.NoError(json.Unmarshal(e.Result, &pre))
+		hasA, hasB := false, false
+		for addr := range pre {
+			switch strings.ToLower(addr) {
+			case senderAHex:
+				hasA = true
+			case senderBHex:
+				hasB = true
+			}
+		}
+		r.Falsef(hasA && hasB, "entry %d leaked both senders into one prestate (accumulation bug)", i)
+		sawA = sawA || hasA
+		sawB = sawB || hasB
+	}
+	r.True(sawA, "senderA must appear in exactly one tx's prestate")
+	r.True(sawB, "senderB must appear in exactly one tx's prestate")
 }


### PR DESCRIPTION
## Problem

`debug_traceBlockByNumber` / `debug_traceBlockByHash` created a **single tracer instance** and shared it across every transaction in the block, diverging from geth (which instantiates a fresh tracer per tx via `DefaultDirectory.New`). The shared tracer accumulated per-tx state:

- **prestateTracer**: `t.pre` grew across txs, so tx N's result contained the combined prestates of tx 0…N instead of only tx N's touched accounts.
- **callTracer**: the callstack was never reset between txs. After tx0's `OnEnter` added a frame, tx1's `OnEnter` pushed a second; `GetResult()` requires `len(callstack) == 1` and returned `"incorrect number of top-level calls"`, **silently dropping that tx's result** from the output array.

## Root cause

`coreService.traceBlock` builds one tracer up front and passes it to `WorkingSetAtTransaction`, which processes all block actions in a single pass. There was no mechanism to reset/replace the tracer between transactions.

## Fix

The block is processed in a single pass over a working set that must carry state forward from one tx to the next, so we cannot simply re-invoke the trace entrypoint per tx. Instead:

- Wire a **stable `*tracing.Hooks`** into the EVM via `VMConfigCtx`.
- Between transactions, swap in a **freshly instantiated tracer** (built exactly like the single-tx `debug_traceTransaction` path, via `parseTracer`). `CaptureTx` — invoked once per traced user tx after its hooks have fired — collects the current tracer's result and rearms a new tracer for the next tx.

Per-tx traces are now fully independent and preserve execution order. Single-tx tracing is unchanged. System actions (e.g. `GrantReward`) already skip `TraceStart`/`TraceEnd`, so they never appear in results.

This is a **read-only tracing (debug API) path** and does not affect state or receipt roots — non-consensus.

## Test

Adds `TestTraceBlockPerTxIsolation` (e2e): traces a block containing two independent transfers (two disjoint senders) and asserts:
- **callTracer** returns one valid top-level call result per tx (none dropped),
- each **prestateTracer** entry contains only its own tx's accounts (no single entry leaks both senders).

The test fails on `master` (callTracer returns 1 entry instead of 2) and passes with this fix.

## Verification

- `go build ./...`, `gofmt -l` clean, `go vet ./api/...` clean
- `go test ./api/... -run 'Trace|trace'` and `go test ./e2etest/ -run 'Trace'` pass
- Independent Codex adversarial review: CONVERGED (isolation/ordering/nil-safety correct; only note was a pre-existing `parseTracer` timeout no-op shared with the single-tx path, out of scope)

Closes #4825

🤖 Generated with [Claude Code](https://claude.com/claude-code)