### PR TITLE
feat(rewarding): add DelegateDistributed batched log encoder (IIP-59 PR 4.7)

### DIFF
--- a/action/protocol/rewarding/distributedlog/abi.go
+++ b/action/protocol/rewarding/distributedlog/abi.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package distributedlog
+
+// abiJSON declares the single event this package encodes. Field ordering
+// and indexed flags mirror IIP-59 §3.2 exactly; off-chain verifiers pin
+// the selector derived from this signature.
+const abiJSON = `[
+	{
+		"anonymous": false,
+		"inputs": [
+			{"indexed": true,  "name": "epoch",           "type": "uint64"},
+			{"indexed": true,  "name": "delegate",        "type": "address"},
+			{"indexed": false, "name": "rewardAddr",      "type": "address"},
+			{"indexed": false, "name": "totalCommission", "type": "uint256"},
+			{"indexed": false, "name": "totalVoterPool",  "type": "uint256"},
+			{"indexed": false, "name": "snapshotHash",    "type": "bytes32"},
+			{"indexed": false, "name": "voters",          "type": "address[]"},
+			{"indexed": false, "name": "amounts",         "type": "uint256[]"},
+			{"indexed": false, "name": "routings",        "type": "uint8[]"}
+		],
+		"name": "DelegateDistributed",
+		"type": "event"
+	}
+]`
+
+// eventName is the event's ABI name; used for method lookup and error text.
+const eventName = "DelegateDistributed"
+
+// eventSignature is the canonical Solidity signature. keccak256 of this
+// string is Topics[0]. Kept as a const for the golden-selector test.
+const eventSignature = "DelegateDistributed(uint64,address,address,uint256,uint256,bytes32,address[],uint256[],uint8[])"

