### PR TITLE
fix(evm): quieter expected-path logs and action hash on EVM error logs

### DIFF
--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -236,7 +236,11 @@ func newParams(
 func securityDeposit(ps *Params, stateDB vm.StateDB, gasLimit uint64) error {
 	executorNonce := stateDB.GetNonce(ps.txCtx.Origin)
 	if executorNonce > ps.nonce {
-		log.S().Errorf("Nonce on %v: %d vs %d", ps.txCtx.Origin, executorNonce, ps.nonce)
+		log.L().Error("Inconsistent nonce.",
+			zap.String("origin", ps.txCtx.Origin.Hex()),
+			zap.Uint64("executorNonce", executorNonce),
+			zap.Uint64("nonce", ps.nonce),
+			log.Hex("actionHash", ps.actionCtx.ActionHash[:]))
 		// TODO ignore inconsistent nonce problem until the actions are executed sequentially
 		// return ErrInconsistentNonce
 	}
@@ -620,7 +624,8 @@ func executeInEVM(ctx context.Context, evmParams *Params, stateDB stateDB) ([]by
 		chainConfig  = evmParams.chainConfig
 	)
 	if err := securityDeposit(evmParams, stateDB, gasLimit); err != nil {
-		log.T(ctx).Warn("unexpected error: not enough security deposit", zap.Error(err))
+		log.T(ctx).Warn("unexpected error: not enough security deposit", zap.Error(err),
+			log.Hex("actionHash", evmParams.actionCtx.ActionHash[:]))
 		return nil, 0, 0, action.EmptyAddress, iotextypes.ReceiptStatus_Failure, err
 	}
 	var (
@@ -709,7 +714,7 @@ func executeInEVM(ctx context.Context, evmParams *Params, stateDB stateDB) ([]by
 		ret, remainingGas, evmErr = evm.Call(executor, *evmParams.contract, evmParams.data, remainingGas, amount)
 	}
 	if evmErr != nil {
-		log.T(ctx).Debug("evm error", zap.Error(evmErr))
+		log.T(ctx).Debug("evm error", zap.Error(evmErr), log.Hex("actionHash", evmParams.actionCtx.ActionHash[:]))
 		// The only possible consensus-error would be if there wasn't
 		// sufficient balance to make the transfer happen.
 		// Should be a hard fork (Bering)
@@ -718,7 +723,7 @@ func executeInEVM(ctx context.Context, evmParams *Params, stateDB stateDB) ([]by
 		}
 	}
 	if stateDB.Error() != nil {
-		log.T(ctx).Debug("statedb error", zap.Error(stateDB.Error()))
+		log.T(ctx).Debug("statedb error", zap.Error(stateDB.Error()), log.Hex("actionHash", evmParams.actionCtx.ActionHash[:]))
 	}
 	if !rules.IsLondon {
 		// Before EIP-3529: refunds were capped to gasUsed / 2
@@ -770,6 +775,7 @@ func executeInEVM(ctx context.Context, evmParams *Params, stateDB stateDB) ([]by
 			}
 			log.T(ctx).Warn("evm internal error", zap.Error(evmErr),
 				zap.String("address", addr),
+				log.Hex("actionHash", evmParams.actionCtx.ActionHash[:]),
 				log.Hex("calldata", evmParams.data))
 		}
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -287,10 +287,17 @@ func (stateDB *StateDBAdapter) logError(err error) {
 	}
 }
 
+// actionHashField returns the hash of the action being executed as a log
+// field, to correlate EVM troubleshooting logs with the transaction
+func (stateDB *StateDBAdapter) actionHashField() zap.Field {
+	return log.Hex("actionHash", stateDB.executionHash[:])
+}
+
 func (stateDB *StateDBAdapter) assertError(err error, msg string, fields ...zap.Field) bool {
 	if err == nil {
 		return false
 	}
+	fields = append(fields, stateDB.actionHashField())
 	if stateDB.panicUnrecoverableError {
 		log.T(stateDB.ctx).Panic(msg, fields...)
 	}
@@ -374,7 +381,7 @@ func (stateDB *StateDBAdapter) SubBalance(evmAddr common.Address, a256 *uint256.
 func (stateDB *StateDBAdapter) AddBalance(evmAddr common.Address, a256 *uint256.Int, reason tracing.BalanceChangeReason) uint256.Int {
 	if stateDB.ignoreBalanceChangeTouchAccount && reason == tracing.BalanceChangeTouchAccount {
 		if a256.Sign() != 0 {
-			log.T(stateDB.ctx).Panic("Invalid non-zero amount for touch account.", zap.String("address", evmAddr.Hex()), zap.String("amount", a256.String()))
+			log.T(stateDB.ctx).Panic("Invalid non-zero amount for touch account.", zap.String("address", evmAddr.Hex()), zap.String("amount", a256.String()), stateDB.actionHashField())
 		}
 		log.T(stateDB.ctx).Debug("Ignore AddBalance for touch account.", zap.String("address", evmAddr.Hex()))
 		return *common.U2560
@@ -458,9 +465,9 @@ func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
 	state, err := stateDB.accountState(evmAddr)
 	if err != nil {
 		if stateDB.panicUnrecoverableError {
-			log.T(stateDB.ctx).Panic("Failed to get nonce.", zap.Error(err))
+			log.T(stateDB.ctx).Panic("Failed to get nonce.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		} else {
-			log.T(stateDB.ctx).Error("Failed to get nonce.", zap.Error(err))
+			log.T(stateDB.ctx).Error("Failed to get nonce.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 			stateDB.logError(err)
 		}
 	} else {
@@ -472,7 +479,7 @@ func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
 	}
 	if stateDB.useConfirmedNonce {
 		if pendingNonce == 0 {
-			log.T(stateDB.ctx).Panic("invalid pending nonce")
+			log.T(stateDB.ctx).Panic("invalid pending nonce", zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		}
 		pendingNonce--
 	}
@@ -495,7 +502,7 @@ func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64, _ 
 	}
 	if !stateDB.useConfirmedNonce {
 		if nonce == 0 {
-			log.T(stateDB.ctx).Panic("invalid nonce zero")
+			log.T(stateDB.ctx).Panic("invalid nonce zero", zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		}
 		nonce--
 	}
@@ -504,7 +511,7 @@ func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64, _ 
 		zap.Uint64("nonce", nonce))
 	if !s.IsNewbieAccount() || s.AccountType() != 0 || nonce != 0 || stateDB.zeroNonceForFreshAccount {
 		if err := s.SetPendingNonce(nonce + 1); err != nil {
-			log.T(stateDB.ctx).Panic("Failed to set nonce.", zap.Error(err), zap.String("addr", addr.Hex()), zap.Uint64("pendingNonce", s.PendingNonce()), zap.Uint64("nonce", nonce), zap.String("execution", hex.EncodeToString(stateDB.executionHash[:])))
+			log.T(stateDB.ctx).Panic("Failed to set nonce.", zap.Error(err), zap.String("addr", addr.Hex()), zap.Uint64("pendingNonce", s.PendingNonce()), zap.Uint64("nonce", nonce), stateDB.actionHashField())
 			stateDB.logError(err)
 		}
 	}
@@ -517,7 +524,7 @@ func (stateDB *StateDBAdapter) SubRefund(gas uint64) {
 	log.T(stateDB.ctx).Debug("Called SubRefund.", zap.Uint64("gas", gas))
 	// stateDB.journal.append(refundChange{prev: self.refund})
 	if gas > stateDB.refund {
-		log.T(stateDB.ctx).Panic("Refund counter not enough!")
+		log.T(stateDB.ctx).Panic("Refund counter not enough!", zap.Uint64("gas", gas), zap.Uint64("refund", stateDB.refund), stateDB.actionHashField())
 	}
 	stateDB.refund -= gas
 }
@@ -726,7 +733,7 @@ func (stateDB *StateDBAdapter) Empty(evmAddr common.Address) bool {
 func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	ds, ok := stateDB.selfDestructedSnapshot[snapshot]
 	if !ok && stateDB.panicUnrecoverableError {
-		log.T(stateDB.ctx).Panic("Failed to revert to snapshot.", zap.Int("snapshot", snapshot))
+		log.T(stateDB.ctx).Panic("Failed to revert to snapshot.", zap.Int("snapshot", snapshot), stateDB.actionHashField())
 	}
 	err := stateDB.sm.Revert(snapshot)
 	if stateDB.assertError(err, "state manager's Revert() failed.", zap.Error(err), zap.Int("snapshot", snapshot)) {
@@ -734,7 +741,7 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	}
 	if !ok {
 		// this should not happen, b/c we save the SelfDestruct accounts on a successful return of Snapshot(), but check anyway
-		log.T(stateDB.ctx).Error("Failed to revert to snapshot.", zap.Int("snapshot", snapshot))
+		log.T(stateDB.ctx).Error("Failed to revert to snapshot.", zap.Int("snapshot", snapshot), stateDB.actionHashField())
 		return
 	}
 	deleteSnapshot := snapshot
@@ -822,7 +829,7 @@ func (stateDB *StateDBAdapter) RevertToSnapshot(snapshot int) {
 	for _, addr := range stateDB.cachedContractAddrs() {
 		c := stateDB.cachedContract[addr]
 		if err := c.LoadRoot(); err != nil {
-			log.T(stateDB.ctx).Error("Failed to load root for contract.", zap.Error(err), log.Hex("addrHash", addr[:]))
+			log.T(stateDB.ctx).Error("Failed to load root for contract.", zap.Error(err), log.Hex("addrHash", addr[:]), stateDB.actionHashField())
 			return
 		}
 	}
@@ -872,9 +879,9 @@ func (stateDB *StateDBAdapter) Snapshot() int {
 	if _, ok := stateDB.selfDestructedSnapshot[sn]; ok {
 		err := errors.New("unexpected error: duplicate snapshot version")
 		if stateDB.fixSnapshotOrder {
-			log.T(stateDB.ctx).Panic("Failed to snapshot.", zap.Error(err))
+			log.T(stateDB.ctx).Panic("Failed to snapshot.", zap.Error(err), stateDB.actionHashField())
 		} else {
-			log.T(stateDB.ctx).Error("Failed to snapshot.", zap.Error(err))
+			log.T(stateDB.ctx).Error("Failed to snapshot.", zap.Error(err), stateDB.actionHashField())
 		}
 		// stateDB.err = err
 		return sn
@@ -937,7 +944,7 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 		// NOTE: the historical len(topics) != 3 panic is preserved to keep behavior
 		// identical for malformed inputs; hardening that DoS is a separate change.
 		if len(topics) != 3 {
-			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics")
+			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics", zap.String("address", addr.String()), stateDB.actionHashField())
 		}
 		return
 	}
@@ -1047,7 +1054,8 @@ func (stateDB *StateDBAdapter) generateSelfDestructTransferLog(sender string, am
 			}
 		} else {
 			log.T(stateDB.ctx).Panic("SelfDestruct contract's balance does not match",
-				zap.String("beneficiary", stateDB.lastAddBalanceAmount.String()))
+				zap.String("beneficiary", stateDB.lastAddBalanceAmount.String()),
+				stateDB.actionHashField())
 		}
 	}
 }
@@ -1080,7 +1088,14 @@ func (stateDB *StateDBAdapter) GetCode(evmAddr common.Address) []byte {
 	if contract, ok := stateDB.cachedContract[evmAddr]; ok {
 		code, err := contract.GetCode()
 		if err != nil {
-			log.T(stateDB.ctx).Error("Failed to get code hash.", zap.Error(err))
+			// an account without code (e.g. touched by EXTCODESIZE/EXTCODEHASH or
+			// called before deployment) has no entry in the code namespace, which
+			// surfaces as ErrStateNotExist -- this is expected, not a failure
+			if errors.Is(err, state.ErrStateNotExist) {
+				log.T(stateDB.ctx).Debug("Account has no code.", zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
+			} else {
+				log.T(stateDB.ctx).Error("Failed to get code.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
+			}
 			return nil
 		}
 		return code
@@ -1091,8 +1106,9 @@ func (stateDB *StateDBAdapter) GetCode(evmAddr common.Address) []byte {
 	}
 	var code protocol.SerializableBytes
 	if _, err = stateDB.sm.State(&code, protocol.NamespaceOption(CodeKVNameSpace), protocol.KeyOption(account.CodeHash[:])); err != nil {
-		// TODO: Suppress the as it's too much now
-		//log.L().Error("Failed to get code from trie.", zap.Error(err))
+		if !errors.Is(err, state.ErrStateNotExist) {
+			log.T(stateDB.ctx).Error("Failed to get code from trie.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
+		}
 		return nil
 	}
 	return code[:]
@@ -1109,13 +1125,13 @@ func (stateDB *StateDBAdapter) GetCodeSize(evmAddr common.Address) int {
 func (stateDB *StateDBAdapter) SetCode(evmAddr common.Address, code []byte) []byte {
 	contract, err := stateDB.getContract(evmAddr)
 	if err != nil {
-		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 		return nil
 	}
 	prev, err := contract.GetCode()
 	if err != nil && !errors.Is(err, state.ErrStateNotExist) {
-		log.T(stateDB.ctx).Error("Failed to get code.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get code.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 	}
 	contract.SetCode(hash.Hash256b(code), code)
@@ -1126,7 +1142,7 @@ func (stateDB *StateDBAdapter) SetCode(evmAddr common.Address, code []byte) []by
 func (stateDB *StateDBAdapter) GetCommittedState(evmAddr common.Address, k common.Hash) common.Hash {
 	contract, err := stateDB.getContract(evmAddr)
 	if err != nil {
-		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 		return common.Hash{}
 	}
@@ -1143,7 +1159,7 @@ func (stateDB *StateDBAdapter) GetCommittedState(evmAddr common.Address, k commo
 func (stateDB *StateDBAdapter) GetState(evmAddr common.Address, k common.Hash) common.Hash {
 	contract, err := stateDB.getContract(evmAddr)
 	if err != nil {
-		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 		return common.Hash{}
 	}
@@ -1160,7 +1176,7 @@ func (stateDB *StateDBAdapter) GetState(evmAddr common.Address, k common.Hash) c
 func (stateDB *StateDBAdapter) SetState(evmAddr common.Address, k, v common.Hash) common.Hash {
 	contract, err := stateDB.getContract(evmAddr)
 	if err != nil {
-		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get contract.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 		return common.Hash{}
 	}
@@ -1189,7 +1205,7 @@ func (stateDB *StateDBAdapter) GetStorageRoot(evmAddr common.Address) common.Has
 	case state.ErrStateNotExist:
 		return common.Hash{}
 	default:
-		log.T(stateDB.ctx).Error("Failed to get account.", zap.Error(err), zap.String("address", evmAddr.Hex()))
+		log.T(stateDB.ctx).Error("Failed to get account.", zap.Error(err), zap.String("address", evmAddr.Hex()), stateDB.actionHashField())
 		stateDB.logError(err)
 		return common.Hash{}
 	}


### PR DESCRIPTION
## Description

Two related log-quality fixes in the EVM execution layer. **Log levels, messages, and fields only — no consensus or state behavior change** (return values, `stateDB.err` recording, and control flow are untouched).

### 1. Silence the noisy "Failed to get code hash." error (#4222)

`StateDBAdapter.GetCode` logged at Error level whenever `contract.GetCode()` failed. Investigation of the call path (`opExtCodeSize` / `DelegateCall` → `GetCodeSize` → `GetCode` → `contract.GetCode` → `sm.State(ns=Code, key=CodeHash)`) shows the failure in the issue is `state.ErrStateNotExist`: the account has an empty code hash because it simply has no code (e.g. `EXTCODESIZE`/`EXTCODEHASH` on an EOA, or a call to a not-yet-deployed contract). That is an expected condition, not a failure:

- `state.ErrStateNotExist` → now logged at **Debug** ("Account has no code.")
- any other error → stays at **Error**, with the correct message ("Failed to get code.") plus the address and action hash
- the non-cached path's silenced `// TODO: Suppress...` log is restored the same way: silent for the expected no-code case, Error (with context) for genuine trie failures

### 2. Carry the action (tx) hash on EVM troubleshooting logs (#4233)

`StateDBAdapter` already holds the `executionHash`; it is now attached to the significant warn/error/panic logs so they can be correlated with the transaction:

- new `actionHashField()` helper; `assertError` appends it to **every** Error/Panic it emits (covers all ~30 assertError call sites)
- direct Error/Panic sites in `evmstatedbadapter.go` (GetNonce, SetNonce, SetCode, GetState/SetState/GetCommittedState, GetStorageRoot, Snapshot/RevertToSnapshot, SubRefund, AddLog, AddBalance touch-account, selfdestruct mismatch) now include it
- `evm.go`: the `"evm internal error"` warn (which previously only had address+calldata), the security-deposit warn, the nonce-mismatch error in `securityDeposit` (also converted from `Errorf` to structured fields), and the `"evm error"` / `"statedb error"` debug logs now log `actionHash`

## Testing

- `go build ./action/protocol/execution/...`
- `go vet ./action/protocol/execution/evm/`
- `go test ./action/protocol/execution/evm/ -count=1` — pass

Closes #4222
Closes #4233

🤖 Generated with [Claude Code](https://claude.com/claude-code)