### PR TITLE
fix(messagebatcher): prevent options from mutating default writer config

### DIFF
--- a/pkg/messagebatcher/batchwriter.go
+++ b/pkg/messagebatcher/batchwriter.go
@@ -102,14 +102,14 @@ func (bm *Manager) Put(msg *Message, opts ...Option) error {
 	if !exist {
 		cfg := _defaultWriterConfig
 		for _, opt := range opts {
-			opt(cfg)
+			opt(&cfg)
 		}
 		bm.mu.Lock()
 		if len(bm.writerMap) > _maxWriters {
 			bm.mu.Unlock()
 			return errors.New("the batch is full")
 		}
-		writer = newBatchWriter(cfg, bm)
+		writer = newBatchWriter(&cfg, bm)
 		bm.writerMap[id] = writer
 		bm.mu.Unlock()
 	}
@@ -200,7 +200,7 @@ type writerConfig struct {
 	msgInterval      time.Duration
 }
 
-var _defaultWriterConfig = &writerConfig{
+var _defaultWriterConfig = writerConfig{
 	expiredThreshold: 2,
 	msgInterval:      100 * time.Millisecond,
 	sizeLimit:        1000,

--- a/pkg/messagebatcher/batchwriter_test.go
+++ b/pkg/messagebatcher/batchwriter_test.go
@@ -157,6 +157,42 @@ func TestBatchManager(t *testing.T) {
 	})
 }
 
+func TestBatchManagerOptionIsolation(t *testing.T) {
+	require := require.New(t)
+	manager := NewManager(func(*Message) error { return nil })
+
+	msgWithOptions := &Message{
+		ChainID: 1,
+		Data:    txProto1,
+	}
+	msgWithDefaults := &Message{
+		ChainID: 2,
+		Data:    txProto2,
+	}
+
+	require.NoError(manager.Put(msgWithOptions, WithSizeLimit(2), WithInterval(time.Second)))
+	require.NoError(manager.Put(msgWithDefaults))
+
+	configuredID, err := msgWithOptions.batchID()
+	require.NoError(err)
+	defaultID, err := msgWithDefaults.batchID()
+	require.NoError(err)
+
+	configuredWriter := manager.writerMap[configuredID]
+	defaultWriter := manager.writerMap[defaultID]
+	require.NotNil(configuredWriter)
+	require.NotNil(defaultWriter)
+	t.Cleanup(func() {
+		configuredWriter.Close()
+		defaultWriter.Close()
+	})
+
+	require.Equal(uint64(2), configuredWriter.cfg.sizeLimit)
+	require.Equal(time.Second, configuredWriter.cfg.msgInterval)
+	require.Equal(uint64(1000), defaultWriter.cfg.sizeLimit)
+	require.Equal(100*time.Millisecond, defaultWriter.cfg.msgInterval)
+}
+
 func TestBatchDataCorrectness(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
# Description


`Manager.Put` previously assigned the `_defaultWriterConfig` pointer directly to `cfg` before applying writer options. Consequently, options such as `WithSizeLimit` and `WithInterval` mutated the package-level default configuration.

This caused writers created later without options to inherit configuration from earlier writers. Concurrent writer creation could also access the shared configuration without synchronization.

This change stores the default configuration as a value and creates a fresh copy before applying options. Each writer therefore receives an independent configuration.

A regression test verifies that configuring one writer does not change the defaults used by a writer with a different batch ID.

Fixes  https://github.com/iotexproject/iotex-core/issues/4960



## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Code refactor or improvement
- [] Breaking change (fix or feature that would cause a new or changed behavior of existing functionality)
- [] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [] make test
- [] fullsync
- [x] Other test (please specify)

**Test Configuration**:
- Firmware version:
- Hardware:
- Toolchain:
- SDK:

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [] Any dependent changes have been merged and published in downstream modules
