### PR TITLE
fix(p2p): log expected cold-start/transient peer errors at WARN

### DIFF
--- a/p2p/agent.go
+++ b/p2p/agent.go
@@ -735,16 +735,17 @@ func (p *agent) reconnect() {
 		log.L().Info("network lost, try re-connecting.")
 		p.host.ClearBlocklist()
 		if err := p.connectBootNode(context.Background()); err != nil {
-			log.L().Error("fail to connect bootnode", zap.Error(err))
+			// transient network hiccup, will retry on the next reconnect tick
+			log.L().Warn("fail to connect bootnode, will retry.", zap.Error(err))
 			return
 		}
 		if err := p.host.AdvertiseAsync(); err != nil {
-			log.L().Error("fail to advertise", zap.Error(err))
+			log.L().Warn("fail to advertise, will retry.", zap.Error(err))
 			return
 		}
 	}
 	if err := p.host.FindPeersAsync(); err != nil {
-		log.L().Error("fail to find peer", zap.Error(err))
+		log.L().Warn("fail to find peer, will retry.", zap.Error(err))
 	}
 }
 
@@ -765,7 +766,8 @@ func exponentialRetry(f func() error, retryInterval time.Duration, numRetries in
 		if err = f(); err == nil {
 			return
 		}
-		log.L().Error("Error happens, will retry.", zap.Error(err))
+		// expected during cold start (e.g. bootnode not yet reachable), will retry
+		log.L().Warn("Error happens, will retry.", zap.Error(err))
 		time.Sleep(retryInterval)
 		retryInterval *= 2
 	}


### PR DESCRIPTION
## Description

During node startup and periodic reconnect, the P2P agent logged expected, automatically-retried failures at `ERROR` level, producing noisy logs that confuse operators and trigger false alerts in log monitoring.

This PR downgrades the transient/retried paths in `p2p/agent.go` to `WARN` (log level/message changes only, no behavior changes):

- `exponentialRetry()`: per-attempt dial failures ("Error happens, will retry.", e.g. bootnode not yet reachable at cold start, `context deadline exceeded`) — retried with exponential backoff, now `WARN`.
- `reconnect()`: `connectBootNode` / `AdvertiseAsync` / `FindPeersAsync` failures — retried on the next recurring reconnect tick, now `WARN` with ", will retry." appended to the message.

Genuine fatal failures keep `ERROR`: `Start()` still logs `ERROR` and returns the error when it cannot connect to any bootnode after all retries are exhausted.

## Note on upstream go-p2p

The exact lines quoted in the issue:

```
ERROR  go-p2p/peerManager.go:102  error when advertising.  {"error": "failed to find any peer in table"}
ERROR  go-p2p/peerManager.go:117  error when finding peers  {"error": "no peers are found"}
```

live in the upstream `iotexproject/go-p2p` dependency (v0.3.7) and cannot be fixed from this repo; they need a companion fix in go-p2p followed by a dependency bump here. This PR fixes all in-repo cold-start/transient `ERROR` noise.

## Testing

- `go build ./p2p/... ./dispatcher/...` passes
- `go test ./p2p/... ./dispatcher/...` passes

Closes #4814

🤖 Generated with [Claude Code](https://claude.com/claude-code)