### PR TITLE
[evm] fix corrupted SELFDESTRUCT transaction log amount

### DIFF
--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -1076,7 +1076,11 @@ func (stateDB *StateDBAdapter) generateSelfDestructTransferLog(sender string, am
 					Type:      iotextypes.TransactionLogType_IN_CONTRACT_TRANSFER,
 					Sender:    sender,
 					Recipient: stateDB.lastAddBalanceAddr,
-					Amount:    stateDB.lastAddBalanceAmount,
+					// Copy the amount: lastAddBalanceAmount is a mutable *big.Int that is
+					// modified in place by every subsequent AddBalance (e.g. the gas-deposit
+					// refund done right after the EVM returns). Aliasing it here retroactively
+					// corrupts this already-recorded log with a later value.
+					Amount: new(big.Int).Set(stateDB.lastAddBalanceAmount),
 				})
 			}
 		} else {

--- a/e2etest/selfdestruct_txlog_test.go
+++ b/e2etest/selfdestruct_txlog_test.go
@@ -1,0 +1,94 @@
+package e2etest
+
+import (
+	"context"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+// TestSelfDestructTransactionLogAmount is a regression guard for a bug where the
+// IN_CONTRACT_TRANSFER transaction log recorded for a SELFDESTRUCT carried the wrong
+// amount. generateSelfDestructTransferLog stored stateDB.lastAddBalanceAmount (a
+// *big.Int) directly into the log. That big.Int is mutated in place by every later
+// AddBalance — in particular the gas-deposit refund that ExecuteContract performs
+// immediately after the EVM returns (stateDB.AddBalance(origin, depositGas*gasPrice)).
+// So the already-recorded self-destruct log was retroactively overwritten with the
+// gas-refund value instead of the amount actually transferred to the beneficiary.
+//
+// The contract below mirrors the on-chain MEV pattern that triggered this on mainnet:
+// it makes a value-carrying sub-call that reverts (an arbitrage probe) and then
+// self-destructs its own balance. The self-destruct moves V to the beneficiary, so the
+// transaction log must report V — not the (much larger) gas-deposit refund.
+func TestSelfDestructTransactionLogAmount(t *testing.T) {
+	r := require.New(t)
+	deployer := identityset.Address(10).String()
+	deployerSK := identityset.PrivateKey(10)
+
+	cfg := initCfg(r)
+	cfg.Genesis.SumatraBlockHeight = 1
+	cfg.Genesis.UpernavikBlockHeight = 1
+	cfg.Genesis.VanuatuBlockHeight = 1 // activates Cancun / EIP-6780
+	cfg.Genesis.InitBalanceMap[deployer] = unit.ConvertIotxToRau(2000000).String()
+	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+	test := newE2ETest(t, cfg)
+	defer test.teardown()
+
+	bc := test.cs.Blockchain()
+	ap := test.cs.ActionPool()
+	chainID := cfg.Chain.ID
+	gasPrice := big.NewInt(unit.Qev)
+	nonce := uint64(0) // Sumatra active -> fresh account uses zero-nonce
+	hx := func(s string) []byte { b, err := hex.DecodeString(s); r.NoError(err); return b }
+	sign := func(exec *action.Execution) *actionWithTime {
+		tx := action.NewLegacyTx(chainID, nonce, gasLimit, gasPrice)
+		nonce++
+		return &actionWithTime{mustNoErr(action.Sign(action.NewEnvelope(tx, exec), deployerSK)), testutil.TimestampNow()}
+	}
+	ctx := context.Background()
+
+	// R: always reverts on call (runtime: PUSH1 0 PUSH1 0 REVERT)
+	_, rc, _, err := addOneTx(ctx, ap, bc, sign(action.NewExecution("", big.NewInt(0), hx("600580600b6000396000f360006000fd"))))
+	r.NoError(err)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, rc.Status)
+	rAddr := mustNoErr(address.FromString(rc.ContractAddress)).Bytes()
+
+	// P: CALL(R, value=7) which reverts, then SELFDESTRUCT to CALLER.
+	//   PUSH1 0 x4 (ret/args off+size), PUSH1 7 (value), PUSH20 R, GAS, CALL, POP, CALLER, SELFDESTRUCT
+	pRuntime := append(append(hx("6000600060006000"+"6007"+"73"), rAddr...), hx("5af15033ff")...)
+	pInit := append([]byte{0x60, byte(len(pRuntime)), 0x80, 0x60, 0x0b, 0x60, 0x00, 0x39, 0x60, 0x00, 0xf3}, pRuntime...)
+	_, pc, _, err := addOneTx(ctx, ap, bc, sign(action.NewExecution("", big.NewInt(0), pInit)))
+	r.NoError(err)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, pc.Status)
+	pAddr := pc.ContractAddress
+
+	// Call P with value V in a batch of 3 within a single minted block (the on-chain
+	// pattern batches many such calls; they must not share/leak a corrupted amount).
+	V := big.NewInt(100)
+	txs := []*actionWithTime{sign(action.NewExecution(pAddr, V, nil)), sign(action.NewExecution(pAddr, V, nil)), sign(action.NewExecution(pAddr, V, nil))}
+	_, receipts, _, err := runTxs(ctx, ap, bc, txs)
+	r.NoError(err)
+
+	for i, rcpt := range receipts {
+		r.NotNilf(rcpt, "receipt %d", i)
+		r.EqualValuesf(iotextypes.ReceiptStatus_Success, rcpt.Status, "call %d", i)
+		var found bool
+		for _, l := range rcpt.TransactionLogs() {
+			if l.Type == iotextypes.TransactionLogType_IN_CONTRACT_TRANSFER && l.Sender == pAddr {
+				found = true
+				// the self-destruct moved exactly V to the beneficiary
+				r.Equalf(0, V.Cmp(l.Amount), "call %d: self-destruct log amount = %s, want %s", i, l.Amount, V)
+			}
+		}
+		r.Truef(found, "call %d: missing self-destruct transaction log", i)
+	}
+}

