### PR TITLE
fix(factory): error on historical state read on non-archive node instead of returning latest

### DIFF
--- a/api/coreservice.go
+++ b/api/coreservice.go
@@ -422,6 +422,12 @@ func (core *coreService) CodeAt(ctx context.Context, addr address.Address, heigh
 		return nil, nil
 	}
 	ctx, ws, err := core.workingSetAt(ctx, height)
+	if err != nil {
+		// workingSetAt returns a nil ws on error (e.g. a historical read on a
+		// non-archive node now returns ErrNotSupported); guard the deferred
+		// Close against a nil-pointer panic.
+		return nil, err
+	}
 	defer ws.Close()
 	state, err := accountutil.AccountState(ctx, ws, addr)
 	if err != nil {
@@ -2045,6 +2051,12 @@ func (core *coreService) ReadContractStorage(ctx context.Context, addr address.A
 
 func (core *coreService) ReadContractStorageAt(ctx context.Context, addr address.Address, key []byte, height uint64) ([]byte, error) {
 	ctx, ws, err := core.workingSetAt(ctx, height)
+	if err != nil {
+		// workingSetAt returns a nil ws on error (e.g. a historical read on a
+		// non-archive node now returns ErrNotSupported); guard the deferred
+		// Close against a nil-pointer panic.
+		return nil, err
+	}
 	defer ws.Close()
 	state, err := accountutil.AccountState(ctx, ws, addr)
 	if err != nil {

--- a/api/grpcserver_integrity_test.go
+++ b/api/grpcserver_integrity_test.go
@@ -2150,27 +2150,11 @@ func TestGrpcServer_GetEpochMetaIntegrity(t *testing.T) {
 		coreService, ok := svr.core.(*coreService)
 		require.True(ok)
 		coreService.readCache.Clear()
-		res, err := grpcHandler.GetEpochMeta(context.Background(), &iotexapi.GetEpochMetaRequest{EpochNumber: test.EpochNumber})
-		require.NoError(err)
-		require.Equal(test.epochData.Num, res.EpochData.Num)
-		require.Equal(test.epochData.Height, res.EpochData.Height)
-		require.Equal(test.epochData.GravityChainStartHeight, res.EpochData.GravityChainStartHeight)
-		require.Equal(test.numBlksInEpoch, int(res.TotalBlocks))
-		require.Equal(test.numConsenusBlockProducers, len(res.BlockProducersInfo))
-		var numActiveBlockProducers int
-		var prevInfo *iotexapi.BlockProducerInfo
-		for _, bp := range res.BlockProducersInfo {
-			if bp.Active {
-				numActiveBlockProducers++
-			}
-			if prevInfo != nil {
-				prevVotes, _ := strconv.Atoi(prevInfo.Votes)
-				currVotes, _ := strconv.Atoi(bp.Votes)
-				require.True(prevVotes >= currVotes)
-			}
-			prevInfo = bp
-		}
-		require.Equal(test.numActiveCensusBlockProducers, numActiveBlockProducers)
+		// the epoch under test (height 1) is below the non-archive statedb's tip
+		// (height 4): a historical protocol-state read is rejected rather than
+		// silently served from latest state (issue #4916).
+		_, err := grpcHandler.GetEpochMeta(context.Background(), &iotexapi.GetEpochMetaRequest{EpochNumber: test.EpochNumber})
+		require.ErrorContains(err, "not available on a non-archive node")
 	}
 
 	// failure: epoch number

--- a/api/web3server_integrity_test.go
+++ b/api/web3server_integrity_test.go
@@ -272,7 +272,6 @@ func getTransactionCount(t *testing.T, handler *hTTPHandler) {
 		params   string
 		expected int
 	}{
-		{`["0xDa7e12Ef57c236a06117c5e0d04a228e7181CF36", "0x1"]`, 2},
 		{`["0xDa7e12Ef57c236a06117c5e0d04a228e7181CF36", "pending"]`, 2},
 	} {
 		result := serveTestHTTP(require, handler, "eth_getTransactionCount", test.params)
@@ -280,6 +279,22 @@ func getTransactionCount(t *testing.T, handler *hTTPHandler) {
 		require.True(ok)
 		require.Equal(uint64ToHex(uint64(test.expected)), actual)
 	}
+
+	// an explicit historical height ("0x1") on a non-archive node is rejected
+	// rather than silently served from latest state (issue #4916).
+	req, _ := http.NewRequest(http.MethodPost, "http://url.com",
+		strings.NewReader(`[{"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0xDa7e12Ef57c236a06117c5e0d04a228e7181CF36", "0x1"],"id":1}]`))
+	resp := httptest.NewRecorder()
+	handler.ServeHTTP(resp, req)
+	var vals []struct {
+		Error *struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	require.NoError(json.NewDecoder(resp.Body).Decode(&vals))
+	require.NotEmpty(vals)
+	require.NotNil(vals[0].Error)
+	require.Contains(vals[0].Error.Message, "not available on a non-archive node")
 }
 
 func ethCall(t *testing.T, handler *hTTPHandler) {

--- a/blockchain/integrity/integrity_test.go
+++ b/blockchain/integrity/integrity_test.go
@@ -2417,9 +2417,10 @@ func TestHistoryForAccount(t *testing.T) {
 	require.Equal(big.NewInt(90), AccountA.Balance)
 	require.Equal(big.NewInt(110), AccountB.Balance)
 
-	// check history account's balance
+	// a non-archive statedb keeps no historical state: a read below the tip is
+	// rejected rather than silently served from latest state (issue #4916).
 	_, err = sf.WorkingSetAtHeight(ctx, 0)
-	require.NoError(err)
+	require.ErrorIs(err, factory.ErrNotSupported)
 }
 
 func TestHistoryForContract(t *testing.T) {
@@ -2449,9 +2450,10 @@ func TestHistoryForContract(t *testing.T) {
 	require.True(ok)
 	require.Equal(expect, balance)
 
-	// check the original balance again
+	// a non-archive statedb keeps no historical state: a read below the tip is
+	// rejected rather than silently served from latest state (issue #4916).
 	_, err = sf.WorkingSetAtHeight(ctx, bc.TipHeight()-1)
-	require.NoError(err)
+	require.ErrorIs(err, factory.ErrNotSupported)
 }
 
 func deployXrc20(bc blockchain.Blockchain, dao blockdao.BlockDAO, ap actpool.ActPool, t *testing.T) string {

--- a/state/factory/factory_test.go
+++ b/state/factory/factory_test.go
@@ -618,9 +618,10 @@ func testHistoryState(sf Factory, t *testing.T, statetx, archive bool) {
 
 	// check archive data
 	if statetx {
-		// statetx not support archive mode yet
+		// statetx (non-archive) keeps no historical state: a read below the tip
+		// is rejected rather than silently served from latest state (issue #4916).
 		_, err = sf.WorkingSetAtHeight(ctx, 0)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, ErrNotSupported)
 	} else {
 		_, err = sf.WorkingSetAtHeight(ctx, 10)
 		if !archive {

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -466,6 +466,31 @@ func (sdb *stateDB) WorkingSetAtTransaction(ctx context.Context, height uint64, 
 }
 
 func (sdb *stateDB) WorkingSetAtHeight(ctx context.Context, height uint64) (protocol.StateManagerWithCloser, error) {
+	// A non-archive node (no erigonDB) keeps no historical state: daoRetrofitter
+	// .atHeight ignores the height and always returns the latest KV store. A read
+	// at a past height would therefore silently return latest-tip state instead of
+	// the true historical value (e.g. eth_getBalance at an old block returning the
+	// current balance). Reject it so callers get a clear error and know to use an
+	// archive node, rather than a wrong-but-plausible answer. height >= tip (latest,
+	// or the next-block working set) is served normally.
+	// The "latest" sentinel (block number 0) is normalized to the tip by callers
+	// (e.g. BalanceAt/PendingNonceAt map 0 -> TipHeight before calling), so any
+	// height that reaches here is an explicit block height. On a non-archive node
+	// every height strictly below the tip — including an explicit genesis (0) —
+	// cannot be served from historical state and would otherwise fall through to
+	// latest; reject it so callers get a clear error instead of a wrong value.
+	if sdb.erigonDB == nil {
+		sdb.mutex.RLock()
+		tip := sdb.currentChainHeight
+		sdb.mutex.RUnlock()
+		if height < tip {
+			return nil, errors.Wrapf(
+				ErrNotSupported,
+				"historical state at height %d is not available on a non-archive node (current tip %d); use an archive node",
+				height, tip,
+			)
+		}
+	}
 	ws, err := sdb.newReadOnlyWorkingSet(ctx, height)
 	if err != nil {
 		return nil, err

--- a/state/factory/statedb_nonarchive_test.go
+++ b/state/factory/statedb_nonarchive_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package factory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/db"
+)
+
+// TestWorkingSetAtHeightNonArchive verifies that on a non-archive node a
+// historical-height state read is rejected with ErrNotSupported instead of
+// silently returning latest-tip state (issue #4916), while a read at the tip
+// still works. Root cause: daoRetrofitter.atHeight ignores the height and
+// always returns the latest KV store, so without this guard eth_getBalance at
+// an old block returns the current balance.
+func TestWorkingSetAtHeightNonArchive(t *testing.T) {
+	r := require.New(t)
+	cfg := DefaultConfig
+	sdb, err := NewStateDB(cfg, db.NewMemKVStore(), SkipBlockValidationStateDBOption())
+	r.NoError(err)
+	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
+	r.NoError(sdb.Start(ctx))
+	defer func() { r.NoError(sdb.Stop(ctx)) }()
+
+	s := sdb.(*stateDB)
+	r.Nil(s.erigonDB, "test assumes a non-archive (no erigonDB) statedb")
+
+	// simulate a chain that has advanced to height 100
+	s.mutex.Lock()
+	s.currentChainHeight = 100
+	s.mutex.Unlock()
+
+	// latest (height == tip) is served normally
+	wsTip, err := sdb.WorkingSetAtHeight(ctx, 100)
+	r.NoError(err)
+	r.NotNil(wsTip)
+	wsTip.Close()
+
+	// any past height — including an explicit genesis (0) — is rejected, not
+	// silently answered from latest state
+	for _, h := range []uint64{0, 1, 50, 99} {
+		_, err = sdb.WorkingSetAtHeight(ctx, h)
+		r.Error(err)
+		r.True(errors.Is(err, ErrNotSupported), "height %d should be ErrNotSupported, got %v", h, err)
+		r.Contains(err.Error(), "non-archive node")
+	}
+
+	// when the tip is still genesis (0), height 0 is the tip and is served
+	s.mutex.Lock()
+	s.currentChainHeight = 0
+	s.mutex.Unlock()
+	wsGenesis, err := sdb.WorkingSetAtHeight(ctx, 0)
+	r.NoError(err)
+	r.NotNil(wsGenesis)
+	wsGenesis.Close()
+}


### PR DESCRIPTION
## Problem

On a **non-archive** node, `daoRetrofitter.atHeight` ignores the requested height and always returns the latest KV store. So a state read at a past height silently returned **latest-tip** state instead of the true historical value — e.g. `eth_getBalance(addr, <old height>)` returned the *current* balance. This broke exchange reconciliation: Binance saw different balances for the same (addr, height) between a non-archive fullnode and an archive endpoint (`babel-api`). Reported in #4916.

An archive node already handles this correctly (it errors with "history is pruned" via the erigon retention check). Only the non-archive path was silently wrong.

## Fix

Guard `WorkingSetAtHeight`: on a non-archive node (`erigonDB == nil`), any height **strictly below the tip** now returns `ErrNotSupported` with a clear "use an archive node" message, instead of a wrong-but-plausible latest value.

- The "latest" sentinel (block number 0) is normalized to the tip by callers (`BalanceAt`/`PendingNonceAt`) *before* this point, so a height reaching here is an explicit block height — including an explicit genesis (0), which is likewise rejected below the tip.
- `height == tip` is served; when the tip is still genesis (0) a height-0 read is served as the tip.
- Archive nodes unchanged.
- Also hardens `CodeAt` / `ReadContractStorageAt`, which `defer ws.Close()` before checking the `workingSetAt` error — now that the guard can return a nil ws, they check the error first to avoid a nil-pointer panic (found in review).

**Non-consensus, non-hardfork** — query/API state-read path only. Block production/validation build working sets via `newWorkingSet` (not `WorkingSetAtHeight`) and are untouched.

## Testing

- New `TestWorkingSetAtHeightNonArchive`: past heights (incl. genesis 0) → `ErrNotSupported`; `height == tip` served; tip==0 genesis served.
- Existing History tests asserted the old silent-latest behavior on a non-archive statedb; updated to expect `ErrNotSupported`.
- `go build ./...`, `state/factory`, `blockchain/integrity` History tests, and `api` balance/code/storage tests pass. (Pre-existing `TestEstimateExecutionGasConsumption` failure is a local Go 1.26 gomonkey issue, green on CI's Go 1.23, unrelated.)
- codex review: CONVERGED.

Closes #4916

🤖 Generated with [Claude Code](https://claude.com/claude-code)