### PR TITLE
feat(staking): emit a DelegateRewardFrozen log at the era freeze

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -218,6 +218,22 @@ type (
 		// fork any node that resynced. A chain that has not activated sets both
 		// heights to the same value and gets this from the start.
 		RequireProfileForHermesMigration bool
+		// EmitEraFreezeLog, when true, makes the era freeze emit one
+		// DelegateRewardFrozen log per frozen delegate.
+		//
+		// Freezing is otherwise completely silent: the freeze block and its
+		// neighbours carry the same single untopiced block-reward log, so an
+		// event-driven indexer cannot tell that an era was frozen, which
+		// delegates are in it, or what commission each was frozen at. On TestNet
+		// the analyser ran without error across the freeze and settlement heights
+		// and left all four of its tables empty, because none of the three IIP-59
+		// events it follows had occurred.
+		//
+		// Receipt logs are part of the receipt root, so this is gated on
+		// ZanzibarBeta rather than Zanzibar: testnet has already produced freeze
+		// blocks without it, and adding logs to those heights retroactively would
+		// change their receipt roots.
+		EmitEraFreezeLog bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -398,6 +414,7 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			OptionalCandidateBLSPublicKey:           g.IsZanzibar(height),
 			CorrectPrestateForAbsentKeys:            g.IsZanzibar(height),
 			RequireProfileForHermesMigration:        g.IsZanzibarBeta(height),
+			EmitEraFreezeLog:                        g.IsZanzibarBeta(height),
 		},
 	)
 }

--- a/action/protocol/poll/consortium.go
+++ b/action/protocol/poll/consortium.go
@@ -151,7 +151,10 @@ func (cc *consortiumCommittee) CreateGenesisStates(ctx context.Context, sm proto
 		return err
 	}
 
