### PR TITLE
fix(api): serve tx receipt as soon as its block is queryable

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -1066,8 +1066,38 @@ func (core *coreService) TransactionLogByBlockHeight(blockHeight uint64) (*iotex
 	return blockIdentifier, sysLog, nil
 }
 
+// TipHeight returns the tip height that is fully queryable through the API.
+//
+// It is the blockchain tip capped by the action-indexer height. A block is
+// committed to the block store (which advances the blockchain tip) before its
+// actions and receipts are written to the action indexer, and by default that
+// indexing happens asynchronously (see chain config EnableAsyncIndexWrite). This
+// leaves a brief window in which a block is already the "latest" block yet its
+// receipts cannot be resolved by hash, so eth_getTransactionReceipt returns nil
+// even though eth_getBlockByNumber("latest") already returns the block (see
+// https://github.com/iotexproject/iotex-core/issues/4677).
+//
+// Capping the reported tip at the indexer height makes a block become "latest"
+// only once its actions/receipts are indexed and can be served, so the block and
+// its receipts appear atomically to API clients. The action indexer's Height() is
+// an in-memory read guarded by the same lock as its writes, so once it reports
+// height N the action index for block N is committed. This affects only the
+// API's view of the tip; it does not touch consensus, which reads
+// blockchain.TipHeight() directly.
 func (core *coreService) TipHeight() uint64 {
-	return core.bc.TipHeight()
+	tipHeight := core.bc.TipHeight()
+	if core.indexer == nil {
+		return tipHeight
+	}
+	indexHeight, err := core.indexer.Height()
+	if err != nil {
+		// fall back to the blockchain tip if the indexer height is unavailable
+		return tipHeight
+	}
+	if indexHeight < tipHeight {
+		return indexHeight
+	}
+	return tipHeight
 }
 
 // Start starts the API server

--- a/api/coreservice_test.go
+++ b/api/coreservice_test.go
@@ -1055,3 +1055,42 @@ type mockWS struct {
 var _ protocol.StateManagerWithCloser = (*mockWS)(nil)
 
 func (m *mockWS) Close() {}
+
+func TestTipHeight(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	bc := mock_blockchain.NewMockBlockchain(ctrl)
+	indexer := mock_blockindex.NewMockIndexer(ctrl)
+	cs := &coreService{bc: bc}
+
+	t.Run("NoIndexer", func(t *testing.T) {
+		// without an action indexer the blockchain tip is returned as-is
+		bc.EXPECT().TipHeight().Return(uint64(100)).Times(1)
+		require.Equal(uint64(100), cs.TipHeight())
+	})
+
+	cs.indexer = indexer
+
+	t.Run("IndexerBehind", func(t *testing.T) {
+		// block store advanced to 100 but the (async) action indexer only reached
+		// 99; the API must report 99 so a block is advertised as latest only once
+		// its actions/receipts are indexed and queryable. See issue #4677.
+		bc.EXPECT().TipHeight().Return(uint64(100)).Times(1)
+		indexer.EXPECT().Height().Return(uint64(99), nil).Times(1)
+		require.Equal(uint64(99), cs.TipHeight())
+	})
+
+	t.Run("IndexerCaughtUp", func(t *testing.T) {
+		bc.EXPECT().TipHeight().Return(uint64(100)).Times(1)
+		indexer.EXPECT().Height().Return(uint64(100), nil).Times(1)
+		require.Equal(uint64(100), cs.TipHeight())
+	})
+
+	t.Run("IndexerHeightErrorFallsBackToChainTip", func(t *testing.T) {
+		bc.EXPECT().TipHeight().Return(uint64(100)).Times(1)
+		indexer.EXPECT().Height().Return(uint64(0), errors.New("boom")).Times(1)
+		require.Equal(uint64(100), cs.TipHeight())
+	})
+}


### PR DESCRIPTION
## Problem

Closes #4677.

A transaction's receipt was returned as `nil` by `eth_getTransactionReceipt` for a brief window right after its block became the latest block (typically during syncing), then became available a few seconds later. The block was queryable via `eth_getBlockByNumber("latest")` / `eth_getBlockByHash` before its receipt/action index was ready.

## Root cause

Inside `blockdao.PutBlock`, the block is written to the block store first — which advances the blockchain tip and makes the block queryable — and only afterwards are its actions/receipts written to the action indexer. The block store must be written before the indexers because crash recovery (`BlockIndexerChecker`) requires the indexers to never be ahead of the block store.

By default `EnableAsyncIndexWrite` is `true`, so the action indexer is driven by a block subscriber (`IndexBuilder`) on a separate goroutine. This widens the gap: the block is already `latest` while its `actionHash → blockHeight` index (used by both `ActionByActionHash` and `ReceiptByActionHash`) has not been committed yet, so the receipt cannot be resolved by hash.

The receipt data itself is in the block store as soon as the block is queryable; the only missing piece during the window is the action index.

## Fix

Cap the API-visible tip (`coreService.TipHeight()`) at the action-indexer height:

```go
tip := bc.TipHeight()
if idxHeight < tip { return idxHeight }
return tip
```

A block therefore becomes `latest` only once its actions/receipts are indexed and can be served, so the block and its receipts appear atomically to API clients.

## Why it's safe

- **Non-consensus, non-hardfork.** This only changes the API's view of the tip. Consensus reads `blockchain.TipHeight()` directly and is untouched, as are hardfork/chain-id gating checks (`core.bc.TipHeight()`).
- **Correct readiness boundary.** The indexer's `Height()` shares the same lock as its `PutBlock`, so once it reports height `N` the action index for block `N` is committed and queryable.
- **Cheap.** `Height()` is an in-memory `RLock` read of a counting-index size.
- **Monotonic.** Both chain tip and indexer height are append-only, so `min(...)` is non-decreasing. If `Height()` errors, it falls back to the chain tip (no worse than before).

## Tests

Added `TestTipHeight` covering: no indexer, indexer behind, indexer caught up, and indexer error fallback. Codex review: CONVERGED, no blocking issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)