### PR TITLE
fix(api): enforce debug_trace execution timeout (was a no-op)

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -2229,30 +2229,33 @@ func (core *coreService) Track(ctx context.Context, start time.Time, method stri
 }
 
 func (core *coreService) traceTx(ctx context.Context, txctx *tracers.Context, config *tracers.TraceConfig, simulateFn func(ctx context.Context) ([]byte, *action.Receipt, error)) ([]byte, *action.Receipt, any, error) {
-	ctx, tracer, err := core.traceContext(ctx, txctx, config)
+	ctx, tracer, cleanup, err := core.traceContext(ctx, txctx, config)
 	if err != nil {
 		return nil, nil, nil, err
 	}
+	// cleanup disarms the tracer timeout watchdog; it must run after the trace
+	// has executed so the deadline is enforced during simulateFn.
+	defer cleanup()
 	retval, receipt, err := simulateFn(ctx)
 	return retval, receipt, tracer, err
 }
 
-func (core *coreService) traceContext(ctx context.Context, txctx *tracers.Context, config *tracers.TraceConfig) (context.Context, *tracers.Tracer, error) {
+func (core *coreService) traceContext(ctx context.Context, txctx *tracers.Context, config *tracers.TraceConfig) (context.Context, *tracers.Tracer, context.CancelFunc, error) {
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	ctx = evm.WithHelperCtx(ctx, evm.HelperContext{
 		GetBlockHash:   bcCtx.GetBlockHash,
 		GetBlockTime:   bcCtx.GetBlockTime,
 		DepositGasFunc: rewarding.DepositGas,
 	})
-	tracer, err := parseTracer(ctx, txctx, config)
+	tracer, cleanup, err := parseTracer(ctx, txctx, config)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	ctx = protocol.WithVMConfigCtx(ctx, vm.Config{
 		Tracer:    tracer.Hooks,
 		NoBaseFee: true,
 	})
-	return ctx, tracer, nil
+	return ctx, tracer, cleanup, nil
 }
 
 func (core *coreService) simulateExecution(
@@ -2358,7 +2361,6 @@ func (core *coreService) traceBlock(ctx context.Context, blk *block.Block, confi
 	retvals := make([][]byte, 0)
 	receipts := make([]*action.Receipt, 0)
 	results := make([]*blockTraceResult, 0)
-
 	// Every transaction in the block must be traced with a fresh tracer, exactly
 	// like geth's traceBlock (which calls DefaultDirectory.New per tx). Sharing a
 	// single tracer across the whole block leaks state between transactions:
@@ -2372,14 +2374,26 @@ func (core *coreService) traceBlock(ctx context.Context, blk *block.Block, confi
 	// between transactions. CaptureTx (invoked once per traced user tx, after its
 	// hooks have fired) collects the current tracer's result and then rearms a new
 	// tracer for the next tx.
+	//
+	// Each per-tx tracer arms its own timeout watchdog (see parseTracer), so the
+	// trace timeout is enforced per transaction, like geth. Rearming disarms the
+	// previous transaction's watchdog; the deferred cleanup disarms the last one
+	// after the block trace has executed (WorkingSetAtTransaction below).
 	sharedHooks := new(tracing.Hooks)
-	var curTracer *tracers.Tracer
+	var (
+		curTracer  *tracers.Tracer
+		curCleanup context.CancelFunc
+	)
 	newTracer := func() error {
-		t, err := parseTracer(ctx, new(tracers.Context), config)
+		if curCleanup != nil {
+			curCleanup()
+		}
+		t, cleanup, err := parseTracer(ctx, new(tracers.Context), config)
 		if err != nil {
 			return err
 		}
 		curTracer = t
+		curCleanup = cleanup
 		if t.Hooks != nil {
 			*sharedHooks = *t.Hooks
 		} else {
@@ -2390,14 +2404,24 @@ func (core *coreService) traceBlock(ctx context.Context, blk *block.Block, confi
 	if err := newTracer(); err != nil {
 		return nil, nil, nil, err
 	}
+	defer func() { curCleanup() }()
 	ctx = protocol.WithVMConfigCtx(ctx, vm.Config{
 		Tracer:    sharedHooks,
 		NoBaseFee: true,
 	})
+	// traceErr captures a tracer failure (e.g. the timeout watchdog stopping the
+	// tracer, which makes GetResult return "execution timeout"). CaptureTx runs
+	// synchronously in the execution goroutine, so no extra synchronization is
+	// needed. We surface it as the RPC error instead of silently returning
+	// partial/empty results.
+	var traceErr error
 	ctx = evm.WithTracerCtx(ctx, evm.TracerContext{
 		CaptureTx: func(retval []byte, receipt *action.Receipt) {
 			res, err := curTracer.GetResult()
 			if err != nil {
+				if traceErr == nil {
+					traceErr = err
+				}
 				log.L().Error("failed to get tracer result", zap.Error(err))
 			} else {
 				results = append(results, &blockTraceResult{
@@ -2418,6 +2442,9 @@ func (core *coreService) traceBlock(ctx context.Context, blk *block.Block, confi
 		return nil, nil, nil, err
 	}
 	defer ws.Close()
+	if traceErr != nil {
+		return nil, nil, nil, traceErr
+	}
 
 	return retvals, receipts, results, nil
 }

--- a/api/web3server_tracer_timeout_test.go
+++ b/api/web3server_tracer_timeout_test.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/eth/tracers"
+	"github.com/ethereum/go-ethereum/eth/tracers/logger"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+)
+
+// tracerCtxForTest builds a minimal context that satisfies evm.NewChainConfig,
+// which parseTracer invokes for the JS/native tracer branch.
+func tracerCtxForTest() context.Context {
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
+	ctx = protocol.WithBlockchainCtx(ctx, protocol.BlockchainCtx{
+		Tip:          protocol.TipInfo{Height: 1, Timestamp: time.Now()},
+		EvmNetworkID: 1,
+	})
+	ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
+		BlockHeight:    1,
+		BlockTimeStamp: time.Now(),
+	})
+	return ctx
+}
+
+// registerStopRecorderTracer registers a tracer under the given name whose Stop
+// call is observable via the returned atomic pointer (holding the stop error).
+func registerStopRecorderTracer(name string) *atomic.Pointer[error] {
+	stopErr := &atomic.Pointer[error]{}
+	tracers.DefaultDirectory.Register(name, func(_ *tracers.Context, _ json.RawMessage, _ *params.ChainConfig) (*tracers.Tracer, error) {
+		return &tracers.Tracer{
+			Hooks:     &tracing.Hooks{},
+			GetResult: func() (json.RawMessage, error) { return json.RawMessage("{}"), nil },
+			Stop: func(err error) {
+				stopErr.Store(&err)
+			},
+		}, nil
+	}, false)
+	return stopErr
+}
+
+// TestParseTracerTimeoutFires verifies that a configured tracer whose trace runs
+// past the deadline is actually Stopped by the timeout watchdog. This is the bug
+// that was fixed: previously the watchdog was disarmed (via defer cancel) before
+// the trace executed, so the tracer was never stopped and a slow/looping trace
+// could run unbounded (DoS on nodes exposing debug_trace*).
+func TestParseTracerTimeoutFires(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	name := "test-timeout-fires-tracer"
+	stopErr := registerStopRecorderTracer(name)
+	timeout := "20ms"
+	cfg := &tracers.TraceConfig{Tracer: &name, Timeout: &timeout}
+
+	_, cleanup, err := parseTracer(ctx, new(tracers.Context), cfg)
+	require.NoError(err)
+	// Simulate a long-running trace: the caller has NOT yet finished executing,
+	// so cleanup() has not run. The watchdog must fire on the deadline and stop
+	// the tracer while the trace is still "executing".
+	require.Eventually(func() bool {
+		return stopErr.Load() != nil
+	}, 2*time.Second, 5*time.Millisecond, "tracer should be stopped once the deadline expires")
+	require.EqualError(*stopErr.Load(), "execution timeout")
+
+	// cleanup after execution is a safe no-op here (deadline already fired).
+	cleanup()
+}
+
+// TestParseTracerFastTraceNoStopNoLeak verifies that a normal, fast trace is not
+// stopped by the watchdog and that the watchdog goroutine is cleaned up (no leak)
+// once the caller invokes cleanup().
+//
+// It arms a short timeout, then simulates a fast trace by invoking cleanup()
+// *before* the deadline. If cleanup() correctly disarms the watchdog, the
+// deadline context is cancelled (Err == context.Canceled) and the goroutine
+// returns without ever calling Stop. Waiting well past the original deadline and
+// observing that Stop was never called proves both that the timeout does not
+// misfire on a fast trace and that the watchdog goroutine did not leak (it can
+// only avoid calling Stop by having woken on cancellation and returned).
+func TestParseTracerFastTraceNoStopNoLeak(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	name := "test-fast-trace-tracer"
+	stopErr := registerStopRecorderTracer(name)
+	timeout := "30ms"
+	cfg := &tracers.TraceConfig{Tracer: &name, Timeout: &timeout}
+
+	armed := runtime.NumGoroutine()
+	_, cleanup, err := parseTracer(ctx, new(tracers.Context), cfg)
+	require.NoError(err)
+	require.Greater(runtime.NumGoroutine(), armed-1, "watchdog goroutine should be running")
+	// Simulate a fast trace that finishes before the deadline: disarm now.
+	cleanup()
+
+	// Wait well past the original 30ms deadline; the disarmed watchdog must not
+	// fire Stop.
+	time.Sleep(150 * time.Millisecond)
+	require.Nil(stopErr.Load(), "tracer must not be stopped for a fast trace")
+}
+
+// TestParseTracerDefaultTimeout verifies the default-timeout path (Timeout == nil
+// -> defaultTraceTimeout) builds a working tracer + cleanup without firing on a
+// fast trace.
+func TestParseTracerDefaultTimeout(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	name := "test-default-timeout-tracer"
+	stopErr := registerStopRecorderTracer(name)
+	cfg := &tracers.TraceConfig{Tracer: &name} // Timeout nil -> defaultTraceTimeout
+
+	tracer, cleanup, err := parseTracer(ctx, new(tracers.Context), cfg)
+	require.NoError(err)
+	require.NotNil(tracer)
+	require.NotNil(cleanup)
+	cleanup()
+	time.Sleep(20 * time.Millisecond)
+	require.Nil(stopErr.Load(), "default-timeout tracer must not be stopped for a fast trace")
+}
+
+// TestParseTracerConfiguredTimeoutParsed verifies an invalid timeout string is
+// surfaced as an error (configured-timeout path), and no watchdog is leaked.
+func TestParseTracerConfiguredTimeoutParsed(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	name := "test-bad-timeout-tracer"
+	registerStopRecorderTracer(name)
+	bad := "not-a-duration"
+	cfg := &tracers.TraceConfig{Tracer: &name, Timeout: &bad}
+
+	tracer, cleanup, err := parseTracer(ctx, new(tracers.Context), cfg)
+	require.Error(err)
+	require.Nil(tracer)
+	require.Nil(cleanup)
+}
+
+// TestParseTracerDefaultLoggerTimeoutFires verifies the timeout watchdog also
+// covers the default struct-logger path (no named "tracer" in the config). This
+// is the branch used by a plain debug_traceTransaction / debug_traceCall. On
+// expiry the struct logger is Stopped and GetResult returns the timeout error,
+// which the RPC layer surfaces to the caller.
+func TestParseTracerDefaultLoggerTimeoutFires(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	timeout := "10ms"
+	cfg := &tracers.TraceConfig{Timeout: &timeout, Config: &logger.Config{}}
+
+	tracer, cleanup, err := parseTracer(ctx, new(tracers.Context), cfg)
+	require.NoError(err)
+	require.Eventually(func() bool {
+		_, gerr := tracer.GetResult()
+		return gerr != nil && gerr.Error() == "execution timeout"
+	}, 2*time.Second, 5*time.Millisecond, "default struct logger should be stopped on timeout")
+	cleanup()
+}
+
+// TestParseTracerNilConfigDefaultTimeout verifies a nil config still arms the
+// default-timeout watchdog (and does not misfire / leak on a fast trace).
+func TestParseTracerNilConfigDefaultTimeout(t *testing.T) {
+	require := require.New(t)
+	ctx := tracerCtxForTest()
+
+	tracer, cleanup, err := parseTracer(ctx, new(tracers.Context), nil)
+	require.NoError(err)
+	require.NotNil(tracer)
+	require.NotNil(cleanup)
+	cleanup()
+	// Fast trace: the default (5s) watchdog was cancelled, so the struct logger
+	// must not have been stopped.
+	time.Sleep(20 * time.Millisecond)
+	_, gerr := tracer.GetResult()
+	require.NotEqual("execution timeout", errString(gerr))
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -727,11 +727,19 @@ func parseTracerConfig(options *gjson.Result) *tracers.TraceConfig {
 	return cfg
 }
 
-func parseTracer(ctx context.Context, txctx *tracers.Context, config *tracers.TraceConfig) (*tracers.Tracer, error) {
-	var (
-		tracer *tracers.Tracer
-		err    error
-	)
+// parseTracer builds the tracer described by config and arms a timeout watchdog
+// that stops the tracer once the deadline expires. The watchdog covers every
+// tracer type (default struct logger, configured struct logger and named
+// JS/native tracers), since all of them perform per-opcode work that must be
+// bounded.
+//
+// The returned cleanup func MUST be called by the caller *after* the trace has
+// finished executing: it disarms the watchdog goroutine (so it does not leak and
+// does not fire on a fast trace). Because the watchdog must outlive parseTracer's
+// own return, cleanup cannot be deferred here — ownership is handed to the caller
+// that actually runs the EVM.
+func parseTracer(ctx context.Context, txctx *tracers.Context, config *tracers.TraceConfig) (*tracers.Tracer, context.CancelFunc, error) {
+	var tracer *tracers.Tracer
 	switch {
 	case config == nil:
 		loger := logger.NewStructLogger(nil)
@@ -741,29 +749,14 @@ func parseTracer(ctx context.Context, txctx *tracers.Context, config *tracers.Tr
 			Stop:      loger.Stop,
 		}
 	case config.Tracer != nil:
-		// Define a meaningful timeout of a single transaction trace
-		timeout := defaultTraceTimeout
-		if config.Timeout != nil {
-			if timeout, err = time.ParseDuration(*config.Timeout); err != nil {
-				return nil, err
-			}
-		}
 		cc, err := evm.NewChainConfig(ctx)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		t, err := tracers.DefaultDirectory.New(*config.Tracer, txctx, config.TracerConfig, cc)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
-		defer cancel()
-		go func() {
-			<-deadlineCtx.Done()
-			if errors.Is(deadlineCtx.Err(), context.DeadlineExceeded) {
-				t.Stop(errors.New("execution timeout"))
-			}
-		}()
 		tracer = t
 	default:
 		loger := logger.NewStructLogger(config.Config)
@@ -773,5 +766,30 @@ func parseTracer(ctx context.Context, txctx *tracers.Context, config *tracers.Tr
 			Stop:      loger.Stop,
 		}
 	}
-	return tracer, nil
+
+	// Define a meaningful timeout for a single transaction trace. This applies
+	// to all tracer types.
+	timeout := defaultTraceTimeout
+	if config != nil && config.Timeout != nil {
+		var err error
+		if timeout, err = time.ParseDuration(*config.Timeout); err != nil {
+			return nil, nil, err
+		}
+	}
+	// Arm a watchdog that stops the tracer if the trace runs past the deadline.
+	// cleanup (context cancel) is returned to the caller and is invoked once
+	// execution completes: on a fast trace this cancels the context so the
+	// goroutine wakes with context.Canceled and exits without stopping the
+	// tracer; on a slow trace the deadline fires first, the goroutine stops the
+	// tracer, then cleanup is a no-op. Stopping the tracer makes GetResult
+	// return the "execution timeout" error, which the caller surfaces as the RPC
+	// error.
+	deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	go func() {
+		<-deadlineCtx.Done()
+		if errors.Is(deadlineCtx.Err(), context.DeadlineExceeded) {
+			tracer.Stop(errors.New("execution timeout"))
+		}
+	}()
+	return tracer, cancel, nil
 }


### PR DESCRIPTION
## Summary

The trace execution timeout in `parseTracer` (`api/web3server_utils.go`) was a **no-op**, so `debug_trace*` requests could run unbounded — a DoS vector on API nodes that expose debug tracing.

## Root cause

In the named-tracer branch of `parseTracer`:

```go
deadlineCtx, cancel := context.WithTimeout(context.Background(), timeout)
defer cancel()                              // <-- fires when parseTracer RETURNS, before the trace runs
go func() {
    <-deadlineCtx.Done()
    if errors.Is(deadlineCtx.Err(), context.DeadlineExceeded) { // now Canceled, never DeadlineExceeded
        t.Stop(errors.New("execution timeout"))
    }
}()
```

`parseTracer` returns the tracer immediately, so `defer cancel()` runs **before** the EVM trace executes. The watchdog goroutine then wakes with `context.Canceled` (not `DeadlineExceeded`), the check is always false, and `t.Stop("execution timeout")` is never called. The timeout was therefore never enforced.

Additionally the watchdog was only wired for the *named* JS/native tracer branch — the default/configured struct-logger paths (a plain `debug_traceTransaction`/`debug_traceCall` with no `tracer`) had no timeout at all, even though they also do per-opcode work.

## Fix

- `parseTracer` returns a `cleanup` (`context.CancelFunc`) whose ownership is handed to the caller that actually runs the EVM. The watchdog stays armed for the full duration of trace execution and is disarmed afterward with **no goroutine/context leak** (a fast trace cancels the deadline context; the goroutine wakes on `Canceled` and returns without stopping the tracer).
- The watchdog is now armed **uniformly for every tracer type** (default struct logger, configured struct logger, and named JS/native tracers). Both the default (`5s`) and a caller-supplied `timeout` are honored.
- `traceTx` (single-tx: `debug_traceTransaction` / `debug_traceCall`) and `traceBlock` (`debug_traceBlockByNumber` / `debug_traceBlockByHash`) `defer cleanup()` after execution, wiring the timeout consistently across single-tx and block paths.
- `traceBlock` now **surfaces a tracer timeout as the RPC error** instead of silently returning partial/empty results.

On timeout, `tracer.Stop("execution timeout")` makes `GetResult()` return the timeout error, which the RPC layer already surfaces (single-tx via `GetResult()`; block path via the new error propagation).

### Scope note

Fully aborting the underlying EVM (`evm.Cancel()`) is intentionally **out of scope**: the `vm.EVM` is created inside `evm.SimulateExecution`/`ExecuteContract`, which are shared with **consensus** block execution, and the interpreter main loop is gas-bounded regardless. This change is **non-consensus** — it only affects the tracing API and bounds the per-opcode tracer work that is the debug-trace amplification vector. EVM execution remains gas-bounded as before.

## Tests

Added `api/web3server_tracer_timeout_test.go`:
- A configured tracer whose trace runs past a short deadline is actually `Stop`ped with `"execution timeout"`.
- The default struct-logger path is also stopped on timeout (`GetResult` returns the timeout error).
- A fast trace + `cleanup()` does **not** fire the watchdog and leaves no leak (disarmed before the deadline).
- Default (`nil`/unset) and configured timeouts both build a working tracer + cleanup; invalid `timeout` strings return an error with nil tracer/cleanup.

Existing trace tests (`TestTraceTransaction`, `TestTraceCall`, `TestDebugTrace*`) pass; `gofmt` clean, `go build ./...`, `go vet ./api/...` pass. (Pre-existing, unrelated gomonkey-based test failures under Go 1.26 — e.g. `TestEstimateExecutionGasConsumption`, `TestReverseActionsInBlock`, `TestReceiveBlock` — reproduce on clean `master` and are not touched by this change.)

This was surfaced while reviewing tracing/EVM logging during #4825 / #4878. No prior backlog issue exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)