-	return setCandidates(ctx, sm, cc.indexer, cands, uint64(1))
+	// Genesis states carry no receipt, so freeze logs (which cannot occur at
+	// height 1 anyway) are discarded.
+	_, err = setCandidates(ctx, sm, cc.indexer, cands, uint64(1))
+	return err
 }
 
 func (cc *consortiumCommittee) CreatePreStates(ctx context.Context, sm protocol.StateManager) error {

--- a/action/protocol/poll/governance_protocol.go
+++ b/action/protocol/poll/governance_protocol.go
@@ -91,7 +91,10 @@ func (p *governanceChainCommitteeProtocol) CreateGenesisStates(
 	if err = validateDelegates(ds); err != nil {
 		return
 	}
-	return setCandidates(ctx, sm, p.indexer, ds, uint64(1))
+	// Genesis states carry no receipt, so freeze logs (which cannot occur at
+	// height 1 anyway) are discarded.
+	_, err = setCandidates(ctx, sm, p.indexer, ds, uint64(1))
+	return err
 }
 
 func (p *governanceChainCommitteeProtocol) CreatePostSystemActions(ctx context.Context, sr protocol.StateReader) ([]action.Envelope, error) {

--- a/action/protocol/poll/governance_protocol_test.go
+++ b/action/protocol/poll/governance_protocol_test.go
@@ -217,7 +217,7 @@ func initConstruct(ctrl *gomock.Controller) (Protocol, context.Context, protocol
 		return nil, nil, nil, nil, err
 	}
 	ctx = protocol.WithFeatureWithHeightCtx(ctx)
-	if err := setCandidates(ctx, sm, indexer, candidates, 1); err != nil {
+	if _, err := setCandidates(ctx, sm, indexer, candidates, 1); err != nil {
 		return nil, nil, nil, nil, err
 	}
 	if err := setNextEpochProbationList(sm, indexer, 1, vote.NewProbationList(cfg.Genesis.ProbationIntensityRate)); err != nil {
@@ -337,7 +337,8 @@ func TestCreatePreStates(t *testing.T) {
 		candidates, err := p.Candidates(ctx, sm)
 		require.Equal(len(candidates), 6)
 		require.NoError(err)
-		require.NoError(setCandidates(ctx, sm, nil, candidates, nextEpochStartHeight)) // set next candidate
+		_, serr := setCandidates(ctx, sm, nil, candidates, nextEpochStartHeight) // set next candidate
+		require.NoError(serr)
 
 		// at last of epoch, set probationList into next probation key
 		epochLastHeight := rp.GetEpochLastBlockHeight(epochNum)

--- a/action/protocol/poll/lifelong_protocol.go
+++ b/action/protocol/poll/lifelong_protocol.go
@@ -59,7 +59,10 @@ func (p *lifeLongDelegatesProtocol) CreateGenesisStates(
 		return errors.Errorf("Cannot create genesis state for height %d", blkCtx.BlockHeight)
 	}
 	log.L().Info("Creating genesis states for lifelong delegates protocol")
-	return setCandidates(ctx, sm, nil, p.delegates, uint64(1))
+	// Genesis states carry no receipt, so freeze logs (which cannot occur at
+	// height 1 anyway) are discarded.
+	_, err = setCandidates(ctx, sm, nil, p.delegates, uint64(1))
+	return err
 }
 
 func (p *lifeLongDelegatesProtocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {

--- a/action/protocol/poll/nativestakingV2.go
+++ b/action/protocol/poll/nativestakingV2.go
@@ -58,7 +58,10 @@ func (ns *nativeStakingV2) CreateGenesisStates(ctx context.Context, sm protocol.
 	}
 	bcCtx := protocol.MustGetBlockchainCtx(ctx)
 	cands = ns.filterAndSortCandidatesByVoteScore(cands, bcCtx.Tip.Timestamp)
-	return setCandidates(ctx, sm, ns.candIndexer, cands, uint64(1))
+	// Genesis states carry no receipt, so freeze logs (which cannot occur at
+	// height 1 anyway) are discarded.
+	_, err = setCandidates(ctx, sm, ns.candIndexer, cands, uint64(1))
+	return err
 }
 
 func (ns *nativeStakingV2) CreatePreStates(ctx context.Context, sm protocol.StateManager) error {

--- a/action/protocol/poll/util.go
+++ b/action/protocol/poll/util.go
@@ -61,16 +61,21 @@ func handle(ctx context.Context, act action.Action, sm protocol.StateManager, in
 	}
 	zap.L().Debug("Handle PutPollResult Action", zap.Uint64("height", r.Height()))
 
-	if err := setCandidates(ctx, sm, indexer, r.Candidates(), r.Height()); err != nil {
+	freezeLogs, err := setCandidates(ctx, sm, indexer, r.Candidates(), r.Height())
+	if err != nil {
 		return nil, errors.Wrap(err, "failed to set candidates")
 	}
-	return &action.Receipt{
+	receipt := &action.Receipt{
 		Status:          uint64(iotextypes.ReceiptStatus_Success),
 		ActionHash:      actionCtx.ActionHash,
 		BlockHeight:     blkCtx.BlockHeight,
 		GasConsumed:     actionCtx.IntrinsicGas,
 		ContractAddress: protocolAddr,
-	}, nil
+	}
+	for _, l := range freezeLogs {
+		l.ActionHash = actionCtx.ActionHash
+	}
+	return receipt.AddLogs(freezeLogs...), nil
 }
 
 func validate(ctx context.Context, sr protocol.StateReader, p Protocol, act action.Action) error {
@@ -166,12 +171,12 @@ func setCandidates(
 	indexer *CandidateIndexer,
 	candidates state.CandidateList,
 	height uint64, // epoch start height
-) error {
+) ([]*action.Log, error) {
 	featureCtx := protocol.MustGetFeatureWithHeightCtx(ctx)
 	rp := rolldpos.MustGetProtocol(protocol.MustGetRegistry(ctx))
 	epochNum := rp.GetEpochNum(height)
 	if height != rp.GetEpochHeight(epochNum) {
-		return errors.New("put poll result height should be epoch start height")
+		return nil, errors.New("put poll result height should be epoch start height")
 	}
 	loadCandidatesLegacy := featureCtx.LoadCandidatesLegacy(height)
 	accountCreationOpts := []state.AccountCreationOption{}
@@ -183,26 +188,26 @@ func setCandidates(
 	for _, candidate := range candidates {
 		addr, err := address.FromString(candidate.Address)
 		if err != nil {
-			return errors.Wrapf(err, "failed to decode delegate address %s", candidate.Address)
+			return nil, errors.Wrapf(err, "failed to decode delegate address %s", candidate.Address)
 		}
 		delegate, err := accountutil.LoadOrCreateAccount(sm, addr, accountCreationOpts...)
 		if err != nil {
-			return errors.Wrapf(err, "failed to load or create the account for delegate %s", candidate.Address)
+			return nil, errors.Wrapf(err, "failed to load or create the account for delegate %s", candidate.Address)
 		}
 		if protocol.MustGetFeatureCtx(ctx).CreateLegacyNonceAccount {
 			delegate.MarkAsCandidate()
 		}
 		if loadCandidatesLegacy {
 			if err := candidatesutil.LoadAndAddCandidates(sm, height, candidate.Address); err != nil {
-				return err
+				return nil, err
 			}
 		}
 		candAddr, err := address.FromString(candidate.Address)
 		if err != nil && protocol.MustGetFeatureCtx(ctx).FixUnproductiveDelegates {
-			return errors.Wrap(err, "failed to convert candidate address")
+			return nil, errors.Wrap(err, "failed to convert candidate address")
 		}
 		if err := accountutil.StoreAccount(sm, candAddr, delegate); err != nil {
-			return errors.Wrap(err, "failed to update pending account changes to trie")
+			return nil, errors.Wrap(err, "failed to update pending account changes to trie")
 		}
 		log.L().Debug(
 			"add candidate",
@@ -213,20 +218,25 @@ func setCandidates(
 	}
 	if indexer != nil {
 		if err := indexer.PutCandidateList(height, &candidates); err != nil {
-			return errors.Wrapf(err, "failed to put candidatelist into indexer at height %d", height)
+			return nil, errors.Wrapf(err, "failed to put candidatelist into indexer at height %d", height)
 		}
 	}
-	if err := freezeIIP59RewardState(ctx, sm, epochNum); err != nil {
-		return errors.Wrap(err, "failed to freeze IIP-59 reward state")
+	freezeLogs, err := freezeIIP59RewardState(ctx, sm, epochNum)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to freeze IIP-59 reward state")
 	}
 	if loadCandidatesLegacy {
 		key, org := candidatesutil.ConstructLegacyKeyWithOrg(height)
-		_, err := sm.PutState(&candidates, protocol.LegacyKeyOption(key), protocol.ErigonStoreKeyOption(org))
-		return err
+		if _, err := sm.PutState(&candidates, protocol.LegacyKeyOption(key), protocol.ErigonStoreKeyOption(org)); err != nil {
+			return nil, err
+		}
+		return freezeLogs, nil
 	}
 	nextKey := candidatesutil.ConstructKey(candidatesutil.NxtCandidateKey)
-	_, err := sm.PutState(&candidates, protocol.KeyOption(nextKey[:]), protocol.NamespaceOption(protocol.SystemNamespace))
-	return err
+	if _, err := sm.PutState(&candidates, protocol.KeyOption(nextKey[:]), protocol.NamespaceOption(protocol.SystemNamespace)); err != nil {
+		return nil, err
+	}
+	return freezeLogs, nil
 }
 
 // freezeIIP59RewardState freezes the per-candidate reward inputs and then
@@ -267,14 +277,14 @@ func setCandidates(
 // the full-owner commission fallback.
 // Post-fork, era boundary, contract configured: bridge called; snapshot
 // carries frozen rates + commission-configuration bit.
-func freezeIIP59RewardState(ctx context.Context, sm protocol.StateManager, epochNum uint64) error {
+func freezeIIP59RewardState(ctx context.Context, sm protocol.StateManager, epochNum uint64) ([]*action.Log, error) {
 	fCtx := protocol.MustGetFeatureCtx(ctx)
 	if fCtx.NoVoterRewardDistribution {
-		return nil
+		return nil, nil
 	}
 	g := genesis.MustExtractGenesisContext(ctx)
 	if !protocol.IsEraBoundary(epochNum, g.EpochsPerRewardEra) {
-		return nil
+		return nil, nil
 	}
 	contract := g.DelegateProfileContractAddress
 	var (
@@ -284,16 +294,22 @@ func freezeIIP59RewardState(ctx context.Context, sm protocol.StateManager, epoch
 	if contract != "" {
 		b, err := delegateprofile.New(contract)
 		if err != nil {
-			return errors.Wrap(err, "invalid DelegateProfile contract address")
+			return nil, errors.Wrap(err, "invalid DelegateProfile contract address")
 		}
 		bridge = b
 		reader = delegateProfileContractReader(sm)
 	}
 	freezeHeight := protocol.MustGetBlockCtx(ctx).BlockHeight
-	if err := staking.FreezeCandidateRewardSnapshots(ctx, sm, bridge, reader, freezeHeight); err != nil {
-		return err
+	// The era is named by the boundary epoch itself, matching the cursor the
+	// settlement later writes (TargetEra: epochNum).
+	logs, err := staking.FreezeCandidateRewardSnapshots(ctx, sm, bridge, reader, freezeHeight, epochNum)
+	if err != nil {
+		return nil, err
 	}
-	return staking.BeginEraCOWWindow(ctx, sm, freezeHeight)
+	if err := staking.BeginEraCOWWindow(ctx, sm, freezeHeight); err != nil {
+		return nil, err
+	}
+	return logs, nil
 }
 
 // _delegateProfileViewCallGasLimit bounds the simulated DelegateProfile view

--- a/action/protocol/poll/util_test.go
+++ b/action/protocol/poll/util_test.go
@@ -124,7 +124,8 @@ func TestFreezeIIP59RewardState_NonEraBoundarySkipsWrite(t *testing.T) {
 
 	// Non-boundary: epochsPerEra=24, epochNum=25.
 	ctx := freezeSnapshotEraGateCtx(t, 24, 1)
-	r.NoError(freezeIIP59RewardState(ctx, sm, 25))
+	_, ferr1 := freezeIIP59RewardState(ctx, sm, 25)
+	r.NoError(ferr1)
 }
 
 func TestFreezeIIP59RewardState_EraBoundaryProceeds(t *testing.T) {
@@ -149,7 +150,7 @@ func TestFreezeIIP59RewardState_EraBoundaryProceeds(t *testing.T) {
 	sm.EXPECT().ReadView(gomock.Any()).Return(nil, protocol.ErrNoName).AnyTimes()
 
 	ctx := freezeSnapshotEraGateCtx(t, 24, 1)
-	err := freezeIIP59RewardState(ctx, sm, 24)
+	_, err := freezeIIP59RewardState(ctx, sm, 24)
 	r.ErrorIs(err, protocol.ErrNoName)
 	r.Contains(err.Error(), "construct candidate view for reward snapshot")
 }
@@ -164,9 +165,12 @@ func TestFreezeIIP59RewardState_EpochsPerRewardEraZeroDisables(t *testing.T) {
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
 
 	ctx := freezeSnapshotEraGateCtx(t, 0, 1)
-	r.NoError(freezeIIP59RewardState(ctx, sm, 1))
-	r.NoError(freezeIIP59RewardState(ctx, sm, 24))
-	r.NoError(freezeIIP59RewardState(ctx, sm, 1_000_000))
+	_, ferr2 := freezeIIP59RewardState(ctx, sm, 1)
+	r.NoError(ferr2)
+	_, ferr3 := freezeIIP59RewardState(ctx, sm, 24)
+	r.NoError(ferr3)
+	_, ferr4 := freezeIIP59RewardState(ctx, sm, 1_000_000)
+	r.NoError(ferr4)
 }
 
 func TestFreezeIIP59RewardState_PreForkGateStillWins(t *testing.T) {
@@ -187,7 +191,9 @@ func TestFreezeIIP59RewardState_PreForkGateStillWins(t *testing.T) {
 	ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{BlockHeight: 1})
 	ctx = protocol.WithFeatureCtx(ctx)
 
-	r.NoError(freezeIIP59RewardState(ctx, sm, 24))
+	_, ferr5 := freezeIIP59RewardState(ctx, sm, 24)
+
+	r.NoError(ferr5)
 }
 
 func TestDelegateProfileContractReaderInstallsEVMHelperContext(t *testing.T) {

--- a/action/protocol/staking/freezelog/abi.go
+++ b/action/protocol/staking/freezelog/abi.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+// Package freezelog encodes the event emitted when an IIP-59 era freezes a
+// delegate's reward configuration.
+//
+// It is a self-contained ABI rather than an entry in
+// action/native_staking_contract_abi.json because that file is hand-kept in sync
+// with native_staking_contract_interface.sol with no Makefile target to catch
+// drift, and the two have already diverged -- setVoterRewardOptIn and
+// VoterRewardOptInSet are in the JSON and absent from the .sol.
+package freezelog
+
+// ABIJSON declares the single event this package encodes.
+//
+// It is exported so off-chain consumers decode against the protocol's exact
+// definition instead of maintaining copies that can drift.
+const ABIJSON = `[
+	{
+		"anonymous": false,
+		"inputs": [
+			{"indexed": true,  "name": "era",                  "type": "uint64"},
+			{"indexed": true,  "name": "delegate",             "type": "address"},
+			{"indexed": false, "name": "freezeHeight",         "type": "uint64"},
+			{"indexed": false, "name": "blockCommissionBps",   "type": "uint64"},
+			{"indexed": false, "name": "epochCommissionBps",   "type": "uint64"},
+			{"indexed": false, "name": "commissionConfigured", "type": "bool"},
+			{"indexed": false, "name": "totalWeight",          "type": "uint256"},
+			{"indexed": false, "name": "selfStakeBucketIdx",   "type": "uint64"}
+		],
+		"name": "DelegateRewardFrozen",
+		"type": "event"
+	}
+]`
+
+// EventName is the event's ABI name.
+const EventName = "DelegateRewardFrozen"
+
+// EventSignature is the canonical Solidity signature. Its keccak256 is Topics[0].
+//
+// commissionConfigured is not redundant with the two basis-point fields. When a
+// delegate has published no portions the protocol freezes it at 10000/10000, so
+// those values alone cannot tell "this delegate chose to take everything" apart
+// from "this delegate never configured anything" -- and the two mean opposite
+// things to a voter deciding where to stake. The bool is the discriminator.
+const EventSignature = "DelegateRewardFrozen(uint64,address,uint64,uint64,uint64,bool,uint256,uint64)"

--- a/action/protocol/staking/freezelog/event.go
+++ b/action/protocol/staking/freezelog/event.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package freezelog
+
+import (
+	"encoding/binary"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/pkg/errors"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+)
+
+var (
+	// ErrNilAddress is returned when a required address argument is nil.
+	ErrNilAddress = errors.New("freezelog: nil address")
+
+	parseOnce sync.Once
+	parsedABI abi.ABI
+	parseErr  error
+)
+
+func loadABI() (abi.ABI, error) {
+	parseOnce.Do(func() {
+		parsedABI, parseErr = abi.JSON(strings.NewReader(ABIJSON))
+	})
+	return parsedABI, parseErr
+}
+
+// EventArgs are the fields of one DelegateRewardFrozen log. Field order matches
+// the Solidity signature so a struct literal reads left-to-right the same way as
+// the event declaration.
+type EventArgs struct {
+	Era                  uint64          // indexed → Topics[1]
+	Delegate             address.Address // indexed → Topics[2]
+	FreezeHeight         uint64
+	BlockCommissionBps   uint64
+	EpochCommissionBps   uint64
+	CommissionConfigured bool
+	TotalWeight          *big.Int
+	SelfStakeBucketIdx   uint64
+}
+
+// Pack encodes args as an EVM-shaped receipt log, so off-chain consumers can
+// decode it with stock ethers.js / web3.py against ABIJSON.
+//
+// Topics layout:
+//
+//	[0] keccak256(EventSignature)
+//	[1] uint64 era, left-padded to 32 bytes
+//	[2] address delegate, left-padded to 32 bytes
+//
+// Data layout: ABI-standard tuple of the remaining inputs in declaration order.
+//
+// CommissionConfigured is the field to read before trusting the basis points. A
+// delegate that published no portions is frozen at 10000/10000, which is
+// indistinguishable by value from one that deliberately takes everything.
+func Pack(args EventArgs) (action.Topics, []byte, error) {
+	if args.Delegate == nil {
+		return nil, nil, errors.Wrap(ErrNilAddress, "delegate")
+	}
+	weight := args.TotalWeight
+	if weight == nil {
+		weight = new(big.Int)
+	}
+	parsed, err := loadABI()
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "freezelog: parse ABI")
+	}
+	ev, ok := parsed.Events[EventName]
+	if !ok {
+		return nil, nil, errors.Errorf("freezelog: event %q not found in parsed ABI", EventName)
+	}
+	data, err := ev.Inputs.NonIndexed().Pack(
+		args.FreezeHeight,
+		args.BlockCommissionBps,
+		args.EpochCommissionBps,
+		args.CommissionConfigured,
+		weight,
+		args.SelfStakeBucketIdx,
+	)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "freezelog: pack DelegateRewardFrozen data")
+	}
+	topics := make(action.Topics, 3)
+	topics[0] = hash.Hash256(ev.ID)
+	topics[1] = encodeUint64Topic(args.Era)
+	topics[2] = hash.BytesToHash256(args.Delegate.Bytes())
+	return topics, data, nil
+}
+
+// encodeUint64Topic left-pads a uint64 into a 32-byte topic word, matching how
+// the EVM encodes an indexed integer.
+func encodeUint64Topic(v uint64) hash.Hash256 {
+	var out hash.Hash256
+	binary.BigEndian.PutUint64(out[24:], v)
+	return out
+}
+
+// EthAddress is a helper for consumers building topic filters.
+func EthAddress(a address.Address) common.Address {
+	return common.BytesToAddress(a.Bytes())
+}

--- a/action/protocol/staking/freezelog/event_test.go
+++ b/action/protocol/staking/freezelog/event_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package freezelog
+
+import (
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+// The topic0 an off-chain consumer filters on is derived from EventSignature, so
+// the constant and the ABI must not drift apart.
+func TestEventSignatureMatchesABI(t *testing.T) {
+	r := require.New(t)
+	parsed, err := abi.JSON(strings.NewReader(ABIJSON))
+	r.NoError(err)
+	ev, ok := parsed.Events[EventName]
+	r.True(ok)
+	r.Equal(EventSignature, ev.Sig)
+	r.Equal(crypto.Keccak256Hash([]byte(EventSignature)).Bytes(), ev.ID.Bytes())
+}
+
+func TestPackRoundTrip(t *testing.T) {
+	r := require.New(t)
+	delegate := identityset.Address(1)
+	topics, data, err := Pack(EventArgs{
+		Era:                  54888,
+		Delegate:             delegate,
+		FreezeHeight:         46892881,
+		BlockCommissionBps:   2000,
+		EpochCommissionBps:   2500,
+		CommissionConfigured: true,
+		TotalWeight:          big.NewInt(2384539),
+		SelfStakeBucketIdx:   47,
+	})
+	r.NoError(err)
+	r.Len(topics, 3)
+
+	parsed, err := abi.JSON(strings.NewReader(ABIJSON))
+	r.NoError(err)
+	ev := parsed.Events[EventName]
+	r.Equal(ev.ID.Bytes(), topics[0][:])
+
+	// Indexed uint64 is left-padded into a 32-byte word, as the EVM encodes it.
+	r.Equal(uint64(54888), uint64(topics[1][31])|uint64(topics[1][30])<<8|uint64(topics[1][29])<<16)
+	r.Equal(delegate.Bytes(), topics[2][12:])
+
+	out, err := ev.Inputs.NonIndexed().Unpack(data)
+	r.NoError(err)
+	r.Equal(uint64(46892881), out[0])
+	r.Equal(uint64(2000), out[1])
+	r.Equal(uint64(2500), out[2])
+	r.Equal(true, out[3])
+	r.Equal(big.NewInt(2384539), out[4])
+	r.Equal(uint64(47), out[5])
+}
+
+// commissionConfigured is the field that separates "chose to take everything"
+// from "never configured anything" -- by value those two are identical.
+func TestPackCarriesTheUnconfiguredDistinction(t *testing.T) {
+	r := require.New(t)
+	parsed, err := abi.JSON(strings.NewReader(ABIJSON))
+	r.NoError(err)
+	ev := parsed.Events[EventName]
+
+	_, data, err := Pack(EventArgs{
+		Era: 54888, Delegate: identityset.Address(1), FreezeHeight: 1,
+		BlockCommissionBps: 10000, EpochCommissionBps: 10000,
+		CommissionConfigured: false, TotalWeight: big.NewInt(1),
+	})
+	r.NoError(err)
+	out, err := ev.Inputs.NonIndexed().Unpack(data)
+	r.NoError(err)
+	r.Equal(uint64(10000), out[1])
+	r.Equal(false, out[3], "10000bps with configured=false means unconfigured, not a 100% choice")
+}
+
+func TestPackRejectsNilDelegateAndToleratesNilWeight(t *testing.T) {
+	r := require.New(t)
+	_, _, err := Pack(EventArgs{Era: 1})
+	r.ErrorIs(err, ErrNilAddress)
+
+	_, _, err = Pack(EventArgs{Era: 1, Delegate: identityset.Address(1)})
+	r.NoError(err, "a nil weight encodes as zero rather than failing the freeze")
+}

--- a/action/protocol/staking/poll_snapshot.go
+++ b/action/protocol/staking/poll_snapshot.go
@@ -16,8 +16,10 @@ import (
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding/delegateprofile"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/freezelog"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/staking/stakingpb"
 	"github.com/iotexproject/iotex-core/v2/systemcontracts"
 )
@@ -190,9 +192,10 @@ func FreezeCandidateRewardSnapshots(
 	bridge *delegateprofile.Bridge,
 	reader delegateprofile.ContractReader,
 	freezeHeight uint64,
-) error {
+	era uint64,
+) ([]*action.Log, error) {
 	if bridge != nil && reader == nil {
-		return errors.New("staking: nil ContractReader with non-nil DelegateProfile bridge")
+		return nil, errors.New("staking: nil ContractReader with non-nil DelegateProfile bridge")
 	}
 	// The candidate center is the sole source of the frozen set, of
 	// SelfStakeBucketIdx, and of TotalWeight, so failing to reach it is
@@ -213,10 +216,10 @@ func FreezeCandidateRewardSnapshots(
 	// the poll protocol that calls this holds a reference to that protocol.
 	csr, err := ConstructBaseView(sm)
 	if err != nil {
-		return errors.Wrap(err, "staking: construct candidate view for reward snapshots")
+		return nil, errors.Wrap(err, "staking: construct candidate view for reward snapshots")
 	}
 	if v := csr.BaseView(); v == nil || v.candCenter == nil {
-		return errors.New("staking: no candidate center to freeze reward snapshots from")
+		return nil, errors.New("staking: no candidate center to freeze reward snapshots from")
 	}
 
 	all := csr.AllCandidates()
@@ -238,8 +241,23 @@ func FreezeCandidateRewardSnapshots(
 		}
 		rates, err = bridge.Snapshot(ctx, reader, ids)
 		if err != nil {
-			return errors.Wrap(err, "staking: DelegateProfile snapshot failed")
+			return nil, errors.Wrap(err, "staking: DelegateProfile snapshot failed")
 		}
+	}
+
+	// Non-panicking: this function is called directly by tests with a bare
+	// context, and "no feature context" can only mean "not gated on", never
+	// "emit". Production always arrives through poll's handle, which builds one.
+	fCtx, hasFeature := protocol.GetFeatureCtx(ctx)
+	emitLogs := hasFeature && fCtx.EmitEraFreezeLog
+	var (
+		logs         []*action.Log
+		protocolAddr string
+		blockHeight  uint64
+	)
+	if emitLogs {
+		protocolAddr = ProtocolAddr().String()
+		blockHeight = protocol.MustGetBlockCtx(ctx).BlockHeight
 	}
 
 	for _, cand := range frozen {
@@ -262,10 +280,35 @@ func FreezeCandidateRewardSnapshots(
 			snap.TotalWeight = new(big.Int).Set(cand.Votes)
 		}
 		if err := writeCandidateRewardSnapshot(sm, id, snap); err != nil {
-			return err
+			return nil, err
+		}
+		// Emitted inside this loop, which iterates `frozen` -- already sorted by
+		// identifier bytes above. The candidate center enumerates from a Go map,
+		// so without that ordering the log sequence would differ between nodes
+		// and the receipt root with it.
+		if emitLogs {
+			topics, data, err := freezelog.Pack(freezelog.EventArgs{
+				Era:                  era,
+				Delegate:             id,
+				FreezeHeight:         freezeHeight,
+				BlockCommissionBps:   snap.BlockCommissionBasisPoints,
+				EpochCommissionBps:   snap.EpochCommissionBasisPoints,
+				CommissionConfigured: snap.CommissionConfigured,
+				TotalWeight:          snap.TotalWeight,
+				SelfStakeBucketIdx:   snap.SelfStakeBucketIdx,
+			})
+			if err != nil {
+				return nil, errors.Wrapf(err, "staking: pack freeze log for candidate %s", id.String())
+			}
+			logs = append(logs, &action.Log{
+				Address:     protocolAddr,
+				Topics:      topics,
+				Data:        data,
+				BlockHeight: blockHeight,
+			})
 		}
 	}
-	return nil
+	return logs, nil
 }
 
 func writeCandidateRewardSnapshot(

--- a/action/protocol/staking/poll_snapshot_frozen_set_test.go
+++ b/action/protocol/staking/poll_snapshot_frozen_set_test.go
@@ -72,7 +72,8 @@ func TestFreezeCandidateRewardSnapshots_RecordIsIndependentOfSetSize(t *testing.
 	solo := onchainCandidate(1, "solo", big.NewInt(4_200))
 	r.NoError(putOnchainCandidate(newCandidateStateManager(soloSM), solo))
 	installCandCenter(t, soloSM, solo)
-	r.NoError(FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), soloSM, nil, nil, freezeHeight))
+	_, freezeErr1 := FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), soloSM, nil, nil, freezeHeight, 0)
+	r.NoError(freezeErr1)
 	soloBytes := rawPollSnapshotBytes(t, soloSM, solo.GetIdentifier())
 
 	// Run 2: same candidate, same height, but the center now also holds a
@@ -85,7 +86,8 @@ func TestFreezeCandidateRewardSnapshots_RecordIsIndependentOfSetSize(t *testing.
 	r.NoError(putOnchainCandidate(pairCSM, first))
 	r.NoError(putOnchainCandidate(pairCSM, second))
 	installCandCenter(t, pairSM, first, second)
-	r.NoError(FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), pairSM, nil, nil, freezeHeight))
+	_, freezeErr2 := FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), pairSM, nil, nil, freezeHeight, 0)
+	r.NoError(freezeErr2)
 	pairBytes := rawPollSnapshotBytes(t, pairSM, first.GetIdentifier())
 
 	r.Equal(soloBytes, pairBytes,
@@ -129,7 +131,8 @@ func TestFreezeCandidateRewardSnapshots_UnrankedOptedInCandidateIsFrozen(t *test
 	r.NoError(putOnchainCandidate(csm, unranked))
 	installCandCenter(t, sm, ranked, unranked)
 
-	r.NoError(FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), sm, nil, nil, freezeHeight))
+	_, freezeErr3 := FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), sm, nil, nil, freezeHeight, 0)
+	r.NoError(freezeErr3)
 
 	snap, err := CandidateRewardSnapshotFor(sm, unranked.GetIdentifier())
 	r.NoError(err, "an opted-in candidate must be frozen regardless of rank or activity")
@@ -157,7 +160,8 @@ func TestFreezeCandidateRewardSnapshots_NotOptedInCandidateNotFrozen(t *testing.
 	r.NoError(csm.putCandidate(optedOut))
 	installCandCenter(t, sm, optedIn, optedOut)
 
-	r.NoError(FreezeCandidateRewardSnapshots(freezeCtxAt(4_242), sm, nil, nil, 4_242))
+	_, freezeErr4 := FreezeCandidateRewardSnapshots(freezeCtxAt(4_242), sm, nil, nil, 4_242, 0)
+	r.NoError(freezeErr4)
 
 	_, err := CandidateRewardSnapshotFor(sm, optedOut.GetIdentifier())
 	r.ErrorIs(err, state.ErrStateNotExist)
@@ -175,7 +179,8 @@ func TestRewardSnapshotsAndCOWWindowUseExplicitSharedHeight(t *testing.T) {
 	r.NoError(putOnchainCandidate(newCandidateStateManager(sm), candidate))
 	installCandCenter(t, sm, candidate)
 
-	r.NoError(FreezeCandidateRewardSnapshots(ctx, sm, nil, nil, freezeHeight))
+	_, freezeErr5 := FreezeCandidateRewardSnapshots(ctx, sm, nil, nil, freezeHeight, 0)
+	r.NoError(freezeErr5)
 	window, err := LoadEraCOWWindow(sm)
 	r.NoError(err)
 	r.False(window.Open(), "snapshot freezing must not hide the COW lifecycle transition")
@@ -209,7 +214,8 @@ func TestFreezeCandidateRewardSnapshots_FrozenSetOrderIsDeterministic(t *testing
 			cands = append(cands, c)
 		}
 		installCandCenter(t, sm, cands...)
-		r.NoError(FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), sm, nil, nil, freezeHeight))
+		_, freezeErr6 := FreezeCandidateRewardSnapshots(freezeCtxAt(freezeHeight), sm, nil, nil, freezeHeight, 0)
+		r.NoError(freezeErr6)
 
 		got := make([][]byte, 0, len(cands))
 		for _, c := range cands {

--- a/action/protocol/staking/poll_snapshot_test.go
+++ b/action/protocol/staking/poll_snapshot_test.go
@@ -185,7 +185,8 @@ func TestFreezeCandidateRewardSnapshots_LegacyCandidateSkipsProfileAndSnapshot(t
 		return nil, nil
 	})
 	ctx := genesis.WithGenesisContext(context.Background(), genesis.TestDefault())
-	r.NoError(FreezeCandidateRewardSnapshots(ctx, sm, bridge, reader, 0))
+	_, frzErr1 := FreezeCandidateRewardSnapshots(ctx, sm, bridge, reader, 0, 0)
+	r.NoError(frzErr1)
 
 	_, err = CandidateRewardSnapshotFor(sm, candidate.GetIdentifier())
 	r.ErrorIs(errors.Cause(err), state.ErrStateNotExist)
@@ -222,7 +223,9 @@ func TestFreezeCandidateRewardSnapshots_NilBridge(t *testing.T) {
 	r.NoError(putOnchainCandidate(csm, secondCand))
 	installCandCenter(t, sm, firstCand, secondCand)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0))
+	_, frzErr2 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
+
+	r.NoError(frzErr2)
 
 	snap, err := CandidateRewardSnapshotFor(sm, firstCand.Owner)
 	r.NoError(err)
@@ -262,7 +265,9 @@ func TestFreezeCandidateRewardSnapshots_HappyPath(t *testing.T) {
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0))
+	_, frzErr3 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0, 0)
+
+	r.NoError(frzErr3)
 
 	snap, err := CandidateRewardSnapshotFor(sm, cand.Owner)
 	r.NoError(err)
@@ -288,7 +293,8 @@ func TestFreezeCandidateRewardSnapshots_ExplicitZeroProfileIsConfigured(t *testi
 	fake.setPortion(candidate.Owner, "epochRewardPortion", 0)
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0))
+	_, frzErr4 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0, 0)
+	r.NoError(frzErr4)
 
 	snapshot, err := CandidateRewardSnapshotFor(sm, candidate.Owner)
 	r.NoError(err)
@@ -323,7 +329,9 @@ func TestFreezeCandidateRewardSnapshots_UsesCandidateIdentity(t *testing.T) {
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0))
+	_, frzErr5 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0, 0)
+
+	r.NoError(frzErr5)
 
 	snapshot, err := CandidateRewardSnapshotFor(sm, identity)
 	r.NoError(err)
@@ -371,7 +379,9 @@ func TestFreezeCandidateRewardSnapshots_PartialProfile(t *testing.T) {
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0))
+	_, frzErr6 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0, 0)
+
+	r.NoError(frzErr6)
 
 	snap, err := CandidateRewardSnapshotFor(sm, registered.Owner)
 	r.NoError(err)
