### PR TITLE
refactor(rewarding): rename voter reward distribution event

### DIFF
--- a/action/protocol/rewarding/distributedlog/abi.go
+++ b/action/protocol/rewarding/distributedlog/abi.go
@@ -28,13 +28,13 @@ const ABIJSON = `[
 			{"indexed": false, "name": "compoundBucketIds", "type": "uint64[]"},
 			{"indexed": false, "name": "compounded",      "type": "bool[]"}
 		],
-		"name": "DelegateDistributed",
+		"name": "DelegateVoterRewardsDistributed",
 		"type": "event"
 	}
 ]`
 
 // EventName is the event's ABI name; used for method lookup and error text.
-const EventName = "DelegateDistributed"
+const EventName = "DelegateVoterRewardsDistributed"
 
 // EventSignature is the canonical Solidity signature. keccak256 of this
 // string is Topics[0]. Kept as a const for the golden-selector test, and
@@ -47,4 +47,4 @@ const EventName = "DelegateDistributed"
 // -- it is indistinguishable from "voter i was compounded into bucket 0".
 // The parallel bool is the authoritative discriminator; consumers must read
 // compoundBucketIds[i] only when compounded[i] is true.
-const EventSignature = "DelegateDistributed(uint64,address,address,uint256,uint256,bytes32,address[],address[],uint256[],uint64[],bool[])"
+const EventSignature = "DelegateVoterRewardsDistributed(uint64,address,address,uint256,uint256,bytes32,address[],address[],uint256[],uint64[],bool[])"

--- a/action/protocol/rewarding/distributedlog/event.go
+++ b/action/protocol/rewarding/distributedlog/event.go
@@ -3,7 +3,7 @@
 // or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
 // This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
 
-// Package distributedlog encodes the IIP-59 §3.2 DelegateDistributed
+// Package distributedlog encodes the IIP-59 §3.2 DelegateVoterRewardsDistributed
 // receipt event. distributeToVoters (PR 3') calls Pack once per delegate
 // at epoch close and wraps the returned Topics+data into an *action.Log;
 // this package deliberately does NOT construct action.Log itself so it
@@ -46,19 +46,20 @@ var (
 	// any Amounts[i] is nil.
 	ErrNilBigInt = errors.New("distributedlog: nil *big.Int")
 
-	// ErrNotDelegateDistributed is returned by Unpack when the log has no topic
+	// ErrNotDelegateVoterRewardsDistributed is returned by Unpack when the log has no topic
 	// or Topics[0] is not this event's ID. It is the ordinary outcome of scanning
 	// a block's logs and
 	// means "skip this one", so it is deliberately distinct from the
 	// malformed-log errors below, which mean "this IS our event and it is
 	// broken" and are worth alerting on.
-	ErrNotDelegateDistributed = errors.New("distributedlog: not a DelegateDistributed log")
+	ErrNotDelegateVoterRewardsDistributed = errors.New(
+		"distributedlog: not a DelegateVoterRewardsDistributed log")
 
 	// ErrMalformedLog is returned by Unpack when the log carries this
 	// event's topic but its payload does not decode to the expected shape:
 	// a topic with non-zero padding, an unexpected ABI value type, or the
 	// wrong number of non-indexed fields.
-	ErrMalformedLog = errors.New("distributedlog: malformed DelegateDistributed log")
+	ErrMalformedLog = errors.New("distributedlog: malformed DelegateVoterRewardsDistributed log")
 )
 
 // eraSnapshotDomainSeparator scopes EraSnapshotHash so its output cannot
@@ -102,7 +103,7 @@ func ABI() (abi.ABI, error) {
 }
 
 // Topic0 returns keccak256(EventSignature) -- the value every