--- a/action/protocol/rewarding/distributedlog/event.go
+++ b/action/protocol/rewarding/distributedlog/event.go
@@ -1,0 +1,234 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+// Package distributedlog encodes the IIP-59 §3.2 DelegateDistributed
+// receipt event. distributeToVoters (PR 3') calls Pack once per delegate
+// at epoch close and wraps the returned Topics+data into an *action.Log;
+// this package deliberately does NOT construct action.Log itself so it
+// can be unit-tested without block context (mirrors the seam chosen by
+// action/protocol/rewarding/delegateprofile and .../autodeposit).
+package distributedlog
+
+import (
+	"encoding/binary"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/autodeposit"
+)
+
+// Errors returned by Pack. All three indicate a wiring bug in the caller
+// (PR 3'), not on-chain data, so they hard-fail rather than degrade —
+// there is no per-item fallback available at the log-encode layer.
+var (
+	// ErrParallelArrayLengthMismatch is returned when the voters, amounts,
+	// and routings slices in EventArgs do not have identical lengths.
+	// PR 3' constructs these three in lock-step, so a mismatch is a
+	// serialisation bug.
+	ErrParallelArrayLengthMismatch = errors.New(
+		"distributedlog: voters, amounts, and routings must have equal length")
+
+	// ErrNilAddress is returned when Delegate, RewardAddr, or any
+	// Voters[i] is nil. Passing nil is a caller-side mistake and would
+	// otherwise packet as the zero address, silently masking a lost voter.
+	ErrNilAddress = errors.New("distributedlog: nil address")
+
+	// ErrNilBigInt is returned when TotalCommission, TotalVoterPool, or
+	// any Amounts[i] is nil.
+	ErrNilBigInt = errors.New("distributedlog: nil *big.Int")
+)
+
+// snapshotDomainSeparator scopes SnapshotHash so its output cannot
+// collide with a hash computed from the same byte layout in some other
+// context (e.g., a Merkle proof over the same voter list). Value:
+// keccak256("iip59.delegatedistributed.snapshot.v1"), evaluated once at
+// init to keep the hot path allocation-free.
+var snapshotDomainSeparator hash.Hash256
+
+func init() {
+	snapshotDomainSeparator = hash.Hash256b([]byte("iip59.delegatedistributed.snapshot.v1"))
+}
+
+// abiOnce guards parseABI: abi.JSON is not free and the parsed ABI is
+// immutable, so we cache it for the process lifetime.
+var (
+	abiOnce     sync.Once
+	parsedABI   abi.ABI
+	abiParseErr error
+)
+
+func loadABI() (abi.ABI, error) {
+	abiOnce.Do(func() {
+		parsedABI, abiParseErr = abi.JSON(strings.NewReader(abiJSON))
+	})
+	return parsedABI, abiParseErr
+}
+
+// EventArgs are the fields of one DelegateDistributed log. Field order
+// matches the Solidity signature so a struct literal reads left-to-right
+// the same way as the on-chain event definition. Callers build one per
+// delegate (top-N loop and orphan-drain loop use the same shape).
+type EventArgs struct {
+	Epoch           uint64              // indexed → Topics[1]
+	Delegate        address.Address     // indexed → Topics[2]
+	RewardAddr      address.Address     // where commission was credited
+	TotalCommission *big.Int            // aggregate delegate commission
+	TotalVoterPool  *big.Int            // pool split across voters
+	SnapshotHash    hash.Hash256        // frozen voter list digest (see SnapshotHash)
+	Voters          []address.Address   // canonical sorted order per §3.4
+	Amounts         []*big.Int          // parallel to Voters
+	Routings        []autodeposit.Route // parallel to Voters; wire enum from PR 4.6
+}
+
+// Pack encodes args as an EVM-shaped receipt log. The returned Topics
+// and data satisfy the same layout an EVM-emitted DelegateDistributed
+// event would produce, so off-chain verifiers (PR #45) can decode with
+// stock ethers.js / web3.py against this event ABI.
+//
+// Topics layout:
+//
+//	[0] keccak256(eventSignature)
+//	[1] uint64 epoch, left-padded to 32 bytes
+//	[2] address delegate, left-padded to 32 bytes
+//
+// Data layout: ABI-standard tuple of the remaining (non-indexed) inputs
+// in declaration order — rewardAddr, totalCommission, totalVoterPool,
+// snapshotHash, voters[], amounts[], routings[].
+func Pack(args EventArgs) (action.Topics, []byte, error) {
+	if args.Delegate == nil {
+		return nil, nil, errors.Wrap(ErrNilAddress, "delegate")
+	}
+	if args.RewardAddr == nil {
+		return nil, nil, errors.Wrap(ErrNilAddress, "rewardAddr")
+	}
+	if args.TotalCommission == nil {
+		return nil, nil, errors.Wrap(ErrNilBigInt, "totalCommission")
+	}
+	if args.TotalVoterPool == nil {
+		return nil, nil, errors.Wrap(ErrNilBigInt, "totalVoterPool")
+	}
+	if len(args.Voters) != len(args.Amounts) || len(args.Voters) != len(args.Routings) {
+		return nil, nil, errors.Wrapf(ErrParallelArrayLengthMismatch,
+			"voters=%d amounts=%d routings=%d",
+			len(args.Voters), len(args.Amounts), len(args.Routings))
+	}
+
+	voterAddrs := make([]common.Address, len(args.Voters))
+	for i, v := range args.Voters {
+		if v == nil {
+			return nil, nil, errors.Wrapf(ErrNilAddress, "voters[%d]", i)
+		}
+		voterAddrs[i] = common.BytesToAddress(v.Bytes())
+	}
+	amounts := make([]*big.Int, len(args.Amounts))
+	for i, a := range args.Amounts {
+		if a == nil {
+			return nil, nil, errors.Wrapf(ErrNilBigInt, "amounts[%d]", i)
+		}
+		amounts[i] = a
+	}
+	routings := make([]uint8, len(args.Routings))
+	for i, r := range args.Routings {
+		routings[i] = uint8(r)
+	}
+
+	parsed, err := loadABI()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "distributedlog: parse ABI")
+	}
+	ev, ok := parsed.Events[eventName]
+	if !ok {
+		return nil, nil, errors.Errorf("distributedlog: event %q not found in parsed ABI", eventName)
+	}
+	data, err := ev.Inputs.NonIndexed().Pack(
+		common.BytesToAddress(args.RewardAddr.Bytes()),
+		args.TotalCommission,
+		args.TotalVoterPool,
+		[32]byte(args.SnapshotHash),
+		voterAddrs,
+		amounts,
+		routings,
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "distributedlog: pack DelegateDistributed data")
+	}
+
+	topics := make(action.Topics, 3)
+	topics[0] = hash.Hash256(ev.ID)
+	topics[1] = encodeUint64Topic(args.Epoch)
+	topics[2] = hash.BytesToHash256(args.Delegate.Bytes())
+	return topics, data, nil
+}
+
+// encodeUint64Topic returns the 32-byte, left-padded big-endian
+// representation of x — the ABI encoding for an indexed uint64.
+func encodeUint64Topic(x uint64) hash.Hash256 {
+	var buf [32]byte
+	binary.BigEndian.PutUint64(buf[24:], x)
+	return hash.BytesToHash256(buf[:])
+}
+
+// SnapshotHash produces the bytes32 digest of a delegate's frozen voter
+// list. voters and weights are parallel slices in the same canonical
+// (sorted-by-address) order that §3.4 requires the snapshot to store.
+//
+// The hash is domain-separated so it cannot collide with hashes computed
+// from the same byte layout in another context. Layout hashed:
+//
+//	keccak256(
+//	    domainSep ||
+//	    be_uint64(len(voters)) ||
+//	    for each i: voter[i].Bytes()(20B) || left_pad32(weights[i].Bytes())
+//	)
+//
+// Empty list is well-defined and yields a fixed value (asserted by
+// TestSnapshotHash_EmptyList); external verifiers pin the same bytes.
+//
+// If len(voters) != len(weights), the shorter slice determines the
+// hashed prefix — this helper is a pure utility and does not validate
+// its inputs. Callers of Pack pass the two through EventArgs.Voters /
+// EventArgs.Amounts, where Pack does enforce the length invariant.
+func SnapshotHash(voters []address.Address, weights []*big.Int) hash.Hash256 {
+	n := len(voters)
+	if n > len(weights) {
+		n = len(weights)
+	}
+	buf := make([]byte, 0, 32+8+n*(20+32))
+	buf = append(buf, snapshotDomainSeparator[:]...)
+	var lenBuf [8]byte
+	binary.BigEndian.PutUint64(lenBuf[:], uint64(n))
+	buf = append(buf, lenBuf[:]...)
+	for i := 0; i < n; i++ {
+		if voters[i] == nil {
+			buf = append(buf, make([]byte, 20)...)
+		} else {
+			buf = append(buf, voters[i].Bytes()...)
+		}
+		buf = append(buf, leftPad32(weights[i])...)
+	}
+	return hash.Hash256b(buf)
+}
+
+// leftPad32 returns the big-endian, zero-left-padded 32-byte
+// representation of x's absolute value. nil is treated as zero;
+// negative values (not expected in this domain) are encoded by
+// absolute value — the snapshot never contains negative weights.
+func leftPad32(x *big.Int) []byte {
+	var out [32]byte
+	if x == nil {
+		return out[:]
+	}
+	b := x.Bytes()
+	copy(out[32-len(b):], b)
+	return out[:]
+}

