### PR TITLE
fix(evm): don't panic in SetNonce on the simulation/trace path

### DIFF
--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -299,6 +299,21 @@ func (stateDB *StateDBAdapter) assertError(err error, msg string, fields ...zap.
 	return true
 }
 
+// assertMessage mirrors assertError for invariant violations that are not tied to an
+// error value. On the block-processing/consensus path (panicUnrecoverableError == true)
+// it panics, halting the node on a truly unrecoverable state error (poison-block
+// protection). On the simulation/trace/API path (panicUnrecoverableError == false) it
+// degrades to an Error log and records the error, so the caller returns a soft error
+// instead of crashing the process. This keeps these direct panics consistent with
+// assertError, which already never panics when panicUnrecoverableError is false.
+func (stateDB *StateDBAdapter) assertMessage(msg string, fields ...zap.Field) {
+	if stateDB.panicUnrecoverableError {
+		log.T(stateDB.ctx).Panic(msg, fields...)
+	}
+	log.T(stateDB.ctx).Error(msg, fields...)
+	stateDB.logError(errors.New(msg))
+}
+
 // Error returns the first stored error during evm contract execution
 func (stateDB *StateDBAdapter) Error() error {
 	return stateDB.err
@@ -472,7 +487,8 @@ func (stateDB *StateDBAdapter) GetNonce(evmAddr common.Address) uint64 {
 	}
 	if stateDB.useConfirmedNonce {
 		if pendingNonce == 0 {
-			log.T(stateDB.ctx).Panic("invalid pending nonce")
+			stateDB.assertMessage("invalid pending nonce")
+			return pendingNonce
 		}
 		pendingNonce--
 	}
@@ -495,7 +511,8 @@ func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64, _ 
 	}
 	if !stateDB.useConfirmedNonce {
 		if nonce == 0 {
-			log.T(stateDB.ctx).Panic("invalid nonce zero")
+			stateDB.assertMessage("invalid nonce zero")
+			return
 		}
 		nonce--
 	}
@@ -504,8 +521,9 @@ func (stateDB *StateDBAdapter) SetNonce(evmAddr common.Address, nonce uint64, _ 
 		zap.Uint64("nonce", nonce))
 	if !s.IsNewbieAccount() || s.AccountType() != 0 || nonce != 0 || stateDB.zeroNonceForFreshAccount {
 		if err := s.SetPendingNonce(nonce + 1); err != nil {
-			log.T(stateDB.ctx).Panic("Failed to set nonce.", zap.Error(err), zap.String("addr", addr.Hex()), zap.Uint64("pendingNonce", s.PendingNonce()), zap.Uint64("nonce", nonce), zap.String("execution", hex.EncodeToString(stateDB.executionHash[:])))
-			stateDB.logError(err)
+			if stateDB.assertError(err, "Failed to set nonce.", zap.Error(err), zap.String("addr", addr.Hex()), zap.Uint64("pendingNonce", s.PendingNonce()), zap.Uint64("nonce", nonce), zap.String("execution", hex.EncodeToString(stateDB.executionHash[:]))) {
+				return
+			}
 		}
 	}
 	err = accountutil.StoreAccount(stateDB.sm, addr, s)

--- a/action/protocol/execution/evm/evmstatedbadapter_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_test.go
@@ -381,6 +381,65 @@ func TestNonce(t *testing.T) {
 	})
 }
 
