### PR TITLE
feat(state): dump state write queue on delta state digest mismatch

### DIFF
--- a/state/factory/erigonstore/workingsetstore_erigon.go
+++ b/state/factory/erigonstore/workingsetstore_erigon.go
@@ -3,6 +3,7 @@ package erigonstore
 import (
 	"context"
 	"fmt"
+	"io"
 	"math/big"
 
 	"github.com/erigontech/erigon-lib/common/datadir"
@@ -407,6 +408,12 @@ func (store *ErigonWorkingSetStore) States(ns string, obj any, keys [][]byte) (s
 // Digest returns the digest of the ErigonWorkingSetStore
 func (store *ErigonWorkingSetStore) Digest() hash.Hash256 {
 	return hash.ZeroHash256
+}
+
+// DumpWriteQueue is not supported: this store does not keep a serialized write
+// queue (Digest above is a fixed zero hash).
+func (store *ErigonWorkingSetStore) DumpWriteQueue(io.Writer) error {
+	return errors.New("write queue dump is not supported by the erigon working set store")
 }
 
 // CreateGenesisStates creates the genesis states in the ErigonWorkingSetStore

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math/big"
+	"os"
+	"path/filepath"
 	"runtime/debug"
 	"slices"
 	"time"
@@ -95,6 +97,30 @@ func newWorkingSet(height uint64, views protocol.Views, store workingSetStore, s
 	}
 	ws.txValidator = protocol.NewGenericValidator(ws, accountutil.AccountState)
 	return ws
+}
+
+// dumpWriteQueue writes the ordered state-write queue for the given height to
+// $IOTEX_DIGEST_DUMP_DIR, so the same block can be replayed under two binaries
+// and the dumps diffed; the first differing line is the point of divergence.
+// No-op unless the env var is set, so this costs nothing on a normal node.
+func (ws *workingSet) dumpWriteQueue(height uint64) {
+	dir := os.Getenv("IOTEX_DIGEST_DUMP_DIR")
+	if dir == "" {
+		return
+	}
+	path := filepath.Join(dir, fmt.Sprintf("digest-%d.txt", height))
+	f, err := os.Create(path)
+	if err != nil {
+		log.L().Error("failed to create digest dump file", zap.String("path", path), zap.Error(err))
+		return
+	}
+	defer f.Close()
+	if err := ws.store.DumpWriteQueue(f); err != nil {
+		log.L().Error("failed to dump write queue", zap.Uint64("height", height), zap.Error(err))
+		return
+	}
+	log.L().Info("dumped state write queue for digest mismatch",
+		zap.Uint64("height", height), zap.String("path", path))
 }
 
 func (ws *workingSet) digest() (hash.Hash256, error) {
@@ -1171,6 +1197,7 @@ func (ws *workingSet) ValidateBlock(ctx context.Context, blk *block.Block) (err 
 		return err
 	}
 	if !blk.VerifyDeltaStateDigest(digest) {
+		ws.dumpWriteQueue(blk.Height())
 		return errors.Wrapf(block.ErrDeltaStateMismatch, "digest in block '%x' vs digest in workingset '%x' at height %d", blk.DeltaStateDigest(), digest, blk.Height())
 	}
 	receiptRoot := calculateReceiptRoot(ws.receipts)

--- a/state/factory/workingsetstore.go
+++ b/state/factory/workingsetstore.go
@@ -7,6 +7,8 @@ package factory
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"sync"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -30,6 +32,10 @@ type (
 		States(ns string, object any, keys [][]byte) (state.Iterator, error)
 		Commit(context.Context, uint64) error
 		Digest() hash.Hash256
+		// DumpWriteQueue writes the ordered write queue that Digest() hashes over,
+		// one entry per line. Used to diff two binaries' state writes when a delta
+		// state digest mismatch occurs. Returns an error if unsupported.
+		DumpWriteQueue(io.Writer) error
 		Finalize(context.Context) error
 		FinalizeTx(context.Context) error
 		Snapshot() int
@@ -116,6 +122,28 @@ func (store *stateDBWorkingSetStore) Delete(ns string, key []byte) error {
 
 func (store *stateDBWorkingSetStore) Digest() hash.Hash256 {
 	return hash.Hash256b(store.flusher.SerializeQueue())
+}
+
+// DumpWriteQueue dumps the write queue underlying Digest(). Values are recorded
+// as a hash rather than verbatim so a dump stays small on blocks that touch a
+// lot of contract storage; the index of the first differing line between two
+// dumps is what localises a delta state digest mismatch.
+func (store *stateDBWorkingSetStore) DumpWriteQueue(w io.Writer) error {
+	store.lock.Lock()
+	defer store.lock.Unlock()
+	buf := store.flusher.KVStoreWithBuffer()
+	for i := 0; i < buf.Size(); i++ {
+		wi, err := buf.Entry(i)
+		if err != nil {
+			return errors.Wrapf(err, "failed to read write queue entry %d", i)
+		}
+		v := wi.Value()
+		if _, err := fmt.Fprintf(w, "%d\t%d\t%s\t%x\t%x\t%d\n",
+			i, wi.WriteType(), wi.Namespace(), wi.Key(), hash.Hash256b(v), len(v)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (store *stateDBWorkingSetStore) Commit(_ context.Context, _ uint64) error {

--- a/state/factory/workingsetstore_test.go
+++ b/state/factory/workingsetstore_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	"strings"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -142,6 +143,62 @@ func TestStateDBWorkingSetStore(t *testing.T) {
 		require.True(bytes.Equal(heightInStore, byteutil.Uint64ToBytes(height)))
 	})
 	require.NoError(store.Stop(ctx))
+}
+
+func TestStateDBWorkingSetStoreDumpWriteQueue(t *testing.T) {
+	require := require.New(t)
+	ctx := context.Background()
+	flusher, err := db.NewKVStoreFlusher(db.NewMemKVStore(), batch.NewCachedBatch())
+	require.NoError(err)
+	store := newStateDBWorkingSetStore(flusher, true)
+	require.NoError(store.Start(ctx))
+	defer func() { require.NoError(store.Stop(ctx)) }()
+
+	namespace := "namespace"
+	value1 := valueBytes("value1")
+	require.NoError(store.PutObject(namespace, []byte("key1"), &value1))
+	require.NoError(store.DeleteObject(namespace, []byte("key2"), nil))
+
+	var buf bytes.Buffer
+	require.NoError(store.DumpWriteQueue(&buf))
+	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")
+
+	// one line per queued write, in queue order — this ordering is what Digest()
+	// hashes over, so it is the thing a mismatch diff needs to line up on
+	require.Len(lines, 2)
+	require.True(strings.HasPrefix(lines[0], "0\t"))
+	require.True(strings.HasPrefix(lines[1], "1\t"))
+	for i, key := range []string{"key1", "key2"} {
+		fields := strings.Split(lines[i], "\t")
+		require.Len(fields, 6)
+		require.Equal(namespace, fields[2])
+		require.Equal(hex.EncodeToString([]byte(key)), fields[3])
+	}
+	// the put carries its value, the delete does not
+	require.Equal("6", strings.Split(lines[0], "\t")[5])
+	require.Equal("0", strings.Split(lines[1], "\t")[5])
+
+	// dumping twice must give identical output, otherwise diffing two binaries'
+	// dumps would report spurious divergence
+	var buf2 bytes.Buffer
+	require.NoError(store.DumpWriteQueue(&buf2))
+	require.Equal(buf.String(), buf2.String())
+
+	// a differing value shows up as a differing line while ns/key stay equal —
+	// the exact signal used to localise a delta state digest mismatch
+	flusher2, err := db.NewKVStoreFlusher(db.NewMemKVStore(), batch.NewCachedBatch())
+	require.NoError(err)
+	store2 := newStateDBWorkingSetStore(flusher2, true)
+	require.NoError(store2.Start(ctx))
+	defer func() { require.NoError(store2.Stop(ctx)) }()
+	other := valueBytes("valueX")
+	require.NoError(store2.PutObject(namespace, []byte("key1"), &other))
+	var buf3 bytes.Buffer
+	require.NoError(store2.DumpWriteQueue(&buf3))
+	line := strings.Split(strings.TrimRight(buf3.String(), "\n"), "\n")[0]
+	require.NotEqual(lines[0], line)
+	require.Equal(strings.Split(lines[0], "\t")[3], strings.Split(line, "\t")[3]) // same key
+	require.NotEqual(strings.Split(lines[0], "\t")[4], strings.Split(line, "\t")[4])
 }
 
 func TestFactoryWorkingSetStore(t *testing.T) {

--- a/state/factory/workingsetstore_with_secondary.go
+++ b/state/factory/workingsetstore_with_secondary.go
@@ -2,6 +2,7 @@ package factory
 
 import (
 	"context"
+	"io"
 	"time"
 
 	"github.com/iotexproject/go-pkgs/hash"
@@ -55,6 +56,12 @@ func newWorkingSetStoreWithSecondary(store workingSetStore, erigonStore workingS
 		writerSecondary: erigonStore,
 		snMap:           make(map[int]int),
 	}
+}
+
+// DumpWriteQueue delegates to the primary (statedb) store, which is the one
+// whose write queue backs the delta state digest.
+func (store *workingSetStoreWithSecondary) DumpWriteQueue(w io.Writer) error {
+	return store.writer.DumpWriteQueue(w)
 }
 
 func (store *workingSetStoreWithSecondary) Start(context.Context) error {


### PR DESCRIPTION
Cherry-picked from `rc_2.5.0` (`892c355`) so it reaches `master` on its own rather than riding in with the Zanzibar branch.

**Independent of Zanzibar** — confined to `state/factory`, cherry-picks onto `master` with no conflicts.

When a delta state digest mismatch is detected the node currently reports only that the digests differ. Dumping the write queue turns that into something diagnosable: you get the actual sequence of writes that produced the divergent digest, which is the difference between "two nodes disagree" and "here is the write they disagree about".

### Verification

- `go build ./...` clean
- `go test ./state/factory/` — 41 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)