### PR TITLE
fix(staking): drop the snapshot undo log when forking the staking view

### DIFF
--- a/action/protocol/protocol.go
+++ b/action/protocol/protocol.go
@@ -165,11 +165,12 @@ func (views *views) Revert(id int) error {
 			return err
 		}
 	}
-	views.snapshotID = id
-	// clean up snapshots that are not needed anymore
+	// clean up snapshots that are not needed anymore, before snapshotID is
+	// lowered to id and the loop bound collapses
 	for i := id + 1; i <= views.snapshotID; i++ {
 		delete(views.snapshots, i)
 	}
+	views.snapshotID = id
 	return nil
 }
 

--- a/action/protocol/staking/viewdata.go
+++ b/action/protocol/staking/viewdata.go
@@ -70,16 +70,13 @@ func (v *viewData) Fork() protocol.View {
 	fork := &viewData{}
 	fork.candCenter = v.candCenter.Clone()
 	fork.bucketPool = v.bucketPool.Clone()
-	fork.snapshots = make([]Snapshot, len(v.snapshots))
-	for i := range v.snapshots {
-		fork.snapshots[i] = Snapshot{
-			size:           v.snapshots[i].size,
-			changes:        v.snapshots[i].changes,
-			amount:         new(big.Int).Set(v.snapshots[i].amount),
-			count:          v.snapshots[i].count,
-			contractsStake: v.snapshots[i].contractsStake,
-		}
-	}
+	// snapshots is left empty on purpose: it is an in-memory undo log whose
+	// indices never outlive a fork, because protocol.views (its only long-lived
+	// holder) is rebuilt empty by views.Fork() and the two direct callers
+	// (Protocol.Handle here, slashDelegates in rewarding) revert within one call
+	// frame. Copying it only cost a Snapshot plus a big.Int per entry per fork,
+	// which is quadratic whenever the view stays clean and Commit never clears
+	// the log.
 	fork.contractsStake = v.contractsStake.Fork()
 	return fork
 }