--- a/e2etest/selfdestruct_txlog_test.go
+++ b/e2etest/selfdestruct_txlog_test.go
@@ -35,6 +35,11 @@ func TestSelfDestructTransactionLogAmount(t *testing.T) {
 	deployerSK := identityset.PrivateKey(10)
 
 	cfg := initCfg(r)
+	// initCfg uses config.Default's fixed API ports; randomize so this test does
+	// not collide with the fixed :14014 gRPC port of a sibling e2e test.
+	cfg.API.GRPCPort = testutil.RandomPort()
+	cfg.API.HTTPPort = testutil.RandomPort()
+	cfg.API.WebSocketPort = 0
 	cfg.Genesis.SumatraBlockHeight = 1
 	cfg.Genesis.UpernavikBlockHeight = 1
 	cfg.Genesis.VanuatuBlockHeight = 1 // activates Cancun / EIP-6780

--- a/tools/txlogpatch/main.go
+++ b/tools/txlogpatch/main.go
@@ -3,16 +3,22 @@
 // or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
 // This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
 
-// txlogpatch generates a transaction-log patch BoltDB that removes a set of forged
-// IN_CONTRACT_TRANSFER records from specific block heights. A node loads the produced
-// file via chain.patchTransactionLogPath / chain.patchTransactionLogEndHeight and then
-// serves the corrected transaction logs for those heights. Transaction logs are not part
-// of any receipt or state root, so this does not affect consensus.
+// txlogpatch generates a transaction-log patch BoltDB that overrides the
+// IN_CONTRACT_TRANSFER records served for specific block heights. A node loads the
+// produced file via chain.patchTransactionLogPath and serves the corrected transaction
+// logs for those heights. Transaction logs are not part of any receipt or state root,
+// so this does not affect consensus.
 //
-// Usage:
+// Two modes:
 //
-//	go run ./tools/txlogpatch \
-//	  -csv FORGERY_FINAL.csv -endpoint api.mainnet.iotex.one:443 -out txlog.db.patch
+//   - strip (default): removes forged records. CSV columns (amount in IOTX):
+//     block_height,tx_hash,sender,recipient,amount_IOTX
+//     go run ./tools/txlogpatch -csv FORGERY_FINAL.csv -out txlog.db.patch
+//
+//   - correct (-correct): rewrites a record's amount to the correct value, keeping the
+//     record. Used for the SELFDESTRUCT log amount corruption. CSV columns (RAU):
+//     block_height,tx_hash,sender,recipient,wrong_amount_rau,correct_amount_rau
+//     go run ./tools/txlogpatch -correct -csv SELFDESTRUCT_FIX.csv -out txlog.db.patch
 package main
 
 import (
@@ -37,26 +43,28 @@ import (
 	"github.com/iotexproject/iotex-core/v2/db"
 )
 
-type forgedRec struct {
+type patchRec struct {
 	height    uint64
 	actHash   string // hex, no 0x
 	sender    string
 	recipient string
-	amountRau string
+	amountRau string // amount to match in the current log
+	newRau    string // replacement amount (correct mode only)
 }
 
 func main() {
-	csvPath := flag.String("csv", "FORGERY_FINAL.csv", "CSV: block_height,tx_hash,attacker_sender,victim_recipient,amount_IOTX")
+	csvPath := flag.String("csv", "FORGERY_FINAL.csv", "input CSV (see mode docs)")
 	endpoint := flag.String("endpoint", "api.mainnet.iotex.one:443", "iotex gRPC API endpoint")
 	secure := flag.Bool("secure", true, "use TLS for the gRPC endpoint")
 	outPath := flag.String("out", "txlog.db.patch", "output patch BoltDB path")
+	correct := flag.Bool("correct", false, "correct-amount mode: rewrite (not remove) a record's amount; CSV carries a 6th correct_amount_rau column")
 	flag.Parse()
 
-	forged, err := readForged(*csvPath)
+	recs, err := readCSV(*csvPath, *correct)
 	if err != nil {
 		fatal(err)
 	}
-	fmt.Printf("loaded %d forged records\n", len(forged))
+	fmt.Printf("loaded %d record(s) [%s mode]\n", len(recs), mode(*correct))
 
 	dialCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -83,12 +91,12 @@ func main() {
 	}
 	defer ti.Stop(context.Background())
 
-	byHeight := map[uint64][]forgedRec{}
-	for _, f := range forged {
+	byHeight := map[uint64][]patchRec{}
+	for _, f := range recs {
 		byHeight[f.height] = append(byHeight[f.height], f)
 	}
 
-	for height, recs := range byHeight {
+	for height, hr := range byHeight {
 		resp, err := cli.GetTransactionLogByBlockHeight(context.Background(),
 			&iotexapi.GetTransactionLogByBlockHeightRequest{BlockHeight: height})
 		if err != nil {
@@ -96,44 +104,51 @@ func main() {
 		}
 		logs := resp.GetTransactionLogs()
 		before := countTx(logs)
-		corrected, removed := strip(logs, recs)
-		if removed != len(recs) {
-			fatal(fmt.Errorf("height %d: expected to remove %d forged record(s), removed %d — refusing to write an incorrect patch", height, len(recs), removed))
+		out, n := apply(logs, hr, *correct)
+		if n != len(hr) {
+			fatal(fmt.Errorf("height %d: expected to match %d record(s), matched %d — refusing to write an incorrect patch", height, len(hr), n))
 		}
-		if err := ti.Put(height, corrected); err != nil {
+		if err := ti.Put(height, out); err != nil {
 			fatal(fmt.Errorf("put height %d: %w", height, err))
 		}
-		fmt.Printf("height %d: transactions %d -> %d (removed %d forged)\n", height, before, countTx(corrected), removed)
+		fmt.Printf("height %d: transactions %d -> %d (%s %d)\n", height, before, countTx(out), mode(*correct), n)
 	}
 	fmt.Printf("OK: patch written to %s (%d block(s))\n", *outPath, len(byHeight))
 }
 
-// strip returns a copy of logs with the forged IN_CONTRACT_TRANSFER records removed,
-// and the count of records actually removed. Non-forged records (GAS_FEE, PRIORITY_FEE,
-// real transfers, other actions) are preserved. A log entry whose transactions become
-// empty is dropped.
-func strip(logs *iotextypes.TransactionLogs, recs []forgedRec) (*iotextypes.TransactionLogs, int) {
+// apply rewrites (correct mode) or removes (strip mode) the matching
+// IN_CONTRACT_TRANSFER records and returns the resulting logs plus the number matched.
+// Every other record (GAS_FEE, PRIORITY_FEE, real transfers, other actions) is preserved
+// unchanged. In strip mode a log whose transactions all get removed is dropped.
+func apply(logs *iotextypes.TransactionLogs, recs []patchRec, correct bool) (*iotextypes.TransactionLogs, int) {
 	out := &iotextypes.TransactionLogs{}
-	removed := 0
+	matched := 0
 	for _, lg := range logs.GetLogs() {
 		ah := hex.EncodeToString(lg.GetActionHash())
 		kept := make([]*iotextypes.TransactionLog_Transaction, 0, len(lg.GetTransactions()))
 		for _, tx := range lg.GetTransactions() {
-			isForged := false
-			for _, f := range recs {
+			var hit *patchRec
+			for i := range recs {
+				f := &recs[i]
 				if f.actHash == ah &&
 					tx.GetType() == iotextypes.TransactionLogType_IN_CONTRACT_TRANSFER &&
 					tx.GetSender() == f.sender &&
 					tx.GetRecipient() == f.recipient &&
 					tx.GetAmount() == f.amountRau {
-					isForged = true
-					removed++
+					hit = f
 					break
 				}
 			}
-			if !isForged {
+			if hit == nil {
+				kept = append(kept, tx)
+				continue
+			}
+			matched++
+			if correct {
+				tx.Amount = hit.newRau // rewrite the amount, keep the record
 				kept = append(kept, tx)
 			}
+			// strip mode: drop the record (do not append)
 		}
 		if len(kept) == 0 {
 			continue
@@ -144,7 +159,7 @@ func strip(logs *iotextypes.TransactionLogs, recs []forgedRec) (*iotextypes.Tran
 			Transactions:    kept,
 		})
 	}
-	return out, removed
+	return out, matched
 }
 
 func countTx(logs *iotextypes.TransactionLogs) int {
@@ -155,7 +170,7 @@ func countTx(logs *iotextypes.TransactionLogs) int {
 	return n
 }
 
-func readForged(path string) ([]forgedRec, error) {
+func readCSV(path string, correct bool) ([]patchRec, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -165,32 +180,55 @@ func readForged(path string) ([]forgedRec, error) {
 	if err != nil {
 		return nil, err
 	}
-	var out []forgedRec
+	need := 5
+	if correct {
+		need = 6
+	}
+	var out []patchRec
 	oneIOTX := new(big.Int).Exp(big.NewInt(10), big.NewInt(18), nil)
 	for i, r := range rows {
 		if i == 0 && strings.HasPrefix(r[0], "block") { // header
 			continue
 		}
-		if len(r) < 5 {
-			return nil, fmt.Errorf("row %d: expected 5 columns, got %d", i, len(r))
+		if len(r) < need {
+			return nil, fmt.Errorf("row %d: expected %d columns, got %d", i, need, len(r))
 		}
 		var h uint64
 		if _, err := fmt.Sscan(r[0], &h); err != nil {
 			return nil, fmt.Errorf("row %d: bad height %q: %w", i, r[0], err)
 		}
-		iotx, ok := new(big.Int).SetString(strings.TrimSpace(r[4]), 10)
-		if !ok {
-			return nil, fmt.Errorf("row %d: bad amount %q", i, r[4])
-		}
-		out = append(out, forgedRec{
+		rec := patchRec{
 			height:    h,
 			actHash:   strings.TrimPrefix(strings.TrimSpace(r[1]), "0x"),
 			sender:    strings.TrimSpace(r[2]),
 			recipient: strings.TrimSpace(r[3]),
-			amountRau: new(big.Int).Mul(iotx, oneIOTX).String(),
-		})
+		}
+		if correct {
+			// amounts already in RAU
+			for _, c := range []string{r[4], r[5]} {
+				if _, ok := new(big.Int).SetString(strings.TrimSpace(c), 10); !ok {
+					return nil, fmt.Errorf("row %d: bad RAU amount %q", i, c)
+				}
+			}
+			rec.amountRau = strings.TrimSpace(r[4])
+			rec.newRau = strings.TrimSpace(r[5])
+		} else {
+			iotx, ok := new(big.Int).SetString(strings.TrimSpace(r[4]), 10)
+			if !ok {
+				return nil, fmt.Errorf("row %d: bad amount %q", i, r[4])
+			}
+			rec.amountRau = new(big.Int).Mul(iotx, oneIOTX).String()
+		}
+		out = append(out, rec)
 	}
 	return out, nil
+}
+
+func mode(correct bool) string {
+	if correct {
+		return "correct"
+	}
+	return "strip"
 }
 
 func fatal(err error) {


### PR DESCRIPTION
## What

Fixes a bug where the `IN_CONTRACT_TRANSFER` transaction log recorded for a `SELFDESTRUCT` carries the wrong amount.

`generateSelfDestructTransferLog` stored `stateDB.lastAddBalanceAmount` — a `*big.Int` — directly into the transaction log:

```go
Amount: stateDB.lastAddBalanceAmount,
```

That `big.Int` is mutated in place (`SetBytes`/`SetUint64`) by **every subsequent `AddBalance`**. In particular, right after the EVM returns, `ExecuteContract` refunds the gas deposit via `stateDB.AddBalance(origin, depositGas*gasPrice, …)`. Since `SELFDESTRUCT` is the last transfer inside the EVM frame, that gas-refund `AddBalance` runs *after* the self-destruct log was recorded and overwrites the aliased `big.Int` — so the already-recorded log ends up reporting the **gas-refund amount** instead of the value actually transferred to the beneficiary.

## Impact

Transaction logs are not part of any receipt root or state root, so **balances, receipts, and block hashes are unaffected** and nodes do not fork. Only the transaction logs served for such actions are wrong; systems that reconstruct balances from transaction logs (indexers, wallets, exchanges) can be misled.

On mainnet this surfaced on MEV/arbitrage bots that make a value-carrying sub-call which reverts and then self-destruct (post-Upernavik). Because a given bot uses a fixed `gasLimit`/`gasPrice`, the corrupting gas-refund is a constant, so the same wrong amount is stamped onto every such log in a block (e.g. `0.274835 IOTX`), while the real self-destruct amounts differ per action.

## Fix

Copy the amount instead of aliasing the mutable pointer:

```go
Amount: new(big.Int).Set(stateDB.lastAddBalanceAmount),
```

(This matches how the in-contract-transfer log records its amount.)

## Test

`e2etest/TestSelfDestructTransactionLogAmount` reproduces the on-chain pattern — a contract makes a value-carrying sub-call that reverts, then self-destructs, batched in one minted block — and asserts the self-destruct log reports the transferred amount, not the gas refund. It fails on the old code (log amount = gas refund) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Correcting already-recorded logs

`tools/txlogpatch` gains a `-correct` mode so the transaction logs already written for affected heights can be corrected without a re-sync (via the existing `chain.patchTransactionLogPath` / `TransactionLogIndexer` channel). Unlike the default strip mode (which removes a record), correct mode rewrites only the amount of a matched `IN_CONTRACT_TRANSFER` record — CSV: `block_height,tx_hash,sender,recipient,wrong_amount_rau,correct_amount_rau`. The correct amount for each record is the value actually transferred by the self-destruct (the `SELFDESTRUCT` opcode value, obtainable from `debug_traceTransaction`).
