### PR TITLE
feat(blockdao): add -stop-at-height to cap startup replay

### DIFF
--- a/blockchain/blockdao/blockdao.go
+++ b/blockchain/blockdao/blockdao.go
@@ -76,6 +76,7 @@ type (
 		blockCache     cache.LRUCache
 		txLogCache     cache.LRUCache
 		tipHeight      uint64
+		stopAtHeight   uint64
 	}
 )
 
@@ -98,6 +99,14 @@ func WithReceiptIndexer(ri *ReceiptIndexer) Option {
 func WithTransactionLogIndexer(ti *TransactionLogIndexer) Option {
 	return func(dao *blockDAO) {
 		dao.txLogIndexer = ti
+	}
+}
+
+// WithStopAtHeight caps the startup indexer catch-up at the given height instead
+// of running all the way to the block DAO tip. Zero keeps the default behaviour.
+func WithStopAtHeight(height uint64) Option {
+	return func(dao *blockDAO) {
+		dao.stopAtHeight = height
 	}
 }
 
@@ -173,8 +182,12 @@ func (dao *blockDAO) Start(ctx context.Context) error {
 }
 
 func (dao *blockDAO) checkIndexers(ctx context.Context, checker BlockIndexerChecker) error {
+	if dao.stopAtHeight > 0 {
+		log.L().Info("indexer catch-up is capped by stopAtHeight.",
+			zap.Uint64("stopAtHeight", dao.stopAtHeight))
+	}
 	for i, indexer := range dao.indexers {
-		if err := checker.CheckIndexer(ctx, indexer, 0, func(height uint64) {
+		if err := checker.CheckIndexer(ctx, indexer, dao.stopAtHeight, func(height uint64) {
 			if height%5000 == 0 {
 				log.L().Info(
 					"indexer is catching up.",

--- a/blockchain/blockdao/blockdao_test.go
+++ b/blockchain/blockdao/blockdao_test.go
@@ -169,6 +169,39 @@ func Test_blockDAO_checkIndexers(t *testing.T) {
 	})
 }
 
+// recordingChecker captures the targetHeight checkIndexers hands to CheckIndexer.
+type recordingChecker struct{ target uint64 }
+
+func (c *recordingChecker) Height() (uint64, error) { return 0, nil }
+
+func (c *recordingChecker) CheckIndexer(_ context.Context, _ BlockIndexer, targetHeight uint64, _ func(uint64)) error {
+	c.target = targetHeight
+	return nil
+}
+
+func Test_blockDAO_checkIndexers_stopAtHeight(t *testing.T) {
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	indexer := mock_blockdao.NewMockBlockIndexer(ctrl)
+
+	t.Run("Unset", func(t *testing.T) {
+		dao := &blockDAO{indexers: []BlockIndexer{indexer}}
+		checker := &recordingChecker{}
+		r.NoError(dao.checkIndexers(context.Background(), checker))
+		// 0 means "catch up to the block DAO tip" — normal node behaviour
+		r.Zero(checker.target)
+	})
+
+	t.Run("Set", func(t *testing.T) {
+		dao := &blockDAO{indexers: []BlockIndexer{indexer}}
+		WithStopAtHeight(38000000)(dao)
+		checker := &recordingChecker{}
+		r.NoError(dao.checkIndexers(context.Background(), checker))
+		r.Equal(uint64(38000000), checker.target)
+	})
+}
+
 func Test_blockDAO_Stop(t *testing.T) {
 	r := require.New(t)
 

--- a/blockchain/blockdao/blockindexer_test.go
+++ b/blockchain/blockdao/blockindexer_test.go
@@ -97,6 +97,78 @@ func TestCheckIndexer(t *testing.T) {
 	}
 }
 
+// TestCheckIndexerTargetHeight covers the targetHeight cap, which TestCheckIndexer
+// above never exercises (it always passes 0). The cap is what makes a segmented
+// replay stop exactly on its boundary instead of running to the block DAO tip.
+func TestCheckIndexerTargetHeight(t *testing.T) {
+	cases := []struct {
+		name              string
+		daoHeight         uint64
+		indexerTipHeight  uint64
+		targetHeight      uint64
+		expectedPutBlocks []uint64
+	}{
+		{"zero means no cap", 5, 0, 0, []uint64{1, 2, 3, 4, 5}},
+		{"cap below dao tip truncates", 5, 0, 3, []uint64{1, 2, 3}},
+		{"cap below dao tip from a warm indexer", 5, 2, 3, []uint64{3}},
+		{"cap equal to dao tip", 5, 0, 5, []uint64{1, 2, 3, 4, 5}},
+		{"cap above dao tip falls back to dao tip", 5, 0, 9, []uint64{1, 2, 3, 4, 5}},
+		{"cap already reached is a no-op", 5, 3, 3, []uint64{}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require := require.New(t)
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockDao := mock_blockdao.NewMockBlockDAO(ctrl)
+			checker := NewBlockIndexerChecker(mockDao)
+			indexer := mock_blockdao.NewMockBlockIndexer(ctrl)
+
+			putBlocks := make([]*block.Block, 0)
+			mockDao.EXPECT().Height().Return(c.daoHeight, nil).Times(1)
+			mockDao.EXPECT().GetBlockByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Block, error) {
+				pb := &iotextypes.BlockHeader{
+					Core: &iotextypes.BlockHeaderCore{
+						Height:    arg0,
+						Timestamp: timestamppb.Now(),
+					},
+					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
+				}
+				blk := &block.Block{}
+				err := blk.LoadFromBlockHeaderProto(pb)
+				return blk, err
+			}).AnyTimes()
+			mockDao.EXPECT().GetReceipts(gomock.Any()).Return(nil, nil).AnyTimes()
+			mockDao.EXPECT().HeaderByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Header, error) {
+				pb := &iotextypes.BlockHeader{
+					Core: &iotextypes.BlockHeaderCore{
+						Height:    arg0,
+						Timestamp: timestamppb.Now(),
+					},
+					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
+				}
+				blk := &block.Block{}
+				err := blk.LoadFromBlockHeaderProto(pb)
+				return &blk.Header, err
+			}).AnyTimes()
+			indexer.EXPECT().Height().Return(c.indexerTipHeight, nil).Times(1)
+			indexer.EXPECT().PutBlock(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, blk *block.Block) error {
+				putBlocks = append(putBlocks, blk)
+				return nil
+			}).AnyTimes()
+
+			ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{})
+			ctx = genesis.WithGenesisContext(ctx, genesis.TestDefault())
+			require.NoError(checker.CheckIndexer(ctx, indexer, c.targetHeight, func(uint64) {}))
+			require.Len(putBlocks, len(c.expectedPutBlocks))
+			for k, h := range c.expectedPutBlocks {
+				require.Equal(h, putBlocks[k].Height())
+			}
+		})
+	}
+}
+
 func TestBlockIndexerChecker_CheckIndexer(t *testing.T) {
 	r := require.New(t)
 

--- a/blockchain/blockdao/blockindexer_test.go
+++ b/blockchain/blockdao/blockindexer_test.go
@@ -26,6 +26,77 @@ import (
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_blockdao"
 )
 
+// checkIndexerFixture is the mock wiring the two table-driven CheckIndexer tests
+// share. They differ only in what they assert -- TestCheckIndexer covers the
+// indexer-ahead-of-DAO error, TestCheckIndexerTargetHeight the targetHeight cap
+// -- so the setup lives here rather than being written out twice.
+type checkIndexerFixture struct {
+	checker   BlockIndexerChecker
+	indexer   *mock_blockdao.MockBlockIndexer
+	ctx       context.Context
+	putBlocks *[]*block.Block
+}
+
+// newCheckIndexerFixture serves a synthetic header for any height the checker
+// asks for and records every block handed to the indexer.
+//
+// putBlocks is appended to from inside the PutBlock expectation, so read it only
+// after CheckIndexer has returned.
+func newCheckIndexerFixture(t *testing.T, daoHeight, indexerTipHeight uint64) *checkIndexerFixture {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+
+	mockDao := mock_blockdao.NewMockBlockDAO(ctrl)
+	indexer := mock_blockdao.NewMockBlockIndexer(ctrl)
+	putBlocks := make([]*block.Block, 0)
+
+	blockAt := func(height uint64) (*block.Block, error) {
+		pb := &iotextypes.BlockHeader{
+			Core: &iotextypes.BlockHeaderCore{
+				Height:    height,
+				Timestamp: timestamppb.Now(),
+			},
+			ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
+		}
+		blk := &block.Block{}
+		err := blk.LoadFromBlockHeaderProto(pb)
+		return blk, err
+	}
+
+	mockDao.EXPECT().Height().Return(daoHeight, nil).Times(1)
+	mockDao.EXPECT().GetBlockByHeight(gomock.Any()).DoAndReturn(blockAt).AnyTimes()
+	mockDao.EXPECT().GetReceipts(gomock.Any()).Return(nil, nil).AnyTimes()
+	mockDao.EXPECT().HeaderByHeight(gomock.Any()).DoAndReturn(func(height uint64) (*block.Header, error) {
+		blk, err := blockAt(height)
+		return &blk.Header, err
+	}).AnyTimes()
+	indexer.EXPECT().Height().Return(indexerTipHeight, nil).Times(1)
+	indexer.EXPECT().PutBlock(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, blk *block.Block) error {
+		putBlocks = append(putBlocks, blk)
+		return nil
+	}).AnyTimes()
+
+	ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{})
+	ctx = genesis.WithGenesisContext(ctx, genesis.TestDefault())
+
+	return &checkIndexerFixture{
+		checker:   NewBlockIndexerChecker(mockDao),
+		indexer:   indexer,
+		ctx:       ctx,
+		putBlocks: &putBlocks,
+	}
+}
+
+func (f *checkIndexerFixture) requirePutHeights(t *testing.T, expected []uint64) {
+	t.Helper()
+	require := require.New(t)
+	require.Len(*f.putBlocks, len(expected))
+	for i, h := range expected {
+		require.Equal(h, (*f.putBlocks)[i].Height())
+	}
+}
+
 func TestCheckIndexer(t *testing.T) {
 
 	cases := []struct {
@@ -45,54 +116,10 @@ func TestCheckIndexer(t *testing.T) {
 
 	for i, c := range cases {
 		t.Run(strconv.FormatUint(uint64(i), 10), func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			mockDao := mock_blockdao.NewMockBlockDAO(ctrl)
-			checker := NewBlockIndexerChecker(mockDao)
-			indexer := mock_blockdao.NewMockBlockIndexer(ctrl)
-
-			putBlocks := make([]*block.Block, 0)
-			mockDao.EXPECT().Height().Return(c.daoHeight, nil).Times(1)
-			mockDao.EXPECT().GetBlockByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Block, error) {
-				pb := &iotextypes.BlockHeader{
-					Core: &iotextypes.BlockHeaderCore{
-						Height:    arg0,
-						Timestamp: timestamppb.Now(),
-					},
-					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
-				}
-				blk := &block.Block{}
-				err := blk.LoadFromBlockHeaderProto(pb)
-				return blk, err
-			}).AnyTimes()
-			mockDao.EXPECT().GetReceipts(gomock.Any()).Return(nil, nil).AnyTimes()
-			mockDao.EXPECT().HeaderByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Header, error) {
-				pb := &iotextypes.BlockHeader{
-					Core: &iotextypes.BlockHeaderCore{
-						Height:    arg0,
-						Timestamp: timestamppb.Now(),
-					},
-					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
-				}
-				blk := &block.Block{}
-				err := blk.LoadFromBlockHeaderProto(pb)
-				return &blk.Header, err
-			}).AnyTimes()
-			indexer.EXPECT().Height().Return(c.indexerTipHeight, nil).Times(1)
-			indexer.EXPECT().PutBlock(gomock.Any(), gomock.Any()).DoAndReturn(func(arg0 context.Context, arg1 *block.Block) error {
-				putBlocks = append(putBlocks, arg1)
-				return nil
-			}).AnyTimes()
-
-			ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{})
-			ctx = genesis.WithGenesisContext(ctx, genesis.TestDefault())
-			err := checker.CheckIndexer(ctx, indexer, 0, func(u uint64) {})
-			require.Equalf(c.noErr, err == nil, "error: %v", err)
-			require.Len(putBlocks, len(c.expectedPutBlocks))
-			for k, h := range c.expectedPutBlocks {
-				require.Equal(h, putBlocks[k].Height())
-			}
+			f := newCheckIndexerFixture(t, c.daoHeight, c.indexerTipHeight)
+			err := f.checker.CheckIndexer(f.ctx, f.indexer, 0, func(uint64) {})
+			require.Equalf(t, c.noErr, err == nil, "error: %v", err)
+			f.requirePutHeights(t, c.expectedPutBlocks)
 		})
 	}
 }