-// DelegateDistributed log carries in Topics[0], and the filter an indexer
+// DelegateVoterRewardsDistributed log carries in Topics[0], and the filter an indexer
 // matches on.
 func Topic0() (hash.Hash256, error) {
 	parsed, err := loadABI()
@@ -116,7 +117,7 @@ func Topic0() (hash.Hash256, error) {
 	return hash.Hash256(ev.ID), nil
 }
 
-// EventArgs are the fields of one DelegateDistributed log. Field order
+// EventArgs are the fields of one DelegateVoterRewardsDistributed log. Field order
 // matches the Solidity signature so a struct literal reads left-to-right
 // the same way as the on-chain event definition. Callers build one per
 // delegate (top-N loop and orphan-drain loop use the same shape).
@@ -135,7 +136,7 @@ type EventArgs struct {
 }
 
 // Pack encodes args as an EVM-shaped receipt log. The returned Topics
-// and data satisfy the same layout an EVM-emitted DelegateDistributed
+// and data satisfy the same layout an EVM-emitted DelegateVoterRewardsDistributed
 // event would produce, so off-chain verifiers (PR #45) can decode with
 // stock ethers.js / web3.py against this event ABI.
 //
@@ -209,7 +210,7 @@ func Pack(args EventArgs) (action.Topics, []byte, error) {
 		args.Compounded,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "distributedlog: pack DelegateDistributed data")
+		return nil, nil, errors.Wrap(err, "distributedlog: pack DelegateVoterRewardsDistributed data")
 	}
 
 	topics := make(action.Topics, 3)
@@ -219,7 +220,7 @@ func Pack(args EventArgs) (action.Topics, []byte, error) {
 	return topics, data, nil
 }
 
-// Unpack is the inverse of Pack: it decodes an on-chain DelegateDistributed
+// Unpack is the inverse of Pack: it decodes an on-chain DelegateVoterRewardsDistributed
 // log back into EventArgs.
 //
 // It exists so off-chain consumers -- the analyser indexer, explorers -- decode
