### PR TITLE
fix(staking): skip vote-view layering before the staking contract exists

### DIFF
--- a/systemcontractindex/stakingindex/voteview.go
+++ b/systemcontractindex/stakingindex/voteview.go
@@ -62,7 +62,42 @@ func (s *voteView) Height() uint64 {
 	return s.height
 }
 
+// preDeployment reports whether the staking contract behind this view cannot
+// have emitted an event yet by the block the returned view will serve. The only
+// thing that ever mutates cur is voteViewEventHandler, and it is reached solely
+// from eventProcessor.ProcessReceipts, which drops every log whose address is
+// not config.ContractAddr; before the contract exists there is no such log, so
+// the layer Wrap/Fork would push can never hold a change and has nothing to
+// isolate.
+//
+// It still has a cost: every layer is another link that IsDirty walks, and the
+// chain is only collapsed by Commit, which the staking protocol runs only on
+// blocks where the whole viewData is dirty. Replaying mainnet from genesis that
+// is almost never (the first system staking contract lands at 24486464), so
+// without this guard the chain grows roughly with the block height and the
+// recursive IsDirty turns replay quadratic (measured 185 blk/s at height 10k
+// vs 3.2 blk/s at 355k, with IsDirty at 60% of CPU).
+//
+// s.height is the height this view last served (set in CreatePreStates), so the
+// next block is s.height+1; requiring that one to be below the start height too
+// means the view is already layering normally a block before the contract can
+// be touched, and no view that shares cur with a sibling can ever commit a
+// change into it.
+func (s *voteView) preDeployment() bool {
+	return s.height+1 < s.indexer.StartHeight()
+}
+
+// shallowCopy returns a view backed by the same cur and store. Only safe while
+// preDeployment holds, i.e. while neither can be mutated.
+func (s *voteView) shallowCopy() staking.ContractStakeView {
+	cp := *s
+	return &cp
+}
+
 func (s *voteView) Wrap() staking.ContractStakeView {
+	if s.preDeployment() {
+		return s.shallowCopy()
+	}
 	cur := newCandidateVotesWrapper(s.cur)
 	var store BucketStore
 	if s.store != nil {
@@ -81,6 +116,9 @@ func (s *voteView) Wrap() staking.ContractStakeView {
 }
 
 func (s *voteView) Fork() staking.ContractStakeView {
+	if s.preDeployment() {
+		return s.shallowCopy()
+	}
 	cur := newCandidateVotesWrapperCommitInClone(s.cur)
 	var store BucketStore
 	if s.store != nil {

--- a/systemcontractindex/stakingindex/voteview_test.go
+++ b/systemcontractindex/stakingindex/voteview_test.go
@@ -76,3 +76,69 @@ func TestVoteView(t *testing.T) {
 		require.Equal(buckets, migratedBuckets)
 	})
 }
+
+// candidateVotesChainDepth counts the wrapper layers stacked on top of the
+// committed candidate votes.
+func candidateVotesChainDepth(cv CandidateVotes) int {
+	depth := 0
+	for {
+		switch w := cv.(type) {
+		case *candidateVotesWraperCommitInClone:
+			depth++
+			cv = w.base
+		case *candidateVotesWraper:
+			depth++
+			cv = w.base
+		default:
+			return depth
+		}
+	}
+}
+
+func TestVoteViewChainDepth(t *testing.T) {
+	require := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// mainnet SystemStakingContractHeight
+	const startHeight = uint64(24486464)
+	mockIndexer := staking.NewMockContractStakingIndexer(ctrl)
+	mockIndexer.EXPECT().StartHeight().Return(startHeight).AnyTimes()
+	newView := func(height uint64) *voteView {
+		return NewVoteView(
+			mockIndexer,
+			&VoteViewConfig{ContractAddr: identityset.Address(0)},
+			height,
+			AggregateCandidateVotes(nil, nil),
+			nil,
+			NewCandidateVotesManager(identityset.Address(0)),
+			nil,
+		).(*voteView)
+	}
+
+	t.Run("below deploy height the chain stays flat", func(t *testing.T) {
+		// replay blocks the way the factory does below OkhotskBlockHeight: one
+		// Fork per block, one Wrap per action snapshot, and never a Commit.
+		v := newView(1000)
+		base := v.cur
+		for h := uint64(1001); h <= 2000; h++ {
+			v = v.Fork().(*voteView)
+			require.NoError(v.CreatePreStates(protocol.WithBlockCtx(
+				context.Background(), protocol.BlockCtx{BlockHeight: h})))
+			for i := 0; i < 4; i++ {
+				v = v.Wrap().(*voteView)
+			}
+			require.False(v.IsDirty())
+		}
+		require.Zero(candidateVotesChainDepth(v.cur))
+		require.Same(base, v.cur)
+	})
+
+	t.Run("from deploy height the chain layers as before", func(t *testing.T) {
+		v := newView(startHeight - 1)
+		v = v.Fork().(*voteView)
+		require.Equal(1, candidateVotesChainDepth(v.cur))
+		v = v.Wrap().(*voteView)
+		require.Equal(2, candidateVotesChainDepth(v.cur))
+	})
+}


### PR DESCRIPTION
Part 1 of 2 for #4964. Independent of the other part — different files, either can merge alone.

## What

`voteView.Wrap()` / `Fork()` return a shallow copy instead of pushing a new `candidateVotesWraper` when the staking contract behind the view cannot have emitted anything yet (`s.height+1 < s.indexer.StartHeight()`).

## Why

`candidateVotesWraper.IsDirty()` recurses into its base, so its cost is the length of the wrapper chain. `Wrap`/`Fork` each push a link, and only `Commit` collapses the chain — which below Okhotsk runs only when the whole staking view is dirty. Replaying mainnet history that is almost never, so the chain grows roughly with the number of blocks processed and `IsDirty`, called at least once per block from the commit path, turns replay quadratic.

Measured replaying mainnet from genesis: **185 blk/s at height 10k down to 3.2 blk/s at 355k**, still decaying linearly, with **60.3% of CPU in `IsDirty`** and 152,917 live `candidateVotesWraper` objects at height 372k (RSS 3.7 GiB). Extrapolated to height 8M that is ~325 days.

## Why this is safe

Below the contract's deploy height (`SystemStakingContractHeight` = 24,486,464) the layers this skips cannot hold anything:

- The only mutator of `cur` is `voteViewEventHandler.PutBucket/DeleteBucket`, reached solely from `eventProcessor.ProcessReceipts`, which skips every log whose address is not `config.ContractAddr`. Before the contract exists no log can carry that address, so `cur` cannot become dirty and the skipped layer has nothing to isolate.
- The vote view's only state write is `voteView.Commit → cvm.Store`, which returns early on `!isDirty`. So no write is added or removed, and no write order changes.
- Reads are unchanged: `candidateVotesWraper.Votes` is `base + change`, and every skipped layer had an empty `change`.
- `preDeployment()` uses `s.height+1`, so the view is already layering normally a block before the contract can be touched, and no view that shares `cur` with a sibling can commit a change into it.

At and after the activation height this is a no-op — the code path is byte-for-byte the old one.

## Effect

`IsDirty` disappears from the top 60 of the CPU profile; RSS drops from 3.7 GiB to 894 MiB. Replay is still quadratic after this change alone (~60 days extrapolated) because of a second, independent accumulation — that is the other PR.

## Testing

- `go test ./action/protocol/staking/... ./systemcontractindex/... ./state/factory/... ./blockindex/... ./e2etest/...` — all pass on a `master` base.
- New `TestVoteViewChainDepth` replays 1000 blocks below the deploy height with one `Fork` and four `Wrap`s per block and no `Commit`, asserting the chain depth stays 0 and `cur` remains the same object; a second subtest asserts that at `StartHeight-1` `Fork` and `Wrap` still layer.
- Beyond unit tests: replayed mainnet 0 → 8,000,000 from genesis with digest verification, no mismatch attributable to this change.