@@ -118,53 +145,9 @@ func TestCheckIndexerTargetHeight(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			require := require.New(t)
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-			mockDao := mock_blockdao.NewMockBlockDAO(ctrl)
-			checker := NewBlockIndexerChecker(mockDao)
-			indexer := mock_blockdao.NewMockBlockIndexer(ctrl)
-
-			putBlocks := make([]*block.Block, 0)
-			mockDao.EXPECT().Height().Return(c.daoHeight, nil).Times(1)
-			mockDao.EXPECT().GetBlockByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Block, error) {
-				pb := &iotextypes.BlockHeader{
-					Core: &iotextypes.BlockHeaderCore{
-						Height:    arg0,
-						Timestamp: timestamppb.Now(),
-					},
-					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
-				}
-				blk := &block.Block{}
-				err := blk.LoadFromBlockHeaderProto(pb)
-				return blk, err
-			}).AnyTimes()
-			mockDao.EXPECT().GetReceipts(gomock.Any()).Return(nil, nil).AnyTimes()
-			mockDao.EXPECT().HeaderByHeight(gomock.Any()).DoAndReturn(func(arg0 uint64) (*block.Header, error) {
-				pb := &iotextypes.BlockHeader{
-					Core: &iotextypes.BlockHeaderCore{
-						Height:    arg0,
-						Timestamp: timestamppb.Now(),
-					},
-					ProducerPubkey: identityset.PrivateKey(1).PublicKey().Bytes(),
-				}
-				blk := &block.Block{}
-				err := blk.LoadFromBlockHeaderProto(pb)
-				return &blk.Header, err
-			}).AnyTimes()
-			indexer.EXPECT().Height().Return(c.indexerTipHeight, nil).Times(1)
-			indexer.EXPECT().PutBlock(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, blk *block.Block) error {
-				putBlocks = append(putBlocks, blk)
-				return nil
-			}).AnyTimes()
-
-			ctx := protocol.WithBlockchainCtx(context.Background(), protocol.BlockchainCtx{})
-			ctx = genesis.WithGenesisContext(ctx, genesis.TestDefault())
-			require.NoError(checker.CheckIndexer(ctx, indexer, c.targetHeight, func(uint64) {}))
-			require.Len(putBlocks, len(c.expectedPutBlocks))
-			for k, h := range c.expectedPutBlocks {
-				require.Equal(h, putBlocks[k].Height())
-			}
+			f := newCheckIndexerFixture(t, c.daoHeight, c.indexerTipHeight)
+			require.NoError(t, f.checker.CheckIndexer(f.ctx, f.indexer, c.targetHeight, func(uint64) {}))
+			f.requirePutHeights(t, c.expectedPutBlocks)
 		})
 	}
 }

