### PR TITLE
chore(ci): ignore generated and mock files in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,6 +10,9 @@ coverage:
         enabled: yes
         target: auto
 ignore:
+  - "**/*.pb.go"
+  - "**/*_mock.go"
+  - "**/mock_*.go"
   - "action/protocol/rewarding/rewardingpb"
   - "action/protocol/account/accountpb"
   - "action/protocol/poll/*.abi.go"


### PR DESCRIPTION
## Description

Configure codecov to ignore generated source files, as requested in #4089.

Adds three glob patterns to the existing `ignore:` section of `.codecov.yml`:

- `**/*.pb.go` — protobuf/grpc generated files (e.g. `action/protocol/execution/executionpb`, `blockchain/blockdao/blockdaopb`, `db/versionpb`, and others not covered by the existing per-directory entries)
- `**/*_mock.go` — gomock files such as `action/protocol/staking/contractstake_indexer_mock.go`
- `**/mock_*.go` — gomock files such as `action/protocol/mock_protocol.go`, `api/mock_apicoreservice.go`

All patterns were verified against `git ls-files`; every matched file carries a `Code generated by ...` header, and no hand-written file is excluded. The repo has no `*_generated.go` files, and `*.abi.go` files are already covered by the existing `action/protocol/poll/*.abi.go` entry. The config was validated against the codecov validator API (`https://codecov.io/validate` returns Valid).

Closes #4089

## Type of change

- [x] Chore (CI/config change, no code behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)