@@ -234,7 +235,7 @@ func Pack(args EventArgs) (action.Topics, []byte, error) {
 // otherwise an attacker-deployed contract emitting the same topic would be
 // decoded as a protocol payout.
 //
-// Returns ErrNotDelegateDistributed when the log is some other event, which
+// Returns ErrNotDelegateVoterRewardsDistributed when the log is some other event, which
 // callers should treat as "skip", distinct from the malformed-log errors that
 // signal a corrupt or truncated payload and are worth alerting on.
 func Unpack(topics action.Topics, data []byte) (*EventArgs, error) {
@@ -247,10 +248,10 @@ func Unpack(topics action.Topics, data []byte) (*EventArgs, error) {
 		return nil, errors.Errorf("distributedlog: event %q not found in parsed ABI", EventName)
 	}
 	if len(topics) == 0 {
-		return nil, errors.Wrap(ErrNotDelegateDistributed, "log has no topics")
+		return nil, errors.Wrap(ErrNotDelegateVoterRewardsDistributed, "log has no topics")
 	}
 	if topics[0] != hash.Hash256(ev.ID) {
-		return nil, errors.Wrapf(ErrNotDelegateDistributed, "topics[0]=%x", topics[0])
+		return nil, errors.Wrapf(ErrNotDelegateVoterRewardsDistributed, "topics[0]=%x", topics[0])
 	}
 	if len(topics) != 3 {
 		return nil, errors.Wrapf(ErrMalformedLog, "got %d topics, want 3", len(topics))
@@ -268,7 +269,7 @@ func Unpack(topics action.Topics, data []byte) (*EventArgs, error) {
 	values, err := ev.Inputs.NonIndexed().Unpack(data)
 	if err != nil {
 		return nil, errors.Wrapf(ErrMalformedLog,
-			"unpack DelegateDistributed data: %v", err)
+			"unpack DelegateVoterRewardsDistributed data: %v", err)
 	}
 	if len(values) != 9 {
 		return nil, errors.Wrapf(ErrMalformedLog, "got %d non-indexed values, want 9", len(values))
@@ -420,7 +421,7 @@ type EraSnapshotParams struct {
 	OnchainRewardEnabled       bool
 }
 
-// EraSnapshotHash produces the bytes32 digest a DelegateDistributed log
+// EraSnapshotHash produces the bytes32 digest a DelegateVoterRewardsDistributed log
 // carries in its snapshotHash field.
 //
 // One settlement pays a delegate's voters across many blocks and emits one

--- a/action/protocol/rewarding/distributedlog/event_test.go
+++ b/action/protocol/rewarding/distributedlog/event_test.go
@@ -233,7 +233,7 @@ func TestPack_SelectorPinned(t *testing.T) {
 	r.NoError(err)
 
 	expected := crypto.Keccak256Hash([]byte(
-		"DelegateDistributed(uint64,address,address,uint256,uint256,bytes32,address[],address[],uint256[],uint64[],bool[])",
+		"DelegateVoterRewardsDistributed(uint64,address,address,uint256,uint256,bytes32,address[],address[],uint256[],uint64[],bool[])",
 	))
 	r.Equal(hash.Hash256(expected), topics[0])
 }

--- a/action/protocol/rewarding/distributedlog/unpack_test.go
+++ b/action/protocol/rewarding/distributedlog/unpack_test.go
@@ -90,7 +90,7 @@ func TestUnpackEmptyVoterList(t *testing.T) {
 }
 
 // TestUnpackRejectsForeignEvent pins the skip/alert split. A log from some
-// other event must come back as ErrNotDelegateDistributed so an indexer
+// other event must come back as ErrNotDelegateVoterRewardsDistributed so an indexer
 // scanning every log in a block can skip it silently, without that outcome
 // being confusable with a corrupt log of our own.
 func TestUnpackRejectsForeignEvent(t *testing.T) {
@@ -105,7 +105,17 @@ func TestUnpackRejectsForeignEvent(t *testing.T) {
 			hash.Hash256{},
 		}
 		_, err := Unpack(topics, data)
-		require.ErrorIs(t, err, ErrNotDelegateDistributed)
+		require.ErrorIs(t, err, ErrNotDelegateVoterRewardsDistributed)
+	})
+
+	t.Run("retired event name", func(t *testing.T) {
+		topics, _, err := Pack(happyArgs())
+		require.NoError(t, err)
+		topics[0] = hash.Hash256b([]byte(
+			"DelegateDistributed(uint64,address,address,uint256,uint256,bytes32,address[],address[],uint256[],uint64[],bool[])",
+		))
+		_, err = Unpack(topics, data)
+		require.ErrorIs(t, err, ErrNotDelegateVoterRewardsDistributed)
 	})
 
 	t.Run("wrong topic count", func(t *testing.T) {
@@ -117,7 +127,7 @@ func TestUnpackRejectsForeignEvent(t *testing.T) {
 
 	t.Run("no topics", func(t *testing.T) {
 		_, err := Unpack(nil, data)
-		require.ErrorIs(t, err, ErrNotDelegateDistributed)
+		require.ErrorIs(t, err, ErrNotDelegateVoterRewardsDistributed)
 	})
 }
 
@@ -161,7 +171,7 @@ func TestUnpackRejectsTruncatedData(t *testing.T) {
 
 	_, err = Unpack(topics, data[:len(data)/2])
 	r.Error(err)
-	r.NotErrorIs(err, ErrNotDelegateDistributed, "a truncated payload of our own event is corruption, not a foreign event")
+	r.NotErrorIs(err, ErrNotDelegateVoterRewardsDistributed, "a truncated payload of our own event is corruption, not a foreign event")
 	r.ErrorIs(err, ErrMalformedLog)
 }
 

--- a/action/protocol/rewarding/epoch_drain_cursor.go
+++ b/action/protocol/rewarding/epoch_drain_cursor.go
@@ -50,7 +50,7 @@ type epochDrainDelegateWork struct {
 	// and with the list gone that is exactly this field being positive.
 	TotalWeight *big.Int
 	// SnapshotHash is the era snapshot's digest, stamped into every
-	// DelegateDistributed log this settlement emits for the delegate so an
+	// DelegateVoterRewardsDistributed log this settlement emits for the delegate so an
 	// off-chain consumer can group the per-block partial logs back together.
 	SnapshotHash []byte
 	// FreezeHeight is the block height the era's state was frozen at. It is

--- a/action/protocol/rewarding/reward.go
+++ b/action/protocol/rewarding/reward.go
@@ -314,7 +314,7 @@ func (p *Protocol) creditBlockProducer(
 // encodeBlockRewardLog builds the receipt log for a block grant, in whichever
 // of the two wire formats the chain is on. blockCommission is what the producer
 // was actually paid now; post-fork the voter share is attested separately by
-// the batched DelegateDistributed log at era close. A zero payout emits no log
+// the batched DelegateVoterRewardsDistributed log at era close. A zero payout emits no log
 // at all rather than a log naming zero.
 func (p *Protocol) encodeBlockRewardLog(
 	ctx context.Context,

--- a/action/protocol/rewarding/voter_allocation.go
+++ b/action/protocol/rewarding/voter_allocation.go
@@ -20,7 +20,7 @@ import (
 
 // voterDistributionMetadata lifts the two allocation inputs Phase A freezes
 // into a delegate's work item out of the era snapshot: the weight total the
-// drain divides by, and the digest every DelegateDistributed log for this
+// drain divides by, and the digest every DelegateVoterRewardsDistributed log for this
 // delegate is stamped with.
 //
 // Both are read, not derived. TotalWeight is the frozen candidate.Votes the

--- a/action/protocol/rewarding/voter_reward.go
+++ b/action/protocol/rewarding/voter_reward.go
@@ -450,7 +450,7 @@ func frozenEraForBucket(in voterShareInputs, bucket *staking.VoteBucket) staking
 	return staking.FrozenSelfStake{FreezeHeight: work.FreezeHeight, BucketIdx: work.SelfStakeBucketIdx}
 }
 
-// delegateChunkLog accumulates the DelegateDistributed rows for one delegate
+// delegateChunkLog accumulates the DelegateVoterRewardsDistributed rows for one delegate
 // across a whole chunk. The drain is voter-major, so a delegate is touched by
 // many voters within one block; emitting a log per (voter, delegate) pair would
 // multiply the log stream by the average delegate count per voter. One log per
@@ -505,7 +505,7 @@ func voterTransactionLog(payout voterCombinedPayout) *action.TransactionLog {
 	}
 }
 
-// packDelegateChunkLog builds the DelegateDistributed event for one delegate's
+// packDelegateChunkLog builds the DelegateVoterRewardsDistributed event for one delegate's
 // slice of this chunk. Returns nil when the delegate paid no voter this block.
 func (p *Protocol) packDelegateChunkLog(
 	epochNum uint64,
@@ -536,7 +536,7 @@ func (p *Protocol) packDelegateChunkLog(
 		Compounded:        rows.compounded,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "rewarding: pack DelegateDistributed log")
+		return nil, errors.Wrap(err, "rewarding: pack DelegateVoterRewardsDistributed log")
 	}
 	return &action.Log{
 		Address:     p.addr.String(),

--- a/action/protocol/rewarding/voter_reward_test.go
+++ b/action/protocol/rewarding/voter_reward_test.go
@@ -176,7 +176,7 @@ func newRoutingShares(delegate address.Address, amount *big.Int) (voterShareSet,
 
 // TestPayVoterCombinedCustomRewardDestination pins that a voter who has
 // registered a reward destination is credited there rather than at their own
-// address, and that the DelegateDistributed row records both.
+// address, and that the DelegateVoterRewardsDistributed row records both.
 func TestPayVoterCombinedCustomRewardDestination(t *testing.T) {
 	r := require.New(t)
 	ctx, sm, p, _, candAddr := newVoterRewardCtx(t, true)
@@ -297,18 +297,18 @@ func TestPayVoterCombinedCompoundOverridesCustomRewardDestination(t *testing.T) 
 	r.Nil(voterTransactionLog(payout), "compound payout must not emit a direct account transfer")
 }
 
-const delegateDistributedDestinationTestABI = `[{"anonymous":false,"inputs":[
+const delegateVoterRewardsDistributedDestinationTestABI = `[{"anonymous":false,"inputs":[
 	{"indexed":true,"name":"epoch","type":"uint64"},
 	{"indexed":true,"name":"delegate","type":"address"},
 	{"indexed":false,"name":"rewardAddr","type":"address"},
-	{"indexed":false,"name":"totalCommission","type":"uint256"},
-	{"indexed":false,"name":"totalVoterPool","type":"uint256"},
+	{"indexed":false,"name":"eraCommission","type":"uint256"},
+	{"indexed":false,"name":"chunkVoterReward","type":"uint256"},
 	{"indexed":false,"name":"snapshotHash","type":"bytes32"},
 	{"indexed":false,"name":"voters","type":"address[]"},
 	{"indexed":false,"name":"recipients","type":"address[]"},
 	{"indexed":false,"name":"amounts","type":"uint256[]"},
 	{"indexed":false,"name":"compoundBucketIds","type":"uint64[]"}],
-	"name":"DelegateDistributed","type":"event"}]`
+	"name":"DelegateVoterRewardsDistributed","type":"event"}]`
 
 type voterEntry struct {
 	addr   address.Address

--- a/action/protocol/rewarding/voter_zero_work_seal_test.go
+++ b/action/protocol/rewarding/voter_zero_work_seal_test.go
@@ -143,7 +143,7 @@ func TestZeroWorkSealIsIdempotent(t *testing.T) {
 // a voter whose auto-deposit bucket is index 0 compounded successfully and was
 // then reported as a direct credit: a spurious CLAIM_FROM_REWARDING_FUND
 // transaction log for tokens that never left the rewarding fund, the amount
-// missing from the block's compound outflow, and a DelegateDistributed row
+// missing from the block's compound outflow, and a DelegateVoterRewardsDistributed row
 // telling off-chain consumers the voter was paid at their reward address when
 // they were not.
 func TestCompoundIntoNativeBucketZero(t *testing.T) {

--- a/action/protocol/staking/add_deposit_compound.go
+++ b/action/protocol/staking/add_deposit_compound.go
@@ -40,7 +40,7 @@ var ErrCompoundSelfStakeRoleChanged = errors.New(
 // handleDepositToStake: same in-place bucket + candidate + bucket-pool
 // updates, but without the user-action plumbing (no signature check, no gas,
 // no caller balance debit, no receipt log — the caller emits a batched
-// DelegateDistributed log instead).
+// DelegateVoterRewardsDistributed log instead).
 //
 // Preconditions the caller MUST have already established:
 //
@@ -63,7 +63,7 @@ var ErrCompoundSelfStakeRoleChanged = errors.New(
 //   - bucket pool total grows by amount via DebitBucketPool
 //
 // No transaction log is returned: the caller wraps the whole per-delegate
-// distribution into a single DelegateDistributed batched log, and the
+// distribution into a single DelegateVoterRewardsDistributed batched log, and the
 // rewarding→bucket-pool token movement is captured in that batch's
 // transactionLogs slice at the call site.
 func (p *Protocol) AddDepositForCompound(

--- a/action/protocol/staking/poll_snapshot.go
+++ b/action/protocol/staking/poll_snapshot.go
@@ -71,7 +71,7 @@ type CandidatePollSnapshot struct {
 	TotalWeight *big.Int
 	// SnapshotHash is the deterministic digest of this delegate's frozen era
 	// parameters. See eraSnapshotHash: it is the join key that lets off-chain
-	// consumers assemble the partial DelegateDistributed logs one settlement
+	// consumers assemble the partial DelegateVoterRewardsDistributed logs one settlement
 	// emits across many blocks.
 	SnapshotHash hash.Hash256
 	// FreezeHeight is the era boundary height H this snapshot was taken at.
@@ -187,7 +187,7 @@ func safeBigInt(v *big.Int) *big.Int {
 }
 
 // eraSnapshotHash is the deterministic digest stamped into every
-// DelegateDistributed log a settlement emits for this delegate.
+// DelegateVoterRewardsDistributed log a settlement emits for this delegate.
 //
 // Its consumer is off-chain: one settlement pays a delegate's voters across
 // many blocks, so the delegate's payout is reported as a stream of partial logs

--- a/action/protocol/staking/stakingpb/staking.pb.go
+++ b/action/protocol/staking/stakingpb/staking.pb.go
@@ -819,7 +819,7 @@ type CandidatePollSnapshot struct {
 	// Deterministic digest of this delegate's frozen era parameters, computed
 	// at freeze time from the scalars in this message plus the candidate
 	// identifier. It is the join key off-chain consumers use to assemble the
-	// partial DelegateDistributed logs one settlement emits across many blocks.
+	// partial DelegateVoterRewardsDistributed logs one settlement emits across many blocks.
 	SnapshotHash []byte `protobuf:"bytes,7,opt,name=snapshotHash,proto3" json:"snapshotHash,omitempty"`
 	// IIP-59: the height this snapshot was frozen at, i.e. the era boundary H.
 	// The drain runs several blocks later and must evaluate contract-staking

--- a/action/protocol/staking/stakingpb/staking.proto
+++ b/action/protocol/staking/stakingpb/staking.proto
@@ -130,7 +130,7 @@ message CandidatePollSnapshot {
     // Deterministic digest of this delegate's frozen era parameters, computed
     // at freeze time from the scalars in this message plus the candidate
     // identifier. It is the join key off-chain consumers use to assemble the
-    // partial DelegateDistributed logs one settlement emits across many blocks.
+    // partial DelegateVoterRewardsDistributed logs one settlement emits across many blocks.
     bytes snapshotHash = 7;
     // IIP-59: the height this snapshot was frozen at, i.e. the era boundary H.
     // The drain runs several blocks later and must evaluate contract-staking

--- a/docs/iip-59-distribution-architecture.md
+++ b/docs/iip-59-distribution-architecture.md
@@ -132,7 +132,7 @@ The snapshot is **scalars only**:
 | `BlockCommissionBasisPoints`, `EpochCommissionBasisPoints`, `Registered` | the DelegateProfile contract can change between H and the last chunk |
 | `OnchainRewardEnabled` | opt-in must not flip mid-settlement |
 | `TotalWeight` | the denominator of every share; it is `candidate.Votes` at H, and `Votes` keeps moving during the drain window |
-| `SnapshotHash` | join key stamped into every partial `DelegateDistributed` log so off-chain consumers can reassemble one settlement's per-block logs |
+| `SnapshotHash` | join key stamped into every partial `DelegateVoterRewardsDistributed` log so off-chain consumers can reassemble one settlement's per-block logs |
 | `FreezeHeight` (H) | the height every weight recompute is evaluated at |
 | `SelfStakeBucketIdx` | the only candidate field the weight recompute reads |
 


### PR DESCRIPTION
## Summary

Rename the IIP-59 receipt event from `DelegateDistributed` to `DelegateVoterRewardsDistributed`.

The drain traverses voters, but receipt rows are grouped per delegate per chunk. A voter who voted for multiple delegates therefore appears in multiple delegate-scoped events, while the protocol may combine those contributions into one payment. The new name makes that event granularity explicit.

This intentionally changes topic0 before IIP-59 activation. Parameter types, ordering, and data encoding are unchanged.

Also renames the public foreign-event sentinel and updates comments/tests. A regression test confirms the retired selector is rejected.

## Verification

- `go test ./action/protocol/rewarding/distributedlog ./action/protocol/rewarding ./action/protocol/staking -count=1` (556 passed)
- `go test ./action/... -count=1` (1451 passed)