### PR TITLE
fix(actpool): reject actions the protocols will certainly reject

### DIFF
--- a/actpool/options.go
+++ b/actpool/options.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/facebookgo/clock"
+
+	"github.com/iotexproject/iotex-core/v2/action"
 )
 
 // ActQueueOption is the option for actQueue.
@@ -42,6 +44,22 @@ func WithBundlePool(bp *BundlePool) func(*actPool) error {
 			return errors.New("bundle pool cannot be nil")
 		}
 		ap.bundlePool = bp
+		return nil
+	}
+}
+
+// WithPrivateValidator adds a validator that runs on the Add path only.
+//
+// Private validators are deliberately excluded from actPool.Validate, which
+// block validation reaches via the bundle pool. Anything whose rejection would
+// change a block's validity -- rather than merely keeping an action out of this
+// node's pool -- belongs here rather than in AddActionEnvelopeValidators.
+func WithPrivateValidator(v action.SealedEnvelopeValidator) func(*actPool) error {
+	return func(ap *actPool) error {
+		if v == nil {
+			return errors.New("private validator cannot be nil")
+		}
+		ap.privateValidators = append(ap.privateValidators, v)
 		return nil
 	}
 }

--- a/actpool/protocol_validator.go
+++ b/actpool/protocol_validator.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package actpool
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+)
+
+// protocolValidator runs the registered protocols' own validation rules at
+// admission, so an action the protocol will certainly reject is refused by
+// eth_sendRawTransaction instead of being accepted into the pool.
+//
+// Without it the pool applies only GenericValidator -- nonce, balance,
+// signature -- and a feature-gated action that no proposer can ever include
+// still takes a nonce and holds it until ActionExpiry. Because nonces must be
+// consecutive, that one action stalls every later action from the same account,
+// with no receipt and no log to say why. The official CLI reaches this: before
+// Zanzibar, `ioctl stake2 update` without --bls-* flags builds exactly such an
+// action.
+//
+// This validator is deliberately admission-only. It must be registered as a
+// private validator, never via AddActionEnvelopeValidators: those also run in
+// actPool.Validate, which block validation reaches through the bundle pool.
+// Rejecting there would turn "included in a block with a failure receipt" into
+// "block is invalid", which is a consensus change -- see the comment above
+// validateBLSPairing in action/protocol/staking/validations.go.
+type protocolValidator struct {
+	// reg is held as a pointer and read at Validate time, not at construction.
+	// The action pool is built before the protocols are registered
+	// (chainservice/builder.go builds the pool, then registers), so resolving
+	// eagerly would capture an empty registry.
+	reg *protocol.Registry
+	sr  protocol.StateReader
+}
+
+// NewProtocolValidator returns a validator that applies every registered
+// protocol's ActionValidator rules to an incoming action.
+func NewProtocolValidator(reg *protocol.Registry, sr protocol.StateReader) action.SealedEnvelopeValidator {
+	return &protocolValidator{reg: reg, sr: sr}
+}
+
+func (v *protocolValidator) Validate(ctx context.Context, selp *action.SealedEnvelope) error {
+	// System actions are produced by the proposer, never submitted, and several
+	// of them do not carry a sender the ActionCtx below could be built from.
+	if action.IsSystemAction(selp) {
+		return nil
+	}
+	ctx, err := withActionCtx(ctx, selp)
+	if err != nil {
+		return err
+	}
+	for _, p := range v.reg.All() {
+		validator, ok := p.(protocol.ActionValidator)
+		if !ok {
+			continue
+		}
+		if err := validator.Validate(ctx, selp.Envelope, v.sr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// withActionCtx mirrors the ActionCtx the block producer builds in
+// state/factory. The protocols' validation rules read it, so an action has to
+// be judged against the same values here as it would be at proposal time --
+// otherwise the pool and the proposer disagree about what is admissible.
+func withActionCtx(ctx context.Context, selp *action.SealedEnvelope) (context.Context, error) {
+	caller := selp.SenderAddress()
+	if caller == nil {
+		return nil, errors.New("failed to get sender address")
+	}
+	actionCtx := protocol.ActionCtx{
+		Caller:   caller,
+		GasPrice: selp.GasPrice(),
+		Nonce:    selp.Nonce(),
+	}
+	var err error
+	if actionCtx.ActionHash, err = selp.Hash(); err != nil {
+		return nil, err
+	}
+	if actionCtx.IntrinsicGas, err = selp.IntrinsicGas(); err != nil {
+		return nil, err
+	}
+	return protocol.WithActionCtx(ctx, actionCtx), nil
+}

--- a/actpool/protocol_validator_test.go
+++ b/actpool/protocol_validator_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package actpool
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+// rejectingProtocol stands in for a protocol whose feature gate makes an action
+// unacceptable at the current height.
+type rejectingProtocol struct {
+	err    error
+	sawCtx bool
+}
+
+func (p *rejectingProtocol) Name() string { return "rejecting" }
+func (p *rejectingProtocol) Handle(context.Context, action.Envelope, protocol.StateManager) (*action.Receipt, error) {
+	return nil, nil
+}
+func (p *rejectingProtocol) ReadState(context.Context, protocol.StateReader, []byte, ...[]byte) ([]byte, uint64, error) {
+	return nil, 0, nil
+}
+func (p *rejectingProtocol) Register(r *protocol.Registry) error { return r.Register(p.Name(), p) }
+func (p *rejectingProtocol) ForceRegister(r *protocol.Registry) error {
+	return r.ForceRegister(p.Name(), p)
+}
+
+func (p *rejectingProtocol) Validate(ctx context.Context, _ action.Envelope, _ protocol.StateReader) error {
+	// The protocols' own rules read ActionCtx; assert the validator supplies it
+	// rather than leaving them to panic on MustGetActionCtx.
+	if _, ok := protocol.GetActionCtx(ctx); ok {
+		p.sawCtx = true
+	}
+	return p.err
+}
+
+func testEnvelope(t *testing.T) *action.SealedEnvelope {
+	t.Helper()
+	tsf := action.NewTransfer(big.NewInt(1), identityset.Address(1).String(), nil)
+	elp := (&action.EnvelopeBuilder{}).SetNonce(1).SetGasLimit(100000).
+		SetGasPrice(big.NewInt(1)).SetAction(tsf).Build()
+	selp, err := action.Sign(elp, identityset.PrivateKey(0))
+	require.NoError(t, err)
+	return selp
+}
+
+// A protocol that rejects the action must make admission fail, so the sender
+// gets an error from eth_sendRawTransaction instead of a nonce that silently
+// stalls every later action from that account.
+func TestProtocolValidatorRejectsAtAdmission(t *testing.T) {
+	r := require.New(t)
+	reg := protocol.NewRegistry()
+	p := &rejectingProtocol{err: errors.New("feature not enabled yet")}
+	r.NoError(p.Register(reg))
+
+	v := NewProtocolValidator(reg, nil)
+	err := v.Validate(context.Background(), testEnvelope(t))
+	r.ErrorContains(err, "feature not enabled yet")
+	r.True(p.sawCtx, "protocol validators must see an ActionCtx")
+}
+
+// The registry is read at validation time, not captured at construction: the
+// action pool is built before any protocol is registered.
+func TestProtocolValidatorResolvesRegistryLazily(t *testing.T) {
+	r := require.New(t)
+	reg := protocol.NewRegistry()
+
+	// Built while the registry is still empty, exactly as chainservice does.
+	v := NewProtocolValidator(reg, nil)
+	selp := testEnvelope(t)
+	r.NoError(v.Validate(context.Background(), selp))
+
+	p := &rejectingProtocol{err: errors.New("registered later")}
+	r.NoError(p.Register(reg))
+	r.ErrorContains(v.Validate(context.Background(), selp), "registered later")
+}
+
+// System actions are proposer-produced and several carry no sender, so they
+// must bypass the ActionCtx construction rather than error out.
+func TestProtocolValidatorSkipsSystemActions(t *testing.T) {
+	r := require.New(t)
+	reg := protocol.NewRegistry()
+	p := &rejectingProtocol{err: errors.New("should not be consulted")}
+	r.NoError(p.Register(reg))
+
+	gr := action.NewGrantReward(action.BlockReward, 1)
+	elp := (&action.EnvelopeBuilder{}).SetNonce(0).SetGasLimit(0).SetAction(gr).Build()
+	selp, err := action.Sign(elp, identityset.PrivateKey(0))
+	r.NoError(err)
+	r.True(action.IsSystemAction(selp))
+
+	r.NoError(v(reg).Validate(context.Background(), selp))
+	r.False(p.sawCtx)
+}
+
+func v(reg *protocol.Registry) action.SealedEnvelopeValidator {
+	return NewProtocolValidator(reg, nil)
+}
+
+// WithPrivateValidator must land the validator on the Add-only list. Putting it
+// on actionEnvelopeValidators would also run it in actPool.Validate, which
+// block validation reaches through the bundle pool -- turning "included with a
+// failure receipt" into "invalid block", a consensus change.
+func TestPrivateValidatorIsNotOnTheBlockValidationPath(t *testing.T) {
+	r := require.New(t)
+	ap := &actPool{}
+	r.NoError(WithPrivateValidator(NewProtocolValidator(protocol.NewRegistry(), nil))(ap))
+
+	r.Len(ap.privateValidators, 1)
+	r.Empty(ap.actionEnvelopeValidators,
+		"protocol validation must not reach actPool.Validate, which block validation uses")
+
+	r.Error(WithPrivateValidator(nil)(ap))
+}

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -255,6 +255,18 @@ func (builder *Builder) buildActionPool() error {
 			bp := actpool.NewBundlePool(builder.cfg.Genesis)
 			options = append(options, actpool.WithBundlePool(bp))
 		}
+		// Refuse actions the protocols themselves will certainly reject, so a
+		// feature-gated action no proposer can include is turned away at
+		// submission instead of taking a nonce and stalling the account until
+		// it expires.
+		//
+		// The registry is passed by pointer and read at validation time: the
+		// protocols are registered after this pool is built, so the slice is
+		// still empty right now. Registered as a private validator on purpose --
+		// see WithPrivateValidator.
+		options = append(options, actpool.WithPrivateValidator(
+			actpool.NewProtocolValidator(builder.cs.registry, builder.cs.factory),
+		))
 		ac, err := actpool.NewActPool(builder.cfg.Genesis, builder.cs.factory, builder.cfg.ActPool, options...)
 		if err != nil {
 			return errors.Wrap(err, "failed to create actpool")

--- a/e2etest/native_staking_test.go
+++ b/e2etest/native_staking_test.go
@@ -1074,21 +1074,39 @@ func TestCandidateTransferOwnership(t *testing.T) {
 					{mustNoErr(action.SignedCandidateRegister(test.nonceMgr.pop(identityset.Address(candOwnerID).String()), "cand1", identityset.Address(1).String(), identityset.Address(1).String(), identityset.Address(candOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(candOwnerID), action.WithChainID(chainID))), time.Now()},
 					{mustNoErr(action.SignedCreateStake(test.nonceMgr.pop(identityset.Address(stakerID).String()), "cand1", registerAmount.String(), 91, true, nil, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), stakeTime},
 				},
-				act:    &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpEndorse, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
-				expect: []actionExpect{&basicActionExpect{errReceiptNotFound, 0, ""}},
+				act: &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpEndorse, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
+				// Refused at submission now that the pool applies the protocols'
+				// own rules, instead of being accepted and silently never
+				// included -- so it also no longer produces a block.
+				expect: []actionExpect{&basicActionExpect{action.ErrInvalidAct, 0, ""}},
 			},
 			{
-				name:   "intentToRevokeEndorsement action disabled before UpernavikBlockHeight",
-				act:    &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpIntentToRevoke, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
-				expect: []actionExpect{&basicActionExpect{errReceiptNotFound, 0, ""}},
+				name: "intentToRevokeEndorsement action disabled before UpernavikBlockHeight",
+				act:  &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpIntentToRevoke, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
+				// Refused at submission now that the pool applies the protocols'
+				// own rules, instead of being accepted and silently never
+				// included -- so it also no longer produces a block.
+				expect: []actionExpect{&basicActionExpect{action.ErrInvalidAct, 0, ""}},
 			},
 			{
-				name:   "revokeEndorsement action disabled before UpernavikBlockHeight",
-				act:    &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpRevoke, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
-				expect: []actionExpect{&basicActionExpect{errReceiptNotFound, 0, ""}},
+				name: "revokeEndorsement action disabled before UpernavikBlockHeight",
+				act:  &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr[(identityset.Address(stakerID).String())], 1, action.CandidateEndorsementOpRevoke, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
+				// Refused at submission now that the pool applies the protocols'
+				// own rules, instead of being accepted and silently never
+				// included -- so it also no longer produces a block.
+				expect: []actionExpect{&basicActionExpect{action.ErrInvalidAct, 0, ""}},
 			},
 			{
-				name:   "endorse action disabled after UpernavikBlockHeight",
+				name: "endorse action disabled after UpernavikBlockHeight",
+				// The three cases above used to each contribute a block on their
+				// way to being dropped at mint. They are refused at submission
+				// now, so the height they carried has to come from here instead:
+				// UpernavikBlockHeight is 6.
+				preActs: []*actionWithTime{
+					{mustNoErr(action.SignedTransfer(identityset.Address(1).String(), identityset.PrivateKey(candOwnerID2), test.nonceMgr.pop(identityset.Address(candOwnerID2).String()), unit.ConvertIotxToRau(1), nil, gasLimit, gasPrice, action.WithChainID(chainID))), time.Now()},
+					{mustNoErr(action.SignedTransfer(identityset.Address(1).String(), identityset.PrivateKey(candOwnerID2), test.nonceMgr.pop(identityset.Address(candOwnerID2).String()), unit.ConvertIotxToRau(1), nil, gasLimit, gasPrice, action.WithChainID(chainID))), time.Now()},
+					{mustNoErr(action.SignedTransfer(identityset.Address(1).String(), identityset.PrivateKey(candOwnerID2), test.nonceMgr.pop(identityset.Address(candOwnerID2).String()), unit.ConvertIotxToRau(1), nil, gasLimit, gasPrice, action.WithChainID(chainID))), time.Now()},
+				},
 				act:    &actionWithTime{mustNoErr(action.SignedCandidateEndorsement(test.nonceMgr.pop(identityset.Address(stakerID).String()), 1, action.CandidateEndorsementOpEndorse, gasLimit, gasPrice, identityset.PrivateKey(stakerID), action.WithChainID(chainID))), time.Now()},
 				expect: []actionExpect{successExpect},
 			},


### PR DESCRIPTION
## Problem

The action pool applies only `GenericValidator` — nonce, balance, signature. An action that a protocol's own feature gate makes **impossible to include** is accepted anyway: it takes a nonce and holds it until `ActionExpiry` (10 min). Because nonces must be consecutive, that one action stalls every later action from the same account.

Nothing anywhere says so:

- the RPC returns a transaction hash
- `eth_getTransactionCount` counts it
- resubmitting reports `known transaction`, confirming it really is in the pool
- **no receipt, and no warn/error log**
- after expiry the nonce quietly drops back

The user sees a transaction go out and nothing happen.

## The official CLI reaches it

Before Zanzibar, `ioctl stake2 update NAME OPERATOR REWARD` with no `--bls-*` flags builds a BLS-less `candidateUpdate` — which `action/protocol/staking/validations.go` rejects for the entire Xingu..Zanzibar range. No malformed input required.

Observed on TestNet at ~46,864,000 (Zanzibar height 46,880,641, so Xingu rules):

```
nonce 1218  candidateUpdate(name,operator,reward)   entered pool, expired 10 min later, no receipt, no log
nonce 1219  candidateUpdateWithBLS(...)             stuck behind 1218
nonce 1220  plain transfer                          stuck behind 1218

replace 1218 with a higher-priced transfer  -> mined at 46,864,006
1219 then drains on its own                 -> mined at 46,864,041, status success
```

Diagnosing that took hours — gas price, transaction type, submission endpoint, single-node submission, and a restart of all six nodes were all tried, because the chain emits no signal pointing at the real cause.

## Fix

Run the registered protocols' own `ActionValidator.Validate` at admission, mirroring the `ActionCtx` the proposer builds so the pool and the proposer judge an action identically. `actpool.context` already supplies a tip+1 `FeatureCtx`, which is the same height the proposer will evaluate at.

### Why this cannot affect consensus

Registration goes through a new `WithPrivateValidator` option, landing on the **Add-only** list — deliberately *not* `AddActionEnvelopeValidators`.

That distinction is the whole safety argument. `actionEnvelopeValidators` also run in `actPool.Validate`, which block validation reaches through the bundle pool. Rejecting there would turn *"included in a block with a failure receipt"* into *"block is invalid"*. The comment above `validateBLSPairing` makes the same point about gas semantics: **mempool leniency can never fork the chain, but validation strictness can.**

Protocol validation already runs independently at proposal (`workingset.go`, `validateAndRun`) and at block validation (`process` / `processLegacy`). Both still do; neither is touched.

### Registry is resolved lazily

`chainservice` builds the pool (`buildActionPool`) **before** it registers any protocol. The registry is therefore passed by pointer and read at `Validate` time — resolving eagerly would capture an empty registry and silently validate nothing. There is a regression test for exactly this.

System actions are skipped: they are proposer-produced and several carry no sender to build an `ActionCtx` from.

## Tests

4 new tests covering rejection-at-admission, lazy registry resolution, the system-action bypass, and the private-vs-envelope validator list placement.

```
actpool       126 passed
chainservice   31 passed
e2etest        130 passed  (-run 'Staking|ActPool|Native')
```

## Not included

Item 3 of the original report — logging the action hash and reason when `pickAndRunActions` skips an action — is left out; `workingset.go` already logs `failed to validate tx` with the height and error there. Happy to extend it with the action hash if you'd like it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)