--- a/action/protocol/staking/viewdata_test.go
+++ b/action/protocol/staking/viewdata_test.go
@@ -22,7 +22,9 @@ func TestViewData_Fork(t *testing.T) {
 	require.Equal(t, vd.candCenter.base, fork.candCenter.base)
 	require.Equal(t, vd.candCenter.change, fork.candCenter.change)
 	require.NotSame(t, vd.bucketPool, fork.bucketPool)
-	require.Equal(t, vd.snapshots, fork.snapshots)
+	// the undo log is not carried across a fork, and the parent keeps its own
+	require.Empty(t, fork.snapshots)
+	require.Len(t, vd.snapshots, 1)
 
 	sm := mock_chainmanager.NewMockStateManager(gomock.NewController(t))
 	sm.EXPECT().Height().Return(uint64(100), nil).Times(1)
@@ -35,7 +37,7 @@ func TestViewData_Fork(t *testing.T) {
 	require.Equal(t, vd.candCenter.base, fork.candCenter.base)
 	require.Equal(t, vd.candCenter.change, fork.candCenter.change)
 	require.Equal(t, vd.bucketPool, fork.bucketPool)
-	require.Equal(t, vd.snapshots, fork.snapshots)
+	require.Empty(t, fork.snapshots)
 }
 
 func prepareViewData(t *testing.T) (*viewData, int) {
@@ -86,4 +88,53 @@ func TestViewData_Snapshot_Revert(t *testing.T) {
 	require.Equal(t, 1, len(viewData.snapshots))
 	require.NoError(t, viewData.Revert(ss))
 	require.Equal(t, 0, len(viewData.snapshots))
+}
+
+// A fork starts a fresh undo log, so snapshot/revert inside the fork must still
+// restore the exact pre-snapshot state, and must not disturb the parent's log.
+func TestViewData_Snapshot_RevertAfterFork(t *testing.T) {
+	r := require.New(t)
+	parent, _ := prepareViewData(t)
+	r.Len(parent.snapshots, 1)
+
+	fork := parent.Fork().(*viewData)
+	r.Empty(fork.snapshots)
+
+	var (
+		size    = fork.candCenter.size
+		changes = len(fork.candCenter.change.candidates)
+		amount  = new(big.Int).Set(fork.bucketPool.total.amount)
+		count   = fork.bucketPool.total.count
+	)
+
+	ss := fork.Snapshot()
+	r.Equal(0, ss)
+
+	owner := identityset.Address(1)
+	r.NoError(fork.candCenter.Upsert(&Candidate{
+		Owner:              owner,
+		Operator:           owner,
+		Reward:             owner,
+		Identifier:         owner,
+		Name:               "name2",
+		Votes:              big.NewInt(200),
+		SelfStakeBucketIdx: 1,
+		SelfStake:          big.NewInt(0),
+	}))
+	fork.bucketPool.total.amount.SetInt64(999)
+	fork.bucketPool.total.count = 42
+	r.NotEqual(size, fork.candCenter.size)
+
+	r.NoError(fork.Revert(ss))
+	r.Equal(size, fork.candCenter.size)
+	r.Len(fork.candCenter.change.candidates, changes)
+	r.Zero(amount.Cmp(fork.bucketPool.total.amount))
+	r.Equal(count, fork.bucketPool.total.count)
+	r.Empty(fork.snapshots)
+
+	// the parent's entry is neither consumed nor aliased by the fork
+	r.Len(parent.snapshots, 1)
+	r.Zero(parent.snapshots[0].amount.Cmp(amount))
+	r.NoError(parent.Revert(0))
+	r.Empty(parent.snapshots)
 }


### PR DESCRIPTION
Part 2 of 2 for #4964. Independent of #4966 — different files, either can merge alone. This one is the larger win, and also the riskier of the two: unlike #4966 it is **not** height-gated, so it changes behaviour at every height.

## What

`viewData.Fork()` no longer copies the `snapshots` slice; the fork starts with it empty.

Second commit is a one-liner: `views.Revert` set `views.snapshotID = id` *before* its cleanup loop `for i := id + 1; i <= views.snapshotID; i++`, so the loop never ran. Split out so the main diff stays clean — drop it if you would rather it went separately.

## Why

`viewData.Fork()` deep-copied the whole `snapshots` slice on every fork, allocating a `Snapshot` struct **and a `new(big.Int).Set(...)` per retained entry**. `v.snapshots` grows one entry per action-snapshot and is cleared only in `viewData.Commit`, which below Okhotsk runs only when the staking view is dirty — almost never on early mainnet history. So the slice grows roughly with blocks processed and each fork's copy gets more expensive.

With #4966 applied, this is what the profile looks like at height ~750k:

```
      flat  flat%   cum   cum%
    12.84s 19.00%  21.64s 32.02%  runtime.tryDeferToSpanScan
    11.81s 17.47%  31.40s 46.46%  runtime.scanObjectsSmall
     3.62s  5.36%  17.28s 25.57%  action/protocol/staking.(*viewData).Fork
     2.12s  3.14%   2.55s  3.77%  math/big.(*Int).Set
```

`viewData.Fork` breaks down as `runtime.newobject` 55%, `math/big.(*Int).Set` 14.8%, `runtime.makeslice` 5.2% — the copy loop — and essentially all of the remaining profile is GC driven by it.

## Why this is safe

Two independent legs.

**1. `snapshots` cannot reach the write queue.** The field appears only in `viewdata.go`. `viewData.Snapshot()` and `Revert()` take neither a `StateManager` nor a context and cannot write state. `viewData.Commit` reads `candCenter` / `bucketPool` / `contractsStake` and *clears* `snapshots` without reading it. The only channel from `snapshots` to the flusher's ordered write queue is the values `Revert` restores into `candCenter.size`, `candCenter.change`, `bucketPool.total.{amount,count}` and `contractsStake`. So if no `Revert` behaves differently, no write and no write order changes.

**2. No snapshot index survives a fork, so no `Revert` can behave differently.** Every index handed to `viewData.Revert` was produced by a `Snapshot()` on that same instance after its `Fork()`:

- `protocol.views` is the only long-lived holder, and `views.Fork()` returns `NewViews()` — `snapshotID: 0`, empty snapshot map — then repopulates only `vm`. A forked container cannot yield a pre-fork index.
- Two call sites hold an index directly, `staking.Protocol.Handle` and `rewarding.slashDelegates`. Both snapshot and revert within a single call frame, and forking happens only at working-set construction, so no fork can interleave.
- `statedb.go` assigns `sdb.protocolViews = ws.views`, but that field is only ever `Read` or `Fork`ed, never `Snapshot`/`Revert`. `workingSet.viewsSnapshots` is made fresh per working set.

Post-fork indices now start at 0 instead of `len(parent.snapshots)`, but they are only ever positions in this one slice and `Revert` truncates with `v.snapshots[:snapshot]`. Every index shifts by the same constant, so the retained set and the restored values are identical.

The only new failure mode would be a `Revert` landing on an index the fork no longer has, which returns the deterministic error `invalid snapshot index %d`. That string appears nowhere in the full test run.

Incidentally the old copy was latently unsafe: `fork.snapshots[i].contractsStake` was a bare pointer into the **parent's** unforked wrapper chain, so a revert to a pre-fork index would have installed parent-owned mutable state into the child — and it pinned the parent's whole chain alive.

## Effect

Combined with #4966, replaying mainnet from genesis:

| build | throughput | trend | extrapolated 0→8M |
|---|---|---|---|
| `master` | 185 → 3.2 blk/s by height 355k | linear decay | ~325 days |
| + #4966 | 250 → 71 blk/s over 85k blocks | still decaying | ~60 days |
| + this | **500–1000 blk/s**, still 746 blk/s at height 2.67M | **flat** | **~2.7 hours** |

CPU dropped from 296% to 92% — the GC storm is gone. `0 → 8,000,000` has since been replayed end to end.

## Testing

- `go test ./action/protocol/... ./state/factory/... ./systemcontractindex/... ./e2etest/...` — all pass on a `master` base. (`e2etest` builds and validates real blocks, exercising `VerifyDeltaStateDigest`.)
- New `TestViewData_Snapshot_RevertAfterFork`; two assertions in `TestViewData_Fork` updated to the new contract.
- Replay soak with digest verification: 0 → 8,000,000 from genesis, and a post-activation range (32M → 34M, past Okhotsk and past the V1/V2 contract heights, in the heaviest million-block file on the chain) — no digest mismatch. The 32M → 34M soak is still running at the time of writing; I will post the final result here.

Given this one is not height-gated, I would not merge it on the unit tests alone — the post-activation soak is the evidence that matters, and I am happy to run more ranges if you want a specific one covered.