+// TestSetNoncePanicGating verifies that the nonce-related invariant panics reachable from
+// the simulation/trace/API path (panicUnrecoverableError == false) degrade to a recorded
+// soft error instead of crashing the process, while the block-processing/consensus path
+// (panicUnrecoverableError == true) still panics unchanged. These are the replay-data
+// driven panics behind issue #4745.
+func TestSetNoncePanicGating(t *testing.T) {
+	require := require.New(t)
+	addr := common.HexToAddress("02ae2a956d21e8d481c3a69e146633470cf625ec")
+
+	// newStateDB builds a fresh adapter; panicUnrecoverable toggles the consensus flag,
+	// extra lets a case add case-specific options.
+	newStateDB := func(t *testing.T, panicUnrecoverable bool, extra ...StateDBAdapterOption) *StateDBAdapter {
+		ctrl := gomock.NewController(t)
+		sm, err := initMockStateManager(ctrl)
+		require.NoError(err)
+		opts := []StateDBAdapterOption{
+			NotFixTopicCopyBugOption(),
+			FixSnapshotOrderOption(),
+		}
+		opts = append(opts, extra...)
+		if panicUnrecoverable {
+			opts = append(opts, PanicUnrecoverableErrorOption())
+		}
+		stateDB, err := NewStateDBAdapter(sm, 1, hash.ZeroHash256, opts...)
+		require.NoError(err)
+		return stateDB
+	}
+
+	cases := []struct {
+		name string
+		// trigger drives the adapter into the invariant-violation branch.
+		trigger func(stateDB *StateDBAdapter)
+	}{
+		{
+			// SetNonce -> SetPendingNonce returns an error (the exact stack in #4745).
+			// A fresh type-0 account expects pending nonce 2; supplying 3 forces the error.
+			name:    "SetNonce/SetPendingNonce-error",
+			trigger: func(stateDB *StateDBAdapter) { stateDB.SetNonce(addr, 3, 0) },
+		},
+		{
+			// SetNonce with pending-nonce mode and nonce == 0 ("invalid nonce zero").
+			name:    "SetNonce/invalid-nonce-zero",
+			trigger: func(stateDB *StateDBAdapter) { stateDB.SetNonce(addr, 0, 0) },
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name+"/simulation-does-not-panic", func(t *testing.T) {
+			stateDB := newStateDB(t, false)
+			require.NotPanics(func() { c.trigger(stateDB) })
+			require.Error(stateDB.Error())
+		})
+		t.Run(c.name+"/consensus-still-panics", func(t *testing.T) {
+			stateDB := newStateDB(t, true)
+			require.Panics(func() { c.trigger(stateDB) })
+		})
+	}
+}
+
 var tests = []stateDBTest{
 	{
 		[]bal{


### PR DESCRIPTION
## Problem

`StateDBAdapter.SetNonce` (`action/protocol/execution/evm/evmstatedbadapter.go`) had two direct `log.T(ctx).Panic` calls that were **not** gated by `panicUnrecoverableError`. Most error sites in this file go through `assertError`, which only panics when `panicUnrecoverableError == true` (the block-processing/consensus path, enabled post-Upernavik via `featureCtx.PanicUnrecoverableError = IsUpernavik(height)`) and otherwise logs an `Error` + records the error. These two `SetNonce` panics bypassed that gate, so `debug_traceBlock*` / `eth_call` replaying certain historical blocks **crashed the node** instead of returning a soft error.

This is the exact stack in #4745: `SetPendingNonce` returns `"nonce overflow"` while replaying a pre-Upernavik block (height 25,111,171, `0x17f2a83`), where `panicUnrecoverableError` is `false`, yet the ungated direct panic fired anyway — then got recovered in `WorkingSetAtTransaction` and cascaded into a downstream nil-pointer deref in `traceBlock`.

## Fix

Add an `assertMessage` helper that mirrors `assertError`'s gating for panics not tied to an `err` value, and route the ungated nonce panics through gating:

- **`SetNonce` "invalid nonce zero"** (pending-nonce mode, `nonce == 0`) → `assertMessage` + early return.
- **`SetNonce` "Failed to set nonce."** (`SetPendingNonce` returns an error — the #4745 site) → routed through the existing `assertError` (it already carries an `err`), then early return.
- **`GetNonce` "invalid pending nonce"** → `assertMessage` for consistency with the sibling nonce guards.

On the consensus path (`panicUnrecoverableError == true`) all three still `Panic` with the **same message and zap fields** — poison-block protection during block production is preserved. On the simulation/trace/API path (`false`) they now log an `Error`, record the error via `logError`, and return gracefully, exactly like every other `assertError` site.

## Consensus-safety

- **Not a hardfork.** Behavior is byte-for-byte identical when `panicUnrecoverableError == true`; the change only affects the `false` path (simulation/trace/`eth_call`), which is non-consensus.
- The early `return` before `StoreAccount` on a `SetPendingNonce` error is state-neutral: `state.Account.SetPendingNonce`'s error paths do not advance the nonce, so nothing partial is written.
- For any block that does **not** hit these guards, control flow is unchanged.

## Scope / other panic sites audited

Other direct `log.T(ctx).Panic` sites in this file were reviewed and deliberately left unchanged:

- **Already gated** by `panicUnrecoverableError`: `GetNonce` "Failed to get nonce.", `RevertToSnapshot`.
- **Pure EVM-internal invariants** (only an implementation bug, not replay data, can trigger them) with a dedicated security guard/test: `SubRefund` "Refund counter not enough!" (asserted by `TestRefundBounds`), `AddBalance` touch-account non-zero amount. Left as hard guards.
- **Hardfork-flag gated / documented as a separate change**: `Snapshot` duplicate version (`fixSnapshotOrder`), `AddLog` `len(topics)!=3` (explicit "separate change" comment), self-destruct balance mismatch (`suicideTxLogMismatchPanic`).

## The other two #4745 failure modes (out of scope)

The issue reports three block traces. This PR fixes only the hard **panic** (block `0x17f2a83`), which is the crash/DoS. The other two are already returned as graceful JSON-RPC errors, not panics, and are **separate replay-data correctness issues** in how `traceBlock` re-executes historical blocks:

- `"nonce too low"` (`0x248c462`) — trace re-execution computes a different nonce than the original block.
- `"failed to deposit gas: ... state does not exist"` (`0x5281e1`) — historical account state not available during replay.

These need separate investigation and are **not** addressed here.

## Testing

- New `TestSetNoncePanicGating` drives both `SetNonce` panic sites with `panicUnrecoverableError=false` (asserts no panic + `Error()` recorded) and `=true` (asserts `require.Panics`). Confirmed the `false` case panics on master before the fix.
- `go build ./...`, `go test ./action/protocol/execution/evm/ -count=1` pass.

Partially addresses #4745 (fixes the SetNonce panic mode only; the two replay-data modes — "nonce too low" and "state does not exist" — remain open for separate investigation, so this PR intentionally does NOT auto-close the issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)