@@ -413,7 +423,9 @@ func TestFreezeCandidateRewardSnapshots_BridgeErrorDefaultsToFullOwnerCommission
 		return nil, errors.New("rpc down")
 	})
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, failing, 0))
+	_, frzErr7 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, failing, 0, 0)
+
+	r.NoError(frzErr7)
 
 	snap, err := CandidateRewardSnapshotFor(sm, cand.Owner)
 	r.NoError(err)
@@ -443,7 +455,8 @@ func TestFreezeCandidateRewardSnapshots_NilBridgeSkipsReader(t *testing.T) {
 		t.Fatalf("reader must not be called when bridge is nil")
 		return nil, nil
 	})
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, panicReader, 0))
+	_, frzErr8 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, panicReader, 0, 0)
+	r.NoError(frzErr8)
 }
 
 func TestFreezeCandidateRewardSnapshots_NonNilBridgeRequiresReader(t *testing.T) {
@@ -456,7 +469,7 @@ func TestFreezeCandidateRewardSnapshots_NonNilBridgeRequiresReader(t *testing.T)
 
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
-	err = FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, nil, 0)
+	_, err = FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, nil, 0, 0)
 	r.Error(err)
 	r.Contains(err.Error(), "nil ContractReader")
 }
@@ -514,7 +527,9 @@ func TestFreezeCandidateRewardSnapshots_EveryMemberGetsItsOwnRates(t *testing.T)
 	bridge, err := delegateprofile.New("io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u")
 	r.NoError(err)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0))
