### PR TITLE
fix(factory): drop an action that panics during block production

### DIFF
--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -55,6 +55,10 @@ var (
 		},
 		[]string{"type"},
 	)
+	_runActionPanicMtc = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "iotex_mint_action_panics_total",
+		Help: "Number of panics recovered while running an action during block production (the action is dropped from the pool and the draft is discarded).",
+	})
 
 	errInvalidSystemActionLayout = errors.New("system action layout is invalid")
 	errUnfoldTxContainer         = errors.New("failed to unfold tx container")
@@ -64,6 +68,7 @@ var (
 func init() {
 	prometheus.MustRegister(_stateDBMtc)
 	prometheus.MustRegister(_mintAbility)
+	prometheus.MustRegister(_runActionPanicMtc)
 }
 
 type (
@@ -924,7 +929,7 @@ func (ws *workingSet) pickAndRunActions(
 				_mintAbility.WithLabelValues("saturation").Set(0)
 				break
 			}
-			popAccount, deleteAction, receipt, err := ws.validateAndRun(ctxWithBlockContext, reg, nextAction, blkCtx.GasLimit, blobCnt, uint64(blobLimit), true)
+			popAccount, deleteAction, receipt, err := ws.validateAndRunSafely(ctxWithBlockContext, reg, nextAction, blkCtx.GasLimit, blobCnt, uint64(blobLimit))
 			if popAccount {
 				actionIterator.PopAccount()
 			}
@@ -980,6 +985,48 @@ func (ws *workingSet) pickAndRunActions(
 	ws.receipts = receipts
 
 	return executedActions, ws.finalize(ctx)
+}
+
+// validateAndRunSafely runs one action picked from the action pool and turns a
+// panic raised by it into an ordinary error, so that a single malformed action
+// cannot take down block production. The caller drops the action from the pool
+// (deleteAction is set) and abandons the draft: the working set already holds
+// the partial writes of the action that blew up, so it is not safe to keep
+// minting on it. The next round starts from a clean working set without the
+// offending action.
+func (ws *workingSet) validateAndRunSafely(
+	ctx context.Context,
+	reg *protocol.Registry,
+	nextAction *action.SealedEnvelope,
+	gasLimit uint64,
+	blobCnt uint64,
+	blobLimit uint64,
+) (popAccount bool, deleteAction bool, receipt *action.Receipt, err error) {
+	defer func() {
+		r := recover()
+		if r == nil {
+			return
+		}
+		_runActionPanicMtc.Inc()
+		actHash, hashErr := nextAction.Hash()
+		fields := []zap.Field{
+			zap.Any("panic", r),
+			zap.Uint64("height", ws.height),
+			zap.String("stack", string(debug.Stack())),
+		}
+		if hashErr == nil {
+			fields = append(fields, log.Hex("actionHash", actHash[:]))
+		}
+		if sender := nextAction.SenderAddress(); sender != nil {
+			fields = append(fields, zap.String("sender", sender.String()))
+		}
+		log.L().Error("panic while running action during block production, dropping it from the action pool", fields...)
+		popAccount = false
+		deleteAction = true
+		receipt = nil
+		err = errors.Errorf("panic while running action at height %d: %v", ws.height, r)
+	}()
+	return ws.validateAndRun(ctx, reg, nextAction, gasLimit, blobCnt, blobLimit, true)
 }
 
 func (ws *workingSet) validateAndRun(

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
@@ -25,6 +27,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/db"
 	"github.com/iotexproject/iotex-core/v2/pkg/unit"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_actpool"
 	"github.com/iotexproject/iotex-core/v2/testutil"
 )
 
@@ -234,6 +237,112 @@ func TestWorkingSet_ValidateBlock_RecoversPanic(t *testing.T) {
 	require.NotPanics(func() { validateErr = f.Validate(zctx, blk) })
 	require.Error(validateErr)
 	require.Contains(validateErr.Error(), "recovered from panic")
+}
+
+// TestWorkingSet_Mint_SkipsPanickingAction verifies that an action panicking
+// while it is being run during block production does not stall the proposer:
+// the panic is turned into an error, the offending sender is dropped from the
+// action pool, and the next mint produces a block without it.
+func TestWorkingSet_Mint_SkipsPanickingAction(t *testing.T) {
+	require := require.New(t)
+	var (
+		badSender  = identityset.Address(28)
+		goodSender = identityset.Address(29)
+	)
+	cfg := Config{
+		Chain:   blockchain.DefaultConfig,
+		Genesis: genesis.TestDefault(),
+	}
+	cfg.Genesis.InitBalanceMap[badSender.String()] = "100000000000000000000"
+	cfg.Genesis.InitBalanceMap[goodSender.String()] = "100000000000000000000"
+
+	registry := protocol.NewRegistry()
+	// a deposit-gas hook that panics for one particular sender stands in for any
+	// action handler that panics on a specific action
+	depositGas := func(ctx context.Context, _ protocol.StateManager, _ *big.Int, _ ...protocol.DepositOption) ([]*action.TransactionLog, error) {
+		if actCtx, ok := protocol.GetActionCtx(ctx); ok && actCtx.Caller.String() == badSender.String() {
+			panic("injected panic while running action")
+		}
+		return nil, nil
+	}
+	require.NoError(account.NewProtocol(depositGas).Register(registry))
+
+	sdb, err := NewStateDB(cfg, db.NewMemKVStore(), RegistryStateDBOption(registry))
+	require.NoError(err)
+	startCtx := protocol.WithBlockCtx(
+		genesis.WithGenesisContext(context.Background(), cfg.Genesis),
+		protocol.BlockCtx{},
+	)
+	require.NoError(sdb.Start(startCtx))
+	defer func() {
+		require.NoError(sdb.Stop(startCtx))
+	}()
+
+	badAct, err := action.SignedTransfer(goodSender.String(), identityset.PrivateKey(28), 1, big.NewInt(1), nil, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))
+	require.NoError(err)
+	badHash, err := badAct.Hash()
+	require.NoError(err)
+	goodAct, err := action.SignedTransfer(badSender.String(), identityset.PrivateKey(29), 1, big.NewInt(1), nil, testutil.TestGasLimit, big.NewInt(testutil.TestGasPriceInt64))
+	require.NoError(err)
+	goodHash, err := goodAct.Hash()
+	require.NoError(err)
+
+	pending := map[string][]*action.SealedEnvelope{
+		badSender.String():  {badAct},
+		goodSender.String(): {goodAct},
+	}
+	deleted := []string{}
+	ctrl := gomock.NewController(t)
+	ap := mock_actpool.NewMockActPool(ctrl)
+	ap.EXPECT().BundlePool().Return(nil).AnyTimes()
+	ap.EXPECT().PendingActionMap().DoAndReturn(func() map[string][]*action.SealedEnvelope {
+		snapshot := make(map[string][]*action.SealedEnvelope, len(pending))
+		for sender, acts := range pending {
+			snapshot[sender] = acts
+		}
+		return snapshot
+	}).AnyTimes()
+	ap.EXPECT().DeleteAction(gomock.Any()).Do(func(caller address.Address) {
+		deleted = append(deleted, caller.String())
+		delete(pending, caller.String())
+	}).AnyTimes()
+
+	ctx := protocol.WithBlockCtx(context.Background(),
+		protocol.BlockCtx{
+			BlockHeight: 1,
+			Producer:    identityset.Address(27),
+			GasLimit:    testutil.TestGasLimit * 100000,
+		})
+	ctx = protocol.WithBlockchainCtx(
+		genesis.WithGenesisContext(ctx, cfg.Genesis),
+		protocol.BlockchainCtx{},
+	)
+	ctx = protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
+
+	// first round: the offending action aborts the draft and its sender is dropped
+	var blk *block.Block
+	require.NotPanics(func() {
+		blk, err = sdb.Mint(ctx, ap, identityset.PrivateKey(27))
+	})
+	require.Error(err)
+	require.Contains(err.Error(), "panic while running action")
+	require.Nil(blk)
+	require.Equal([]string{badSender.String()}, deleted)
+
+	// second round: block production resumes without the offending action
+	require.NotPanics(func() {
+		blk, err = sdb.Mint(ctx, ap, identityset.PrivateKey(27))
+	})
+	require.NoError(err)
+	require.NotNil(blk)
+	minted := make(map[hash.Hash256]bool)
+	for _, act := range blk.Actions {
+		h, err := act.Hash()
+		require.NoError(err)
+		minted[h] = true
+	}
+	require.True(minted[goodHash])
+	require.False(minted[badHash])
 }
 
 func TestWorkingSet_ValidateBlock_SystemAction(t *testing.T) {


### PR DESCRIPTION
### Description

`pickAndRunActions` runs each action picked from the action pool without any per-action `recover`. If one action panics, the panic unwinds the whole mint and is only caught by the block preparer goroutine, which throws the draft away. The action is also never removed from the pool, because the panic happens before `DeleteAction` is reached, so the same action is picked again on every following round and the proposer keeps producing nothing.

This wraps the per-action call in a `recover` and turns the panic into a normal error:

- the offending sender's queue is deleted from the action pool
- the draft is abandoned exactly as it is today, so the next round starts from a clean working set without that action

The draft is deliberately not continued on the same working set: it still holds the partial writes of the action that panicked, and `runAction`'s deferred `ResetSnapshots` only clears the snapshot list, it does not revert them.

Also adds a `iotex_mint_action_panics_total` counter, next to the existing mint/validate panic counters.

### Test

`TestWorkingSet_Mint_SkipsPanickingAction` in `state/factory/workingset_test.go`: an action whose handler panics aborts the first mint and gets its sender dropped from the pool; the next mint then produces a block containing the remaining action. Fails before the change (the panic escapes `Mint`), passes after.

`go test ./state/factory/... ./actpool/...` passes.