--- a/action/protocol/rewarding/distributedlog/event_test.go
+++ b/action/protocol/rewarding/distributedlog/event_test.go
@@ -1,0 +1,304 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package distributedlog
+
+import (
+	"encoding/binary"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/autodeposit"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+// happyArgs returns a plausible three-voter EventArgs with mixed
+// routings. Each test mutates one field to isolate the property under
+// test.
+func happyArgs() EventArgs {
+	delegate := identityset.Address(1)
+	reward := identityset.Address(2)
+	voters := []address.Address{
+		identityset.Address(3),
+		identityset.Address(4),
+		identityset.Address(5),
+	}
+	return EventArgs{
+		Epoch:           4200,
+		Delegate:        delegate,
+		RewardAddr:      reward,
+		TotalCommission: big.NewInt(1_000_000),
+		TotalVoterPool:  big.NewInt(9_000_000),
+		SnapshotHash:    hash.Hash256b([]byte("snapshot@epoch4200")),
+		Voters:          voters,
+		Amounts: []*big.Int{
+			big.NewInt(3_000_000),
+			big.NewInt(3_000_000),
+			big.NewInt(3_000_000),
+		},
+		Routings: []autodeposit.Route{
+			autodeposit.RouteCredit,
+			autodeposit.RouteCompound,
+			autodeposit.RouteCompound,
+		},
+	}
+}
+
+func TestPack_HappyPath(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+
+	topics, data, err := Pack(args)
+	r.NoError(err)
+	r.Len(topics, 3, "one selector + two indexed args")
+
+	// Topics[0] must equal keccak256(eventSignature); the golden test
+	// below pins the exact bytes, but sanity-check the derivation here.
+	r.Equal(hash.Hash256(crypto.Keccak256Hash([]byte(eventSignature))), topics[0])
+
+	// Topics[1] is the 32-byte left-padded epoch.
+	var epochWord [32]byte
+	binary.BigEndian.PutUint64(epochWord[24:], args.Epoch)
+	r.Equal(hash.BytesToHash256(epochWord[:]), topics[1])
+
+	// Topics[2] is the delegate's 20-byte address left-padded to 32.
+	r.Equal(hash.BytesToHash256(args.Delegate.Bytes()), topics[2])
+
+	// Data must be a valid ABI-encoded tuple — parse it back and compare.
+	parsed, err := abi.JSON(strings.NewReader(abiJSON))
+	r.NoError(err)
+	unpacked, err := parsed.Events[eventName].Inputs.NonIndexed().Unpack(data)
+	r.NoError(err)
+	r.Len(unpacked, 7)
+	r.Equal(common.BytesToAddress(args.RewardAddr.Bytes()), unpacked[0])
+	r.Equal(0, args.TotalCommission.Cmp(unpacked[1].(*big.Int)))
+	r.Equal(0, args.TotalVoterPool.Cmp(unpacked[2].(*big.Int)))
+	r.Equal([32]byte(args.SnapshotHash), unpacked[3])
+}
+
+func TestPack_ZeroVoters(t *testing.T) {
+	// A delegate with no voters still emits a log — a batched log per
+	// delegate is the observability contract, even when the batch is
+	// empty. Guard against a premature len(voters)==0 short-circuit.
+	r := require.New(t)
+	args := happyArgs()
+	args.Voters = nil
+	args.Amounts = nil
+	args.Routings = nil
+
+	topics, data, err := Pack(args)
+	r.NoError(err)
+	r.Len(topics, 3)
+
+	parsed, err := abi.JSON(strings.NewReader(abiJSON))
+	r.NoError(err)
+	unpacked, err := parsed.Events[eventName].Inputs.NonIndexed().Unpack(data)
+	r.NoError(err)
+	r.Len(unpacked[4].([]common.Address), 0, "voters must decode as empty array")
+	r.Len(unpacked[5].([]*big.Int), 0, "amounts must decode as empty array")
+	r.Len(unpacked[6].([]uint8), 0, "routings must decode as empty array")
+}
+
+func TestPack_ParallelLengthMismatch_Amounts(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.Amounts = args.Amounts[:2] // one short
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrParallelArrayLengthMismatch)
+}
+
+func TestPack_ParallelLengthMismatch_Routings(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.Routings = args.Routings[:1] // two short
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrParallelArrayLengthMismatch)
+}
+
+func TestPack_NilDelegate(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.Delegate = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilAddress)
+}
+
+func TestPack_NilRewardAddr(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.RewardAddr = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilAddress)
+}
+
+func TestPack_NilTotalCommission(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.TotalCommission = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilBigInt)
+}
+
+func TestPack_NilTotalVoterPool(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.TotalVoterPool = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilBigInt)
+}
+
+func TestPack_NilPerVoterAmount(t *testing.T) {
+	// Nil per-voter amount would silently pack as zero, dropping a voter
+	// from the split off-chain reconstruction while still crediting them
+	// on-chain elsewhere — must fail loudly.
+	r := require.New(t)
+	args := happyArgs()
+	args.Amounts[1] = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilBigInt)
+	r.Contains(err.Error(), "amounts[1]", "error must name offending index")
+}
+
+func TestPack_NilPerVoterAddress(t *testing.T) {
+	r := require.New(t)
+	args := happyArgs()
+	args.Voters[0] = nil
+
+	_, _, err := Pack(args)
+	r.ErrorIs(err, ErrNilAddress)
+	r.Contains(err.Error(), "voters[0]", "error must name offending index")
+}
+
+func TestPack_SelectorPinned(t *testing.T) {
+	// Pin the exact 32-byte selector. If this test breaks, either the
+	// event signature drifted (spec change → requires a new selector and
+	// coordinated verifier update) or a whitespace typo crept into
+	// eventSignature.
+	r := require.New(t)
+	args := happyArgs()
+	topics, _, err := Pack(args)
+	r.NoError(err)
+
+	expected := crypto.Keccak256Hash([]byte(
+		"DelegateDistributed(uint64,address,address,uint256,uint256,bytes32,address[],uint256[],uint8[])",
+	))
+	r.Equal(hash.Hash256(expected), topics[0])
+}
+
+func TestPack_RoundTrip(t *testing.T) {
+	// Full byte-level round trip: encode via Pack, decode via the same
+	// ABI, verify every field equals the input. This is the contract
+	// PR #45's off-chain verifier depends on.
+	r := require.New(t)
+	args := happyArgs()
+
+	topics, data, err := Pack(args)
+	r.NoError(err)
+
+	parsed, err := abi.JSON(strings.NewReader(abiJSON))
+	r.NoError(err)
+
+	// Topics[1] round-trip → epoch.
+	var epochOut uint64
+	epochWord := topics[1]
+	epochOut = binary.BigEndian.Uint64(epochWord[24:])
+	r.Equal(args.Epoch, epochOut)
+
+	// Topics[2] round-trip → delegate.
+	delegateOut := topics[2]
+	r.Equal(args.Delegate.Bytes(), delegateOut[12:])
+
+	// Data round-trip: every non-indexed field.
+	unpacked, err := parsed.Events[eventName].Inputs.NonIndexed().Unpack(data)
+	r.NoError(err)
+	r.Equal(common.BytesToAddress(args.RewardAddr.Bytes()), unpacked[0])
+	r.Equal(0, args.TotalCommission.Cmp(unpacked[1].(*big.Int)))
+	r.Equal(0, args.TotalVoterPool.Cmp(unpacked[2].(*big.Int)))
+	r.Equal([32]byte(args.SnapshotHash), unpacked[3])
+
+	votersOut := unpacked[4].([]common.Address)
+	r.Len(votersOut, len(args.Voters))
+	for i, v := range args.Voters {
+		r.Equal(common.BytesToAddress(v.Bytes()), votersOut[i])
+	}
+	amountsOut := unpacked[5].([]*big.Int)
+	r.Len(amountsOut, len(args.Amounts))
+	for i, a := range args.Amounts {
+		r.Equal(0, a.Cmp(amountsOut[i]))
+	}
+	routingsOut := unpacked[6].([]uint8)
+	r.Len(routingsOut, len(args.Routings))
+	for i, rt := range args.Routings {
+		r.Equal(uint8(rt), routingsOut[i])
+	}
+}
+
+func TestSnapshotHash_Determinism(t *testing.T) {
+	// Same input twice → same hash; reversed order → different hash.
+	// Canonical ordering is load-bearing per §3.4.
+	r := require.New(t)
+	voters := []address.Address{
+		identityset.Address(3),
+		identityset.Address(4),
+		identityset.Address(5),
+	}
+	weights := []*big.Int{big.NewInt(100), big.NewInt(200), big.NewInt(300)}
+
+	h1 := SnapshotHash(voters, weights)
+	h2 := SnapshotHash(voters, weights)
+	r.Equal(h1, h2, "same input must hash identically")
+
+	reversedVoters := []address.Address{voters[2], voters[1], voters[0]}
+	reversedWeights := []*big.Int{weights[2], weights[1], weights[0]}
+	h3 := SnapshotHash(reversedVoters, reversedWeights)
+	r.NotEqual(h1, h3, "reversed order must hash differently")
+}
+
+func TestSnapshotHash_EmptyList(t *testing.T) {
+	// A zero-voter delegate still needs a well-defined snapshot hash.
+	// This asserts the exact bytes so external verifiers can pin them.
+	r := require.New(t)
+
+	empty := SnapshotHash(nil, nil)
+
+	// Domain separator || big-endian uint64(0) — no per-voter payload.
+	var expectedBuf []byte
+	expectedBuf = append(expectedBuf, snapshotDomainSeparator[:]...)
+	expectedBuf = append(expectedBuf, make([]byte, 8)...)
+	expected := hash.Hash256b(expectedBuf)
+	r.Equal(expected, empty)
+}
+
+func TestSnapshotHash_MismatchedLengthTruncates(t *testing.T) {
+	// SnapshotHash is a pure utility; length invariants live in Pack.
+	// If len(voters) > len(weights), the extra voters are ignored (the
+	// shorter slice bounds the loop). Guards against surprises for
+	// callers who bypass Pack.
+	r := require.New(t)
+	voters := []address.Address{
+		identityset.Address(3),
+		identityset.Address(4),
+	}
+	weights := []*big.Int{big.NewInt(100)} // one short
+
+	h1 := SnapshotHash(voters, weights)
+	h2 := SnapshotHash(voters[:1], weights)
+	r.Equal(h1, h2, "extra voters must be ignored, not silently zero-weighted")
+}