+	_, frzErr9 := FreezeCandidateRewardSnapshots(context.Background(), sm, bridge, fake.reader(t), 0, 0)
+
+	r.NoError(frzErr9)
 	for i, c := range cands {
 		snap, err := CandidateRewardSnapshotFor(sm, c.Owner)
 		r.NoError(err)

--- a/action/protocol/staking/poll_snapshot_totalweight_test.go
+++ b/action/protocol/staking/poll_snapshot_totalweight_test.go
@@ -85,7 +85,9 @@ func TestFreezeCandidateRewardSnapshots_TotalWeightIsCandidateVotes(t *testing.T
 	r.NoError(putOnchainCandidate(csm, cand))
 	installCandCenter(t, sm, cand)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0))
+	_, frzE1 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
+
+	r.NoError(frzE1)
 
 	snap, err := CandidateRewardSnapshotFor(sm, cand.Owner)
 	r.NoError(err)
@@ -111,7 +113,9 @@ func TestFreezeCandidateRewardSnapshots_TotalWeightMultipleCandidatesIsolated(t 
 	r.NoError(putOnchainCandidate(csm, candB))
 	installCandCenter(t, sm, candA, candB)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0))
+	_, frzE2 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
+
+	r.NoError(frzE2)
 
 	snapA, err := CandidateRewardSnapshotFor(sm, candA.Owner)
 	r.NoError(err)
