### PR TITLE
feat(rewarding): EpochDrainCursor scaffolding for IIP-59 era drain (PR C1)

### DIFF
--- a/action/protocol/rewarding/epoch_drain_cursor.go
+++ b/action/protocol/rewarding/epoch_drain_cursor.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rewarding
+
+import (
+	"context"
+	"math/big"
+
+	"github.com/pkg/errors"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
+	"github.com/iotexproject/iotex-core/v2/state"
+)
+
+// epochDrainDelegateWork is one frozen per-delegate work item captured
+// at an era boundary: the delegate identifier plus the pool balance to
+// drain. Continuation chunks read this rather than the live
+// PendingBlockRewardPool entry, which may keep accruing behind the
+// drain if a new epoch closes mid-drain.
+type epochDrainDelegateWork struct {
+	CandidateIdentifier []byte
+	PoolAmountFrozen    *big.Int
+}
+
+// epochDrainCursor checkpoints an in-progress IIP-59 era-boundary drain
+// of PendingBlockRewardPool balances into voter accounts. TargetEra is
+// the era ID being drained; DelegateIndex is the resume position in
+// the frozen Delegates slice; Delegates is the frozen work list.
+// Cursor presence in the RewardingNamespace signals a drain is live
+// and the system-action layer must emit a continuation grant on the
+// next block. Absence = no drain in progress.
+type epochDrainCursor struct {
+	TargetEra     uint64
+	DelegateIndex uint32
+	Delegates     []epochDrainDelegateWork
+}
+
+// Serialize marshals the cursor to its proto wire form.
+func (c epochDrainCursor) Serialize() ([]byte, error) {
+	m := &rewardingpb.EpochDrainCursor{
+		TargetEra:     c.TargetEra,
+		DelegateIndex: c.DelegateIndex,
+	}
+	if len(c.Delegates) > 0 {
+		m.Delegates = make([]*rewardingpb.EpochDrainDelegateWork, len(c.Delegates))
+		for i, d := range c.Delegates {
+			m.Delegates[i] = &rewardingpb.EpochDrainDelegateWork{
+				CandidateIdentifier: d.CandidateIdentifier,
+				PoolAmountFrozen:    epochDrainBigIntBytes(d.PoolAmountFrozen),
+			}
+		}
+	}
+	return proto.Marshal(m)
+}
+
+// Deserialize populates the cursor from its proto wire form.
+func (c *epochDrainCursor) Deserialize(data []byte) error {
+	m := &rewardingpb.EpochDrainCursor{}
+	if err := proto.Unmarshal(data, m); err != nil {
+		return err
+	}
+	c.TargetEra = m.GetTargetEra()
+	c.DelegateIndex = m.GetDelegateIndex()
+	c.Delegates = nil
+	if ds := m.GetDelegates(); len(ds) > 0 {
+		c.Delegates = make([]epochDrainDelegateWork, len(ds))
+		for i, d := range ds {
+			c.Delegates[i] = epochDrainDelegateWork{
+				CandidateIdentifier: d.GetCandidateIdentifier(),
+				PoolAmountFrozen:    epochDrainBytesBigInt(d.GetPoolAmountFrozen()),
+			}
+		}
+	}
+	return nil
+}
+
+// epochDrainBigIntBytes returns big-endian bytes, or nil for nil.
+func epochDrainBigIntBytes(v *big.Int) []byte {
+	if v == nil {
+		return nil
+	}
+	return v.Bytes()
+}
+
+// epochDrainBytesBigInt returns a big.Int from big-endian bytes. Zero-
+// length input yields a zero-valued big.Int (not nil), so callers can
+// compare with .Sign() without a nil check.
+func epochDrainBytesBigInt(b []byte) *big.Int {
+	out := new(big.Int)
+	if len(b) > 0 {
+		out.SetBytes(b)
+	}
+	return out
+}
+
+// readEpochDrainCursor returns the live cursor, or (nil, nil) when no
+// drain is in progress.
+func (p *Protocol) readEpochDrainCursor(
+	ctx context.Context,
+	sm protocol.StateReader,
+) (*epochDrainCursor, error) {
+	c := &epochDrainCursor{}
+	if _, err := p.state(ctx, sm, state.EpochDrainCursorKey, c); err != nil {
+		if errors.Is(err, state.ErrStateNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return c, nil
+}
+
+// writeEpochDrainCursor persists a cursor. Overwrites any prior value.
+func (p *Protocol) writeEpochDrainCursor(
+	ctx context.Context,
+	sm protocol.StateManager,
+	c *epochDrainCursor,
+) error {
+	return p.putState(ctx, sm, state.EpochDrainCursorKey, c)
+}
+
+// deleteEpochDrainCursor removes the cursor entry. Idempotent — the
+// underlying deleteState swallows ErrStateNotExist.
+func (p *Protocol) deleteEpochDrainCursor(
+	ctx context.Context,
+	sm protocol.StateManager,
+) error {
+	return p.deleteState(ctx, sm, state.EpochDrainCursorKey, &epochDrainCursor{})
+}

--- a/action/protocol/rewarding/epoch_drain_cursor_test.go
+++ b/action/protocol/rewarding/epoch_drain_cursor_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package rewarding
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+// TestEpochDrainCursor_RoundTrip — Serialize→Deserialize preserves
+// every field, including the frozen delegate work list with big.Int
+// pool balances and the resume index.
+func TestEpochDrainCursor_RoundTrip(t *testing.T) {
+	r := require.New(t)
+
+	in := epochDrainCursor{
+		TargetEra:     42,
+		DelegateIndex: 7,
+		Delegates: []epochDrainDelegateWork{
+			{
+				CandidateIdentifier: identityset.Address(1).Bytes(),
+				PoolAmountFrozen:    big.NewInt(1_000),
+			},
+			{
+				CandidateIdentifier: identityset.Address(2).Bytes(),
+				PoolAmountFrozen:    big.NewInt(2_500_000),
+			},
+		},
+	}
+
+	raw, err := in.Serialize()
+	r.NoError(err)
+	r.NotEmpty(raw)
+
+	var out epochDrainCursor
+	r.NoError(out.Deserialize(raw))
+	r.Equal(in.TargetEra, out.TargetEra)
+	r.Equal(in.DelegateIndex, out.DelegateIndex)
+	r.Len(out.Delegates, 2)
+	for i := range in.Delegates {
+		r.Equal(in.Delegates[i].CandidateIdentifier, out.Delegates[i].CandidateIdentifier)
+		r.Zero(in.Delegates[i].PoolAmountFrozen.Cmp(out.Delegates[i].PoolAmountFrozen),
+			"delegate %d pool amount mismatch: in=%s out=%s",
+			i, in.Delegates[i].PoolAmountFrozen, out.Delegates[i].PoolAmountFrozen)
+	}
+}
+
+// TestEpochDrainCursor_EmptyDelegates — a cursor with no delegate work
+// (era boundary hit but pool was empty) round-trips as an empty slice,
+// not a nil.
+func TestEpochDrainCursor_EmptyDelegates(t *testing.T) {
+	r := require.New(t)
+
+	in := epochDrainCursor{TargetEra: 1, DelegateIndex: 0}
+	raw, err := in.Serialize()
+	r.NoError(err)
+
+	var out epochDrainCursor
+	r.NoError(out.Deserialize(raw))
+	r.Equal(uint64(1), out.TargetEra)
+	r.Equal(uint32(0), out.DelegateIndex)
+	r.Empty(out.Delegates)
+}
+
+// TestEpochDrainCursor_ZeroPoolAmount — a delegate whose pool balance
+// is zero at Phase A freeze round-trips as a big.Int with Sign() == 0
+// (not nil), so chunk callers can safely call amt.Sign() without a
+// nil check.
+func TestEpochDrainCursor_ZeroPoolAmount(t *testing.T) {
+	r := require.New(t)
+
+	in := epochDrainCursor{
+		TargetEra: 3,
+		Delegates: []epochDrainDelegateWork{
+			{
+				CandidateIdentifier: identityset.Address(5).Bytes(),
+				PoolAmountFrozen:    new(big.Int),
+			},
+		},
+	}
+	raw, err := in.Serialize()
+	r.NoError(err)
+
+	var out epochDrainCursor
+	r.NoError(out.Deserialize(raw))
+	r.Len(out.Delegates, 1)
+	r.NotNil(out.Delegates[0].PoolAmountFrozen)
+	r.Equal(0, out.Delegates[0].PoolAmountFrozen.Sign())
+}
+
+// TestEpochDrainCursor_ReadMissingReturnsNil — an unpopulated cursor
+// key returns (nil, nil) so callers can use presence as the drain-in-
+// progress signal without a distinct sentinel error.
+func TestEpochDrainCursor_ReadMissingReturnsNil(t *testing.T) {
+	r := require.New(t)
+	ctx, sm, p, _, _ := newVoterRewardCtx(t, true)
+
+	c, err := p.readEpochDrainCursor(ctx, sm)
+	r.NoError(err)
+	r.Nil(c)
+}
+
+// TestEpochDrainCursor_WriteReadDelete — full lifecycle. Write persists
+// the cursor; read returns byte-equal fields; delete makes read return
+// (nil, nil); a second delete is a no-op (idempotency).
+func TestEpochDrainCursor_WriteReadDelete(t *testing.T) {
+	r := require.New(t)
+	ctx, sm, p, _, _ := newVoterRewardCtx(t, true)
+
+	in := &epochDrainCursor{
+		TargetEra:     99,
+		DelegateIndex: 3,
+		Delegates: []epochDrainDelegateWork{
+			{
+				CandidateIdentifier: identityset.Address(1).Bytes(),
+				PoolAmountFrozen:    big.NewInt(10_000),
+			},
+		},
+	}
+	r.NoError(p.writeEpochDrainCursor(ctx, sm, in))
+
+	got, err := p.readEpochDrainCursor(ctx, sm)
+	r.NoError(err)
+	r.NotNil(got)
+	r.Equal(in.TargetEra, got.TargetEra)
+	r.Equal(in.DelegateIndex, got.DelegateIndex)
+	r.Len(got.Delegates, 1)
+	r.Equal(in.Delegates[0].CandidateIdentifier, got.Delegates[0].CandidateIdentifier)
+	r.Zero(in.Delegates[0].PoolAmountFrozen.Cmp(got.Delegates[0].PoolAmountFrozen))
+
+	r.NoError(p.deleteEpochDrainCursor(ctx, sm))
+	got, err = p.readEpochDrainCursor(ctx, sm)
+	r.NoError(err)
+	r.Nil(got)
+
+	// Second delete: no error even though the key is already gone.
+	r.NoError(p.deleteEpochDrainCursor(ctx, sm))
+}
+
+// TestEpochDrainCursor_WriteOverwrites — writing a new cursor over an
+// existing entry replaces it wholesale (proto3 wire semantics for
+// repeated fields could otherwise merge lists on some codecs).
+func TestEpochDrainCursor_WriteOverwrites(t *testing.T) {
+	r := require.New(t)
+	ctx, sm, p, _, _ := newVoterRewardCtx(t, true)
+
+	first := &epochDrainCursor{
+		TargetEra:     10,
+		DelegateIndex: 0,
+		Delegates: []epochDrainDelegateWork{
+			{CandidateIdentifier: identityset.Address(1).Bytes(), PoolAmountFrozen: big.NewInt(1)},
+			{CandidateIdentifier: identityset.Address(2).Bytes(), PoolAmountFrozen: big.NewInt(2)},
+		},
+	}
+	r.NoError(p.writeEpochDrainCursor(ctx, sm, first))
+
+	second := &epochDrainCursor{
+		TargetEra:     10,
+		DelegateIndex: 1,
+		Delegates: []epochDrainDelegateWork{
+			{CandidateIdentifier: identityset.Address(3).Bytes(), PoolAmountFrozen: big.NewInt(9)},
+		},
+	}
+	r.NoError(p.writeEpochDrainCursor(ctx, sm, second))
+
+	got, err := p.readEpochDrainCursor(ctx, sm)
+	r.NoError(err)
+	r.NotNil(got)
+	r.Equal(uint32(1), got.DelegateIndex)
+	r.Len(got.Delegates, 1, "second write must replace, not append")
+	r.Equal(identityset.Address(3).Bytes(), got.Delegates[0].CandidateIdentifier)
+}

--- a/action/protocol/rewarding/rewardingpb/rewarding.pb.go
+++ b/action/protocol/rewarding/rewardingpb/rewarding.pb.go
@@ -536,6 +536,136 @@ func (x *PendingBlockRewardPool) GetAmount() []byte {
 	return nil
 }
 
+// EpochDrainDelegateWork is one frozen per-delegate work item captured
+// at the era boundary: the delegate identifier plus the pool balance to
+// drain. Chunks in later blocks read this frozen record so the credit
+// path is stable even if PendingBlockRewardPool for the same delegate
+// keeps accruing new epoch rewards behind the drain.
+type EpochDrainDelegateWork struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	CandidateIdentifier []byte `protobuf:"bytes,1,opt,name=candidate_identifier,json=candidateIdentifier,proto3" json:"candidate_identifier,omitempty"`
+	PoolAmountFrozen    []byte `protobuf:"bytes,2,opt,name=pool_amount_frozen,json=poolAmountFrozen,proto3" json:"pool_amount_frozen,omitempty"`
+}
+
+func (x *EpochDrainDelegateWork) Reset() {
+	*x = EpochDrainDelegateWork{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_rewarding_proto_msgTypes[8]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *EpochDrainDelegateWork) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EpochDrainDelegateWork) ProtoMessage() {}
+
+func (x *EpochDrainDelegateWork) ProtoReflect() protoreflect.Message {
+	mi := &file_rewarding_proto_msgTypes[8]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EpochDrainDelegateWork.ProtoReflect.Descriptor instead.
+func (*EpochDrainDelegateWork) Descriptor() ([]byte, []int) {
+	return file_rewarding_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *EpochDrainDelegateWork) GetCandidateIdentifier() []byte {
+	if x != nil {
+		return x.CandidateIdentifier
+	}
+	return nil
+}
+
+func (x *EpochDrainDelegateWork) GetPoolAmountFrozen() []byte {
+	if x != nil {
+		return x.PoolAmountFrozen
+	}
+	return nil
+}
+
+// EpochDrainCursor checkpoints a multi-block IIP-59 era-boundary drain
+// of PendingBlockRewardPool balances into voter accounts. TargetEra is
+// the era ID being drained; DelegateIndex is the resume position in
+// the frozen Delegates slice. Cursor presence in the
+// RewardingNamespace signals a drain is in progress and the
+// system-action layer must emit a continuation grant on the next
+// block. Absence = no drain in progress.
+type EpochDrainCursor struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	TargetEra     uint64                    `protobuf:"varint,1,opt,name=target_era,json=targetEra,proto3" json:"target_era,omitempty"`
+	DelegateIndex uint32                    `protobuf:"varint,2,opt,name=delegate_index,json=delegateIndex,proto3" json:"delegate_index,omitempty"`
+	Delegates     []*EpochDrainDelegateWork `protobuf:"bytes,3,rep,name=delegates,proto3" json:"delegates,omitempty"`
+}
+
+func (x *EpochDrainCursor) Reset() {
+	*x = EpochDrainCursor{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_rewarding_proto_msgTypes[9]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *EpochDrainCursor) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*EpochDrainCursor) ProtoMessage() {}
+
+func (x *EpochDrainCursor) ProtoReflect() protoreflect.Message {
+	mi := &file_rewarding_proto_msgTypes[9]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use EpochDrainCursor.ProtoReflect.Descriptor instead.
+func (*EpochDrainCursor) Descriptor() ([]byte, []int) {
+	return file_rewarding_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *EpochDrainCursor) GetTargetEra() uint64 {
+	if x != nil {
+		return x.TargetEra
+	}
+	return 0
+}
+
+func (x *EpochDrainCursor) GetDelegateIndex() uint32 {
+	if x != nil {
+		return x.DelegateIndex
+	}
+	return 0
+}
+
+func (x *EpochDrainCursor) GetDelegates() []*EpochDrainDelegateWork {
+	if x != nil {
+		return x.Delegates
+	}
+	return nil
+}
+
 var File_rewarding_proto protoreflect.FileDescriptor
 
 var file_rewarding_proto_rawDesc = []byte{
@@ -597,12 +727,30 @@ var file_rewarding_proto_rawDesc = []byte{
 	0x04, 0x6c, 0x6f, 0x67, 0x73, 0x22, 0x30, 0x0a, 0x16, 0x50, 0x65, 0x6e, 0x64, 0x69, 0x6e, 0x67,
 	0x42, 0x6c, 0x6f, 0x63, 0x6b, 0x52, 0x65, 0x77, 0x61, 0x72, 0x64, 0x50, 0x6f, 0x6f, 0x6c, 0x12,
 	0x16, 0x0a, 0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52,
-	0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x42, 0x4a, 0x5a, 0x48, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x69, 0x6f, 0x74, 0x65, 0x78, 0x70, 0x72, 0x6f, 0x6a, 0x65,
-	0x63, 0x74, 0x2f, 0x69, 0x6f, 0x74, 0x65, 0x78, 0x2d, 0x63, 0x6f, 0x72, 0x65, 0x2f, 0x61, 0x63,
-	0x74, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2f, 0x72, 0x65,
-	0x77, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x2f, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x69, 0x6e,
-	0x67, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x06, 0x61, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x22, 0x79, 0x0a, 0x16, 0x45, 0x70, 0x6f, 0x63, 0x68,
+	0x44, 0x72, 0x61, 0x69, 0x6e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x57, 0x6f, 0x72,
+	0x6b, 0x12, 0x31, 0x0a, 0x14, 0x63, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x5f, 0x69,
+	0x64, 0x65, 0x6e, 0x74, 0x69, 0x66, 0x69, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0c, 0x52,
+	0x13, 0x63, 0x61, 0x6e, 0x64, 0x69, 0x64, 0x61, 0x74, 0x65, 0x49, 0x64, 0x65, 0x6e, 0x74, 0x69,
+	0x66, 0x69, 0x65, 0x72, 0x12, 0x2c, 0x0a, 0x12, 0x70, 0x6f, 0x6f, 0x6c, 0x5f, 0x61, 0x6d, 0x6f,
+	0x75, 0x6e, 0x74, 0x5f, 0x66, 0x72, 0x6f, 0x7a, 0x65, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0c,
+	0x52, 0x10, 0x70, 0x6f, 0x6f, 0x6c, 0x41, 0x6d, 0x6f, 0x75, 0x6e, 0x74, 0x46, 0x72, 0x6f, 0x7a,
+	0x65, 0x6e, 0x22, 0x9b, 0x01, 0x0a, 0x10, 0x45, 0x70, 0x6f, 0x63, 0x68, 0x44, 0x72, 0x61, 0x69,
+	0x6e, 0x43, 0x75, 0x72, 0x73, 0x6f, 0x72, 0x12, 0x1d, 0x0a, 0x0a, 0x74, 0x61, 0x72, 0x67, 0x65,
+	0x74, 0x5f, 0x65, 0x72, 0x61, 0x18, 0x01, 0x20, 0x01, 0x28, 0x04, 0x52, 0x09, 0x74, 0x61, 0x72,
+	0x67, 0x65, 0x74, 0x45, 0x72, 0x61, 0x12, 0x25, 0x0a, 0x0e, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61,
+	0x74, 0x65, 0x5f, 0x69, 0x6e, 0x64, 0x65, 0x78, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0d, 0x52, 0x0d,
+	0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x49, 0x6e, 0x64, 0x65, 0x78, 0x12, 0x41, 0x0a,
+	0x09, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x73, 0x18, 0x03, 0x20, 0x03, 0x28, 0x0b,
+	0x32, 0x23, 0x2e, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x70, 0x62, 0x2e, 0x45,
+	0x70, 0x6f, 0x63, 0x68, 0x44, 0x72, 0x61, 0x69, 0x6e, 0x44, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74,
+	0x65, 0x57, 0x6f, 0x72, 0x6b, 0x52, 0x09, 0x64, 0x65, 0x6c, 0x65, 0x67, 0x61, 0x74, 0x65, 0x73,
+	0x42, 0x4a, 0x5a, 0x48, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x69,
+	0x6f, 0x74, 0x65, 0x78, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x2f, 0x69, 0x6f, 0x74, 0x65,
+	0x78, 0x2d, 0x63, 0x6f, 0x72, 0x65, 0x2f, 0x61, 0x63, 0x74, 0x69, 0x6f, 0x6e, 0x2f, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x63, 0x6f, 0x6c, 0x2f, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67,
+	0x2f, 0x72, 0x65, 0x77, 0x61, 0x72, 0x64, 0x69, 0x6e, 0x67, 0x70, 0x62, 0x62, 0x06, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -618,7 +766,7 @@ func file_rewarding_proto_rawDescGZIP() []byte {
 }
 
 var file_rewarding_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_rewarding_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_rewarding_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_rewarding_proto_goTypes = []interface{}{
 	(RewardLog_RewardType)(0),      // 0: rewardingpb.RewardLog.RewardType
 	(*Admin)(nil),                  // 1: rewardingpb.Admin
@@ -629,15 +777,18 @@ var file_rewarding_proto_goTypes = []interface{}{
 	(*RewardLog)(nil),              // 6: rewardingpb.RewardLog
 	(*RewardLogs)(nil),             // 7: rewardingpb.RewardLogs
 	(*PendingBlockRewardPool)(nil), // 8: rewardingpb.PendingBlockRewardPool
+	(*EpochDrainDelegateWork)(nil), // 9: rewardingpb.EpochDrainDelegateWork
+	(*EpochDrainCursor)(nil),       // 10: rewardingpb.EpochDrainCursor
 }
 var file_rewarding_proto_depIdxs = []int32{
 	0, // 0: rewardingpb.RewardLog.type:type_name -> rewardingpb.RewardLog.RewardType
 	6, // 1: rewardingpb.RewardLogs.logs:type_name -> rewardingpb.RewardLog
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	9, // 2: rewardingpb.EpochDrainCursor.delegates:type_name -> rewardingpb.EpochDrainDelegateWork
+	3, // [3:3] is the sub-list for method output_type
+	3, // [3:3] is the sub-list for method input_type
+	3, // [3:3] is the sub-list for extension type_name
+	3, // [3:3] is the sub-list for extension extendee
+	0, // [0:3] is the sub-list for field type_name
 }
 
 func init() { file_rewarding_proto_init() }
@@ -742,6 +893,30 @@ func file_rewarding_proto_init() {
 				return nil
 			}
 		}
+		file_rewarding_proto_msgTypes[8].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*EpochDrainDelegateWork); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_rewarding_proto_msgTypes[9].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*EpochDrainCursor); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -749,7 +924,7 @@ func file_rewarding_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_rewarding_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/action/protocol/rewarding/rewardingpb/rewarding.proto
+++ b/action/protocol/rewarding/rewardingpb/rewarding.proto
@@ -61,3 +61,26 @@ message RewardLogs {
 message PendingBlockRewardPool {
     bytes amount = 1;
 }
+
+// EpochDrainDelegateWork is one frozen per-delegate work item captured
+// at the era boundary: the delegate identifier plus the pool balance to
+// drain. Chunks in later blocks read this frozen record so the credit
+// path is stable even if PendingBlockRewardPool for the same delegate
+// keeps accruing new epoch rewards behind the drain.
+message EpochDrainDelegateWork {
+    bytes candidate_identifier = 1;
+    bytes pool_amount_frozen   = 2;
+}
+
+// EpochDrainCursor checkpoints a multi-block IIP-59 era-boundary drain
+// of PendingBlockRewardPool balances into voter accounts. TargetEra is
+// the era ID being drained; DelegateIndex is the resume position in
+// the frozen Delegates slice. Cursor presence in the
+// RewardingNamespace signals a drain is in progress and the
+// system-action layer must emit a continuation grant on the next
+// block. Absence = no drain in progress.
+message EpochDrainCursor {
+    uint64 target_era     = 1;
+    uint32 delegate_index = 2;
+    repeated EpochDrainDelegateWork delegates = 3;
+}

--- a/state/tables.go
+++ b/state/tables.go
@@ -83,6 +83,11 @@ var (
 	BlockRewardHistoryKeyPrefix = []byte("brh")
 	// EpochRewardHistoryKeyPrefix is the key prefix for epoch reward history
 	EpochRewardHistoryKeyPrefix = []byte("erh")
+	// EpochDrainCursorKey is the singleton key for the IIP-59 multi-block
+	// era-boundary drain cursor (RewardingNamespace). The payload carries
+	// target_era so a chunk running mid-drain can detect a stale cursor
+	// left by a prior era. Absence of the key = no drain in progress.
+	EpochDrainCursorKey = []byte("edc")
 )
 
 const PollCandidatesPrefix = "Candidates."


### PR DESCRIPTION
## Summary

Adds the state schema + Go helpers for a multi-block era-boundary drain
of \`PendingBlockRewardPool\` balances into voter accounts. This PR is
additive only — the cursor is not yet read or written by
\`GrantEpochReward\`. That wiring lands in PR C2. Splitting it off
isolates the schema/helper piece so the follow-up refactor diff stays
readable.

## What's in

- \`proto EpochDrainCursor {target_era, delegate_index, repeated
  EpochDrainDelegateWork}\` and \`EpochDrainDelegateWork\` in
  \`rewardingpb/rewarding.proto\`.
- \`state.EpochDrainCursorKey\` (singleton \`\"edc\"\` in
  \`RewardingNamespace\`, mirroring the sentinel patterns for block/epoch
  reward history already there).
- \`action/protocol/rewarding/epoch_drain_cursor.go\` — cursor Go type,
  Serialize/Deserialize, and read/write/delete helpers
  (\`readEpochDrainCursor\` returns \`(nil, nil)\` when absent; delete is
  idempotent via the existing \`deleteState\` \`ErrStateNotExist\`
  swallow).

## Test plan

- [x] \`go test -run TestEpochDrainCursor -count=1 -v\` — 6 passed:
      round-trip, empty delegate list, zero pool amount, missing-key
      returns nil, write→read→delete lifecycle + idempotent second delete,
      write overwrites rather than merges.
- [x] \`go test ./action/protocol/rewarding/... -count=1\` — 109 passed
- [x] \`go build ./...\` clean
- [x] \`go vet\` clean on \`rewarding/\` and \`state/\`

## Stack

- Base: #4926 (PR 4' — block reward folding; provides \`PendingBlockRewardPool\`)
- Depends-on (referenced only, not merged into this branch):
  #4939 (PR A — \`IsEraBoundary\` helper the follow-up chunked-drain PR
  will use for the era-boundary trigger).

## Explicitly deferred (PR C2 / C3)

- \`GrantEpochReward\` refactor into chunked Phase A/B/C
- \`CreatePostSystemActions\` continuation dispatch keyed off cursor
  presence
- \`IsEraBoundary\` gate wiring
- \`EpochDrainChunkSize\` / \`CompoundBatchSize\` genesis field usage
- End-to-end \"chunked matches single\" byte-equivalence test

🤖 Generated with [Claude Code](https://claude.com/claude-code)