### PR TITLE
fix(api): serialize tracer Stop against GetResult

### DIFF
--- a/api/web3server_utils.go
+++ b/api/web3server_utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -727,6 +728,41 @@ func parseTracerConfig(options *gjson.Result) *tracers.TraceConfig {
 	return cfg
 }
 
+// serializeStopAndResult returns t with its Stop and GetResult serialized
+// against each other.
+//
+// The timeout watchdog armed by parseTracer calls Stop from its own goroutine
+// while the goroutine running the trace calls GetResult. geth's StructLogger
+// stores the interruption reason on a plain field -- Stop writes l.reason and
+// only then flips the atomic l.interrupt, and GetResult reads l.reason without
+// consulting that atomic -- so the two overlap without a happens-before edge.
+// Holding a mutex across both calls supplies it. Hooks are passed through
+// untouched: they run on the tracing goroutine and coordinate through
+// l.interrupt, which is already atomic.
+func serializeStopAndResult(t *tracers.Tracer) *tracers.Tracer {
+	var (
+		mu        sync.Mutex
+		getResult = t.GetResult
+		stop      = t.Stop
+	)
+	guarded := &tracers.Tracer{Hooks: t.Hooks}
+	if getResult != nil {
+		guarded.GetResult = func() (json.RawMessage, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			return getResult()
+		}
+	}
+	if stop != nil {
+		guarded.Stop = func(err error) {
+			mu.Lock()
+			defer mu.Unlock()
+			stop(err)
+		}
+	}
+	return guarded
+}
+
 // parseTracer builds the tracer described by config and arms a timeout watchdog
 // that stops the tracer once the deadline expires. The watchdog covers every
 // tracer type (default struct logger, configured struct logger and named
@@ -766,6 +802,10 @@ func parseTracer(ctx context.Context, txctx *tracers.Context, config *tracers.Tr
 			Stop:      loger.Stop,
 		}
 	}
+
+	// The watchdog below calls Stop concurrently with the caller's GetResult,
+	// so hand back a tracer that serializes the two.
+	tracer = serializeStopAndResult(tracer)
 
 	// Define a meaningful timeout for a single transaction trace. This applies
 	// to all tracer types.


### PR DESCRIPTION
## The race

`parseTracer` arms a timeout watchdog that calls `tracer.Stop` from its own goroutine, while the goroutine running the trace calls `GetResult`. geth's `StructLogger` stores the interruption reason on a plain field:

```go
func (l *StructLogger) Stop(err error) {
	l.reason = err            // plain write
	l.interrupt.Store(true)   // atomic, but *after*
}

func (l *StructLogger) GetResult() (json.RawMessage, error) {
	if l.reason != nil {      // plain read, never consults l.interrupt
		return nil, l.reason
	}
	...
```

`reason` is written and read without synchronisation, and the atomic `interrupt` establishes no happens-before edge for it because `GetResult` never reads it. Any `debug_trace*` request that hits its deadline can trip this.

## The fix

Wrap the tracer so `Stop` and `GetResult` hold a common mutex. `Hooks` are passed through untouched — they run on the tracing goroutine and coordinate through `l.interrupt`, which is already atomic. Nothing in the geth fork is modified.

The guard is applied to every branch of `parseTracer` (default struct logger, configured struct logger, and named JS/native tracers), since the watchdog covers all of them.

## Reproduction

`TestParseTracerDefaultLoggerTimeoutFires` already exercises the path; the race detector is what surfaces it, so no new test is needed.

On `master` (85fd452c6):

```
$ go test -count=1 -gcflags="all=-N -l" -short -race \
    -run TestParseTracerDefaultLoggerTimeoutFires ./api/
exit=1   WARNING: DATA RACE x2
```

With this commit:

```
exit=0   WARNING: DATA RACE x0
```

Full `./api/` package under the same flags: `ok`, 0 races.

## Notes

Found while integrating this fix into `rc_2.5.0`; opening it separately against `master` so the branches don't diverge on it.