### PR DESCRIPTION
## Summary

Adds the encoder primitives for IIP-59 §3.2's per-delegate batched `DelegateDistributed` receipt log. `distributeToVoters` (PR 3', upcoming) will call `Pack` once per delegate at epoch close and wrap the returned `(topics, data)` into an `*action.Log`.

Batching keeps total epoch-last-block logs bounded by `|topDelegates| + |orphanDrain|` (~200) regardless of voter count, avoiding receipt-trie bloat under load (top 100 delegates × ~2k voters each).

Structural sibling of PR 4.5 (\`delegateprofile\`) and PR 4.6 (\`autodeposit\`) — same minimal-ABI package shape, same discipline about where the seam lands.

## What lands

**New package \`action/protocol/rewarding/distributedlog\`**

- \`Pack(EventArgs) → (action.Topics, []byte, error)\` produces the exact wire layout an EVM-emitted \`DelegateDistributed\` event would produce, so \`eth_getLogs\` clients (and PR #45's off-chain verifier) decode with stock \`ethers.js\` / \`web3.py\` against the same ABI.
- \`EventArgs\` mirrors §3.2's Solidity signature field-for-field: \`Epoch(indexed)\` + \`Delegate(indexed)\` + \`RewardAddr\` + \`TotalCommission\` + \`TotalVoterPool\` + \`SnapshotHash\` + \`Voters[]\` + \`Amounts[]\` + \`Routings[]\`.
- \`Routings[]\` reuses \`autodeposit.Route\` verbatim — PR 4.6's enum is the single source of truth for the credit/compound wire encoding.
- \`SnapshotHash(voters, weights)\` computes the \`bytes32\` digest of a delegate's frozen voter list, domain-separated (\`iip59.delegatedistributed.snapshot.v1\`) so verifiers can pin the exact bytes and it cannot collide with same-layout hashes from other contexts.

## Semantics

Hard-error on caller-side wiring bugs:

| Condition | Error |
|---|---|
| nil \`Delegate\` / \`RewardAddr\` / any \`Voters[i]\` | \`ErrNilAddress\` |
| nil \`TotalCommission\` / \`TotalVoterPool\` / any \`Amounts[i]\` | \`ErrNilBigInt\` |
| \`len(Voters) != len(Amounts) != len(Routings)\` | \`ErrParallelArrayLengthMismatch\` |

The encoder is not a consensus path, so there is no per-item to degrade — loud failure surfaces PR 3' bugs. **Empty voter list is NOT an error**: a delegate with zero voters still emits a log for observability, per §3.2's \"one log per delegate\".

## Explicit non-goals

- **No \`*action.Log\` construction.** Block context (height, action hash, protocol address) belongs to PR 3'. Mirrors PR 4.5 / 4.6 seams.
- **No event dispatch / subscription.** Encoder, not bus.
- **No proto message.** The event is ABI-encoded so decode-time behaviour is identical to a Solidity-emitted event.
- **No orphan-drain log variant.** §3.3's orphan drain emits the same shape; one encoder covers both call sites.
- **No \`foundationBonus\` field.** §3.5 leaves foundation bonus out of scope.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`gofmt -l\` clean on touched files
- [x] \`go vet ./action/protocol/rewarding/distributedlog/...\` clean
- [x] \`go test ./action/protocol/rewarding/distributedlog/... -count=1 -v\` — 15 tests, all green
- [x] Regression \`go test ./action/protocol/rewarding/... ./action/...\` — 1104 tests across 31 packages, all green

Test coverage: happy path, zero voters, both parallel-length mismatch variants, nil-field variants (delegate/reward/commission/pool/per-voter address/per-voter amount), **selector pin** (golden 32 bytes so external verifiers can hard-code the same signature hash), full byte-level **round-trip** via the same ABI, and \`SnapshotHash\` determinism + empty-list constant + truncation semantics.

## Stack

Branched on top of \`iip-59/pr4.6-autodeposit-bridge\` (#4922) because this PR imports \`autodeposit.Route\` at the Go-module level. Once PR 4.6 merges to \`master\`, the base of this PR can be flipped to \`master\` without conflict.

- Depended on by: PR 3' (rework \`distributeVoterReward\`), PR #45 (off-chain verifier).
- Depends on: PR 4.6 (#4922).

🤖 Generated with [Claude Code](https://claude.com/claude-code)