### PR TITLE
ci: derive Go version from go.mod instead of a stale pin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.0
+          go-version-file: go.mod
           cache: false
 
       - name: Build Go


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yaml` pins `go-version: 1.23.0`, but `go.mod` requires `go 1.25.7`.

Under `actions/setup-go@v4` this mismatch is invisible: v4 does not set `GOTOOLCHAIN`, so Go silently downloads and switches to whatever toolchain `go.mod` asks for. **The pin has therefore been a no-op for some time — CI has not been building with 1.23.0 as the file claims.**

`setup-go` v5+ exports `GOTOOLCHAIN=local`, which disables that automatic switch and turns the latent mismatch into a hard failure on the very first `go build ./...`:

```
go: go.mod requires go >= 1.25.7 (running go 1.23.0; GOTOOLCHAIN=local)
```

This is exactly what blocks #4949 (`setup-go` v4 → v7) today.

## Change

Point `ci.yaml` at `go.mod` so the toolchain has a single source of truth and survives future `go` directive bumps (the last one arrived via #4933, which moved `go 1.25.0` → `go 1.25.7`):

```diff
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.23.0
+          go-version-file: go.mod
           cache: false
```

`release.yaml` already does this — the change just brings `ci.yaml` in line.

## Scope

Deliberately **keeps `setup-go` at v4** so this lands as an isolated, reviewable fix. Once it is in, #4949 can bump the action on its own and should go green without further changes.

`ci.yaml` was the only workflow carrying a hard-coded `go-version`; `release.yaml` was already on `go-version-file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)