--- a/blockchain/config.go
+++ b/blockchain/config.go
@@ -36,25 +36,31 @@ type (
 		CandidateIndexDBPath   string `yaml:"candidateIndexDBPath"`
 		StakingIndexDBPath     string `yaml:"stakingIndexDBPath"`
 		// deprecated
-		SGDIndexDBPath             string           `yaml:"sgdIndexDBPath"`
-		ContractStakingIndexDBPath string           `yaml:"contractStakingIndexDBPath"`
-		BlobStoreDBPath            string           `yaml:"blobStoreDBPath"`
-		BlobStoreRetentionDays     uint32           `yaml:"blobStoreRetentionDays"`
-		PatchReceiptIndexPath      string           `yaml:"patchReceiptIndexPath"`
-		PatchReceiptIndexEndHeight uint64           `yaml:"patchReceiptIndexEndHeight"`
-		PatchTransactionLogPath    string           `yaml:"patchTransactionLogPath"`
-		HistoryIndexPath           string           `yaml:"historyIndexPath"`
-		HistoryBlockRetention      uint64           `yaml:"historyBlockRetention"`
-		ID                         uint32           `yaml:"id"`
-		EVMNetworkID               uint32           `yaml:"evmNetworkID"`
-		Address                    string           `yaml:"address"`
-		ProducerPrivKey            string           `yaml:"producerPrivKey"`
-		ProducerPrivKeySchema      string           `yaml:"producerPrivKeySchema"`
-		ProducerPrivKeyRange       string           `yaml:"producerPrivKeyRange"`
-		SignatureScheme            []string         `yaml:"signatureScheme"`
-		EmptyGenesis               bool             `yaml:"emptyGenesis"`
-		GravityChainDB             db.Config        `yaml:"gravityChainDB"`
-		Committee                  committee.Config `yaml:"committee"`
+		SGDIndexDBPath             string `yaml:"sgdIndexDBPath"`
+		ContractStakingIndexDBPath string `yaml:"contractStakingIndexDBPath"`
+		BlobStoreDBPath            string `yaml:"blobStoreDBPath"`
+		BlobStoreRetentionDays     uint32 `yaml:"blobStoreRetentionDays"`
+		PatchReceiptIndexPath      string `yaml:"patchReceiptIndexPath"`
+		PatchReceiptIndexEndHeight uint64 `yaml:"patchReceiptIndexEndHeight"`
+		PatchTransactionLogPath    string `yaml:"patchTransactionLogPath"`
+		HistoryIndexPath           string `yaml:"historyIndexPath"`
+		HistoryBlockRetention      uint64 `yaml:"historyBlockRetention"`
+		// StopAtHeight, when non-zero, caps the startup indexer catch-up at this
+		// height and shuts the node down cleanly once it is reached. Zero (the
+		// default) means "catch up to the block DAO tip and keep running", i.e.
+		// normal node behaviour. Intended for segmented replay/verification runs
+		// (see the fullsync test), not for production nodes.
+		StopAtHeight          uint64           `yaml:"stopAtHeight"`
+		ID                    uint32           `yaml:"id"`
+		EVMNetworkID          uint32           `yaml:"evmNetworkID"`
+		Address               string           `yaml:"address"`
+		ProducerPrivKey       string           `yaml:"producerPrivKey"`
+		ProducerPrivKeySchema string           `yaml:"producerPrivKeySchema"`
+		ProducerPrivKeyRange  string           `yaml:"producerPrivKeyRange"`
+		SignatureScheme       []string         `yaml:"signatureScheme"`
+		EmptyGenesis          bool             `yaml:"emptyGenesis"`
+		GravityChainDB        db.Config        `yaml:"gravityChainDB"`
+		Committee             committee.Config `yaml:"committee"`
 
 		// EnableTrielessStateDB enables trieless state db (deprecated)
 		EnableTrielessStateDB bool `yaml:"enableTrielessStateDB"`

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -341,6 +341,9 @@ func (builder *Builder) buildBlockDAO(forTest bool) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Chain.StopAtHeight > 0 {
+		opts = append(opts, blockdao.WithStopAtHeight(cfg.Chain.StopAtHeight))
+	}
 	builder.cs.blockdao = blockdao.NewBlockDAOWithIndexersAndCache(
 		store, indexers, cfg.DB.MaxCacheSize, opts...)
 

--- a/server/itx/server.go
+++ b/server/itx/server.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/crypto"
@@ -345,6 +346,18 @@ func StartServer(ctx context.Context, svr *Server, probeSvr *probe.Server, cfg c
 			log.L().Panic("Failed to stop server.", zap.Error(err))
 		}
 	}()
