### PR TITLE
feat(genesis): add zanzibarBetaHeight

### DIFF
--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -83,6 +83,7 @@ func defaultConfig() Genesis {
 			YapBlockHeight:            48985561,
 			YapBetaBlockHeight:        48985561,
 			ZanzibarBlockHeight:       math.MaxUint64,
+			ZanzibarBetaBlockHeight:   math.MaxUint64,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 		},
 		Account: Account{
@@ -404,6 +405,16 @@ type (
 		// 4. stop GetCommittedState returning post-mutation values for
 		//    storage slots absent from the pre-tx trie
 		ZanzibarBlockHeight uint64 `yaml:"zanzibarHeight"`
+		// ZanzibarBetaBlockHeight is the start height for corrections to Zanzibar
+		// that cannot be made at ZanzibarBlockHeight itself.
+		//
+		// Zanzibar has already activated on testnet, and its one-shot work runs
+		// in the single block at ZanzibarBlockHeight. Changing what that block
+		// does would make a node replaying history compute a different receipt
+		// root, so a resync would fork. A chain that has not activated yet sets
+		// this equal to ZanzibarBlockHeight and gets the corrected behaviour at
+		// activation, exactly as mainnet does for XinguBeta.
+		ZanzibarBetaBlockHeight uint64 `yaml:"zanzibarBetaHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -879,6 +890,11 @@ func (g *Blockchain) IsYapBeta(height uint64) bool {
 // IsZanzibar checks whether height is equal to or larger than zanzibar height
 func (g *Blockchain) IsZanzibar(height uint64) bool {
 	return g.isPost(g.ZanzibarBlockHeight, height)
+}
+
+// IsZanzibarBeta checks whether height is equal to or larger than zanzibar beta height
+func (g *Blockchain) IsZanzibarBeta(height uint64) bool {
+	return g.isPost(g.ZanzibarBetaBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height

--- a/config/config.go
+++ b/config/config.go
@@ -355,6 +355,8 @@ func ValidateForkHeights(cfg Config) error {
 		return errors.Wrap(ErrInvalidCfg, "Yap is heigher than YapBeta")
 	case hu.YapBetaBlockHeight > hu.ZanzibarBlockHeight:
 		return errors.Wrap(ErrInvalidCfg, "YapBeta is heigher than Zanzibar")
+	case hu.ZanzibarBlockHeight > hu.ZanzibarBetaBlockHeight:
+		return errors.Wrap(ErrInvalidCfg, "Zanzibar is heigher than ZanzibarBeta")
 	}
 	return nil
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -394,6 +394,12 @@ func TestValidateForkHeights(t *testing.T) {
 			"Yap", ErrInvalidCfg, "Yap is heigher than YapBeta",
 		},
 		{
+			"YapBeta", ErrInvalidCfg, "YapBeta is heigher than Zanzibar",
+		},
+		{
+			"Zanzibar", ErrInvalidCfg, "Zanzibar is heigher than ZanzibarBeta",
+		},
+		{
 			"", nil, "",
 		},
 	}
@@ -467,6 +473,15 @@ func newTestCfg(fork string) Config {
 		cfg.Genesis.XinguBetaBlockHeight = cfg.Genesis.YapBlockHeight + 1
 	case "Yap":
 		cfg.Genesis.YapBlockHeight = cfg.Genesis.YapBetaBlockHeight + 1
+	case "YapBeta":
+		// Zanzibar defaults to MaxUint64, so it has to be pinned to a real
+		// height first -- otherwise +1 wraps to 0 and an earlier case fires.
+		cfg.Genesis.ZanzibarBlockHeight = cfg.Genesis.YapBetaBlockHeight + 100
+		cfg.Genesis.ZanzibarBetaBlockHeight = cfg.Genesis.ZanzibarBlockHeight
+		cfg.Genesis.YapBetaBlockHeight = cfg.Genesis.ZanzibarBlockHeight + 1
+	case "Zanzibar":
+		cfg.Genesis.ZanzibarBetaBlockHeight = cfg.Genesis.YapBetaBlockHeight + 100
+		cfg.Genesis.ZanzibarBlockHeight = cfg.Genesis.ZanzibarBetaBlockHeight + 1
 	}
 	return cfg
 }

--- a/testutil/genesis.go
+++ b/testutil/genesis.go
@@ -37,6 +37,7 @@ func NormalizeGenesisHeights(g *genesis.Blockchain) {
 		&g.YapBlockHeight,
 		&g.YapBetaBlockHeight,
 		&g.ZanzibarBlockHeight,
+		&g.ZanzibarBetaBlockHeight,
 		&g.ToBeEnabledBlockHeight,
 	}
 	for i := len(heights) - 2; i >= 0; i-- {


### PR DESCRIPTION
Plumbing only — **no behaviour is gated on it yet.** This is the base the two Zanzibar corrections land on.

## Why a beta height is needed

Zanzibar has already activated on testnet (46,880,641), and its one-shot work runs in the **single block** at `ZanzibarBlockHeight` — `migrateHermesRewardOptIn` and `backfillOwnerIndex`, both from `CreatePreStates`.

Correcting either in place would make a node replaying history compute a different receipt root for that block. **A resync would fork off the live chain.**

A beta height is how this codebase has handled the situation before. A chain that has not activated yet sets `zanzibarBetaHeight == zanzibarHeight` and gets the corrected behaviour at activation — the same arrangement mainnet already uses for XinguBeta (`41648761` for both) and YapBeta.

## What's here

The five sites the existing pattern requires:

| file | change |
|---|---|
| `blockchain/genesis/genesis.go` | field + `yaml:"zanzibarBetaHeight"` |
| " | `math.MaxUint64` default |
| " | `IsZanzibarBeta` predicate |
| `config/config.go` | ordering case in `ValidateForkHeights` |
| `testutil/genesis.go` | entry in `NormalizeGenesisHeights`' ordered slice |

That last one matters more than it looks: the slice is walked pairwise, so a height **not** listed in it is silently skipped by the clamp and tests can construct orderings that `ValidateForkHeights` would reject.

**No `FeatureCtx` flag.** A flag with no consumer is dead code; it lands with the change that reads it.

## Test coverage gap closed along the way

The ordering table gained the `Zanzibar`/`ZanzibarBeta` pair — and also the `YapBeta`/`Zanzibar` pair, which `ValidateForkHeights` has implemented since Zanzibar went in but the table never covered.

Both new cases pin Zanzibar to a real height first. It defaults to `MaxUint64`, so the table's usual "successor + 1" wraps to **0** and trips an earlier case instead of the one under test — which is exactly what happened on the first attempt here.

## Hash neutrality

Fork heights are not part of the genesis hash. `Genesis.Hash()` covers eight consensus parameters plus accounts and delegates. Adding one is hash-neutral; existing chains are unaffected.

## Tests

```
config + blockchain/genesis + testutil    41 passed
e2etest                                  128 passed   (-run 'Staking|Native')
```

## Deployment note

`iotex-bootstrap/genesis_{mainnet,testnet}.yaml` will need the key once the behaviour PRs land — mainnet at `zanzibarHeight`, testnet at a height past activation. Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)