@@ -137,7 +141,9 @@ func TestFreezeCandidateRewardSnapshots_TotalWeightZeroVotes(t *testing.T) {
 	r.NoError(putOnchainCandidate(csm, cand))
 	installCandCenter(t, sm, cand)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0))
+	_, frzE3 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
+
+	r.NoError(frzE3)
 
 	snap, err := CandidateRewardSnapshotFor(sm, cand.Owner)
 	r.NoError(err)
@@ -172,7 +178,7 @@ func TestFreezeCandidateRewardSnapshots_MissingViewIsFatal(t *testing.T) {
 	r.NoError(putOnchainCandidate(csm, cand))
 	// deliberately no installCandCenter
 
-	err := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0)
+	_, err := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
 	r.Error(err)
 	r.Contains(err.Error(), "candidate view")
 
@@ -195,7 +201,7 @@ func TestFreezeCandidateRewardSnapshots_EmptyCandCenterIsFatal(t *testing.T) {
 	r.NoError(putOnchainCandidate(csm, cand))
 	r.NoError(sm.WriteView(_protocolID, &viewData{}))
 
-	err := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0)
+	_, err := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
 	r.Error(err)
 	r.Contains(err.Error(), "no candidate center")
 }
@@ -216,7 +222,9 @@ func TestFreezeCandidateRewardSnapshots_VotesCloneIsolation(t *testing.T) {
 	r.NoError(putOnchainCandidate(csm, cand))
 	installCandCenter(t, sm, cand)
 
-	r.NoError(FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0))
+	_, frzE4 := FreezeCandidateRewardSnapshots(context.Background(), sm, nil, nil, 0, 0)
+
+	r.NoError(frzE4)
 
 	// Mutate the same *big.Int the candidate record carries, in place —
 	// this is what a post-freeze stake change looks like to an aliasing bug.