+	if h := cfg.Chain.StopAtHeight; h > 0 {
+		// Start() only returns once the indexer catch-up has reached StopAtHeight
+		// (blockdao caps CheckIndexer at it), so getting here means we are done.
+		// Raise SIGTERM on ourselves rather than returning early: that reuses the
+		// normal signal path, so ctx is cancelled, the deferred Stop() runs, and
+		// the process exits 0 with the state DB closed cleanly — which is what
+		// makes the resulting data dir usable as a checkpoint.
+		log.L().Info("Reached stop-at-height, shutting down.", zap.Uint64("height", h))
+		if err := syscall.Kill(syscall.Getpid(), syscall.SIGTERM); err != nil {
+			log.L().Error("Failed to signal self for stop-at-height shutdown.", zap.Error(err))
+		}
+	}
 	if _, isGateway := cfg.Plugins[config.GatewayPlugin]; isGateway && cfg.API.ReadyDuration > 0 {
 		// wait for a while to make sure the server is ready
 		// The original intention was to ensure that all transactions that were not received during the restart were included in block, thereby avoiding inconsistencies in the state of the API node.

--- a/server/main.go
+++ b/server/main.go
@@ -44,6 +44,7 @@ var (
 	_secretPath    string
 	_subChainPath  string
 	_plugins       strs
+	_stopAtHeight  uint64
 )
 
 type strs []string
@@ -65,6 +66,8 @@ func init() {
 	flag.StringVar(&_secretPath, "secret-path", "", "Secret path")
 	flag.StringVar(&_subChainPath, "sub-config-path", "", "Sub chain Config path")
 	flag.Var(&_plugins, "plugin", "Plugin of the node")
+	flag.Uint64Var(&_stopAtHeight, "stop-at-height", 0,
+		"Replay blocks only up to this height, then shut down cleanly (0 = run normally)")
 	flag.Usage = func() {
 		_, _ = fmt.Fprintf(os.Stderr,
 			"usage: server -config-path=[string]\n")
@@ -116,6 +119,9 @@ func main() {
 	}
 
 	cfg.Genesis = genesisCfg
+	if _stopAtHeight > 0 {
+		cfg.Chain.StopAtHeight = _stopAtHeight
+	}
 	cfgToLog := cfg
 	cfgToLog.Chain.ProducerPrivKey = ""
 	cfgToLog.Network.MasterKey = ""


### PR DESCRIPTION
Cherry-picked from `rc_2.5.0` (`209382c`) so it reaches `master` on its own rather than riding in with the Zanzibar branch.

**Independent of Zanzibar** — it touches only blockdao, blockchain config, chainservice wiring and the server entry point, and cherry-picks onto `master` with no conflicts.

Lets an operator cap how far startup replay goes, which is what made it practical to reproduce and bisect replay-time state divergence during the v2.5.0 rollout.

### Verification

- `go build ./...` clean
- `go test ./blockchain/blockdao/` — one pre-existing failure, `blockindexer_test.go:216` (`"failed to get pubkey" does not contain "failed to get producer address"`), reproduces identically on an unmodified `master` checkout and is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)