### PR TITLE
fix(staking): require a complete DelegateProfile before Hermes migration

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -206,6 +206,18 @@ type (
 		// for such slots, causing EIP-2200 SSTORE dynamic gas to misclassify
 		// dirty in-place writes as SSTORE_RESET (100 → 2900 gas overcharge per hit).
 		CorrectPrestateForAbsentKeys bool
+		// RequireProfileForHermesMigration, when true, makes the fork-block
+		// Hermes opt-in migration skip candidates whose DelegateProfile portions
+		// are missing or only half set, leaving them on the off-chain Hermes
+		// payout instead of moving them into an on-chain path that would freeze
+		// them at 100% commission and pay their voters nothing.
+		//
+		// Gated on ZanzibarBeta rather than Zanzibar because the migration runs
+		// in the single block at ZanzibarBlockHeight, which testnet has already
+		// passed; changing what that block did would alter its receipt root and
+		// fork any node that resynced. A chain that has not activated sets both
+		// heights to the same value and gets this from the start.
+		RequireProfileForHermesMigration bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -385,6 +397,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			EnforceBLSPoP:                           g.IsZanzibar(height),
 			OptionalCandidateBLSPublicKey:           g.IsZanzibar(height),
 			CorrectPrestateForAbsentKeys:            g.IsZanzibar(height),
+			RequireProfileForHermesMigration:        g.IsZanzibarBeta(height),
 		},
 	)
 }

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -306,6 +306,18 @@ const _delegateProfileViewCallGasLimit uint64 = 10_000_000
 // target contract, wrap it in an envelope, and call evm.SimulateExecution
 // with the zero-address caller. The pattern is deterministic (fixed caller,
 // no gas billing to a real account) and reuses the existing view-call plumb.
