### PR TITLE
fix(api): populate block-level gasUsed from fetched receipts (#4937)

### DIFF
--- a/api/web3server_marshal.go
+++ b/api/web3server_marshal.go
@@ -48,6 +48,7 @@ type (
 
 	getBlockResult struct {
 		blk          *block.Block
+		receipts     []*action.Receipt
 		transactions []interface{}
 	}
 
@@ -191,7 +192,15 @@ func (obj *getBlockResult) MarshalJSON() ([]byte, error) {
 	for _, tx := range obj.blk.Actions {
 		gasLimit += tx.Gas()
 	}
-	for _, r := range obj.blk.Receipts {
+	// Prefer the receipts explicitly fetched from storage so that the block-level
+	// gasUsed aggregate is correct on read regardless of recency or node type. The
+	// in-memory block loaded from the DAO does not carry its receipts, so falling
+	// back to obj.blk.Receipts would yield 0x0 for historical/archive reads.
+	receipts := obj.receipts
+	if len(receipts) == 0 {
+		receipts = obj.blk.Receipts
+	}
+	for _, r := range receipts {
 		gasUsed += r.GasConsumed
 	}
 	if logsBloom := obj.blk.Header.LogsBloomfilter(); logsBloom != nil {

--- a/api/web3server_marshal_test.go
+++ b/api/web3server_marshal_test.go
@@ -227,6 +227,32 @@ func TestBlockObjectMarshal(t *testing.T) {
 		 }
 		`, string(res))
 	})
+
+	t.Run("BlockGasUsedFromFetchedReceipts", func(t *testing.T) {
+		// Blocks loaded from storage (historical reads / archive nodes) do not carry
+		// their receipts on the block object; the receipts are fetched separately and
+		// supplied via the receipts field. The block-level gasUsed must still be the
+		// sum of those receipts, not 0x0. See iotexproject/iotex-core#4937.
+		storageBlk := blk
+		storageBlk.Receipts = nil
+		res, err := json.Marshal(&getBlockResult{
+			blk: &storageBlk,
+			receipts: []*action.Receipt{{
+				Status:      1,
+				BlockHeight: 1,
+				ActionHash:  txHash,
+				GasConsumed: 21000,
+				TxIndex:     1,
+			}},
+			transactions: []interface{}{string("0x2133ee7ff4562535166e3f16fd7407c19e5ed1acd036f78d3528a5a40e40ad42")},
+		})
+		require.NoError(err)
+		var obj struct {
+			GasUsed string `json:"gasUsed"`
+		}
+		require.NoError(json.Unmarshal(res, &obj))
+		require.Equal("0x5208", obj.GasUsed)
+	})
 }
 
 func TestTransactionObjectMarshal(t *testing.T) {

--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -120,6 +120,7 @@ func (svr *web3Handler) getBlockWithTransactions(blk *block.Block, receipts []*a
 	}
 	return &getBlockResult{
 		blk:          blk,
+		receipts:     receipts,
 		transactions: transactions,
 	}, nil
 }


### PR DESCRIPTION
## Problem

Fixes #4937.

`eth_getBlockByNumber` / `eth_getBlockByHash` return `gasUsed: "0x0"` at the **block level** for essentially all blocks past a short recent window, even though the block's transactions clearly burned gas. Per the Ethereum JSON-RPC spec, a block's `gasUsed` should equal the sum of the per-transaction receipt `gasUsed`.

Observed behavior (from the issue):
- **Archive nodes: always `0x0`** — they always serve blocks from storage.
- **Babel (non-archive): correct only for a very recent window, then decays to `0x0`.**

## Root cause

`getBlockResult.MarshalJSON` (`api/web3server_marshal.go`) summed block-level `gasUsed` from `obj.blk.Receipts`:

```go
for _, r := range obj.blk.Receipts {
    gasUsed += r.GasConsumed
}
```

But blocks loaded from storage via the DAO do **not** carry their receipts on the `block.Block` object — receipts are persisted and read separately (`dao.GetReceipts`). So `blk.Receipts` is empty for any storage-served block, yielding `0x0`. This exactly explains the two behaviors: archive nodes always serve from storage; non-archive nodes are correct only while the freshly-committed block is still in the DAO block LRU cache (receipts populated in memory), then decay to `0x0` once evicted and reloaded.

The correct receipts are **already fetched** on this path — `BlockByHeight` / `BlockByHash` call `dao.GetReceipts` unconditionally and pass them into `getBlockWithTransactions` — but they were dropped instead of stored on the result.

## Fix

- Carry the explicitly-fetched `receipts` on `getBlockResult` and sum `gasUsed` from them.
- Fall back to `obj.blk.Receipts` only when no receipts were supplied, which preserves the websocket `newHeads` streaming path (`blocklistener.go`) that uses an in-memory block with receipts already attached.

This adds **no extra I/O** — it reuses receipts that were already read from storage on every block query; previously they were read and then discarded for the aggregate.

### Note vs go-ethereum

Unlike go-ethereum, IoTeX's block header does not carry `gasUsed` (it is not committed by the block hash), so `internal/ethapi` reading `head.GasUsed` directly is not an option here — the block-level aggregate must be recomputed from receipts on read. Since receipts are already loaded on this path, there is no performance regression.

## Test

Added `TestBlockObjectMarshal/BlockGasUsedFromFetchedReceipts`, which simulates a storage-loaded block (`blk.Receipts = nil`) with receipts supplied separately and asserts `gasUsed == 0x5208`. Verified this test reproduces the bug (`0x0`) without the fix and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)