### PR TITLE
fix(evm): drop reserved-topic logs with unexpected topic count

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -170,8 +170,9 @@ type (
 		// AlwaysWriteCachedContract if true, CommitContracts writes back all cached
 		// contracts regardless of whether they were modified; if false, only dirty
 		// contracts are committed and written back
-		AlwaysWriteCachedContract bool
-		NoCandidateExitQueue      bool
+		AlwaysWriteCachedContract     bool
+		NoCandidateExitQueue          bool
+		FixInContractTransferLogTopic bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -346,6 +347,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			PrePectraEVM:                            !g.IsYap(height),
 			AlwaysWriteCachedContract:               !g.IsYap(height),
 			NoCandidateExitQueue:                    !g.IsYap(height),
+			FixInContractTransferLogTopic:           g.IsToBeEnabled(height),
 		},
 	)
 }

--- a/action/protocol/execution/evm/evm.go
+++ b/action/protocol/execution/evm/evm.go
@@ -527,6 +527,9 @@ func prepareStateDBAdapter(ctx context.Context, sm protocol.StateManager) (*Stat
 	if featureCtx.SuicideTxLogMismatchPanic {
 		opts = append(opts, SuicideTxLogMismatchPanicOption())
 	}
+	if featureCtx.FixInContractTransferLogTopic {
+		opts = append(opts, FixInContractTransferTopicOption())
+	}
 	if featureCtx.PanicUnrecoverableError {
 		opts = append(opts, PanicUnrecoverableErrorOption())
 	}

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -91,6 +91,7 @@ type (
 		panicUnrecoverableError    bool
 		enableCancun               bool
 		fixRevertSnapshot          bool
+		fixInContractTransferTopic bool
 		// ignoreBalanceChangeTouchAccount indicates whether to ignore balance change touch account
 		ignoreBalanceChangeTouchAccount bool
 		// skipWriteCleanContract indicates whether to skip writing back read-only
@@ -174,6 +175,15 @@ func ManualCorrectGasRefundOption() StateDBAdapterOption {
 func SuicideTxLogMismatchPanicOption() StateDBAdapterOption {
 	return func(adapter *StateDBAdapter) error {
 		adapter.suicideTxLogMismatchPanic = true
+		return nil
+	}
+}
+
+// FixInContractTransferTopicOption drops reserved-topic logs with an unexpected
+// topic count uniformly instead of special-casing them.
+func FixInContractTransferTopicOption() StateDBAdapterOption {
+	return func(adapter *StateDBAdapter) error {
+		adapter.fixInContractTransferTopic = true
 		return nil
 	}
 }
@@ -941,9 +951,10 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 		// log. It is dropped here, exactly as before it was never appended to
 		// stateDB.logs, so receipt.Logs (and thus the receipt root) is unchanged.
 		//
-		// NOTE: the historical len(topics) != 3 panic is preserved to keep behavior
-		// identical for malformed inputs; hardening that DoS is a separate change.
-		if len(topics) != 3 {
+		// A malformed one (topic count != 3) used to be special-cased; it is now
+		// dropped uniformly with the rest. The legacy special case is kept verbatim
+		// before the upgrade so block replay stays byte-identical, and removed after.
+		if !stateDB.fixInContractTransferTopic && len(topics) != 3 {
 			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics", zap.String("address", addr.String()), stateDB.actionHashField())
 		}
 		return

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -946,18 +946,21 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 	if len(topics) > 0 && topics[0] == _inContractTransfer {
 		// The reserved in-contract-transfer topic is emitted only by the node's own
 		// MakeTransfer, which now records the transaction log directly via
-		// AddInContractTransferLog. Any EVM log reaching AddLog with this topic is
-		// therefore contract-emitted (i.e. forged) and must NOT become a transaction
-		// log. It is dropped here, exactly as before it was never appended to
-		// stateDB.logs, so receipt.Logs (and thus the receipt root) is unchanged.
-		//
-		// A malformed one (topic count != 3) used to be special-cased; it is now
-		// dropped uniformly with the rest. The legacy special case is kept verbatim
-		// before the upgrade so block replay stays byte-identical, and removed after.
-		if !stateDB.fixInContractTransferTopic && len(topics) != 3 {
+		// AddInContractTransferLog. A well-formed 3-topic log reaching AddLog with
+		// this topic therefore collides with that reserved log's shape (i.e.
+		// forged) and must NOT become a transaction log: it is dropped here,
+		// exactly as before it was never appended to stateDB.logs, so
+		// receipt.Logs (and thus the receipt root) is unchanged.
+		if len(topics) == 3 {
+			return
+		}
+		// A malformed one (topic count != 3) doesn't actually collide with the
+		// reserved log's shape. Before the upgrade it is kept panicking verbatim
+		// so block replay stays byte-identical; after the upgrade it is just a
+		// regular log like any other and falls through to be recorded below.
+		if !stateDB.fixInContractTransferTopic {
 			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics", zap.String("address", addr.String()), stateDB.actionHashField())
 		}
-		return
 	}
 
 	stateDB.logs = append(stateDB.logs, &action.Log{

--- a/action/protocol/execution/evm/evmstatedbadapter.go
+++ b/action/protocol/execution/evm/evmstatedbadapter.go
@@ -943,24 +943,19 @@ func (stateDB *StateDBAdapter) AddLog(evmLog *types.Log) {
 		copy(topic[:], evmTopic.Bytes())
 		topics = append(topics, topic)
 	}
-	if len(topics) > 0 && topics[0] == _inContractTransfer {
-		// The reserved in-contract-transfer topic is emitted only by the node's own
-		// MakeTransfer, which now records the transaction log directly via
-		// AddInContractTransferLog. A well-formed 3-topic log reaching AddLog with
-		// this topic therefore collides with that reserved log's shape (i.e.
-		// forged) and must NOT become a transaction log: it is dropped here,
-		// exactly as before it was never appended to stateDB.logs, so
-		// receipt.Logs (and thus the receipt root) is unchanged.
-		if len(topics) == 3 {
-			return
-		}
-		// A malformed one (topic count != 3) doesn't actually collide with the
-		// reserved log's shape. Before the upgrade it is kept panicking verbatim
-		// so block replay stays byte-identical; after the upgrade it is just a
-		// regular log like any other and falls through to be recorded below.
-		if !stateDB.fixInContractTransferTopic {
+	if len(topics) > 0 && topics[0] == _inContractTransfer && !stateDB.fixInContractTransferTopic {
+		// Before the upgrade: the reserved in-contract-transfer topic is emitted
+		// only by the node's own MakeTransfer, which records the transaction log
+		// directly via AddInContractTransferLog. Any EVM log reaching AddLog with
+		// this topic is therefore contract-emitted (i.e. forged) and must NOT
+		// become a transaction log. It is dropped here, exactly as before it was
+		// never appended to stateDB.logs, so receipt.Logs (and thus the receipt
+		// root) is unchanged. Kept verbatim (including the malformed-topic-count
+		// panic) so block replay stays byte-identical pre-upgrade.
+		if len(topics) != 3 {
 			log.T(stateDB.ctx).Panic("Invalid in contract transfer topics", zap.String("address", addr.String()), stateDB.actionHashField())
 		}
+		return
 	}
 
 	stateDB.logs = append(stateDB.logs, &action.Log{

--- a/action/protocol/execution/evm/evmstatedbadapter_security_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_security_test.go
@@ -138,6 +138,30 @@ func TestAddLogReservedTopicInvariants(t *testing.T) {
 	})
 }
 
+// TestAddLogReservedTopicMalformedDroppedAfterUpgrade pins the post-upgrade
+// counterpart of the "wrong topic count panics" invariant above: once
+// FixInContractTransferTopicOption is active, a reserved-topic log with an
+// unexpected topic count is dropped uniformly (no panic, no event log, no
+// tx-log, no balance change), exactly like a well-formed contract-emitted one.
+func TestAddLogReservedTopicMalformedDroppedAfterUpgrade(t *testing.T) {
+	require := require.New(t)
+	from, to := _c1, _c2
+	for _, topics := range [][]common.Hash{
+		{reservedTopic()},                  // 1 topic
+		{reservedTopic(), addrTopic(from)}, // 2 topics
+		{reservedTopic(), addrTopic(from), addrTopic(to), addrTopic(from)}, // 4 topics
+	} {
+		stateDB := newAdapter(t, FixInContractTransferTopicOption())
+		stateDB.AddBalance(from, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
+		log := &types.Log{Address: _c3, Topics: topics, Data: big.NewInt(1).Bytes()}
+		require.NotPanics(func() { stateDB.AddLog(log) })
+		require.Zero(len(stateDB.Logs()))                             // not an event log
+		require.Zero(len(stateDB.TransactionLogs()))                  // not a tx-log
+		require.Equal(uint256.NewInt(1000), stateDB.GetBalance(from)) // no balance moved
+		require.True(stateDB.GetBalance(to).IsZero())
+	}
+}
+
 // TestTransferVsForgedLog is the adversarial contrast codex asked for: a forged
 // reserved-topic EVM log and a genuine MakeTransfer of the SAME from/to/amount
 // must diverge. The forged log moves no balance; the real transfer both moves

--- a/action/protocol/execution/evm/evmstatedbadapter_security_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_security_test.go
@@ -138,12 +138,14 @@ func TestAddLogReservedTopicInvariants(t *testing.T) {
 	})
 }
 
-// TestAddLogReservedTopicMalformedDroppedAfterUpgrade pins the post-upgrade
-// counterpart of the "wrong topic count panics" invariant above: once
-// FixInContractTransferTopicOption is active, a reserved-topic log with an
-// unexpected topic count is dropped uniformly (no panic, no event log, no
-// tx-log, no balance change), exactly like a well-formed contract-emitted one.
-func TestAddLogReservedTopicMalformedDroppedAfterUpgrade(t *testing.T) {
+// TestAddLogReservedTopicMalformedBecomesRegularLogAfterUpgrade pins the
+// post-upgrade counterpart of the "wrong topic count panics" invariant above:
+// once FixInContractTransferTopicOption is active, a reserved-topic log with
+// an unexpected topic count no longer panics, but it also isn't the reserved
+// marker's shape (that's always exactly 3 topics), so it is recorded as an
+// ordinary event log instead of being dropped — never a tx-log, never a
+// balance change.
+func TestAddLogReservedTopicMalformedBecomesRegularLogAfterUpgrade(t *testing.T) {
 	require := require.New(t)
 	from, to := _c1, _c2
 	for _, topics := range [][]common.Hash{
@@ -155,11 +157,33 @@ func TestAddLogReservedTopicMalformedDroppedAfterUpgrade(t *testing.T) {
 		stateDB.AddBalance(from, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
 		log := &types.Log{Address: _c3, Topics: topics, Data: big.NewInt(1).Bytes()}
 		require.NotPanics(func() { stateDB.AddLog(log) })
-		require.Zero(len(stateDB.Logs()))                             // not an event log
-		require.Zero(len(stateDB.TransactionLogs()))                  // not a tx-log
+		require.Len(stateDB.Logs(), 1) // recorded as a regular event log
+		gotTopics := stateDB.Logs()[0].Topics
+		require.Len(gotTopics, len(topics))
+		for i, tp := range topics {
+			require.Equal(tp.Bytes(), gotTopics[i][:]) // untouched, not reinterpreted
+		}
+		require.Zero(len(stateDB.TransactionLogs()))                  // never a tx-log
 		require.Equal(uint256.NewInt(1000), stateDB.GetBalance(from)) // no balance moved
 		require.True(stateDB.GetBalance(to).IsZero())
 	}
+}
+
+// TestAddLogReservedTopicWellFormedStillDroppedAfterUpgrade pins that, unlike
+// the malformed case above, a well-formed 3-topic reserved log (the shape that
+// actually collides with AddInContractTransferLog's own record) is still
+// dropped after the upgrade, exactly as before.
+func TestAddLogReservedTopicWellFormedStillDroppedAfterUpgrade(t *testing.T) {
+	require := require.New(t)
+	from, to := _c1, _c2
+	stateDB := newAdapter(t, FixInContractTransferTopicOption())
+	stateDB.AddBalance(from, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
+	log := &types.Log{Address: _c3, Topics: []common.Hash{reservedTopic(), addrTopic(from), addrTopic(to)}, Data: big.NewInt(1).Bytes()}
+	require.NotPanics(func() { stateDB.AddLog(log) })
+	require.Zero(len(stateDB.Logs()))
+	require.Zero(len(stateDB.TransactionLogs()))
+	require.Equal(uint256.NewInt(1000), stateDB.GetBalance(from))
+	require.True(stateDB.GetBalance(to).IsZero())
 }
 
 // TestTransferVsForgedLog is the adversarial contrast codex asked for: a forged

--- a/action/protocol/execution/evm/evmstatedbadapter_security_test.go
+++ b/action/protocol/execution/evm/evmstatedbadapter_security_test.go
@@ -138,19 +138,20 @@ func TestAddLogReservedTopicInvariants(t *testing.T) {
 	})
 }
 
-// TestAddLogReservedTopicMalformedBecomesRegularLogAfterUpgrade pins the
-// post-upgrade counterpart of the "wrong topic count panics" invariant above:
-// once FixInContractTransferTopicOption is active, a reserved-topic log with
-// an unexpected topic count no longer panics, but it also isn't the reserved
-// marker's shape (that's always exactly 3 topics), so it is recorded as an
-// ordinary event log instead of being dropped — never a tx-log, never a
-// balance change.
-func TestAddLogReservedTopicMalformedBecomesRegularLogAfterUpgrade(t *testing.T) {
+// TestAddLogReservedTopicBecomesRegularLogAfterUpgrade pins the post-upgrade
+// counterpart of the reserved-topic invariants above: once
+// FixInContractTransferTopicOption is active, AddLog no longer special-cases
+// the reserved topic at all — regardless of topic count (including the
+// well-formed 3-topic shape that collides with AddInContractTransferLog's own
+// record), the log is recorded as an ordinary event log instead of being
+// dropped or panicking. It is still never a tx-log and never moves a balance.
+func TestAddLogReservedTopicBecomesRegularLogAfterUpgrade(t *testing.T) {
 	require := require.New(t)
 	from, to := _c1, _c2
 	for _, topics := range [][]common.Hash{
-		{reservedTopic()},                  // 1 topic
-		{reservedTopic(), addrTopic(from)}, // 2 topics
+		{reservedTopic()},                                                  // 1 topic
+		{reservedTopic(), addrTopic(from)},                                 // 2 topics
+		{reservedTopic(), addrTopic(from), addrTopic(to)},                  // 3 topics (well-formed shape)
 		{reservedTopic(), addrTopic(from), addrTopic(to), addrTopic(from)}, // 4 topics
 	} {
 		stateDB := newAdapter(t, FixInContractTransferTopicOption())
@@ -167,23 +168,6 @@ func TestAddLogReservedTopicMalformedBecomesRegularLogAfterUpgrade(t *testing.T)
 		require.Equal(uint256.NewInt(1000), stateDB.GetBalance(from)) // no balance moved
 		require.True(stateDB.GetBalance(to).IsZero())
 	}
-}
-
-// TestAddLogReservedTopicWellFormedStillDroppedAfterUpgrade pins that, unlike
-// the malformed case above, a well-formed 3-topic reserved log (the shape that
-// actually collides with AddInContractTransferLog's own record) is still
-// dropped after the upgrade, exactly as before.
-func TestAddLogReservedTopicWellFormedStillDroppedAfterUpgrade(t *testing.T) {
-	require := require.New(t)
-	from, to := _c1, _c2
-	stateDB := newAdapter(t, FixInContractTransferTopicOption())
-	stateDB.AddBalance(from, uint256.NewInt(1000), tracing.BalanceChangeUnspecified)
-	log := &types.Log{Address: _c3, Topics: []common.Hash{reservedTopic(), addrTopic(from), addrTopic(to)}, Data: big.NewInt(1).Bytes()}
-	require.NotPanics(func() { stateDB.AddLog(log) })
-	require.Zero(len(stateDB.Logs()))
-	require.Zero(len(stateDB.TransactionLogs()))
-	require.Equal(uint256.NewInt(1000), stateDB.GetBalance(from))
-	require.True(stateDB.GetBalance(to).IsZero())
 }
 
 // TestTransferVsForgedLog is the adversarial contrast codex asked for: a forged


### PR DESCRIPTION
After #4868 the reserved in-contract-transfer topic only appears on contract-emitted logs, which are already dropped from the receipt (never appended to `stateDB.logs`, so `receipt.Logs` and the receipt root are unaffected).

A malformed one (topic count != 3) was still special-cased separately. This drops it uniformly with the rest so the reserved-topic handling is consistent.

Gated on the next upgrade (`ToBeEnabled`) so block replay stays byte-identical before activation. Adds the post-upgrade regression test alongside the existing pre-upgrade invariant.