### PR DESCRIPTION
> Stacked on #4990, which is stacked on #4989. Base retargets as those merge.

## Problem

Freezing an era is **completely silent** on chain. The freeze block and its neighbours carry the same single untopiced block-reward log, so an event-driven indexer cannot tell that an era was frozen, which delegates are in it, or what commission each was frozen at.

Measured on TestNet:

```
chain state                            analyser observed
uuu/robotex/faucet/iotextest12         delegate_reward_config      0 rows
all optedIn=true                       voter_reward_era            0 rows
all with freezeHeight=46892881         voter_reward_distribution   0 rows
                                       voter_reward_destination    0 rows
```

The indexer ran across both the freeze and the settlement heights **without a single error**. It followed the three IIP-59 events faithfully; none of them had occurred.

## Fix

One log per frozen delegate: `era`, `delegate`, `freezeHeight`, both commission rates, `totalWeight`, `selfStakeBucketIdx` — and `commissionConfigured`.

That last field is the one that matters most. A delegate that published no portions is frozen at `10000/10000`, which **by value is indistinguishable** from one that deliberately takes everything — and the two mean opposite things to a voter deciding where to stake. The bool is the only discriminator, and it is exactly what an indexer needs in order to warn.

## Why a separate ABI package

Rather than an entry in `action/native_staking_contract_abi.json`. That file is hand-kept in sync with `native_staking_contract_interface.sol` with no Makefile target to catch drift — and the two have **already** diverged: `setVoterRewardOptIn` and `VoterRewardOptInSet` are in the JSON and absent from the `.sol`. This follows the `distributedlog` precedent instead.