+// NewDelegateProfileContractReader exposes the view-call reader so callers
+// outside this package can read the DelegateProfile contract with the same
+// deterministic plumbing the era freeze uses.
+//
+// It exists because the Hermes opt-in migration in the staking protocol needs
+// the same reader, and staking cannot import poll (poll imports staking) nor
+// evm without taking on a new dependency edge. chainservice imports both and
+// injects it.
+func NewDelegateProfileContractReader(sm protocol.StateManager) delegateprofile.ContractReader {
+	return delegateProfileContractReader(sm)
+}
+
 func delegateProfileContractReader(sm protocol.StateManager) delegateprofile.ContractReader {
 	return delegateprofile.ContractReaderFunc(func(ctx context.Context, contract string, callData []byte) (ret []byte, err error) {
 		gasLimit := _delegateProfileViewCallGasLimit

--- a/action/protocol/staking/candidate_reward_migration.go
+++ b/action/protocol/staking/candidate_reward_migration.go
@@ -10,22 +10,50 @@ import (
 	"context"
 	"sort"
 
+	"github.com/iotexproject/iotex-address/address"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/delegateprofile"
+	"github.com/iotexproject/iotex-core/v2/pkg/log"
 )
 
 // migrateHermesRewardOptIn converts the pre-IIP-59 Hermes convention into the
 // persisted opt-in bit. After this one-time migration, reward routing never
 // needs to infer opt-in from a candidate's reward address again.
+//
+// From ZanzibarBeta on, a candidate is only migrated if the DelegateProfile
+// contract holds *both* of its commission portions.
+//
+// Being migrated and having a usable commission configuration are independent
+// facts: migration looks only at the reward address. A candidate that is opted
+// in without portions is frozen at 100% commission -- poll_snapshot writes
+// _fullCommissionBasisPoints into the snapshot when CommissionConfigured is
+// false -- so its voters receive nothing, with no error and no event anywhere on
+// chain. TestNet froze its first era with three of four migrated delegates in
+// exactly that state, one of them the highest-weighted delegate on the network.
+// Mainnet has 90 candidates whose reward address points at a Hermes vault and
+// whose portions live in the Hermes service rather than in DelegateProfile.
+//
+// Leaving them opted out keeps them on the Hermes off-chain payout they are
+// already using, which is the outcome they expect, instead of moving them into
+// an on-chain path that pays their voters zero.
+//
+// Half a configuration counts as none: TestNet's uuu had set blockRewardPortion
+// and not epochRewardPortion, and the result was identical to setting neither.
+// readOne already collapses that case, so this reads Configured and nothing else.
 func migrateHermesRewardOptIn(
 	ctx context.Context,
 	sm protocol.StateManager,
 	hermesVaults []string,
+	bridge *delegateprofile.Bridge,
+	reader delegateprofile.ContractReader,
 ) error {
 	if len(hermesVaults) == 0 {
 		return nil
 	}
+	requireProfile := protocol.MustGetFeatureCtx(ctx).RequireProfileForHermesMigration
 	vaults := make(map[string]struct{}, len(hermesVaults))
 	for _, vault := range hermesVaults {
 		vaults[vault] = struct{}{}
@@ -45,11 +73,27 @@ func migrateHermesRewardOptIn(
 	sort.Slice(candidates, func(i, j int) bool {
 		return bytes.Compare(candidates[i].GetIdentifier().Bytes(), candidates[j].GetIdentifier().Bytes()) < 0
 	})
+	eligible := make([]*Candidate, 0, len(candidates))
 	for _, candidate := range candidates {
 		if candidate.Reward == nil || candidate.VoterRewardOnchainOptIn {
 			continue
 		}
 		if _, ok := vaults[candidate.Reward.String()]; !ok {
+			continue
+		}
+		eligible = append(eligible, candidate)
+	}
+
+	configured, err := hermesMigrationProfileFilter(ctx, requireProfile, bridge, reader, eligible)
+	if err != nil {
+		return err
+	}
+
+	for _, candidate := range eligible {
+		if configured != nil && !configured[candidate.GetIdentifier().String()] {
+			log.L().Info("staking: candidate not migrated to on-chain rewards, DelegateProfile portions incomplete",
+				zap.String("candidate", candidate.GetIdentifier().String()),
+				zap.String("name", candidate.Name))
 			continue
 		}
 		candidate.VoterRewardOnchainOptIn = true
@@ -58,4 +102,40 @@ func migrateHermesRewardOptIn(
 		}
 	}
 	return nil
+}
+
+// hermesMigrationProfileFilter returns which of the candidates have a complete
+// DelegateProfile configuration, or nil when every candidate should be migrated
+// regardless.
+//
+// nil is returned in three cases, all of which mean "do not filter": before
+// ZanzibarBeta, so replaying history reproduces the original migration exactly;
+// and when the chain has no DelegateProfile contract configured or no reader was
+// injected, where filtering on an unreadable contract would opt everyone out
+// rather than the ones that are actually misconfigured.
+func hermesMigrationProfileFilter(
+	ctx context.Context,
+	requireProfile bool,
+	bridge *delegateprofile.Bridge,
+	reader delegateprofile.ContractReader,
+	candidates []*Candidate,
+) (map[string]bool, error) {
+	if !requireProfile || bridge == nil || reader == nil || len(candidates) == 0 {
+		return nil, nil
+	}
+	addrs := make([]address.Address, 0, len(candidates))
+	for _, c := range candidates {
+		addrs = append(addrs, c.GetIdentifier())
+	}
+	// Snapshot reads in the order given, and candidates is already sorted by
+	// identifier bytes, so every node performs the same calls in the same order.
+	rates, err := bridge.Snapshot(ctx, reader, addrs)
+	if err != nil {
+		return nil, errors.Wrap(err, "staking: read DelegateProfile for Hermes opt-in migration")
+	}
+	out := make(map[string]bool, len(rates))
+	for id, r := range rates {
+		out[id] = r != nil && r.Configured
+	}
+	return out, nil
 }

--- a/action/protocol/staking/candidate_reward_migration_test.go
+++ b/action/protocol/staking/candidate_reward_migration_test.go
@@ -13,9 +13,28 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/delegateprofile"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 )
+
+// migrationCtx builds the feature context the migration reads, with ZanzibarBeta
+// either live or still ahead.
+func migrationCtx(betaActive bool) context.Context {
+	g := genesis.TestDefault()
+	g.ZanzibarBlockHeight = 0
+	if betaActive {
+		g.ZanzibarBetaBlockHeight = 0
+	} else {
+		g.ZanzibarBetaBlockHeight = 100
+	}
+	return protocol.WithFeatureCtx(protocol.WithBlockCtx(
+		genesis.WithGenesisContext(context.Background(), g),
+		protocol.BlockCtx{BlockHeight: 1},
+	))
+}
 
 func TestMigrateHermesRewardOptIn(t *testing.T) {
 	r := require.New(t)
@@ -36,7 +55,7 @@ func TestMigrateHermesRewardOptIn(t *testing.T) {
 	}
 	installCandCenter(t, sm, legacy, explicit, hermes)
 
-	r.NoError(migrateHermesRewardOptIn(context.Background(), sm, []string{vault.String()}))
+	r.NoError(migrateHermesRewardOptIn(migrationCtx(false), sm, []string{vault.String()}, nil, nil))
 	csr, err := ConstructBaseView(sm)
 	r.NoError(err)
 	r.True(csr.GetByIdentifier(hermes.GetIdentifier()).VoterRewardOnchainOptIn)
@@ -76,4 +95,119 @@ func TestMigrateHermesRewardOptInThroughCreatePreStates(t *testing.T) {
 	r.NoError(err)
 	r.False(lateCandidate.VoterRewardOnchainOptIn,
 		"using a Hermes vault after activation must not implicitly opt in")
+}
+
+// From ZanzibarBeta on, a Hermes candidate with no usable commission
+// configuration stays opted out.
+//
+// Being migrated and having portions published are independent facts, and the
+// gap between them is silent: the candidate is frozen at 100% commission and its
+// voters receive nothing, with no error and no event. TestNet froze its first era
+// with three of four migrated delegates in that state.
+func TestMigrateHermesRewardOptInRequiresProfileAfterBeta(t *testing.T) {
+	r := require.New(t)
+	sm := testdb.NewMockStateManager(gomock.NewController(t))
+	vault := identityset.Address(10)
+
+	full := &Candidate{
+		Owner: identityset.Address(1), Operator: identityset.Address(2), Reward: vault,
+		Name: "full", Votes: big.NewInt(1), SelfStakeBucketIdx: 1, SelfStake: big.NewInt(1),
+	}
+	// Half a configuration is the same as none -- this is TestNet's uuu, which
+	// had set blockRewardPortion and not epochRewardPortion and was frozen at
+	// 100% commission exactly like the candidates that had set neither.
+	half := &Candidate{
+		Owner: identityset.Address(3), Operator: identityset.Address(4), Reward: vault,
+		Name: "half", Votes: big.NewInt(1), SelfStakeBucketIdx: 2, SelfStake: big.NewInt(1),
+	}
+	none := &Candidate{
+		Owner: identityset.Address(5), Operator: identityset.Address(6), Reward: vault,
+		Name: "none", Votes: big.NewInt(1), SelfStakeBucketIdx: 3, SelfStake: big.NewInt(1),
+	}
+	installCandCenter(t, sm, full, half, none)
+
+	store := newFakeProfileStore()
+	store.setPortion(full.GetIdentifier(), "blockRewardPortion", 8500)
+	store.setPortion(full.GetIdentifier(), "epochRewardPortion", 8600)
+	store.setPortion(half.GetIdentifier(), "blockRewardPortion", 8500)
+
+	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
+	r.NoError(err)
+
+	r.NoError(migrateHermesRewardOptIn(
+		migrationCtx(true), sm, []string{vault.String()}, bridge, store.reader(t)))
+
+	csr, err := ConstructBaseView(sm)
+	r.NoError(err)
+	r.True(csr.GetByIdentifier(full.GetIdentifier()).VoterRewardOnchainOptIn,
+		"a complete profile migrates")
+	r.False(csr.GetByIdentifier(half.GetIdentifier()).VoterRewardOnchainOptIn,
+		"block portion without epoch portion is not a usable configuration")
+	r.False(csr.GetByIdentifier(none.GetIdentifier()).VoterRewardOnchainOptIn,
+		"no profile means stay on the Hermes off-chain payout")
+}
+
+// Before ZanzibarBeta the migration must behave exactly as it did, profile or
+// not. Testnet already ran this block; changing what it did would alter its
+// receipt root and fork any node that resynced.
+func TestMigrateHermesRewardOptInUnchangedBeforeBeta(t *testing.T) {
+	r := require.New(t)
+	sm := testdb.NewMockStateManager(gomock.NewController(t))
+	vault := identityset.Address(10)
+	none := &Candidate{
+		Owner: identityset.Address(5), Operator: identityset.Address(6), Reward: vault,
+		Name: "none", Votes: big.NewInt(1), SelfStakeBucketIdx: 3, SelfStake: big.NewInt(1),
+	}
+	installCandCenter(t, sm, none)
+
+	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
+	r.NoError(err)
+	reader := delegateprofile.ContractReaderFunc(func(context.Context, string, []byte) ([]byte, error) {
+		t.Fatal("the profile must not be consulted before ZanzibarBeta")
+		return nil, nil
+	})
+
+	r.NoError(migrateHermesRewardOptIn(migrationCtx(false), sm, []string{vault.String()}, bridge, reader))
+
+	csr, err := ConstructBaseView(sm)
+	r.NoError(err)
+	r.True(csr.GetByIdentifier(none.GetIdentifier()).VoterRewardOnchainOptIn,
+		"pre-Beta behaviour is migrate-on-reward-address, unchanged")
+}
+
+// A chain with no DelegateProfile contract, or a node with no reader injected,
+// must not filter: treating an unreadable contract as "nobody is configured"
+// would opt out every candidate rather than the misconfigured ones.
+func TestMigrateHermesRewardOptInWithoutProfileSourceDoesNotFilter(t *testing.T) {
+	r := require.New(t)
+	for _, tc := range []struct {
+		name   string
+		bridge *delegateprofile.Bridge
+		reader delegateprofile.ContractReader
+	}{
+		{"no contract configured", nil, nil},
+		{"no reader injected", mustBridge(t), nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			sm := testdb.NewMockStateManager(gomock.NewController(t))
+			vault := identityset.Address(10)
+			cand := &Candidate{
+				Owner: identityset.Address(1), Operator: identityset.Address(2), Reward: vault,
+				Name: "c", Votes: big.NewInt(1), SelfStakeBucketIdx: 1, SelfStake: big.NewInt(1),
+			}
+			installCandCenter(t, sm, cand)
+			r.NoError(migrateHermesRewardOptIn(
+				migrationCtx(true), sm, []string{vault.String()}, tc.bridge, tc.reader))
+			csr, err := ConstructBaseView(sm)
+			r.NoError(err)
+			r.True(csr.GetByIdentifier(cand.GetIdentifier()).VoterRewardOnchainOptIn)
+		})
+	}
+}
+
+func mustBridge(t *testing.T) *delegateprofile.Bridge {
+	t.Helper()
+	b, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
+	require.NoError(t, err)
+	return b
 }

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -26,6 +26,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/delegateprofile"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/contractstaking"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
@@ -122,6 +123,7 @@ type (
 		blockStore               BlockStore
 		blocksToDurationFn       func(startHeight, endHeight, currentHeight uint64) time.Duration
 		genesisStateSeeder       GenesisStateSeeder
+		delegateProfileReader    func(protocol.StateManager) delegateprofile.ContractReader
 	}
 
 	// GenesisStateSeeder plants additional genesis state inside the same
@@ -196,6 +198,23 @@ func WithBlockStore(bs BlockStore) Option {
 func WithGenesisStateSeeder(seeder GenesisStateSeeder) Option {
 	return func(p *Protocol) {
 		p.genesisStateSeeder = seeder
+	}
+}
+
+// WithDelegateProfileReader injects the reader used to consult the
+// DelegateProfile contract during the Hermes opt-in migration.
+//
+// It is injected rather than constructed here because the reader runs a
+// simulated view call, which lives in the evm package. staking cannot reach the
+// existing one in poll (poll imports staking), and importing evm directly would
+// add a dependency edge to a package that otherwise only touches state.
+// chainservice imports both and wires the two together.
+//
+// Left unset, the migration falls back to its pre-ZanzibarBeta behaviour of
+// migrating on reward address alone.
+func WithDelegateProfileReader(fn func(protocol.StateManager) delegateprofile.ContractReader) Option {
+	return func(p *Protocol) {
+		p.delegateProfileReader = fn
 	}
 }
 
@@ -650,7 +669,11 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 	// into state) sees the state they produced, and before the epoch-boundary
 	// indexer work below, which returns early on most blocks.
 	if blkCtx.BlockHeight == g.ZanzibarBlockHeight {
-		if err := migrateHermesRewardOptIn(ctx, sm, g.HermesRewardVaultAddresses); err != nil {
+		bridge, reader, err := p.delegateProfileFor(sm, g.DelegateProfileContractAddress)
+		if err != nil {
+			return err
+		}
+		if err := migrateHermesRewardOptIn(ctx, sm, g.HermesRewardVaultAddresses, bridge, reader); err != nil {
 			return err
 		}
 		if err := backfillOwnerIndex(ctx, sm); err != nil {
@@ -1359,4 +1382,21 @@ func contractStakingIndexerAt(index ContractStakingIndexer, sr protocol.StateRea
 		return nil, errors.Errorf("indexer height %d is too old for state reader height %d", indexHeight, srHeight)
 	}
 	return index.IndexerAt(sr), nil
+}
+
+// delegateProfileFor builds the bridge and reader the Hermes opt-in migration
+// consults, or (nil, nil) when the chain has no DelegateProfile contract or no
+// reader was injected. Both nils mean "do not filter" -- see
+// hermesMigrationProfileFilter.
+func (p *Protocol) delegateProfileFor(
+	sm protocol.StateManager, contract string,
+) (*delegateprofile.Bridge, delegateprofile.ContractReader, error) {
+	if contract == "" || p.delegateProfileReader == nil {
+		return nil, nil, nil
+	}
+	bridge, err := delegateprofile.New(contract)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "staking: invalid DelegateProfile contract address")
+	}
+	return bridge, p.delegateProfileReader(sm), nil
 }

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -737,6 +737,10 @@ func (builder *Builder) registerStakingProtocol() error {
 		opts = append(opts, staking.WithContractStakingIndexerV3(builder.cs.contractStakingIndexerV3))
 	}
 	opts = append(opts, staking.WithBlockStore(builder.cs.blockdao))
+	// The Hermes opt-in migration consults DelegateProfile before opting a
+	// candidate in. The reader runs a simulated view call, which staking cannot
+	// build itself without importing evm or poll; this is the seam.
+	opts = append(opts, staking.WithDelegateProfileReader(poll.NewDelegateProfileContractReader))
 	opts = append(opts, builder.stakingOpts...)
 	stakingProtocol, err := staking.NewProtocol(
 		staking.HelperCtx{


### PR DESCRIPTION
> Stacked on #4989 (`feat-zanzibar-beta-height`). Review that one first; this PR's base will retarget to `rc_2.5.0` once it merges.

## Problem

Being **migrated** and having a **usable commission configuration** are independent facts.

`migrateHermesRewardOptIn` looks only at the reward address. A candidate whose portions were never published in DelegateProfile is opted in anyway — and `poll_snapshot` then writes `_fullCommissionBasisPoints` into its era snapshot, because `CommissionConfigured` is false.

The result is **100% commission**. Its voters receive nothing, and nothing on chain says so: no error, no event, and every view returns successfully.

These candidates never chose any of it. They were migrated, so they never pass through the opt-in flow where a client could have prompted them to publish portions — which is exactly why the mitigation shipped in the wallet does not cover them.

## Measured

TestNet's first era freeze (46,892,881), all four migrated delegates:

```
delegate       blockBps  epochBps  configured  weight       voters get
uuu (rank 1)     10000     10000     false     14,898,927      0%
robotex          10000     10000     false      2,384,539      0%
faucet           10000     10000     false      1,635,067      0%
iotextest12       1500      1400     true             303    85/86%
```

**Three of four at 100%**, one of them the highest-weighted delegate on the network. `iotextest12` confirms the commission arithmetic itself is fine (`10000−8500`, `10000−8600`) — the defect is that a *missing* configuration is silently read as *100% commission* rather than as *not configured*.

**Mainnet exposure: 90 candidates** whose reward address points at a Hermes vault, with their portions living in the Hermes service rather than in DelegateProfile.

## Fix

From ZanzibarBeta on, migrate only candidates whose profile holds **both** portions. The rest stay opted out and keep the Hermes off-chain payout they are already using — the outcome they expect — instead of moving into an on-chain path that pays their voters zero.

**Half a configuration counts as none.** TestNet's `uuu` had published `blockRewardPortion` and not `epochRewardPortion`, and was frozen at 100% exactly like the candidates that had published neither. `readOne` already collapses that case, so this reads `Configured` and nothing else.

## Why ZanzibarBeta

The migration runs in the single block at `ZanzibarBlockHeight`, which testnet has passed. Changing what that block did would alter its receipt root and **fork any node that resynced**. Mainnet sets both heights to the same value and gets this at activation.

There is a test asserting pre-Beta behaviour is byte-for-byte unchanged, with a reader that fails the test if it is consulted at all.

## Two deliberate choices

**Filtering is skipped** when the chain has no DelegateProfile contract or no reader was injected. Treating an unreadable contract as *"nobody is configured"* would opt out **every** candidate rather than the misconfigured ones — strictly worse than today.

**The reader is injected, not constructed in staking.** It runs a simulated view call, which lives in `evm`. staking cannot reach poll's copy (poll imports staking), and importing `evm` would add a dependency edge to a package that otherwise only touches state. `chainservice` imports both and wires them together.

## Determinism

Candidates are already sorted by identifier bytes before the reads, and `Bridge.Snapshot` reads in the order given — so every node issues the same calls in the same order, and collapses a failed read to `Configured=false` identically.

## Tests

```
staking + poll + protocol + chainservice   514 passed
e2etest                                    134 passed   (-run 'Staking|Native|IIP59')
```

New coverage: complete profile migrates; block-without-epoch does not; no profile does not; pre-Beta unchanged (reader must not be touched); and both no-contract / no-reader paths migrate everyone rather than nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)