### PR TITLE
fix(blocksync): cap per-request served range and default-enable peer sync rate limit

### DIFF
--- a/blocksync/blocksync.go
+++ b/blocksync/blocksync.go
@@ -316,6 +316,11 @@ func (bs *blockSyncer) ProcessBlock(ctx context.Context, peer string, blk *block
 
 func (bs *blockSyncer) ProcessSyncRequest(ctx context.Context, peer peer.AddrInfo, start uint64, end uint64) error {
 	tip := bs.tipHeightHandler()
+	// Reject an inverted window outright: there is nothing to serve.
+	if start > end {
+		return nil
+	}
+	// Never serve above the local tip.
 	if end > tip {
 		log.L().Debug(
 			"Do not have requested blocks",
@@ -324,6 +329,17 @@ func (bs *blockSyncer) ProcessSyncRequest(ctx context.Context, peer peer.AddrInf
 			zap.Uint64("tipHeight", tip),
 		)
 		end = tip
+	}
+	// After clamping `end` to tip, the window may become empty.
+	if start > tip || start > end {
+		return nil
+	}
+	// Bound the per-request served range so a cheap {start:0,end:tip} request cannot
+	// make us re-serialize and unicast the entire chain (serve amplification). We keep
+	// the tail of the window (the highest maxBlocks blocks), which is what a syncing
+	// peer actually needs. 0 means "disabled" (not recommended).
+	if limit := bs.cfg.MaxBlocksPerSyncRequest; limit > 0 && end-start+1 > limit {
+		start = end - limit + 1
 	}
 	// TODO: send back multiple blocks in one shot
 	for i := start; i <= end; i++ {

--- a/blocksync/blocksync_dos_repro_test.go
+++ b/blocksync/blocksync_dos_repro_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2024 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package blocksync
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+// TestBlockSyncerSyncRequestServeBounded regression-guards the availability fix for
+// blocksync.ProcessSyncRequest: a cheap connected peer must NOT be able to force the
+// node to re-serialize and unicast its ENTIRE chain in a single {start:0,end:tip}
+// request. Before the fix the request served start..tip (tip+1 blocks) with no range
+// cap; now the served window is clamped to end/tip and bounded by
+// Config.MaxBlocksPerSyncRequest (keeping the tail of the window).
+func TestBlockSyncerSyncRequestServeBounded(t *testing.T) {
+	require := require.New(t)
+
+	const tip = uint64(300) // chain of 301 blocks (0..300), larger than the default cap
+	cap_ := uint64(DefaultConfig.MaxBlocksPerSyncRequest)
+
+	var (
+		blockByHeightCalls int64 // total DB reads triggered by serving
+		outboundCalls      int64 // total outbound unicast messages (blocks sent)
+	)
+
+	bs, err := NewBlockSyncer(
+		DefaultConfig,
+		func() uint64 { return tip }, // TipHeight
+		func(_ uint64) (*block.Block, error) { // BlockByHeight: count every read; fixed lightweight block
+			atomic.AddInt64(&blockByHeightCalls, 1)
+			return block.NewBlockDeprecated(
+				uint32(1),
+				0,
+				hash.Hash256{},
+				testutil.TimestampNow(),
+				identityset.PrivateKey(27).PublicKey(),
+				nil,
+			), nil
+		},
+		func(_ *block.Block) error { return nil },           // CommitBlock (unused here)
+		func() ([]peer.AddrInfo, error) { return nil, nil }, // Neighbors (unused here)
+		func(_ context.Context, _ peer.AddrInfo, msg proto.Message) error { // UniCastOutbound
+			atomic.AddInt64(&outboundCalls, 1)
+			return nil
+		},
+		func(_ string) {}, // BlockPeer (unused)
+		nil,               // nodeInfoManager
+	)
+	require.NoError(err)
+
+	peerInfo := peer.AddrInfo{ID: peer.ID("remote-cheap-peer")}
+
+	// ---- Honest incremental request: serves exactly its own (tip..tip) range. ----
+	atomic.StoreInt64(&blockByHeightCalls, 0)
+	atomic.StoreInt64(&outboundCalls, 0)
+	require.NoError(bs.ProcessSyncRequest(context.Background(), peerInfo, tip, tip))
+	require.Equal(int64(1), atomic.LoadInt64(&blockByHeightCalls), "honest tip-range request must read 1 block")
+	require.Equal(int64(1), atomic.LoadInt64(&outboundCalls), "honest tip-range request must send 1 block")
+
+	// ---- Attack #1: {start:0, end:tip} must now be capped to the per-request limit. ----
+	atomic.StoreInt64(&blockByHeightCalls, 0)
+	atomic.StoreInt64(&outboundCalls, 0)
+	require.NoError(bs.ProcessSyncRequest(context.Background(), peerInfo, 0, tip))
+	served := atomic.LoadInt64(&outboundCalls)
+	require.Equal(int64(cap_), served,
+		"a full-chain request must serve at most MaxBlocksPerSyncRequest blocks (not the whole chain)")
+	require.Equal(int64(cap_), atomic.LoadInt64(&blockByHeightCalls),
+		"every served block triggers a DB read; the read count must equal the capped serve count")
+
+	// ---- Attack #2: inverted / empty windows must cost nothing. ----
+	atomic.StoreInt64(&blockByHeightCalls, 0)
+	atomic.StoreInt64(&outboundCalls, 0)
+	require.NoError(bs.ProcessSyncRequest(context.Background(), peerInfo, tip+1, tip)) // start > end
+	require.Equal(int64(0), atomic.LoadInt64(&outboundCalls), "inverted window must serve nothing")
+	// start beyond tip: after clamping end to tip the window is empty.
+	require.NoError(bs.ProcessSyncRequest(context.Background(), peerInfo, tip+5, tip+10)) // entirely above tip
+	require.Equal(int64(0), atomic.LoadInt64(&outboundCalls), "window above tip must serve nothing")
+
+	// ---- Repeated cheap full-chain requests stay bounded per request (no per-request cost growth). ----
+	atomic.StoreInt64(&blockByHeightCalls, 0)
+	atomic.StoreInt64(&outboundCalls, 0)
+	const repeat = 10
+	for i := 0; i < repeat; i++ {
+		require.NoError(bs.ProcessSyncRequest(context.Background(), peerInfo, 0, tip))
+	}
+	require.Equal(int64(repeat*int(cap_)), atomic.LoadInt64(&outboundCalls),
+		"each identical full-chain request is independently capped; no unbounded per-request amplification")
+
+	// NOTE: repeated re-requests are additionally rate-limited by the dispatcher's
+	// ProcessSyncRequestInterval (default now positive) — tested in dispatcher/; this
+	// unit test only locks in the per-request serve cap.
+}

--- a/blocksync/config.go
+++ b/blocksync/config.go
@@ -17,14 +17,21 @@ type Config struct {
 	MaxRepeat int `yaml:"maxRepeat"`
 	// RepeatDecayStep is the step for repeat number decreasing by 1
 	RepeatDecayStep int `yaml:"repeatDecayStep"`
+	// MaxBlocksPerSyncRequest is the maximal number of blocks a single
+	// ProcessSyncRequest may serve, regardless of the requested start..end range.
+	// It bounds the serve-amplification of a cheap {start:0,end:tip} request: a
+	// peer cannot force the node to re-serialize and unicast its entire chain in
+	// one request. If 0, the cap is disabled (NOT recommended).
+	MaxBlocksPerSyncRequest uint64 `yaml:"maxBlocksPerSyncRequest"`
 }
 
 // DefaultConfig is the default config
 var DefaultConfig = Config{
-	Interval:              30 * time.Second,
-	ProcessSyncRequestTTL: 10 * time.Second,
-	BufferSize:            200,
-	IntervalSize:          20,
-	MaxRepeat:             3,
-	RepeatDecayStep:       1,
+	Interval:                30 * time.Second,
+	ProcessSyncRequestTTL:   10 * time.Second,
+	BufferSize:              200,
+	IntervalSize:            20,
+	MaxRepeat:               3,
+	RepeatDecayStep:         1,
+	MaxBlocksPerSyncRequest: 128,
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -52,7 +52,10 @@ var (
 		MiscChanSize:      1000,
 		AccountRateLimit:  100,
 
-		ProcessSyncRequestInterval: 0 * time.Second,
+		// Positive by default so the per-peer block-sync request rate limit in
+		// filter() is active out of the box; an attacker-connected peer cannot issue
+		// an unbounded sequential stream of {start:0,end:tip} re-sync requests.
+		ProcessSyncRequestInterval: 2 * time.Second,
 	}
 )
 

--- a/dispatcher/dispatcher_test.go
+++ b/dispatcher/dispatcher_test.go
@@ -282,3 +282,50 @@ func (cs *counterSubscriber) HandleActionHash(context.Context, hash.Hash256, str
 	cs.actionHash.Inc()
 	return nil
 }
+
+// TestDispatcherDefaultBlockSyncRateLimit regression-guards the availability fix:
+// Config.ProcessSyncRequestInterval must be positive by default so IotxDispatcher.filter()
+// rate-limits BLOCK_REQUEST messages per peer. Before the fix the default was 0, which
+// disabled the filter and let a cheap peer stream an unbounded sequence of full-chain
+// {start:0,end:tip} sync requests. Now two rapid BLOCK_REQUESTs from the same peer are
+// throttled, while a fresh peer is served.
+func TestDispatcherDefaultBlockSyncRateLimit(t *testing.T) {
+	require := require.New(t)
+
+	// DefaultConfig.ProcessSyncRequestInterval must be enabled out of the box.
+	require.Positive(DefaultConfig.ProcessSyncRequestInterval,
+		"ProcessSyncRequestInterval default must be positive so the per-peer filter is active")
+
+	d := &IotxDispatcher{
+		peerLastSync: make(map[string]time.Time),
+		syncInterval: DefaultConfig.ProcessSyncRequestInterval,
+	}
+
+	blockReq := &message{msgType: iotexrpc.MessageType_BLOCK_REQUEST, peer: "peer-A"}
+
+	// First request passes the filter.
+	require.True(d.filter(blockReq), "first BLOCK_REQUEST of a peer is served")
+
+	// An immediate second request from the same peer is rate-limited.
+	require.False(d.filter(blockReq), "rapid repeated BLOCK_REQUEST from the same peer must be throttled")
+
+	// A different peer is unaffected.
+	other := &message{msgType: iotexrpc.MessageType_BLOCK_REQUEST, peer: "peer-B"}
+	require.True(d.filter(other), "a fresh peer is not throttled by another peer's requests")
+}
+
+// TestDispatcherFilterIgnoresNonBlockRequest guards that the filter only throttles
+// BLOCK_REQUEST and leaves other message types untouched even when the default interval
+// is active.
+func TestDispatcherFilterIgnoresNonBlockRequest(t *testing.T) {
+	require := require.New(t)
+
+	d := &IotxDispatcher{
+		peerLastSync: make(map[string]time.Time),
+		syncInterval: DefaultConfig.ProcessSyncRequestInterval,
+	}
+
+	consensus := &message{msgType: iotexrpc.MessageType_CONSENSUS, peer: "peer-A"}
+	require.True(d.filter(consensus), "non-BLOCK_REQUEST messages are never throttled")
+	require.True(d.filter(consensus), "repeated non-BLOCK_REQUEST messages are never throttled")
+}


### PR DESCRIPTION
## Summary

Fixes an availability (DoS/amplification) finding from a security audit of the
blocksync node behavior. No chain state, receipt, or consensus logic is touched —
this is a **node-behaviour change and does not require a hardfork gate**, but per
AGENTS.md should be reviewed by a maintainer.

## Problem

`blocksync.ProcessSyncRequest` served an unbounded `start..end` range for every
`BLOCK_REQUEST`. A connected peer could ask `{start:0,end:tip}` and force the node to
re-serialize and unicast **its entire chain** in a single request (each block = one DB
read + one outbound unicast). With the dispatcher's per-peer `BLOCK_REQUEST` rate limit
disabled by default (`ProcessSyncRequestInterval=0`), a cheap peer — no delegate keys,
no stake — could repeat this indefinitely to drain the victim's outbound bandwidth and
drive unbounded DB reads.

## Changes

- **`blocksync/config.go`**: add `Config.MaxBlocksPerSyncRequest` (default `128`).
- **`blocksync/blocksync.go`** `ProcessSyncRequest`:
  - reject inverted windows (`start > end`) — zero cost;
  - keep clamping `end` to the local tip; return early when the window is empty;
  - cap the served window to the **newest** `MaxBlocksPerSyncRequest` blocks, so a
    full-chain request cannot force serving the whole chain.
- **`dispatcher/dispatcher.go`**: enable `ProcessSyncRequestInterval` by default
  (`2s`) so `filter()`'s per-peer rate limit is active out of the box.
- **tests**:
  - invert the earlier repro into a regression test asserting the serve cap
    (`blocksync/blocksync_dos_repro_test.go`);
  - add dispatcher tests for the default rate limit and that non-`BLOCK_REQUEST`
    messages are never throttled (`dispatcher/dispatcher_test.go`).

## Testing

`go vet ./blocksync/... ./dispatcher/...` clean; `go test ./blocksync/... ./dispatcher/...` pass.
`gofmt` clean.

## Notes / follow-ups (not in this PR)

- `peerLastSync` / `blockRequestPeers` maps still have no size/GC bound (informational).
- `ProcessSyncRequest` uses `defer cancel()` in the loop; could use a single
  per-request timeout (informational).