## Plumbing

`FreezeCandidateRewardSnapshots` now returns logs, threaded up through `freezeIIP59RewardState` → `setCandidates` → `handle`, which already builds a receipt and simply never populated `Logs`. The four `CreateGenesisStates` callers of `setCandidates` discard them — a freeze cannot occur at height 1.

## Determinism

Logs are emitted **inside the loop over `frozen`**, which is already sorted by identifier bytes. The candidate center enumerates from a Go map, so without that ordering the log sequence would differ between nodes and the receipt root with it.

## Why ZanzibarBeta

Receipt logs are part of the receipt root. Testnet has already produced freeze blocks without these logs; adding them to those heights retroactively would change their receipt roots and fork any node that resynced.

The feature read is the non-panicking `GetFeatureCtx`. This function is called directly by tests with a bare context, and "no feature context" can only mean "not gated on", never "emit" — production always arrives through poll's `handle`, which builds one.

## Not included

An event for the **fork-block Hermes migration**. `CreatePreStates` returns only an error and runs before `withActionCtx`, so there is no log channel and `MustGetActionCtx` would panic there. Giving it one means widening `PreStatesCreator` across 8 implementations and 3 workingset call sites, or moving the migration into a system action. Both are worth a separate discussion; neither belongs here.

Practically, testnet's migration has already happened and cannot be backfilled either way. Mainnet's can be reconstructed by a one-off state sweep at activation.

## Tests

```
staking + poll + protocol + chainservice   660 passed
e2etest                                    134 passed   (-run 'Staking|Native|IIP59|Poll')
```

New: signature/ABI agreement (the topic0 consumers filter on is derived from `EventSignature`, so the constant and the ABI must not drift), pack/unpack round-trip, the unconfigured-vs-100% distinction, and nil handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)