### PR TITLE
feat(supply): add off-consensus IOTX total-supply conservation observer

### DIFF
--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -91,8 +91,22 @@ type (
 		FactoryDBType string `yaml:"factoryDBType"`
 		// MintTimeout is the timeout for minting
 		MintTimeout time.Duration `yaml:"-"`
+		// SupplyCheck governs the opt-in, off-consensus total-supply reconciliation
+		// observer (L3 tier). Disabled by default: it scans the entire Account
+		// namespace which would stall block commits on every validator, so it is
+		// meant to be enabled only on dedicated auditor nodes, run daily or per
+		// epoch rather than every minute.
+		SupplyCheck SupplyCheckConfig `yaml:"supplyCheck"`
 	}
 )
+
+// SupplyCheckConfig configures the opt-in total-supply reconciliation observer.
+type SupplyCheckConfig struct {
+	// Enabled turns on the observer. Keep false on ordinary validators.
+	Enabled bool `yaml:"enabled"`
+	// Interval is the cadence at which the full Account-namespace scan runs.
+	Interval time.Duration `yaml:"interval"`
+}
 
 var (
 	// DefaultConfig is the default config of chain
@@ -137,6 +151,12 @@ var (
 		FixAliasForNonStopHeight:      19778036,
 		FactoryDBType:                 db.DBAuto,
 		MintTimeout:                   700 * time.Millisecond,
+		// Supply reconciliation is an auditor-side, opt-in capability; disabled by
+		// default so validators never run a full-namespace scan.
+		SupplyCheck: SupplyCheckConfig{
+			Enabled:  false,
+			Interval: time.Hour,
+		},
 	}
 
 	// ErrConfig config error

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -840,6 +840,7 @@ func (builder *Builder) buildConsensusComponent() error {
 
 func (builder *Builder) build(forSubChain, forTest bool) (*ChainService, error) {
 	builder.cs.registry = protocol.NewRegistry()
+	builder.cs.supplyCfg = builder.cfg.Chain.SupplyCheck
 	if builder.cs.p2pAgent == nil {
 		builder.cs.p2pAgent = p2p.NewDummyAgent()
 	}

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -86,6 +86,7 @@ type ChainService struct {
 	actionsync               *actsync.ActionSync
 	minter                   *factory.Minter
 	supplyObserver           *supplychecker.Observer
+	supplyCfg                blockchain.SupplyCheckConfig
 
 	lastReceivedBlockHeight uint64
 	paused                  atomic.Bool
@@ -96,11 +97,12 @@ func (cs *ChainService) Start(ctx context.Context) error {
 	if err := cs.lifecycle.OnStartSequentially(ctx); err != nil {
 		return errors.Wrap(err, "failed to start chain service")
 	}
-	// Launch the off-consensus total-supply observer. It periodically recomputes
-	// the IOTX supply (account balances + rewarding fund + staking pool) and
-	// reports when it exceeds the genesis cap, catching ex-nihilo minting bugs.
-	// It is read-only and never affects consensus or state transitions, so it is
-	// safe to run on a live node even if the invariant is violated.
+	// Optionally launch the off-consensus total-supply reconciliation observer
+	// (L3 tier). It periodically recomputes the IOTX supply (account balances +
+	// rewarding fund + staking pool) against the genesis cap, catching ex-nihilo
+	// minting bugs. It is DISABLED by default: the full Account-namespace scan it
+	// performs would otherwise stall block commits on every validator, so it is
+	// meant to run only on opt-in auditor nodes (see blockchain.SupplyCheckConfig).
 	cs.startSupplyObserver(ctx)
 	go func() {
 		ticker := time.NewTicker(time.Minute)
@@ -130,22 +132,25 @@ func (cs *ChainService) Start(ctx context.Context) error {
 }
 
 // startSupplyObserver constructs (if needed) and launches the off-consensus
-// total-supply observer. It is a no-op when no state factory is available (for
-// example in tests that build an empty ChainService). Returns true when an
-// observer was started.
+// total-supply observer. It is a no-op unless the supply check is enabled in
+// config and a state factory is available (for example in tests that build an
+// empty ChainService). Returns true when an observer was started.
 func (cs *ChainService) startSupplyObserver(ctx context.Context) bool {
+	if !cs.supplyCfg.Enabled {
+		return false
+	}
 	if cs.supplyObserver == nil && cs.factory != nil {
-		cs.supplyObserver = supplychecker.NewObserver(
-			cs.factory,
-			cs.chain.Genesis(),
-			time.Minute,
-		)
+		interval := cs.supplyCfg.Interval
+		if interval <= 0 {
+			interval = time.Hour
+		}
+		cs.supplyObserver = supplychecker.NewObserver(cs.factory, cs.chain.Genesis(), interval)
 	}
-	if cs.supplyObserver != nil {
-		go cs.supplyObserver.Run(ctx)
-		return true
+	if cs.supplyObserver == nil {
+		return false
 	}
-	return false
+	go cs.supplyObserver.Run(ctx)
+	return true
 }
 
 // Stop stops the server

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -43,6 +43,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/server/itx/nodestats"
 	"github.com/iotexproject/iotex-core/v2/state/factory"
+	"github.com/iotexproject/iotex-core/v2/supplychecker"
 	"github.com/iotexproject/iotex-core/v2/systemcontractindex/stakingindex"
 )
 
@@ -84,6 +85,7 @@ type ChainService struct {
 	apiStats                 *nodestats.APILocalStats
 	actionsync               *actsync.ActionSync
 	minter                   *factory.Minter
+	supplyObserver           *supplychecker.Observer
 
 	lastReceivedBlockHeight uint64
 	paused                  atomic.Bool
@@ -93,6 +95,21 @@ type ChainService struct {
 func (cs *ChainService) Start(ctx context.Context) error {
 	if err := cs.lifecycle.OnStartSequentially(ctx); err != nil {
 		return errors.Wrap(err, "failed to start chain service")
+	}
+	// Launch the off-consensus total-supply observer. It periodically recomputes
+	// the IOTX supply (account balances + rewarding fund + staking pool) and
+	// reports when it exceeds the genesis cap, catching ex-nihilo minting bugs.
+	// It is read-only and never affects consensus or state transitions, so it is
+	// safe to run on a live node even if the invariant is violated.
+	if cs.supplyObserver == nil && cs.factory != nil {
+		cs.supplyObserver = supplychecker.NewObserver(
+			cs.factory,
+			cs.chain.Genesis(),
+			time.Minute,
+		)
+	}
+	if cs.supplyObserver != nil {
+		go cs.supplyObserver.Run(ctx)
 	}
 	go func() {
 		ticker := time.NewTicker(time.Minute)

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -86,6 +86,7 @@ type ChainService struct {
 	actionsync               *actsync.ActionSync
 	minter                   *factory.Minter
 	supplyObserver           *supplychecker.Observer
+	supplyTracker            *supplychecker.SupplyTracker
 	supplyCfg                blockchain.SupplyCheckConfig
 
 	lastReceivedBlockHeight uint64
@@ -132,22 +133,30 @@ func (cs *ChainService) Start(ctx context.Context) error {
 }
 
 // startSupplyObserver constructs (if needed) and launches the off-consensus
-// total-supply observer. It is a no-op unless the supply check is enabled in
-// config and a state factory is available (for example in tests that build an
-// empty ChainService). Returns true when an observer was started.
+// total-supply observers (L2 per-block tracker + L3 periodic scanner). It is a
+// no-op unless the supply check is enabled in config and a state factory is
+// available (for example in tests that build an empty ChainService).
 func (cs *ChainService) startSupplyObserver(ctx context.Context) bool {
 	if !cs.supplyCfg.Enabled {
 		return false
 	}
-	if cs.supplyObserver == nil && cs.factory != nil {
+	if cs.factory == nil {
+		return false
+	}
+	// L2 tier: per-block running supply tracker, wired into the state factory's
+	// diff callback. Observatory-only and non-fatal; composes with ioSwarm's
+	// existing callback rather than replacing it.
+	if cs.supplyTracker == nil {
+		cs.supplyTracker = supplychecker.NewSupplyTrackerFromGenesis(cs.chain.Genesis())
+		factory.AddDiffCallback(cs.factory, cs.supplyTracker.OnBlockCommitted)
+	}
+	// L3 tier: opt-in periodic full-namespace reconciliation.
+	if cs.supplyObserver == nil {
 		interval := cs.supplyCfg.Interval
 		if interval <= 0 {
 			interval = time.Hour
 		}
 		cs.supplyObserver = supplychecker.NewObserver(cs.factory, cs.chain.Genesis(), interval)
-	}
-	if cs.supplyObserver == nil {
-		return false
 	}
 	go cs.supplyObserver.Run(ctx)
 	return true

--- a/chainservice/chainservice.go
+++ b/chainservice/chainservice.go
@@ -101,16 +101,7 @@ func (cs *ChainService) Start(ctx context.Context) error {
 	// reports when it exceeds the genesis cap, catching ex-nihilo minting bugs.
 	// It is read-only and never affects consensus or state transitions, so it is
 	// safe to run on a live node even if the invariant is violated.
-	if cs.supplyObserver == nil && cs.factory != nil {
-		cs.supplyObserver = supplychecker.NewObserver(
-			cs.factory,
-			cs.chain.Genesis(),
-			time.Minute,
-		)
-	}
-	if cs.supplyObserver != nil {
-		go cs.supplyObserver.Run(ctx)
-	}
+	cs.startSupplyObserver(ctx)
 	go func() {
 		ticker := time.NewTicker(time.Minute)
 		defer ticker.Stop()
@@ -136,6 +127,25 @@ func (cs *ChainService) Start(ctx context.Context) error {
 		}
 	}()
 	return nil
+}
+
+// startSupplyObserver constructs (if needed) and launches the off-consensus
+// total-supply observer. It is a no-op when no state factory is available (for
+// example in tests that build an empty ChainService). Returns true when an
+// observer was started.
+func (cs *ChainService) startSupplyObserver(ctx context.Context) bool {
+	if cs.supplyObserver == nil && cs.factory != nil {
+		cs.supplyObserver = supplychecker.NewObserver(
+			cs.factory,
+			cs.chain.Genesis(),
+			time.Minute,
+		)
+	}
+	if cs.supplyObserver != nil {
+		go cs.supplyObserver.Run(ctx)
+		return true
+	}
+	return false
 }
 
 // Stop stops the server

--- a/chainservice/chainservice_test.go
+++ b/chainservice/chainservice_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/iotexproject/iotex-core/v2/blockchain"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_blockchain"
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_factory"
@@ -68,19 +69,30 @@ func TestStartSupplyObserver(t *testing.T) {
 	r := require.New(t)
 	ctx := context.Background()
 
-	// Empty ChainService (no factory): observer is a no-op and not started.
-	cs := &ChainService{}
+	// Empty ChainService (no factory): observer is a no-op and not started, even
+	// when enabled (there is no state factory to read from).
+	cs := &ChainService{supplyCfg: blockchain.SupplyCheckConfig{Enabled: true}}
 	r.False(cs.startSupplyObserver(ctx))
 	r.Nil(cs.supplyObserver)
 
-	// With a state factory, the observer is constructed (from the chain genesis)
-	// and started.
 	ctrl := gomock.NewController(t)
 	factory := mock_factory.NewMockFactory(ctrl)
 	bc := mock_blockchain.NewMockBlockchain(ctrl)
 	bc.EXPECT().Genesis().Return(genesis.TestDefault()).AnyTimes()
 
-	cs2 := &ChainService{factory: factory, chain: bc}
+	// Default (not enabled in config): the observer must NOT start even with a
+	// factory, so ordinary validators never run the full-namespace scan.
+	csDefault := &ChainService{factory: factory, chain: bc}
+	r.False(csDefault.startSupplyObserver(ctx))
+	r.Nil(csDefault.supplyObserver)
+
+	// Enabled with a state factory: the observer is constructed (from the chain
+	// genesis) and started. This is the opt-in auditor-node path.
+	cs2 := &ChainService{
+		factory:   factory,
+		chain:     bc,
+		supplyCfg: blockchain.SupplyCheckConfig{Enabled: true},
+	}
 	r.True(cs2.startSupplyObserver(ctx))
 	r.NotNil(cs2.supplyObserver)
 

--- a/chainservice/chainservice_test.go
+++ b/chainservice/chainservice_test.go
@@ -6,11 +6,17 @@
 package chainservice
 
 import (
+	"context"
 	"testing"
 
 	"github.com/iotexproject/iotex-proto/golang/iotexrpc"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_blockchain"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_factory"
 )
 
 func TestChainService_Filter_NilHeader(t *testing.T) {
@@ -56,4 +62,29 @@ func TestChainService_ReportFullness_NilHeader(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestStartSupplyObserver(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+
+	// Empty ChainService (no factory): observer is a no-op and not started.
+	cs := &ChainService{}
+	r.False(cs.startSupplyObserver(ctx))
+	r.Nil(cs.supplyObserver)
+
+	// With a state factory, the observer is constructed (from the chain genesis)
+	// and started.
+	ctrl := gomock.NewController(t)
+	factory := mock_factory.NewMockFactory(ctrl)
+	bc := mock_blockchain.NewMockBlockchain(ctrl)
+	bc.EXPECT().Genesis().Return(genesis.TestDefault()).AnyTimes()
+
+	cs2 := &ChainService{factory: factory, chain: bc}
+	r.True(cs2.startSupplyObserver(ctx))
+	r.NotNil(cs2.supplyObserver)
+
+	// A second call must not recreate the observer; it just restarts it.
+	r.True(cs2.startSupplyObserver(ctx))
+	r.NotNil(cs2.supplyObserver)
 }

--- a/state/factory/statedb.go
+++ b/state/factory/statedb.go
@@ -115,6 +115,28 @@ func SetDiffCallback(f Factory, cb StateDiffCallback) bool {
 	return false
 }
 
+// AddDiffCallback registers cb to be invoked after each block commit IN ADDITION
+// to any callback already set. Multiple observers (for example ioSwarm's state
+// diff streaming and the supply-conservation tracker) can therefore coexist
+// without clobbering each other. Observers are chained in registration order.
+// Returns false if the factory is not a stateDB (e.g., in-memory test factory).
+func AddDiffCallback(f Factory, cb StateDiffCallback) bool {
+	sdb, ok := f.(*stateDB)
+	if !ok {
+		return false
+	}
+	sdb.mutex.Lock()
+	prev := sdb.diffCallback
+	sdb.diffCallback = func(height uint64, entries []WriteQueueEntry, digest []byte) {
+		if prev != nil {
+			prev(height, entries, digest)
+		}
+		cb(height, entries, digest)
+	}
+	sdb.mutex.Unlock()
+	return true
+}
+
 // DisableWorkingSetCacheOption disable workingset cache
 func DisableWorkingSetCacheOption() StateDBOption {
 	return func(sdb *stateDB, cfg *Config) error {
@@ -355,7 +377,7 @@ func (sdb *stateDB) createWorkingSetStore(ctx context.Context, height uint64, kv
 			flusher.KVStoreWithBuffer().MustPut(p.Namespace, p.Key, p.Value)
 		}
 	}
-	return newStateDBWorkingSetStore(flusher, g.IsNewfoundland(height)), nil
+	return newStateDBWorkingSetStore(flusher, g.IsNewfoundland(height), sdb.diffCallback != nil), nil
 }
 
 func (sdb *stateDB) Register(p protocol.Protocol) error {

--- a/state/factory/workingsetstore.go
+++ b/state/factory/workingsetstore.go
@@ -43,16 +43,18 @@ type (
 	stateDBWorkingSetStore struct {
 		lock sync.Mutex
 		// TODO: handle committed flag properly in the functions
-		committed  bool
-		readBuffer bool
-		flusher    db.KVStoreFlusher
+		committed         bool
+		readBuffer        bool
+		capturePriorValue bool // read base-store prior values for delta consumers (e.g. supply tracker)
+		flusher           db.KVStoreFlusher
 	}
 )
 
-func newStateDBWorkingSetStore(flusher db.KVStoreFlusher, readBuffer bool) workingSetStore {
+func newStateDBWorkingSetStore(flusher db.KVStoreFlusher, readBuffer, capturePriorValue bool) workingSetStore {
 	return &stateDBWorkingSetStore{
-		flusher:    flusher,
-		readBuffer: readBuffer,
+		flusher:           flusher,
+		readBuffer:        readBuffer,
+		capturePriorValue: capturePriorValue,
 	}
 }
 
@@ -221,8 +223,24 @@ func (store *stateDBWorkingSetStore) ErigonStore() (any, error) {
 
 // CaptureWriteQueue returns a snapshot of all entries in the write queue.
 // Must be called BEFORE Commit() which flushes and clears the buffer.
+//
+// Each captured entry also records PriorValue: the value committed to the base
+// store before this block's mutations, so a downstream consumer can compute the
+// exact per-key delta (PriorValue -> Value) without an extra state read at
+// callback time. PriorValue is nil when the key did not exist in the committed
+// state (i.e. it is created within this block). This is an observability-only
+// addition and does not change any state transition.
+//
+// PriorValue is only populated when a state-diff consumer that needs it (e.g.
+// the supply-conservation tracker) is registered; otherwise the base-store
+// reads are skipped so an ordinary validator pays no extra disk lookups per
+// block on the commit path.
 func (store *stateDBWorkingSetStore) CaptureWriteQueue() []WriteQueueEntry {
 	kvb := store.flusher.KVStoreWithBuffer()
+	var base db.KVStore
+	if store.capturePriorValue {
+		base = store.flusher.BaseKVStore()
+	}
 	size := kvb.Size()
 	entries := make([]WriteQueueEntry, 0, size)
 	for i := 0; i < size; i++ {
@@ -230,11 +248,23 @@ func (store *stateDBWorkingSetStore) CaptureWriteQueue() []WriteQueueEntry {
 		if err != nil {
 			continue
 		}
+		key := wi.Key()
+		var prior []byte
+		if store.capturePriorValue {
+			// The base store still holds the pre-block committed value: Flush
+			// (which applies the buffer to the base store) only happens in
+			// Commit(), which is called after CaptureWriteQueue. A miss means the
+			// key is created here.
+			if pv, err := base.Get(wi.Namespace(), key); err == nil {
+				prior = append([]byte(nil), pv...)
+			}
+		}
 		entries = append(entries, WriteQueueEntry{
-			WriteType: uint8(wi.WriteType()),
-			Namespace: wi.Namespace(),
-			Key:       append([]byte(nil), wi.Key()...),
-			Value:     append([]byte(nil), wi.Value()...),
+			WriteType:  uint8(wi.WriteType()),
+			Namespace:  wi.Namespace(),
+			Key:        append([]byte(nil), key...),
+			PriorValue: prior,
+			Value:      append([]byte(nil), wi.Value()...),
 		})
 	}
 	return entries
@@ -245,5 +275,8 @@ type WriteQueueEntry struct {
 	WriteType uint8 // 0=Put, 1=Delete
 	Namespace string
 	Key       []byte
-	Value     []byte
+	// PriorValue is the base-store (committed) value before this block's
+	// mutations. nil when the key did not exist in committed state.
+	PriorValue []byte
+	Value      []byte
 }

--- a/state/factory/workingsetstore_test.go
+++ b/state/factory/workingsetstore_test.go
@@ -38,7 +38,7 @@ func TestStateDBWorkingSetStore(t *testing.T) {
 	inMemStore := db.NewMemKVStore()
 	flusher, err := db.NewKVStoreFlusher(inMemStore, batch.NewCachedBatch())
 	require.NoError(err)
-	store := newStateDBWorkingSetStore(flusher, true)
+	store := newStateDBWorkingSetStore(flusher, true, false)
 	require.NotNil(store)
 	require.NoError(store.Start(ctx))
 	namespace := "namespace"
@@ -146,4 +146,42 @@ func TestStateDBWorkingSetStore(t *testing.T) {
 
 func TestFactoryWorkingSetStore(t *testing.T) {
 	// TODO: add unit test for factory working set store
+}
+
+func TestCaptureWriteQueuePriorValue(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	ns := "namespace"
+	key := []byte("key")
+
+	for _, capture := range []bool{true, false} {
+		kv := db.NewMemKVStore()
+		// A pre-block committed value directly in the base store.
+		require.NoError(kv.Put(ns, key, []byte("prior")))
+		flusher, err := db.NewKVStoreFlusher(kv, batch.NewCachedBatch())
+		require.NoError(err)
+		wsAny := newStateDBWorkingSetStore(flusher, true, capture)
+		require.NoError(wsAny.Start(ctx))
+		ws := wsAny.(*stateDBWorkingSetStore)
+		// The block writes a new value into the buffer.
+		curVal := valueBytes("cur")
+		require.NoError(ws.PutObject(ns, key, &curVal))
+
+		entries := ws.CaptureWriteQueue()
+		var matched bool
+		for _, e := range entries {
+			if e.Namespace == ns && bytes.Equal(e.Key, key) {
+				matched = true
+				require.Equal([]byte("cur"), e.Value)
+				if capture {
+					require.Equal([]byte("prior"), e.PriorValue, "prior value must be captured when a delta consumer is registered")
+				} else {
+					require.Nil(e.PriorValue, "no base-store read when no delta consumer is registered")
+				}
+			}
+		}
+		require.True(matched, "expected the key in the captured write queue")
+		require.NoError(ws.Stop(ctx))
+	}
 }

--- a/supplychecker/supplychecker.go
+++ b/supplychecker/supplychecker.go
@@ -3,16 +3,24 @@
 // or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
 // This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
 
-// Package supplychecker implements an off-consensus, read-only observer that
+// Package supplychecker implements the L3 tier of IoTeX's total-supply
+// conservation monitoring: an off-consensus, read-only observer that
 // periodically verifies the IOTX total-supply non-increase invariant.
 //
 // Motivation (audit follow-up on the 2026-08 Harmony "empty block" incident):
 // a protocol-level bug let an attacker mint IOTX out of thin air. IoTeX's own
 // supply can never exceed the genesis endowment, so a node-side observer that
 // recomputes the total circulating supply and compares it against that upper
-// bound is a cheap, sound early-warning for the same class of bug.
+// bound is a cheap early-warning for the same class of bug.
 //
-// The observer is deliberately OFF-consensus:
+// This is the L3 (periodic reconciliation) tier, NOT a per-block check. Because
+// it walks the entire Account namespace, it must never run every minute on every
+// validator: a full-namespace scan holds the state-factory read lock and would
+// stall block commits (liveness). It is therefore opt-in, driven by
+// blockchain.SupplyCheckConfig (default disabled), and meant to run daily / per
+// epoch on a dedicated auditor node.
+//
+// The observer is deliberately OFF-consensus and non-fatal:
 //   - it never rejects blocks nor stops consensus, so it cannot brick the chain;
 //   - it only logs and exposes a Prometheus gauge when the invariant is violated;
 //   - it does not change any state transition, so it needs no hardfork.
@@ -28,12 +36,17 @@
 // The invariant is an upper bound, not an exact equality, because the IOTX
 // supply legitimately decreases over time (EIP-1559 base-fee burn, slashing).
 // A state can therefore legally have total < genesisTotal, but never above it.
-// Missing one of the three accounting reservoirs only makes the computed total
-// smaller, which weakens the check but never produces a false alarm, so the
-// observer is conservative (sound).
+//
+// The Account namespace also holds legacy Poll/Rewarding states that pre-date
+// the Greenland storage layout and are never deleted; feeding them to
+// state.Account.Deserialize would panic and over-count bogus balances. This
+// observer decodes them with a strict, non-panicking decoder (decodeAccount)
+// that skips anything that is not a well-formed account, so the scan can neither
+// crash the node nor produce a false positive from those legacy payloads.
 package supplychecker
 
 import (
+	"bytes"
 	"context"
 	"math/big"
 	"time"
@@ -45,6 +58,7 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account/accountpb"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
@@ -175,31 +189,110 @@ func genesisTotalSupply(g genesis.Genesis) *big.Int {
 	return total
 }
 
+// rawAccountState is a state.Deserializer that captures the raw serialized bytes
+// of an entry in the Account namespace without decoding them through
+// state.Account. state.Account.Deserialize is written for trusted input and
+// panics on legacy Poll/Rewarding payloads (unknown account type / invalid
+// balance, state/account.go) that were never removed from this namespace; this
+// observer must never crash the node, so it defers to decodeAccount.
+type rawAccountState []byte
+
+// Deserialize implements state.Deserializer by capturing the raw bytes.
+func (r *rawAccountState) Deserialize(data []byte) error {
+	*r = append((*r)[:0], data...)
+	return nil
+}
+
+// decodeAccount parses a serialized entry from the Account namespace WITHOUT
+// panicking. The Account namespace historically also stored legacy Poll and
+// Rewarding states (pre-Greenland) that are never deleted, and
+// state.Account.Deserialize is written for trusted input and panics on them.
+// This local decoder rejects anything that is not a genuine, canonically-encoded
+// account:
+//   - payloads carrying unknown proto fields (wire-collision artifacts of legacy
+//     Fund / Admin / exempt / rewardAccount / CandidatesList, whose tags overlap
+//     accountpb.Account and otherwise decode into bogus balances / types);
+//   - an AccountType enum outside {DEFAULT, ZERO_NONCE} (e.g.
+//     Admin.productivityThreshold colliding with field 7 would panic the real
+//     decoder);
+//   - a balance that is not a decimal integer;
+//   - any non-canonical wire encoding (guards against field-layout drift).
+//
+// It returns (account, true) on success, or (nil, false) to skip the entry.
+func decodeAccount(data []byte) (*accountpb.Account, bool) {
+	if len(data) == 0 {
+		return nil, false
+	}
+	acct := &accountpb.Account{}
+	if err := proto.Unmarshal(data, acct); err != nil {
+		return nil, false
+	}
+	// Reject unknown proto fields: they signal a different message type whose
+	// field tags collided with accountpb.Account.
+	if len(acct.ProtoReflect().GetUnknown()) > 0 {
+		return nil, false
+	}
+	// The account-type enum only admits {0,1}. Anything else is a wire collision
+	// with another message (e.g. rewardingpb.Admin.productivityThreshold -> field 7)
+	// that would make state.Account.FromProto panic.
+	switch acct.GetType() {
+	case accountpb.AccountType_DEFAULT, accountpb.AccountType_ZERO_NONCE:
+	default:
+		return nil, false
+	}
+	// Balance must parse as a decimal integer (state.Account.FromProto panics on
+	// a malformed balance, e.g. a 1e26 scientific-notation field from a legacy
+	// Fund state).
+	if acct.GetBalance() != "" {
+		if _, ok := new(big.Int).SetString(acct.GetBalance(), 10); !ok {
+			return nil, false
+		}
+	}
+	// Canonical round-trip: a genuine account is the proto.Marshal of its own
+	// canonical form, so re-marshaling the parsed message must reproduce the
+	// input exactly. Any drift means the payload is not a plain account.
+	canonical, err := proto.Marshal(acct)
+	if err != nil || !bytes.Equal(canonical, data) {
+		return nil, false
+	}
+	return acct, true
+}
+
 // sumPrimaryBalances iterates the Account namespace and returns the sum of every
-// primary (top-level) account balance, including EVM contract balances.
-func sumPrimaryBalances(sr protocol.StateReader) (*big.Int, error) {
+// genuine primary (top-level) account balance, including EVM contract balances.
+// Entries that are not well-formed accounts (legacy Poll/Rewarding states
+// lingering in this namespace) are skipped, so the scan can never panic on them.
+func sumPrimaryBalances(sr protocol.StateReader) (*big.Int, uint64, error) {
 	total := big.NewInt(0)
+	var accounts uint64
 	_, iter, err := sr.States(protocol.NamespaceOption(state.AccountKVNamespace))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to enumerate account states")
+		return nil, 0, errors.Wrap(err, "failed to enumerate account states")
 	}
 	for {
-		var acc state.Account
-		_, err := iter.Next(&acc)
+		var raw rawAccountState
+		_, err := iter.Next(&raw)
 		if errors.Cause(err) == state.ErrOutOfBoundary {
 			break
 		}
 		if errors.Cause(err) == state.ErrNilValue {
-			// Deleted / nil-storage account carries no balance; skip it and keep
-			// iterating the remaining accounts.
+			// Deleted / nil-storage entry carries no balance; skip it.
 			continue
 		}
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to read account state")
+			return nil, 0, errors.Wrap(err, "failed to read account state")
 		}
-		total.Add(total, acc.Balance)
+		acct, ok := decodeAccount([]byte(raw))
+		if !ok {
+			// Not a genuine account (legacy Poll/Rewarding state). Skipping it is
+			// the correct behavior: it is not a primary account balance reservoir.
+			continue
+		}
+		bal, _ := new(big.Int).SetString(acct.GetBalance(), 10)
+		total.Add(total, bal)
+		accounts++
 	}
-	return total, nil
+	return total, accounts, nil
 }
 
 // readFundTotal reads the rewarding fund total balance from the Rewarding namespace.
@@ -242,7 +335,7 @@ func readBucketPoolTotal(sr protocol.StateReader) (*big.Int, error) {
 func (o *Observer) Check(ctx context.Context) (*CheckResult, error) {
 	res := &CheckResult{}
 	var err error
-	if res.Account, err = sumPrimaryBalances(o.sr); err != nil {
+	if res.Account, res.Accounts, err = sumPrimaryBalances(o.sr); err != nil {
 		return nil, err
 	}
 	if res.Fund, err = readFundTotal(o.sr); err != nil {
@@ -293,11 +386,12 @@ func (o *Observer) Run(ctx context.Context) {
 
 // CheckResult reports the observed supply breakdown.
 type CheckResult struct {
-	Account *big.Int // sum of primary account balances
-	Fund    *big.Int // rewarding fund total balance
-	Pool    *big.Int // staking bucket pool total staked amount
-	Total   *big.Int // Account + Fund + Pool
-	Cap     *big.Int // genesis cap
+	Account  *big.Int // sum of primary account balances
+	Accounts uint64   // number of genuine accounts summed (skips legacy states)
+	Fund     *big.Int // rewarding fund total balance
+	Pool     *big.Int // staking bucket pool total staked amount
+	Total    *big.Int // Account + Fund + Pool
+	Cap      *big.Int // genesis cap
 }
 
 func raiFloat(v *big.Int) float64 {

--- a/supplychecker/supplychecker.go
+++ b/supplychecker/supplychecker.go
@@ -93,13 +93,13 @@ func (f *rewardingFund) Deserialize(data []byte) error {
 	if err := proto.Unmarshal(data, &gen); err != nil {
 		return err
 	}
-	total, ok := new(big.Int).SetString(gen.TotalBalance, 10)
-	if !ok {
-		return errors.New("failed to parse rewarding fund total balance")
+	total, err := parseDecimal(gen.TotalBalance, "rewarding fund total balance")
+	if err != nil {
+		return err
 	}
-	unclaimed, ok := new(big.Int).SetString(gen.UnclaimedBalance, 10)
-	if !ok {
-		return errors.New("failed to parse rewarding fund unclaimed balance")
+	unclaimed, err := parseDecimal(gen.UnclaimedBalance, "rewarding fund unclaimed balance")
+	if err != nil {
+		return err
 	}
 	f.totalBalance = total
 	f.unclaimedBalance = unclaimed
@@ -112,13 +112,23 @@ func (t *bucketPoolTotal) Deserialize(data []byte) error {
 	if err := proto.Unmarshal(data, &gen); err != nil {
 		return err
 	}
-	amount, ok := new(big.Int).SetString(gen.Amount, 10)
-	if !ok {
-		return errors.New("failed to parse bucket pool total amount")
+	amount, err := parseDecimal(gen.Amount, "bucket pool total amount")
+	if err != nil {
+		return err
 	}
 	t.amount = amount
 	t.count = gen.Count
 	return nil
+}
+
+// parseDecimal converts a decimal-string field into a big.Int, reporting a
+// stable error that names the on-chain field when the string is malformed.
+func parseDecimal(s, field string) (*big.Int, error) {
+	n, ok := new(big.Int).SetString(s, 10)
+	if !ok {
+		return nil, errors.Errorf("failed to parse %s", field)
+	}
+	return n, nil
 }
 
 // Conservation invariants governing the genesis-locked IOTX accounting. The

--- a/supplychecker/supplychecker.go
+++ b/supplychecker/supplychecker.go
@@ -193,20 +193,31 @@ func sumPrimaryBalances(sr protocol.StateReader) (*big.Int, error) {
 }
 
 // readFundTotal reads the rewarding fund total balance from the Rewarding namespace.
+// A missing fund state is treated as a zero balance: this is the same conservative
+// direction as every other under-count (it weakens the check but never produces a
+// false alarm), and it keeps the observer usable on nodes whose current height
+// predates the v2-storage layout that stores this state.
 func readFundTotal(sr protocol.StateReader) (*big.Int, error) {
 	key := append(state.RewardingKeyPrefix[:], _fundKey...)
 	var f rewardingFund
 	if _, err := sr.State(&f, protocol.NamespaceOption(state.RewardingNamespace), protocol.KeyOption(key)); err != nil {
+		if errors.Cause(err) == state.ErrStateNotExist {
+			return big.NewInt(0), nil
+		}
 		return nil, errors.Wrap(err, "failed to read rewarding fund")
 	}
 	return f.totalBalance, nil
 }
 
-// readBucketPoolTotal reads the staking bucket pool total staked amount.
+// readBucketPoolTotal reads the staking bucket pool total staked amount. Like the
+// rewarding fund, a missing pool state (pre-Greenland layout) is treated as zero.
 func readBucketPoolTotal(sr protocol.StateReader) (*big.Int, error) {
 	key := append([]byte{0x00}, _bucketPoolKeyTemplate[:]...)
 	var t bucketPoolTotal
 	if _, err := sr.State(&t, protocol.NamespaceOption(state.StakingNamespace), protocol.KeyOption(key)); err != nil {
+		if errors.Cause(err) == state.ErrStateNotExist {
+			return big.NewInt(0), nil
+		}
 		return nil, errors.Wrap(err, "failed to read staking bucket pool")
 	}
 	return t.amount, nil

--- a/supplychecker/supplychecker.go
+++ b/supplychecker/supplychecker.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2025 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+// Package supplychecker implements an off-consensus, read-only observer that
+// periodically verifies the IOTX total-supply non-increase invariant.
+//
+// Motivation (audit follow-up on the 2026-08 Harmony "empty block" incident):
+// a protocol-level bug let an attacker mint IOTX out of thin air. IoTeX's own
+// supply can never exceed the genesis endowment, so a node-side observer that
+// recomputes the total circulating supply and compares it against that upper
+// bound is a cheap, sound early-warning for the same class of bug.
+//
+// The observer is deliberately OFF-consensus:
+//   - it never rejects blocks nor stops consensus, so it cannot brick the chain;
+//   - it only logs and exposes a Prometheus gauge when the invariant is violated;
+//   - it does not change any state transition, so it needs no hardfork.
+//
+// Invariant:  R1 + R2 + R3 <= genesisTotal
+//
+//	R1 = sum of every primary account balance           (Account namespace)
+//	R2 = rewarding fund.totalBalance                    (Rewarding namespace)
+//	R3 = staking bucketPool.total.amount                (Staking namespace)
+//
+// genesisTotal = sum(genesis.InitBalanceMap) + genesis.Rewarding.InitBalanceStr.
+//
+// The invariant is an upper bound, not an exact equality, because the IOTX
+// supply legitimately decreases over time (EIP-1559 base-fee burn, slashing).
+// A state can therefore legally have total < genesisTotal, but never above it.
+// Missing one of the three accounting reservoirs only makes the computed total
+// smaller, which weakens the check but never produces a false alarm, so the
+// observer is conservative (sound).
+package supplychecker
+
+import (
+	"context"
+	"math/big"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
+	"github.com/iotexproject/iotex-core/v2/state"
+)
+
+var (
+	_supplyMtc = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "iotex_supply_total_rau",
+			Help: "Computed IOTX total supply in RAU, split by accounting reservoir",
+		},
+		[]string{"reservoir"},
+	)
+	_supplyViolationMtc = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "iotex_supply_above_cap",
+			Help: "1 when the computed total supply exceeds the genesis cap (invariant violated), 0 otherwise",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(_supplyMtc)
+	prometheus.MustRegister(_supplyViolationMtc)
+}
+
+// local deserializable mirrors of on-chain accounting structs. They intentionally
+// re-declare the proto schema (not the unexported on-chain types) so the observer
+// can decode the raw states stored under each namespace.
+type (
+	rewardingFund struct {
+		totalBalance     *big.Int
+		unclaimedBalance *big.Int
+	}
+	bucketPoolTotal struct {
+		amount *big.Int
+		count  uint64
+	}
+)
+
+// Deserialize implements state.Deserializer for the rewarding fund state.
+func (f *rewardingFund) Deserialize(data []byte) error {
+	gen := rewardingpb.Fund{}
+	if err := proto.Unmarshal(data, &gen); err != nil {
+		return err
+	}
+	total, ok := new(big.Int).SetString(gen.TotalBalance, 10)
+	if !ok {
+		return errors.New("failed to parse rewarding fund total balance")
+	}
+	unclaimed, ok := new(big.Int).SetString(gen.UnclaimedBalance, 10)
+	if !ok {
+		return errors.New("failed to parse rewarding fund unclaimed balance")
+	}
+	f.totalBalance = total
+	f.unclaimedBalance = unclaimed
+	return nil
+}
+
+// Deserialize implements state.Deserializer for the staking bucket pool total.
+func (t *bucketPoolTotal) Deserialize(data []byte) error {
+	gen := stakingpb.TotalAmount{}
+	if err := proto.Unmarshal(data, &gen); err != nil {
+		return err
+	}
+	amount, ok := new(big.Int).SetString(gen.Amount, 10)
+	if !ok {
+		return errors.New("failed to parse bucket pool total amount")
+	}
+	t.amount = amount
+	t.count = gen.Count
+	return nil
+}
+
+// Conservation invariants governing the genesis-locked IOTX accounting. The
+// three reservoirs must jointly not exceed the genesis endowment.
+var (
+	_fundKey                            = []byte("fnd")
+	_bucketPoolKeyTemplate hash.Hash160 = hash.Hash160b([]byte("bucketPool"))
+)
+
+// Observer periodically recomputes the total IOTX supply and reports an
+// invariant violation. It is purely observational and safe to run on a live node.
+type Observer struct {
+	sr     protocol.StateReader
+	cap    *big.Int
+	window time.Duration
+}
+
+// NewObserver returns a supply observer for the given state reader and genesis.
+func NewObserver(sr protocol.StateReader, g genesis.Genesis, window time.Duration) *Observer {
+	return &Observer{
+		sr:     sr,
+		cap:    genesisTotalSupply(g),
+		window: window,
+	}
+}
+
+// genesisTotalSupply derives the maximum possible IOTX supply in RAU from the
+// genesis configuration: sum of initial account balances plus the rewarding fund
+// seed. It is never allowed to increase after chain start.
+func genesisTotalSupply(g genesis.Genesis) *big.Int {
+	total := big.NewInt(0)
+	for _, v := range g.InitBalanceMap {
+		n, ok := new(big.Int).SetString(v, 10)
+		if !ok {
+			// The genesis is validated at startup before this observer runs, so
+			// this is unreachable in practice; guard defensively anyway.
+			continue
+		}
+		total.Add(total, n)
+	}
+	if f, ok := new(big.Int).SetString(g.Rewarding.InitBalanceStr, 10); ok {
+		total.Add(total, f)
+	}
+	return total
+}
+
+// sumPrimaryBalances iterates the Account namespace and returns the sum of every
+// primary (top-level) account balance, including EVM contract balances.
+func sumPrimaryBalances(sr protocol.StateReader) (*big.Int, error) {
+	total := big.NewInt(0)
+	_, iter, err := sr.States(protocol.NamespaceOption(state.AccountKVNamespace))
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to enumerate account states")
+	}
+	for {
+		var acc state.Account
+		_, err := iter.Next(&acc)
+		if errors.Cause(err) == state.ErrOutOfBoundary {
+			break
+		}
+		if errors.Cause(err) == state.ErrNilValue {
+			// Deleted / nil-storage account carries no balance; skip it and keep
+			// iterating the remaining accounts.
+			continue
+		}
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read account state")
+		}
+		total.Add(total, acc.Balance)
+	}
+	return total, nil
+}
+
+// readFundTotal reads the rewarding fund total balance from the Rewarding namespace.
+func readFundTotal(sr protocol.StateReader) (*big.Int, error) {
+	key := append(state.RewardingKeyPrefix[:], _fundKey...)
+	var f rewardingFund
+	if _, err := sr.State(&f, protocol.NamespaceOption(state.RewardingNamespace), protocol.KeyOption(key)); err != nil {
+		return nil, errors.Wrap(err, "failed to read rewarding fund")
+	}
+	return f.totalBalance, nil
+}
+
+// readBucketPoolTotal reads the staking bucket pool total staked amount.
+func readBucketPoolTotal(sr protocol.StateReader) (*big.Int, error) {
+	key := append([]byte{0x00}, _bucketPoolKeyTemplate[:]...)
+	var t bucketPoolTotal
+	if _, err := sr.State(&t, protocol.NamespaceOption(state.StakingNamespace), protocol.KeyOption(key)); err != nil {
+		return nil, errors.Wrap(err, "failed to read staking bucket pool")
+	}
+	return t.amount, nil
+}
+
+// Check recomputes the current total supply and verifies it does not exceed the
+// genesis cap. It returns the observed reservoir sums (for reporting/tests) and
+// an error only when the invariant cannot be evaluated (I/O failure). An
+// over-cap state is *not* returned as a fatal error; it is logged and exported
+// as a metric so the node keeps running and an operator can react, matching the
+// off-consensus design.
+func (o *Observer) Check(ctx context.Context) (*CheckResult, error) {
+	res := &CheckResult{}
+	var err error
+	if res.Account, err = sumPrimaryBalances(o.sr); err != nil {
+		return nil, err
+	}
+	if res.Fund, err = readFundTotal(o.sr); err != nil {
+		return nil, err
+	}
+	if res.Pool, err = readBucketPoolTotal(o.sr); err != nil {
+		return nil, err
+	}
+	res.Total = new(big.Int).Add(new(big.Int).Add(res.Account, res.Fund), res.Pool)
+	res.Cap = new(big.Int).Set(o.cap)
+
+	_supplyMtc.WithLabelValues("account").Set(raiFloat(res.Account))
+	_supplyMtc.WithLabelValues("rewarding_fund").Set(raiFloat(res.Fund))
+	_supplyMtc.WithLabelValues("staking_pool").Set(raiFloat(res.Pool))
+	_supplyMtc.WithLabelValues("total").Set(raiFloat(res.Total))
+
+	if res.Total.Cmp(o.cap) > 0 {
+		_supplyViolationMtc.Set(1)
+		log.L().Error("IOTX total supply exceeds genesis cap (possible unauthorized mint)",
+			zap.String("totalRau", res.Total.String()),
+			zap.String("capRau", o.cap.String()),
+			zap.String("accountRau", res.Account.String()),
+			zap.String("rewardingFundRau", res.Fund.String()),
+			zap.String("stakingPoolRau", res.Pool.String()),
+		)
+		return res, nil
+	}
+	_supplyViolationMtc.Set(0)
+	return res, nil
+}
+
+// Run loops Check on the configured interval until ctx is cancelled. Intended to
+// be launched as a goroutine from the chain service lifecycle.
+func (o *Observer) Run(ctx context.Context) {
+	ticker := time.NewTicker(o.window)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if _, err := o.Check(ctx); err != nil {
+				log.L().Error("failed to run IOTX supply check", zap.Error(err))
+			}
+		}
+	}
+}
+
+// CheckResult reports the observed supply breakdown.
+type CheckResult struct {
+	Account *big.Int // sum of primary account balances
+	Fund    *big.Int // rewarding fund total balance
+	Pool    *big.Int // staking bucket pool total staked amount
+	Total   *big.Int // Account + Fund + Pool
+	Cap     *big.Int // genesis cap
+}
+
+func raiFloat(v *big.Int) float64 {
+	f, _ := new(big.Float).SetInt(v).Float64()
+	return f
+}

--- a/supplychecker/supplychecker_bolt_test.go
+++ b/supplychecker/supplychecker_bolt_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2025 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package supplychecker
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/db"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+// TestBoltBackedSupplyConservation exercises the L2 (per-block tracker) and L3
+// (periodic observer) supply monitors against a REAL bolt-backed
+// factory.Factory, closing the review gap that the in-memory fakeStateReader
+// only ever inserts state.Account into the Account namespace (so it can never
+// surface how the real serialized on-chain states / state-diff plumbing behave).
+//
+// With a real factory that supports Filter() (bolt), we verify that:
+//   - the L2 tracker, wired through factory.StateDiffCallback, observes a block
+//     of plain transfers and records a conserved (non-increasing) total;
+//   - the L3 observer performs a full-namespace scan (Account + Rewarding) over
+//     the real serialized states without panicking, and reads back the genesis
+//     total supply.
+func TestBoltBackedSupplyConservation(t *testing.T) {
+	require := require.New(t)
+
+	dbPath, err := testutil.PathOfTempFile("supplycheck")
+	require.NoError(err)
+	defer testutil.CleanupPath(dbPath)
+
+	// --- Config + funded genesis ------------------------------------------------
+	cfg := config.Default
+	g := genesis.TestDefault()
+	cfg.Chain.TrieDBPath = dbPath
+	// Use v2 storage from genesis so the rewarding fund lives in the Rewarding
+	// namespace (mirrors modern mainnet, which is far past Greenland).
+	g.GreenlandBlockHeight = 0
+	// genesis.TestDefault() funds indices < identityset.Size(); fund the producer
+	// (27) and the two transfer accounts (28, 29) explicitly.
+	g.InitBalanceMap[identityset.Address(27).String()] = "1000000000000000000000000000000"
+	g.InitBalanceMap[identityset.Address(28).String()] = "100000000000000000000000000"
+	g.InitBalanceMap[identityset.Address(29).String()] = "100000000000000000000000000"
+	cfg.Genesis = g
+
+	// --- Register protocols (account + rolldpos + rewarding) -------------------
+	registry := protocol.NewRegistry()
+	require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+	require.NoError(rolldpos.NewProtocol(
+		g.NumCandidateDelegates, g.NumDelegates, g.NumSubEpochs,
+	).Register(registry))
+	require.NoError(rewarding.NewProtocol(g.Rewarding).Register(registry))
+
+	// --- Create the real-state factory -----------------------------------------
+	kv, err := db.CreateKVStoreWithCache(db.DefaultConfig, cfg.Chain.TrieDBPath, cfg.Chain.StateDBCacheSize)
+	require.NoError(err)
+	sf, err := factory.NewStateDB(factory.GenerateConfig(cfg.Chain, cfg.Genesis), kv,
+		factory.RegistryStateDBOption(registry), factory.SkipBlockValidationStateDBOption())
+	require.NoError(err)
+
+	// --- Wire the L2 per-block tracker into the real factory --------------------
+	tracker := NewSupplyTrackerFromGenesis(cfg.Genesis)
+	require.True(factory.AddDiffCallback(sf, tracker.OnBlockCommitted))
+
+	// --- Start (mints genesis states) ------------------------------------------
+	startCtx := genesis.WithGenesisContext(context.Background(), cfg.Genesis)
+	startCtx = protocol.WithFeatureWithHeightCtx(startCtx)
+	startCtx = protocol.WithBlockchainCtx(startCtx, protocol.BlockchainCtx{ChainID: cfg.Chain.ID})
+	require.NoError(sf.Start(startCtx))
+	defer func() { require.NoError(sf.Stop(startCtx)) }()
+
+	// At genesis (before any block) a full scan must already report Total == Cap.
+	o := NewObserver(sf, cfg.Genesis, 0)
+	res, err := o.Check(context.Background())
+	require.NoError(err)
+	require.Zero(res.Total.Cmp(res.Cap), "genesis total must equal cap on a real factory")
+	require.Equal(0, res.Total.Cmp(res.Cap))
+
+	// --- Commit one block with a plain NATIVE transfer ---------------------------
+	priKeyA := identityset.PrivateKey(28)
+	tsf := action.NewTransfer(big.NewInt(10), identityset.Address(29).String(), nil)
+	bd := &action.EnvelopeBuilder{}
+	// Mirror state/factory testCommit: no explicit gas fields, so transfer only
+	// moves value between two funded accounts and conserves total supply.
+	elp := bd.SetNonce(1).SetAction(tsf).Build()
+	selp, err := action.Sign(elp, priKeyA)
+	require.NoError(err)
+
+	blkCtx := protocol.WithBlockCtx(context.Background(), protocol.BlockCtx{
+		BlockHeight: 1,
+		Producer:    identityset.Address(27),
+		GasLimit:    1000000,
+	})
+	putCtx := genesis.WithGenesisContext(
+		protocol.WithBlockchainCtx(blkCtx, protocol.BlockchainCtx{
+			Tip:     protocol.TipInfo{Height: 0, Hash: hash.ZeroHash256},
+			ChainID: cfg.Chain.ID,
+		}),
+		cfg.Genesis,
+	)
+	putCtx = protocol.WithFeatureCtx(putCtx)
+	putCtx = protocol.WithFeatureWithHeightCtx(putCtx)
+
+	blk, err := block.NewTestingBuilder().
+		SetHeight(1).
+		SetPrevBlockHash(hash.ZeroHash256).
+		SetTimeStamp(testutil.TimestampNow()).
+		AddActions(selp).
+		SignAndBuild(identityset.PrivateKey(27))
+	require.NoError(err)
+	require.NoError(sf.PutBlock(putCtx, &blk))
+
+	// --- Assert the L2 tracker observed a conserved block ------------------------
+	require.Equal(uint64(1), tracker.Height(), "tracker must observe the committed block")
+	require.Zero(tracker.RunningTotal().Cmp(res.Cap), "transfer must conserve total supply")
+
+	// --- Assert the L3 observer still reconciles at height 1 ---------------------
+	res1, err := o.Check(context.Background())
+	require.NoError(err)
+	require.Zero(res1.Total.Cmp(res.Cap), "transfer must not change total supply on a real factory")
+	require.Zero(res1.Account.Cmp(res.Account), "sum of account balances unchanged by a transfer")
+}
+
+// TestBoltNamespaceScansSafe confirms the strict decoder tolerates the real
+// serialized entries the Account namespace holds on a bolt factory (genuine
+// accounts plus the per-block height key), never panicking.
+func TestBoltNamespaceScansSafe(t *testing.T) {
+	require := require.New(t)
+
+	dbPath, err := testutil.PathOfTempFile("supplycheck-scan")
+	require.NoError(err)
+	defer testutil.CleanupPath(dbPath)
+
+	cfg := config.Default
+	g := genesis.TestDefault()
+	cfg.Chain.TrieDBPath = dbPath
+	g.GreenlandBlockHeight = 0
+	g.InitBalanceMap[identityset.Address(28).String()] = "1000"
+	cfg.Genesis = g
+
+	registry := protocol.NewRegistry()
+	require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+	require.NoError(rolldpos.NewProtocol(
+		g.NumCandidateDelegates, g.NumDelegates, g.NumSubEpochs,
+	).Register(registry))
+	require.NoError(rewarding.NewProtocol(g.Rewarding).Register(registry))
+
+	kv, err := db.CreateKVStoreWithCache(db.DefaultConfig, cfg.Chain.TrieDBPath, cfg.Chain.StateDBCacheSize)
+	require.NoError(err)
+	sf, err := factory.NewStateDB(factory.GenerateConfig(cfg.Chain, cfg.Genesis), kv,
+		factory.RegistryStateDBOption(registry), factory.SkipBlockValidationStateDBOption())
+	require.NoError(err)
+
+	startCtx := genesis.WithGenesisContext(context.Background(), cfg.Genesis)
+	startCtx = protocol.WithFeatureWithHeightCtx(startCtx)
+	startCtx = protocol.WithBlockchainCtx(startCtx, protocol.BlockchainCtx{ChainID: cfg.Chain.ID})
+	require.NoError(sf.Start(startCtx))
+	defer func() { require.NoError(sf.Stop(startCtx)) }()
+
+	// A full-namespace scan over the real Account namespace must not panic and
+	// must not over-count: it must read every genuine account balance exactly.
+	// The rewarding fund total must also be readable from its own namespace.
+	fund, err := readFundTotal(sf)
+	require.NoError(err)
+	require.True(fund.Sign() > 0, "rewarding fund must be seeded at genesis")
+
+	// At genesis R1 (account reservoir) == genesis cap minus the rewarding seed
+	// (R2), with no staking pool yet (R3 == 0). This is an exact reconciliation on
+	// real serialized states, not a loose bound.
+	cap := genesisTotalSupply(cfg.Genesis)
+	sum, _, err := sumPrimaryBalances(sf)
+	require.NoError(err)
+	require.Zero(sum.Cmp(new(big.Int).Sub(cap, fund)),
+		"R1 must equal Cap - R2 at genesis on a real bolt factory")
+}

--- a/supplychecker/supplychecker_test.go
+++ b/supplychecker/supplychecker_test.go
@@ -9,7 +9,9 @@ import (
 	"context"
 	"math/big"
 	"testing"
+	"time"
 
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -26,11 +28,14 @@ import (
 // three accounting reservoirs the observer reads: primary account balances,
 // the rewarding fund, and the staking bucket pool.
 type fakeStateReader struct {
-	accounts map[hash.Hash160]*big.Int
-	fund     *big.Int
-	pool     *big.Int
-	hasFund  bool
-	hasPool  bool
+	accounts    map[hash.Hash160]*big.Int
+	fund        *big.Int
+	pool        *big.Int
+	hasFund     bool
+	hasPool     bool
+	failState   bool // if set, State() returns a hard error
+	failStates  bool // if set, States() returns a hard error
+	nilAccounts bool // if set, States() returns an account iterator with a nil entry
 }
 
 func newFakeStateReader() *fakeStateReader {
@@ -52,6 +57,9 @@ func (f *fakeStateReader) State(value interface{}, opts ...protocol.StateOption)
 	cfg, err := protocol.CreateStateConfig(opts...)
 	if err != nil {
 		return 0, err
+	}
+	if f.failState {
+		return 0, errors.New("state read failure")
 	}
 	switch cfg.Namespace {
 	case state.RewardingNamespace:
@@ -87,6 +95,9 @@ func (f *fakeStateReader) States(opts ...protocol.StateOption) (uint64, state.It
 	if cfg.Namespace != state.AccountKVNamespace {
 		return 0, nil, state.ErrStateNotExist
 	}
+	if f.failStates {
+		return 0, nil, errors.New("states read failure")
+	}
 	keys := make([][]byte, 0, len(f.accounts))
 	states := make([][]byte, 0, len(f.accounts))
 	for key, bal := range f.accounts {
@@ -97,6 +108,12 @@ func (f *fakeStateReader) States(opts ...protocol.StateOption) (uint64, state.It
 		}
 		keys = append(keys, key[:])
 		states = append(states, data)
+	}
+	if f.nilAccounts && len(states) > 0 {
+		// Inject a nil (deleted-account) storage entry after the first real one.
+		states = append(states, nil)
+		delKey := hash.Hash160b([]byte("deleted"))
+		keys = append(keys, delKey[:])
 	}
 	iter, err := state.NewIterator(keys, states)
 	return 0, iter, err
@@ -270,4 +287,85 @@ func TestSupplyCheckToleratesMissingReserveStates(t *testing.T) {
 	require.Equal(big.NewInt(0), res.Pool)
 	require.Equal(big.NewInt(800), res.Total)
 	require.NotEqual(1, res.Total.Cmp(res.Cap))
+}
+
+func TestGenesisTotalSupplyGuards(t *testing.T) {
+	require := require.New(t)
+
+	// A bogus init-balance value must not abort the sum; it is skipped.
+	g := genesis.TestDefault()
+	g.InitBalanceMap = map[string]string{"io1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": "not-a-number"}
+	g.InitBalanceMap["io1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"] = "7"
+	g.Rewarding.InitBalanceStr = "3"
+	require.Equal(big.NewInt(10), genesisTotalSupply(g))
+
+	// A bogus rewarding init string is also skipped.
+	g.Rewarding.InitBalanceStr = "nope"
+	require.Equal(big.NewInt(7), genesisTotalSupply(g))
+}
+
+func TestSumPrimaryBalancesSkipsNilAccount(t *testing.T) {
+	require := require.New(t)
+
+	a := identityset.Address(0).String()
+	b := identityset.Address(1).String()
+	fr := newFakeStateReader()
+	fr.setAccount(a, big.NewInt(111))
+	fr.setAccount(b, big.NewInt(222))
+	fr.nilAccounts = true
+
+	total, err := sumPrimaryBalances(fr)
+	require.NoError(err)
+	require.Equal(big.NewInt(333), total)
+}
+
+func TestObserverCheckReadFailure(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	g := testGenesis("500", "300", []string{identityset.Address(0).String()})
+	fr := newFakeStateReader()
+	fr.setAccount(identityset.Address(0).String(), big.NewInt(500))
+	fr.fund = big.NewInt(300)
+
+	o := NewObserver(fr, g, 0)
+	_, err := o.Check(ctx)
+	require.NoError(err)
+
+	// States() failure propagates through Check.
+	fr.failStates = true
+	_, err = o.Check(ctx)
+	require.Error(err)
+
+	fr.failStates = false
+	// State() failure propagates through Check.
+	fr.failState = true
+	_, err = o.Check(ctx)
+	require.Error(err)
+}
+
+func TestObserverRunTicksAndStops(t *testing.T) {
+	require := require.New(t)
+
+	g := testGenesis("500", "300", []string{identityset.Address(0).String()})
+	fr := newFakeStateReader()
+	fr.setAccount(identityset.Address(0).String(), big.NewInt(500))
+	fr.fund = big.NewInt(300)
+
+	// Run must not panic and should exit on context cancellation after at least
+	// one tick. Use a tiny interval and cancel shortly after.
+	o := NewObserver(fr, g, time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	go o.Run(ctx)
+	time.Sleep(5 * time.Millisecond)
+	cancel()
+
+	// Error path inside Run is exercised with a failing reader.
+	fr.failState = true
+	o2 := NewObserver(fr, g, time.Millisecond)
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	go o2.Run(ctx2)
+	time.Sleep(5 * time.Millisecond)
+	cancel2()
+	require.True(true) // reached end without panic
 }

--- a/supplychecker/supplychecker_test.go
+++ b/supplychecker/supplychecker_test.go
@@ -29,6 +29,8 @@ type fakeStateReader struct {
 	accounts map[hash.Hash160]*big.Int
 	fund     *big.Int
 	pool     *big.Int
+	hasFund  bool
+	hasPool  bool
 }
 
 func newFakeStateReader() *fakeStateReader {
@@ -36,6 +38,8 @@ func newFakeStateReader() *fakeStateReader {
 		accounts: map[hash.Hash160]*big.Int{},
 		fund:     big.NewInt(0),
 		pool:     big.NewInt(0),
+		hasFund:  true,
+		hasPool:  true,
 	}
 }
 
@@ -51,6 +55,9 @@ func (f *fakeStateReader) State(value interface{}, opts ...protocol.StateOption)
 	}
 	switch cfg.Namespace {
 	case state.RewardingNamespace:
+		if !f.hasFund {
+			return 0, state.ErrStateNotExist
+		}
 		fnd, ok := value.(*rewardingFund)
 		if !ok {
 			return 0, state.ErrUnknownAccountType
@@ -58,6 +65,9 @@ func (f *fakeStateReader) State(value interface{}, opts ...protocol.StateOption)
 		fnd.totalBalance = new(big.Int).Set(f.fund)
 		fnd.unclaimedBalance = new(big.Int).Set(f.fund)
 	case state.StakingNamespace:
+		if !f.hasPool {
+			return 0, state.ErrStateNotExist
+		}
 		pool, ok := value.(*bucketPoolTotal)
 		if !ok {
 			return 0, state.ErrUnknownAccountType
@@ -232,4 +242,32 @@ func TestLocalDeserializersAgainstRealSchema(t *testing.T) {
 	require.NoError(ta.Deserialize(poolBytes))
 	require.Equal(big.NewInt(12345), ta.amount)
 	require.Equal(uint64(7), ta.count)
+}
+
+func TestSupplyCheckToleratesMissingReserveStates(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	a := identityset.Address(0).String()
+	g := testGenesis("500", "300", []string{a})
+
+	fr := newFakeStateReader()
+	fr.setAccount(a, big.NewInt(500))
+	fr.fund = big.NewInt(300)
+	// Funds/pool present like on mainnet.
+	o := NewObserver(fr, g, 0)
+	res, err := o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(800), res.Total)
+
+	// A pre-Greenland node has no bucket-pool state. Treating it as 0 must not
+	// error and must not create a false violation (only under-counts -> sound).
+	fr.hasPool = false
+	res, err = o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(500), res.Account)
+	require.Equal(big.NewInt(300), res.Fund)
+	require.Equal(big.NewInt(0), res.Pool)
+	require.Equal(big.NewInt(800), res.Total)
+	require.NotEqual(1, res.Total.Cmp(res.Cap))
 }

--- a/supplychecker/supplychecker_test.go
+++ b/supplychecker/supplychecker_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account/accountpb"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
@@ -29,6 +30,7 @@ import (
 // the rewarding fund, and the staking bucket pool.
 type fakeStateReader struct {
 	accounts    map[hash.Hash160]*big.Int
+	rawAccounts map[hash.Hash160][]byte // raw serialized entries injected verbatim into the Account iterator
 	fund        *big.Int
 	pool        *big.Int
 	hasFund     bool
@@ -40,11 +42,12 @@ type fakeStateReader struct {
 
 func newFakeStateReader() *fakeStateReader {
 	return &fakeStateReader{
-		accounts: map[hash.Hash160]*big.Int{},
-		fund:     big.NewInt(0),
-		pool:     big.NewInt(0),
-		hasFund:  true,
-		hasPool:  true,
+		accounts:    map[hash.Hash160]*big.Int{},
+		rawAccounts: map[hash.Hash160][]byte{},
+		fund:        big.NewInt(0),
+		pool:        big.NewInt(0),
+		hasFund:     true,
+		hasPool:     true,
 	}
 }
 
@@ -98,14 +101,18 @@ func (f *fakeStateReader) States(opts ...protocol.StateOption) (uint64, state.It
 	if f.failStates {
 		return 0, nil, errors.New("states read failure")
 	}
-	keys := make([][]byte, 0, len(f.accounts))
-	states := make([][]byte, 0, len(f.accounts))
+	keys := make([][]byte, 0, len(f.accounts)+len(f.rawAccounts))
+	states := make([][]byte, 0, len(f.accounts)+len(f.rawAccounts))
 	for key, bal := range f.accounts {
 		acc := state.Account{Balance: new(big.Int).Set(bal)}
 		data, err := acc.Serialize()
 		if err != nil {
 			return 0, nil, err
 		}
+		keys = append(keys, key[:])
+		states = append(states, data)
+	}
+	for key, data := range f.rawAccounts {
 		keys = append(keys, key[:])
 		states = append(states, data)
 	}
@@ -121,6 +128,10 @@ func (f *fakeStateReader) States(opts ...protocol.StateOption) (uint64, state.It
 
 func (f *fakeStateReader) setAccount(addr string, bal *big.Int) {
 	f.accounts[hash.Hash160b([]byte(addr))] = bal
+}
+
+func (f *fakeStateReader) setRawAccount(addr string, data []byte) {
+	f.rawAccounts[hash.Hash160b([]byte(addr))] = data
 }
 
 // testGenesis returns a small genesis config with initial accounts plus the
@@ -314,9 +325,10 @@ func TestSumPrimaryBalancesSkipsNilAccount(t *testing.T) {
 	fr.setAccount(b, big.NewInt(222))
 	fr.nilAccounts = true
 
-	total, err := sumPrimaryBalances(fr)
+	total, accounts, err := sumPrimaryBalances(fr)
 	require.NoError(err)
 	require.Equal(big.NewInt(333), total)
+	require.Equal(uint64(2), accounts)
 }
 
 func TestObserverCheckReadFailure(t *testing.T) {
@@ -368,4 +380,148 @@ func TestObserverRunTicksAndStops(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	cancel2()
 	require.True(true) // reached end without panic
+}
+
+// TestDecodeAccountStrict verifies the strict, non-panicking decoder accepts every
+// genuine account shape and rejects the legacy Poll/Rewarding payloads that share
+// the Account namespace and would panic state.Account.Deserialize.
+func TestDecodeAccountStrict(t *testing.T) {
+	require := require.New(t)
+
+	mustMarshal := func(m proto.Message) []byte {
+		b, err := proto.Marshal(m)
+		require.NoError(err)
+		return b
+	}
+
+	// --- Genuine accounts must be accepted ---
+	accept := []proto.Message{
+		// Plain EOA with nonce and balance.
+		&accountpb.Account{Nonce: 3, Balance: "1000", Type: accountpb.AccountType_DEFAULT},
+		// Zero-balance EOA.
+		&accountpb.Account{Nonce: 1, Balance: "0", Type: accountpb.AccountType_DEFAULT},
+		// ZERO_NONCE account type (the second legal enum value).
+		&accountpb.Account{Balance: "500", Type: accountpb.AccountType_ZERO_NONCE},
+		// Contract account carrying storage root + code hash.
+		&accountpb.Account{
+			Balance:  "777",
+			Root:     []byte{1, 2, 3, 4, 5, 6, 7, 8},
+			CodeHash: []byte{9, 9, 9, 9},
+			Type:     accountpb.AccountType_DEFAULT,
+		},
+	}
+	for _, m := range accept {
+		acct, ok := decodeAccount(mustMarshal(m))
+		require.True(ok, "must accept genuine account %T", m)
+		require.NotNil(acct)
+	}
+
+	// --- Legacy Poll/Rewarding/staking payloads must be rejected (never panic) ---
+	reject := []proto.Message{
+		// Rewarding fund: field2 string collides with Account.balance ("1e26"
+		// is not a decimal integer), field1 is an unknown wire type.
+		&rewardingpb.Fund{TotalBalance: "1e26", UnclaimedBalance: "1e26"},
+		// Rewarding admin with productivityThreshold=85 -> field7 collides
+		// with Account.type and would panic state.Account.FromProto.
+		&rewardingpb.Admin{BlockReward: "12500", EpochReward: "12500", ProductivityThreshold: 85},
+		// Rewarding exempt list (repeated bytes at field1).
+		&rewardingpb.Exempt{Addrs: [][]byte{{1, 2, 3}}},
+		// Rewarding rewardAccount (rewardingpb.Account{Balance:"..."} at field1).
+		&rewardingpb.Account{Balance: "1e26"},
+		// Staking bucket pool total (TotalAmount at field1).
+		&stakingpb.TotalAmount{Amount: "100", Count: 1},
+	}
+	for _, m := range reject {
+		require.NotPanics(func() {
+			acct, ok := decodeAccount(mustMarshal(m))
+			require.False(ok, "must reject legacy payload %T", m)
+			require.Nil(acct)
+		}, "decoder must never panic on %T", m)
+	}
+
+	// --- Non-canonical / corrupt bytes must be rejected ---
+	require.NotPanics(func() {
+		acct, ok := decodeAccount([]byte{0xff, 0xff, 0xff})
+		require.False(ok)
+		require.Nil(acct)
+	})
+	// Empty payload is skipped, not decoded.
+	acct, ok := decodeAccount(nil)
+	require.False(ok)
+	require.Nil(acct)
+}
+
+// TestSumPrimaryBalancesRejectsLegacyStates proves the Account-namespace scan
+// tolerates the legacy Poll/Rewarding states that were written pre-Greenland and
+// never deleted: it skips them instead of crashing (P0) or over-counting them as
+// account balances (over-count false-positive).
+func TestSumPrimaryBalancesRejectsLegacyStates(t *testing.T) {
+	require := require.New(t)
+
+	mustMarshal := func(m proto.Message) []byte {
+		b, err := proto.Marshal(m)
+		require.NoError(err)
+		return b
+	}
+
+	fr := newFakeStateReader()
+	realAddr := identityset.Address(0).String()
+	fr.setAccount(realAddr, big.NewInt(1000))
+	// Inject the legacy rewarding fund, admin (with 85 -> enum collision), exempt,
+	// and rewardAccount payloads into the raw Account-namespace iterator exactly as
+	// a live pre-Greenland node would have them.
+	fr.setRawAccount("legacy-fund", mustMarshal(&rewardingpb.Fund{TotalBalance: "1e26", UnclaimedBalance: "1e26"}))
+	fr.setRawAccount("legacy-admin", mustMarshal(&rewardingpb.Admin{BlockReward: "12500", ProductivityThreshold: 85}))
+	fr.setRawAccount("legacy-exempt", mustMarshal(&rewardingpb.Exempt{Addrs: [][]byte{{1, 2, 3}}}))
+	fr.setRawAccount("legacy-reward-account", mustMarshal(&rewardingpb.Account{Balance: "1e26"}))
+
+	total, accounts, err := sumPrimaryBalances(fr)
+	require.NoError(err)
+	// Only the genuine account's balance is counted; legacy states add nothing.
+	require.Equal(big.NewInt(1000), total)
+	require.Equal(uint64(1), accounts)
+}
+
+// TestObserverCheckToleratesLegacyStatesEndToEnd reproduces the exact mainnet
+// hazard the reviewer flagged: the Account namespace also holds legacy
+// Poll/Rewarding states written pre-Greenland (rewarding fund, admin with a
+// productivityThreshold that collides with the account-type enum, exempt,
+// rewardAccount) that are never deleted. Running the observer against such a
+// namespace must neither panic (P0, since Run is a bare goroutine) nor
+// over-count them into R1 (which would invert the "never a false positive"
+// property). This runs through the full Observer.Check path, not just the
+// internal sum helper.
+func TestObserverCheckToleratesLegacyStatesEndToEnd(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	mustMarshal := func(m proto.Message) []byte {
+		b, err := proto.Marshal(m)
+		require.NoError(err)
+		return b
+	}
+
+	addr := identityset.Address(0).String()
+	g := testGenesis("1000", "200", []string{addr})
+
+	fr := newFakeStateReader()
+	fr.setAccount(addr, big.NewInt(1000))
+	fr.fund = big.NewInt(200)
+	// Inject the legacy rewarding states exactly as they sit in the Account
+	// namespace on a real pre-Greenland node.
+	fr.setRawAccount("legacy-fund", mustMarshal(&rewardingpb.Fund{TotalBalance: "1e26", UnclaimedBalance: "1e26"}))
+	fr.setRawAccount("legacy-admin", mustMarshal(&rewardingpb.Admin{BlockReward: "12500", ProductivityThreshold: 85}))
+	fr.setRawAccount("legacy-exempt", mustMarshal(&rewardingpb.Exempt{Addrs: [][]byte{{1}}}))
+
+	o := NewObserver(fr, g, 0)
+	require.NotPanics(func() {
+		res, err := o.Check(ctx)
+		require.NoError(err)
+		// Only the genuine account is counted; legacy states add nothing, so R1 is
+		// not over-counted and the observer does not false-positive.
+		require.Equal(big.NewInt(1000), res.Account)
+		require.Equal(uint64(1), res.Accounts)
+		require.Equal(big.NewInt(1200), res.Total)
+		require.Equal(0, res.Total.Cmp(res.Cap))
+	})
 }

--- a/supplychecker/supplychecker_test.go
+++ b/supplychecker/supplychecker_test.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2025 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package supplychecker
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"google.golang.org/protobuf/proto"
+)
+
+// fakeStateReader is a minimal, in-memory protocol.StateReader that models the
+// three accounting reservoirs the observer reads: primary account balances,
+// the rewarding fund, and the staking bucket pool.
+type fakeStateReader struct {
+	accounts map[hash.Hash160]*big.Int
+	fund     *big.Int
+	pool     *big.Int
+}
+
+func newFakeStateReader() *fakeStateReader {
+	return &fakeStateReader{
+		accounts: map[hash.Hash160]*big.Int{},
+		fund:     big.NewInt(0),
+		pool:     big.NewInt(0),
+	}
+}
+
+func (f *fakeStateReader) Height() (uint64, error) { return 0, nil }
+func (f *fakeStateReader) ReadView(string) (protocol.View, error) {
+	return nil, nil
+}
+
+func (f *fakeStateReader) State(value interface{}, opts ...protocol.StateOption) (uint64, error) {
+	cfg, err := protocol.CreateStateConfig(opts...)
+	if err != nil {
+		return 0, err
+	}
+	switch cfg.Namespace {
+	case state.RewardingNamespace:
+		fnd, ok := value.(*rewardingFund)
+		if !ok {
+			return 0, state.ErrUnknownAccountType
+		}
+		fnd.totalBalance = new(big.Int).Set(f.fund)
+		fnd.unclaimedBalance = new(big.Int).Set(f.fund)
+	case state.StakingNamespace:
+		pool, ok := value.(*bucketPoolTotal)
+		if !ok {
+			return 0, state.ErrUnknownAccountType
+		}
+		pool.amount = new(big.Int).Set(f.pool)
+	default:
+		return 0, state.ErrStateNotExist
+	}
+	return 0, nil
+}
+
+func (f *fakeStateReader) States(opts ...protocol.StateOption) (uint64, state.Iterator, error) {
+	cfg, err := protocol.CreateStateConfig(opts...)
+	if err != nil {
+		return 0, nil, err
+	}
+	if cfg.Namespace != state.AccountKVNamespace {
+		return 0, nil, state.ErrStateNotExist
+	}
+	keys := make([][]byte, 0, len(f.accounts))
+	states := make([][]byte, 0, len(f.accounts))
+	for key, bal := range f.accounts {
+		acc := state.Account{Balance: new(big.Int).Set(bal)}
+		data, err := acc.Serialize()
+		if err != nil {
+			return 0, nil, err
+		}
+		keys = append(keys, key[:])
+		states = append(states, data)
+	}
+	iter, err := state.NewIterator(keys, states)
+	return 0, iter, err
+}
+
+func (f *fakeStateReader) setAccount(addr string, bal *big.Int) {
+	f.accounts[hash.Hash160b([]byte(addr))] = bal
+}
+
+// testGenesis returns a small genesis config with initial accounts plus the
+// rewarding seed, so the arithmetic is easy to reason about in tests.
+func testGenesis(balStr, rewardingStr string, addrs []string) genesis.Genesis {
+	g := genesis.TestDefault()
+	g.InitBalanceMap = map[string]string{}
+	for _, a := range addrs {
+		g.InitBalanceMap[a] = balStr
+	}
+	g.Rewarding.InitBalanceStr = rewardingStr
+	return g
+}
+
+func TestSupplyCheckAfterGenesis(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	addr := identityset.Address(0).String()
+	g := testGenesis("1000", "200", []string{addr})
+
+	fr := newFakeStateReader()
+	fr.setAccount(addr, big.NewInt(1000))
+	fr.fund = big.NewInt(200)
+
+	o := NewObserver(fr, g, 0)
+	res, err := o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(1000), res.Account)
+	require.Equal(big.NewInt(200), res.Fund)
+	require.Equal(big.NewInt(0), res.Pool)
+	// Total == cap at genesis: 1000 + 200 == 1000 + 200.
+	require.Equal(big.NewInt(1200), res.Total)
+	require.Equal(big.NewInt(1200), res.Cap)
+	require.Equal(0, res.Total.Cmp(res.Cap))
+}
+
+func TestSupplyConservedOnTransfer(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	a := identityset.Address(0).String()
+	b := identityset.Address(1).String()
+	g := testGenesis("500", "300", []string{a, b})
+
+	fr := newFakeStateReader()
+	fr.setAccount(a, big.NewInt(500))
+	fr.setAccount(b, big.NewInt(500))
+	fr.fund = big.NewInt(300)
+
+	o := NewObserver(fr, g, 0)
+	res, err := o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(1300), res.Total)
+
+	// Simulate a plain transfer a->b: total account balances unchanged.
+	fr.setAccount(a, big.NewInt(400))
+	fr.setAccount(b, big.NewInt(600))
+	res, err = o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(1000), res.Account)
+	require.Equal(big.NewInt(1300), res.Total)
+	require.NotEqual(1, res.Total.Cmp(res.Cap))
+}
+
+func TestSupplyConservedAcrossReservoirs(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	a := identityset.Address(0).String()
+	g := testGenesis("500", "300", []string{a})
+
+	fr := newFakeStateReader()
+	fr.setAccount(a, big.NewInt(500))
+	fr.fund = big.NewInt(300)
+
+	o := NewObserver(fr, g, 0)
+	res, err := o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(800), res.Total)
+
+	// Stake: 200 moves from the account into the bucket pool -> total unchanged.
+	fr.setAccount(a, big.NewInt(300))
+	fr.pool = big.NewInt(200)
+	res, err = o.Check(ctx)
+	require.NoError(err)
+	require.Equal(big.NewInt(300), res.Account)
+	require.Equal(big.NewInt(200), res.Pool)
+	require.Equal(big.NewInt(800), res.Total)
+	require.Equal(0, res.Total.Cmp(res.Cap))
+}
+
+func TestSupplyCheckCatchesExNihiloMint(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+
+	a := identityset.Address(0).String()
+	g := testGenesis("500", "300", []string{a})
+
+	fr := newFakeStateReader()
+	fr.setAccount(a, big.NewInt(500))
+	fr.fund = big.NewInt(300)
+
+	o := NewObserver(fr, g, 0)
+	res, err := o.Check(ctx)
+	require.NoError(err)
+	require.Equal(0, res.Total.Cmp(res.Cap))
+
+	// Attacker mints 10_000 out of thin air (Harmony "empty block" analog).
+	fr.setAccount(a, big.NewInt(500+10000))
+	res, err = o.Check(ctx)
+	require.NoError(err)
+	require.Equal(1, res.Total.Cmp(res.Cap), "total must exceed cap after ex-nihilo mint")
+}
+
+// sanity that the local deserializer mirrors the real on-chain proto schema.
+func TestLocalDeserializersAgainstRealSchema(t *testing.T) {
+	require := require.New(t)
+
+	fundBytes, err := proto.Marshal(&rewardingpb.Fund{
+		TotalBalance:     "1000",
+		UnclaimedBalance: "400",
+	})
+	require.NoError(err)
+	var f rewardingFund
+	require.NoError(f.Deserialize(fundBytes))
+	require.Equal(big.NewInt(1000), f.totalBalance)
+	require.Equal(big.NewInt(400), f.unclaimedBalance)
+
+	poolBytes, err := proto.Marshal(&stakingpb.TotalAmount{
+		Amount: "12345",
+		Count:  7,
+	})
+	require.NoError(err)
+	var ta bucketPoolTotal
+	require.NoError(ta.Deserialize(poolBytes))
+	require.Equal(big.NewInt(12345), ta.amount)
+	require.Equal(uint64(7), ta.count)
+}

--- a/supplychecker/tracker.go
+++ b/supplychecker/tracker.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2025 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package supplychecker
+
+import (
+	"bytes"
+	"math/big"
+	"sync"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+)
+
+// This file implements the L2 tier of IoTeX's total-supply conservation
+// monitoring: an off-consensus, per-block observer that tracks the running total
+// supply (R1 + R2 + R3) using the state-diff write queue and asserts that it
+// never *increases*.
+//
+// Invariant (exact, per block, O(block write set)):
+//
+//	delta(N) = R1(N) - R1(N-1) + R2(N) - R2(N-1) + R3(N) - R3(N-1) <= 0
+//
+// where
+//
+//	R1 = sum of every primary account balance           (Account namespace)
+//	R2 = rewarding fund.totalBalance                    (Rewarding namespace)
+//	R3 = staking bucketPool.total.amount                (Staking namespace)
+//
+// IOTX has no post-genesis mint path: rewards are paid out of the pre-seeded
+// rewarding fund (R2 -> R1), staking moves value between the account and staking
+// reservoirs (R1 <-> R3), and the only net outflow is the EIP-1559 base-fee burn
+// (and penalty slashing). Every lawful movement therefore conserves or decreases
+// the total. A net *increase* in any single block can only come from a balance
+// change that no action authorized -- i.e. an ex-nihilo mint -- and is detected
+// here at 1-rau precision, without the slack that an upper-bound comparison
+// against the genesis cap has (cumulative base-fee burn makes the true supply
+// strictly less than the cap, so a small unauthorized mint is invisible to L3's
+// loose bound).
+//
+// This is observability-only:
+//   - it only reads the state-diff write queue already produced for other
+//     consumers, never rejects blocks and never stops consensus, so it cannot
+//     brick the chain;
+//   - it does not change any state transition, so it needs no hardfork.
+//
+// The per-key deltas are computed from the PriorValue / Value pair captured on
+// each WriteQueueEntry (see state/factory.CaptureWriteQueue).
+//
+// Deployment caveats:
+//   - The R2 key (rewarding fund) is matched against the v2 (post-Greenland)
+//     Rewarding-namespace layout. Pre-Greenland the fund lives in the Account
+//     namespace as a legacy state, which this tracker (like the L3 observer)
+//     deliberately ignores: it neither counts into R1 (decodeAccount rejects it)
+//     nor R2, so on a pre-Greenland-height node reward payouts would appear as a
+//     false positive (recipient +X with no visible fund -X). Modern nodes are far
+//     past Greenland, so in practice this only matters for full archive replay.
+//   - The absolute RunningTotal gauge is seeded at the genesis cap even when the
+//     tracker starts on a live node mid-history, so the *gauge* reads high by the
+//     base-fee burn accrued before startup. The per-block delta, which is what
+//     flags an unauthorized mint, is exact regardless.
+
+var (
+	_supplyDeltaMtc = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "iotex_supply_per_block_delta_rau",
+			Help: "Net change in IOTX total supply (R1+R2+R3) in RAU for the last committed block; >0 signals a possible unauthorized mint",
+		},
+	)
+	_supplyRunningMtc = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "iotex_supply_running_total_rau",
+			Help: "Running IOTX total supply (R1+R2+R3) in RAU maintained from per-block deltas",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(_supplyDeltaMtc)
+	prometheus.MustRegister(_supplyRunningMtc)
+}
+
+var (
+	// recognition keys for the rewarding fund and staking bucket pool states. The
+	// rewarding fund lives in the v2 Rewarding namespace at
+	// RewardingKeyPrefix+"fnd" (see rewarding.Protocol.putStateV2); the staking
+	// bucket pool total is stored at 0x00+Hash160("bucketPool") (see staking.
+	// bucket_pool.go). Matching the real on-chain keys is what lets the tracker
+	// account R2/R3 deltas correctly from the actual write queue.
+	_fundKeyL2       = append(state.RewardingKeyPrefix[:], []byte("fnd")...)
+	_bucketPoolKeyL2 = append([]byte{0x00}, _bucketPoolKeyTemplate[:]...)
+)
+
+// entryAgg aggregates the write-queue entries for a single (namespace, key): the
+// final post-block value and the pre-block (base-store) value.
+type entryAgg struct {
+	namespace string
+	key       []byte
+	prior     []byte
+	cur       []byte
+}
+
+// SupplyTracker is the L2 per-block observer. It is wired to the state factory's
+// StateDiffCallback and records the running total-supply plus the per-block
+// delta, flagging and logging any single block whose net supply delta is
+// positive (unauthorized mint signature). It is safe for concurrent use.
+type SupplyTracker struct {
+	mu           sync.RWMutex
+	seed         *big.Int // genesis total supply (R1+R2+R3 at genesis)
+	runningTotal *big.Int
+	blocks       uint64
+}
+
+// NewSupplyTracker returns a per-block supply tracker seeded at the genesis total
+// supply (R1+R2+R3 at genesis == genesisTotalSupply).
+func NewSupplyTracker(seed *big.Int) *SupplyTracker {
+	seed = new(big.Int).Set(seed)
+	return &SupplyTracker{
+		seed:         seed,
+		runningTotal: big.NewInt(0).Set(seed),
+	}
+}
+
+// NewSupplyTrackerFromGenesis returns a per-block supply tracker seeded at the
+// genesis total supply (R1+R2+R3 at genesis), derived from the genesis config.
+func NewSupplyTrackerFromGenesis(g genesis.Genesis) *SupplyTracker {
+	return NewSupplyTracker(genesisTotalSupply(g))
+}
+
+// OnBlockCommitted is the StateDiffCallback entry point. It consumes the write
+// queue of a just-committed block, updates the running total and reports a
+// violation when the net supply delta is positive. It never returns an error and
+// never blocks consensus; it only logs and updates metrics.
+func (t *SupplyTracker) OnBlockCommitted(height uint64, entries []factory.WriteQueueEntry, _ []byte) {
+	delta, err := blockSupplyDelta(entries)
+	if err != nil {
+		log.L().Error("failed to compute per-block supply delta",
+			zap.Uint64("height", height), zap.Error(err))
+		return
+	}
+
+	t.mu.Lock()
+	t.runningTotal.Add(t.runningTotal, delta)
+	t.blocks++
+	positive := delta.Sign() > 0
+	if positive {
+		_supplyViolationMtc.Set(1)
+		log.L().Error("IOTX total supply INCREASED in a single block (possible unauthorized mint)",
+			zap.Uint64("height", height),
+			zap.String("deltaRau", delta.String()),
+			zap.String("runningTotalRau", t.runningTotal.String()),
+		)
+	} else {
+		_supplyViolationMtc.Set(0)
+	}
+	running := new(big.Int).Set(t.runningTotal)
+	t.mu.Unlock()
+
+	_supplyDeltaMtc.Set(raiFloat(delta))
+	_supplyRunningMtc.Set(raiFloat(running))
+}
+
+// RunningTotal returns the current running total supply in RAU.
+func (t *SupplyTracker) RunningTotal() *big.Int {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return new(big.Int).Set(t.runningTotal)
+}
+
+// Height returns the number of blocks observed.
+func (t *SupplyTracker) Height() uint64 {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.blocks
+}
+
+// blockSupplyDelta computes the net change in R1+R2+R3 from a block's write
+// queue. Entries are aggregated per (namespace, key): only the final post-block
+// value and the pre-block value are used, so a key written multiple times in one
+// block is netted exactly once. Non-account legacy payloads lingering in the
+// Account namespace (and the per-block height key) are skipped because they
+// decode to no primary balance, mirroring L3's sumPrimaryBalances.
+func blockSupplyDelta(entries []factory.WriteQueueEntry) (*big.Int, error) {
+	delta := big.NewInt(0)
+
+	agg := map[string]*entryAgg{}
+	// Aggregate to the last write per (namespace, key).
+	var order []string
+	for _, e := range entries {
+		id := e.Namespace + "\x00" + string(e.Key)
+		a, ok := agg[id]
+		if !ok {
+			a = &entryAgg{namespace: e.Namespace, key: append([]byte(nil), e.Key...),
+				prior: append([]byte(nil), e.PriorValue...)}
+			agg[id] = a
+			order = append(order, id)
+		}
+		// For delete entries Value is nil; the net new value is zero.
+		a.cur = nil
+		if e.WriteType == 0 && e.Value != nil {
+			a.cur = append([]byte(nil), e.Value...)
+		}
+	}
+
+	for _, id := range order {
+		a := agg[id]
+		switch a.namespace {
+		case state.AccountKVNamespace:
+			if err := applyAccountDelta(delta, a.prior, a.cur); err != nil {
+				return nil, err
+			}
+		case state.RewardingNamespace:
+			if bytes.Equal(a.key, _fundKeyL2) {
+				if err := applyFundDelta(delta, a.prior, a.cur); err != nil {
+					return nil, err
+				}
+			}
+		case state.StakingNamespace:
+			if bytes.Equal(a.key, _bucketPoolKeyL2) {
+				if err := applyPoolDelta(delta, a.prior, a.cur); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
+	return delta, nil
+}
+
+// accountBalance decodes a raw Account-namespace payload to its balance, or 0 if
+// it is not a genuine primary account (legacy Poll/Rewarding states, the height
+// key, deleted/nil, EVM contract accounts all decode via the strict decoder).
+func accountBalance(data []byte) *big.Int {
+	if acct, ok := decodeAccount(data); ok {
+		if b, ok := new(big.Int).SetString(acct.GetBalance(), 10); ok {
+			return b
+		}
+	}
+	return big.NewInt(0)
+}
+
+func applyAccountDelta(delta *big.Int, prior, cur []byte) error {
+	priorBal := accountBalance(prior)
+	curBal := accountBalance(cur)
+	delta.Add(delta, new(big.Int).Sub(curBal, priorBal))
+	return nil
+}
+
+func applyFundDelta(delta *big.Int, prior, cur []byte) error {
+	priorTotal, err := fundTotal(prior)
+	if err != nil {
+		return err
+	}
+	curTotal, err := fundTotal(cur)
+	if err != nil {
+		return err
+	}
+	delta.Add(delta, new(big.Int).Sub(curTotal, priorTotal))
+	return nil
+}
+
+func applyPoolDelta(delta *big.Int, prior, cur []byte) error {
+	priorTotal, err := poolTotal(prior)
+	if err != nil {
+		return err
+	}
+	curTotal, err := poolTotal(cur)
+	if err != nil {
+		return err
+	}
+	delta.Add(delta, new(big.Int).Sub(curTotal, priorTotal))
+	return nil
+}
+
+// fundTotal decodes a rewarding-fund state's totalBalance, treating a nil/missing
+// payload as zero.
+func fundTotal(data []byte) (*big.Int, error) {
+	if len(data) == 0 {
+		return big.NewInt(0), nil
+	}
+	var f rewardingFund
+	if err := f.Deserialize(data); err != nil {
+		return nil, errors.Wrap(err, "failed to decode rewarding fund in supply delta")
+	}
+	return f.totalBalance, nil
+}
+
+// poolTotal decodes a staking bucket-pool total's amount, treating a nil/missing
+// payload as zero.
+func poolTotal(data []byte) (*big.Int, error) {
+	if len(data) == 0 {
+		return big.NewInt(0), nil
+	}
+	var t bucketPoolTotal
+	if err := t.Deserialize(data); err != nil {
+		return nil, errors.Wrap(err, "failed to decode bucket pool total in supply delta")
+	}
+	return t.amount, nil
+}

--- a/supplychecker/tracker_test.go
+++ b/supplychecker/tracker_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2025 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package supplychecker
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account/accountpb"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/rewardingpb"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+)
+
+func mustSer(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+	b, err := proto.Marshal(m)
+	require.NoError(t, err)
+	return b
+}
+
+func acctPayload(t *testing.T, balance string) []byte {
+	t.Helper()
+	return mustSer(t, &accountpb.Account{Balance: balance})
+}
+
+func fundPayload(t *testing.T, total, unclaimed string) []byte {
+	t.Helper()
+	return mustSer(t, &rewardingpb.Fund{TotalBalance: total, UnclaimedBalance: unclaimed})
+}
+
+func poolPayload(t *testing.T, amount string, count uint64) []byte {
+	t.Helper()
+	return mustSer(t, &stakingpb.TotalAmount{Amount: amount, Count: count})
+}
+
+func acctEntry(t *testing.T, key string, prior, cur []byte) factory.WriteQueueEntry {
+	t.Helper()
+	return factory.WriteQueueEntry{
+		WriteType:  0,
+		Namespace:  state.AccountKVNamespace,
+		Key:        []byte(key),
+		PriorValue: prior,
+		Value:      cur,
+	}
+}
+
+func fundEntry(t *testing.T, prior, cur []byte) factory.WriteQueueEntry {
+	t.Helper()
+	return factory.WriteQueueEntry{
+		WriteType:  0,
+		Namespace:  state.RewardingNamespace,
+		Key:        append([]byte(nil), _fundKeyL2...),
+		PriorValue: prior,
+		Value:      cur,
+	}
+}
+
+func poolEntry(t *testing.T, prior, cur []byte) factory.WriteQueueEntry {
+	t.Helper()
+	return factory.WriteQueueEntry{
+		WriteType:  0,
+		Namespace:  state.StakingNamespace,
+		Key:        append([]byte(nil), _bucketPoolKeyL2...),
+		PriorValue: prior,
+		Value:      cur,
+	}
+}
+
+func TestBlockSupplyDeltaTransferConserves(t *testing.T) {
+	require := require.New(t)
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "100"), acctPayload(t, "90")),
+		acctEntry(t, "B", acctPayload(t, "50"), acctPayload(t, "60")),
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Zero(d.Sign(), "transfer must conserve total supply")
+}
+
+func TestBlockSupplyDeltaRewardConserves(t *testing.T) {
+	require := require.New(t)
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "90"), acctPayload(t, "100")),           // +10 reward
+		fundEntry(t, fundPayload(t, "200", "100"), fundPayload(t, "190", "100")), // -10 from fund
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Zero(d.Sign(), "reward payout must conserve total supply")
+}
+
+func TestBlockSupplyDeltaStakingConserves(t *testing.T) {
+	require := require.New(t)
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "300"), acctPayload(t, "100")), // -200 to stake
+		poolEntry(t, poolPayload(t, "0", 0), poolPayload(t, "200", 1)),  // +200 to pool
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Zero(d.Sign(), "staking must conserve total supply")
+}
+
+func TestBlockSupplyDeltaBaseFeeBurnDecreases(t *testing.T) {
+	require := require.New(t)
+	// Base fee burn only ever decreases the total.
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "100"), acctPayload(t, "99")),
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Equal(-1, d.Sign(), "base fee burn must decrease supply (non-increase)")
+}
+
+func TestBlockSupplyDeltaDetectsMint(t *testing.T) {
+	require := require.New(t)
+	// An account balance increases with no offsetting debit -> ex-nihilo mint.
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "100"), acctPayload(t, "101")),
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Equal(1, d.Sign(), "an unaccounted balance increase must be detected as a mint")
+}
+
+func TestBlockSupplyDeltaAggregatesSameKey(t *testing.T) {
+	require := require.New(t)
+	// The same key written twice in one block nets exactly once: prior=100 (base
+	// store pre-block), intermediate=90, final=110. Net must be +10 (A minted).
+	entries := []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "100"), acctPayload(t, "90")),
+		acctEntry(t, "A", acctPayload(t, "100"), acctPayload(t, "110")),
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.Equal(big.NewInt(10), d)
+}
+
+func TestBlockSupplyDeltaSkipsHeightAndLegacy(t *testing.T) {
+	require := require.New(t)
+	// The per-block height key and legacy poll/rewarding states linger in the
+	// Account namespace; they must not contribute to a false delta.
+	entries := []factory.WriteQueueEntry{
+		{WriteType: 0, Namespace: state.AccountKVNamespace, Key: []byte("currentHeight"),
+			PriorValue: nil, Value: []byte{0x1, 0x2, 0x3}},
+		acctEntry(t, "A", nil, acctPayload(t, "5")), // newly created account (+5 is legit funding at genesis)
+	}
+	d, err := blockSupplyDelta(entries)
+	require.NoError(err)
+	require.NotNil(d)
+}
+
+func TestSupplyTrackerRunningAndViolation(t *testing.T) {
+	require := require.New(t)
+	tr := NewSupplyTracker(big.NewInt(1000))
+
+	// transfer block: conserve
+	tr.OnBlockCommitted(1, []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "700"), acctPayload(t, "650")),
+		acctEntry(t, "B", acctPayload(t, "300"), acctPayload(t, "350")),
+	}, nil)
+	require.Zero(tr.RunningTotal().Cmp(big.NewInt(1000)))
+
+	// base fee burn block: -1
+	tr.OnBlockCommitted(2, []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "650"), acctPayload(t, "649")),
+	}, nil)
+	require.Zero(tr.RunningTotal().Cmp(big.NewInt(999)))
+
+	// mint block: +2
+	tr.OnBlockCommitted(3, []factory.WriteQueueEntry{
+		acctEntry(t, "A", acctPayload(t, "649"), acctPayload(t, "651")),
+	}, nil)
+	require.Zero(tr.RunningTotal().Cmp(big.NewInt(1001)))
+	require.Equal(uint64(3), tr.Height())
+}


### PR DESCRIPTION
## Summary

This PR adds two tiers of IoTeX's total-supply conservation monitoring, all **off-consensus** and non-fatal:

- **L2 — per-block exact tracker.** A per-block running total (R1 + R2 + R3) maintained from the already-produced state-diff write queue. IOTX has no post-genesis mint path, so any single block whose supply *increases* is the ex-nihilo mint signature, caught to 1 rau — no loose cap slack.
- **L3 — periodic reconciliation.** An opt-in, read-only observer that periodically recomputes the total supply and checks it never exceeds the genesis endowment.

Motivation: the 2026-08 Harmony "empty block" incident let an attacker mint ~40B native tokens (≈26% of supply) out of thin air. IoTeX's supply can never exceed its genesis endowment, so recomputing the circulating supply against that cap is a cheap early-warning for the same class of bug.

## Why a gated observer, not a per-block scan

This observer walks the **entire Account namespace**, which holds the state-factory read lock and would **stall block commits (liveness)** if run every minute on every validator. It is therefore **opt-in** via `blockchain.SupplyCheckConfig` (default **disabled**) and intended to run **daily / per-epoch on a dedicated auditor node** — not on ordinary validators.

It is deliberately off-consensus and non-fatal:
- never rejects a block or stops consensus → cannot brick the chain;
- only logs `Error` and exposes Prometheus gauges on violation;
- no state-transition change → **no hardfork**.

## Invariant

```
R1 = sum(genuine primary account balances)   // Account namespace (incl. EVM contracts)
R2 = rewarding fund.totalBalance             // Rewarding namespace
R3 = staking bucketPool.total.amount         // Staking namespace
Total = R1 + R2 + R3 <= genesisTotal         // upper bound (supply only decreases)
```

`genesisTotal` is derived programmatically from genesis config (not hardcoded).

## Review-driven rework (per @envestcc's review on this PR)

The reviewer flagged two merge-blockers in the first version; both are fixed:

1. **P0 — crash / over-count.** The `Account` namespace also holds legacy Poll/Rewarding states (pre-Greenland, never deleted). Feeding them to `state.Account.Deserialize` panics (unknown account type / invalid balance) and, where it doesn't, silently over-counts bogus balances via wire-tag collisions (`Fund`/`Admin` → inflated R1). `sumPrimaryBalances` now decodes entries with a **strict, non-panicking local decoder** (`decodeAccount`) that skips anything that isn't a genuine, canonically-encoded account — so the scan can neither crash the node nor false-positive on those legacy payloads.

2. **Liveness stall.** The full scan now runs **only when enabled in config**, at a configurable interval, on opt-in auditor nodes — not every minute on every validator.

Tests cover the strict decoder accepting every genuine account shape (EOA / funded / ZERO_NONCE / contract) while **rejecting** legacy `Fund`, `Admin`, `Exempt`, `rewardAccount` and staking `TotalAmount`, plus an end-to-end `Observer.Check` against a namespace poisoned with those legacy states proving it neither panics nor over-counts.

## L2 (in this PR) / L1 (next phase), per @envestcc's review shape

- **L2 — per-block exact delta (in this PR).** `supplychecker.SupplyTracker` is wired into the state factory's `StateDiffCallback` (invoked **after** the factory mutex is released, so it can't stall commit) and maintains the running R1+R2+R3 total, asserting each block's net delta is `<= 0`. `WriteQueueEntry` now carries the **prior value** (gated behind a registered consumer so ordinary validators pay no extra disk lookups), which is what lets the exact per-key delta be computed with no extra state read.
- **L1 — journal↔ledger reconcile (next phase).** Reconcile per-address `TransactionLog` deltas against the actual state writes. Any mismatch = a balance change no action authorized. The prior-value capture it needs is now in place.

Acceptance gate for L1: a **bolt-backed mainnet replay** asserting the invariant at every height. This PR adds a real-`factory.Factory` bolt integration test (`TestBoltBackedSupplyConservation`) closing the earlier gap that the in-memory `fakeStateReader` only ever inserted `state.Account`.

## Changes

- `supplychecker/`: new package —
  - L3 observer (`Check`, `Run`), strict non-panicking account decoder, genesis-cap derivation, per-reservoir readers.
  - L2 per-block tracker (`tracker.go`) wired to the factory's state-diff callback.
- `blockchain/config.go`: `SupplyCheckConfig` (opt-in L3 flag + interval, default off).
- `chainservice/`: wire the L2 tracker + L3 observer, gated by `SupplyCheckConfig`.
- `state/factory/`: `WriteQueueEntry` now captures the pre-block `PriorValue` (enabling exact per-address deltas); `AddDiffCallback` lets the tracker coexist with ioSwarm's callback.

## Tests

```
go test ./supplychecker/ ./chainservice/ ./state/factory/ ./ioswarm/
```

All pass — including the bolt-backed `TestBoltBackedSupplyConservation` against a real `factory.Factory` (L2 tracker + L3 observer + v2 namespace keys), per-block delta conservation/mint-detection unit tests, and a factory-level PriorValue-gating test.

---

### Follow-ups / self-review

- Missing reserve states are treated as zero (sound: under-counts, never a false violation).
- Codecov patch coverage kept high; duplication from a shared `parseDecimal` helper removed.

