### PR TITLE
feat(genesis): testnet-only balance grant at a scheduled height

### DIFF
--- a/action/protocol/account/protocol.go
+++ b/action/protocol/account/protocol.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/pkg/log"
 	"github.com/iotexproject/iotex-core/v2/state"
@@ -151,6 +152,65 @@ func (p *Protocol) CreateGenesisStates(ctx context.Context, sm protocol.StateMan
 		if err := createAccount(sm, addr.String(), amounts[i], opts...); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// CreatePreStates credits the testnet balance grant scheduled at this height,
+// if there is one. It runs once per block on every node, before any action in
+// the block executes, so the credit is in place for actions in the very block
+// that activates it.
+//
+// This is the escape hatch for a test network that has lost the owner keys of
+// its delegate set: there is no way to move the old delegates' stake, and no
+// account left with enough balance to register replacements. Rather than
+// restart the chain, a grant funds fresh owner accounts in place, and delegate
+// registration then proceeds through the ordinary CandidateRegister path with
+// real keys, real receipts and real transaction logs.
+//
+// It is not available on mainnet -- genesis.ValidateTestnetGrants refuses to
+// load a config that schedules one there, and chainservice refuses to build a
+// node whose chain ID is mainnet's.
+//
+// Writes go through the state manager rather than straight at the trie, so they
+// reach the Erigon secondary store too and archive nodes stay consistent. There
+// is no transaction log: nothing spends here, so there is no sender to record.
+// Downstream indexers that derive balances from transfer logs alone will not
+// see this credit, which is the one externally visible cost of the mechanism.
+func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager) error {
+	blkCtx := protocol.MustGetBlockCtx(ctx)
+	g := genesis.MustExtractGenesisContext(ctx)
+	addrs, amounts, err := g.GrantsAtHeight(blkCtx.BlockHeight)
+	if err != nil {
+		return err
+	}
+	if len(addrs) == 0 {
+		return nil
+	}
+	opts := []state.AccountCreationOption{}
+	if protocol.MustGetFeatureCtx(ctx).CreateLegacyNonceAccount {
+		opts = append(opts, state.LegacyNonceAccountTypeOption())
+	}
+	for i, addr := range addrs {
+		acct, err := accountutil.LoadOrCreateAccount(sm, addr, opts...)
+		if err != nil {
+			return errors.Wrapf(err, "failed to load account %s for testnet grant", addr)
+		}
+		if err := acct.AddBalance(amounts[i]); err != nil {
+			return errors.Wrapf(err, "failed to credit %s to %s", amounts[i], addr)
+		}
+		if err := accountutil.StoreAccount(sm, addr, acct); err != nil {
+			return errors.Wrapf(err, "failed to store account %s after testnet grant", addr)
+		}
+		// Warn, not Info: minting balance outside the normal issuance path is
+		// exactly the event an operator reading logs after the fact needs to
+		// find, and it happens at most a handful of times in a chain's life.
+		log.L().Warn("credited testnet balance grant",
+			zap.Uint64("height", blkCtx.BlockHeight),
+			zap.String("address", addr.String()),
+			zap.String("amount", amounts[i].String()),
+			zap.String("balance", acct.Balance.String()),
+		)
 	}
 	return nil
 }

--- a/action/protocol/account/protocol.go
+++ b/action/protocol/account/protocol.go
@@ -185,6 +185,14 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 		if err := acct.AddBalance(amounts[i]); err != nil {
 			return errors.Wrapf(err, "failed to credit %s to %s", amounts[i], addr)
 		}
+		// ValidateTestnetGrants bounds the configured amount, but the balance it
+		// lands on is only known here. Over the bound the Erigon store panics in
+		// uint256.MustFromBig; returning an error rejects the block instead.
+		if acct.Balance.BitLen() > genesis.MaxBalanceBits {
+			return errors.Errorf(
+				"testnet grant of %s puts %s over %d bits of balance",
+				amounts[i], addr, genesis.MaxBalanceBits)
+		}
 		if err := accountutil.StoreAccount(sm, addr, acct); err != nil {
 			return errors.Wrapf(err, "failed to store account %s after testnet grant", addr)
 		}

--- a/action/protocol/account/protocol.go
+++ b/action/protocol/account/protocol.go
@@ -164,6 +164,12 @@ func (p *Protocol) CreateGenesisStates(ctx context.Context, sm protocol.StateMan
 // reach the Erigon secondary store too. There is no transaction log, since
 // nothing spends -- indexers deriving balances from transfer logs alone will not
 // see the credit.
+//
+// A grant can only be scheduled at a height that has not happened yet, which on
+// any live chain is past Okhotsk, so a recipient that does not exist yet is
+// created with the default zero-nonce account type. No
+// LegacyNonceAccountTypeOption here, unlike the paths that also replay
+// pre-Okhotsk history.
 func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager) error {
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	g := genesis.MustExtractGenesisContext(ctx)
@@ -171,15 +177,8 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 	if err != nil {
 		return err
 	}
-	if len(addrs) == 0 {
-		return nil
-	}
-	opts := []state.AccountCreationOption{}
-	if protocol.MustGetFeatureCtx(ctx).CreateLegacyNonceAccount {
-		opts = append(opts, state.LegacyNonceAccountTypeOption())
-	}
 	for i, addr := range addrs {
-		acct, err := accountutil.LoadOrCreateAccount(sm, addr, opts...)
+		acct, err := accountutil.LoadOrCreateAccount(sm, addr)
 		if err != nil {
 			return errors.Wrapf(err, "failed to load account %s for testnet grant", addr)
 		}

--- a/action/protocol/account/protocol.go
+++ b/action/protocol/account/protocol.go
@@ -156,27 +156,14 @@ func (p *Protocol) CreateGenesisStates(ctx context.Context, sm protocol.StateMan
 	return nil
 }
 
-// CreatePreStates credits the testnet balance grant scheduled at this height,
-// if there is one. It runs once per block on every node, before any action in
-// the block executes, so the credit is in place for actions in the very block
-// that activates it.
-//
-// This is the escape hatch for a test network that has lost the owner keys of
-// its delegate set: there is no way to move the old delegates' stake, and no
-// account left with enough balance to register replacements. Rather than
-// restart the chain, a grant funds fresh owner accounts in place, and delegate
-// registration then proceeds through the ordinary CandidateRegister path with
-// real keys, real receipts and real transaction logs.
-//
-// It is not available on mainnet -- genesis.ValidateTestnetGrants refuses to
-// load a config that schedules one there, and chainservice refuses to build a
-// node whose chain ID is mainnet's.
+// CreatePreStates credits the testnet balance grant scheduled at this height, if
+// there is one, before any action in the block executes. See
+// genesis.TestnetGrants; it is refused on mainnet.
 //
 // Writes go through the state manager rather than straight at the trie, so they
-// reach the Erigon secondary store too and archive nodes stay consistent. There
-// is no transaction log: nothing spends here, so there is no sender to record.
-// Downstream indexers that derive balances from transfer logs alone will not
-// see this credit, which is the one externally visible cost of the mechanism.
+// reach the Erigon secondary store too. There is no transaction log, since
+// nothing spends -- indexers deriving balances from transfer logs alone will not
+// see the credit.
 func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager) error {
 	blkCtx := protocol.MustGetBlockCtx(ctx)
 	g := genesis.MustExtractGenesisContext(ctx)
@@ -202,9 +189,6 @@ func (p *Protocol) CreatePreStates(ctx context.Context, sm protocol.StateManager
 		if err := accountutil.StoreAccount(sm, addr, acct); err != nil {
 			return errors.Wrapf(err, "failed to store account %s after testnet grant", addr)
 		}
-		// Warn, not Info: minting balance outside the normal issuance path is
-		// exactly the event an operator reading logs after the fact needs to
-		// find, and it happens at most a handful of times in a chain's life.
 		log.L().Warn("credited testnet balance grant",
 			zap.Uint64("height", blkCtx.BlockHeight),
 			zap.String("address", addr.String()),

--- a/action/protocol/account/testnet_grant_test.go
+++ b/action/protocol/account/testnet_grant_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package account
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/db/batch"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_chainmanager"
+)
+
+// newGrantStateManager returns a state manager backed by an in-memory batch,
+// the same shape the other tests in this package use.
+func newGrantStateManager(t *testing.T) protocol.StateManager {
+	ctrl := gomock.NewController(t)
+	sm := mock_chainmanager.NewMockStateManager(ctrl)
+	cb := batch.NewCachedBatch()
+	sm.EXPECT().State(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(account interface{}, opts ...protocol.StateOption) (uint64, error) {
+			cfg, err := protocol.CreateStateConfig(opts...)
+			if err != nil {
+				return 0, err
+			}
+			val, err := cb.Get("state", cfg.Key)
+			if err != nil {
+				return 0, state.ErrStateNotExist
+			}
+			return 0, state.Deserialize(account, val)
+		}).AnyTimes()
+	sm.EXPECT().PutState(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(account interface{}, opts ...protocol.StateOption) (uint64, error) {
+			cfg, err := protocol.CreateStateConfig(opts...)
+			if err != nil {
+				return 0, err
+			}
+			ss, err := state.Serialize(account)
+			if err != nil {
+				return 0, err
+			}
+			cb.Put("state", cfg.Key, ss, "failed to put state")
+			return 0, nil
+		}).AnyTimes()
+	return sm
+}
+
+func grantCtx(g genesis.Genesis, height uint64) context.Context {
+	ctx := protocol.WithBlockCtx(context.Background(), protocol.BlockCtx{BlockHeight: height})
+	return protocol.WithFeatureCtx(genesis.WithGenesisContext(ctx, g))
+}
+
+func TestCreatePreStatesGrant(t *testing.T) {
+	r := require.New(t)
+
+	var (
+		fresh   = identityset.Address(10)
+		funded  = identityset.Address(11)
+		ungrant = identityset.Address(12)
+		p       = NewProtocol(rewarding.DepositGas)
+		sm      = newGrantStateManager(t)
+	)
+
+	g := genesis.TestDefault()
+	g.Account.TestnetGrants = []genesis.TestnetGrant{{
+		Height: 100,
+		Recipients: []genesis.GrantRecipient{
+			{Address: fresh.String(), Amount: "500"},
+			{Address: funded.String(), Amount: "700"},
+		},
+	}}
+	r.NoError(g.ValidateTestnetGrants())
+
+	// `funded` already exists with a balance and a bumped nonce; the grant must
+	// add to it rather than replace it, which is the whole reason this goes
+	// through LoadOrCreateAccount instead of writing a fresh Account.
+	pre, err := accountutil.LoadOrCreateAccount(sm, funded)
+	r.NoError(err)
+	r.NoError(pre.AddBalance(big.NewInt(42)))
+	// two bumps, so the expected nonce below is one a fresh account could not
+	// coincidentally have
+	r.NoError(pre.SetPendingNonce(1))
+	r.NoError(pre.SetPendingNonce(2))
+	r.NoError(accountutil.StoreAccount(sm, funded, pre))
+
+	// nothing happens at a height with no grant
+	r.NoError(p.CreatePreStates(grantCtx(g, 99), sm))
+	acct, err := accountutil.LoadAccount(sm, fresh)
+	r.NoError(err)
+	r.Equal("0", acct.Balance.String())
+
+	r.NoError(p.CreatePreStates(grantCtx(g, 100), sm))
+
+	acct, err = accountutil.LoadAccount(sm, fresh)
+	r.NoError(err)
+	r.Equal("500", acct.Balance.String())
+
+	acct, err = accountutil.LoadAccount(sm, funded)
+	r.NoError(err)
+	r.Equal("742", acct.Balance.String())
+	r.Equal(uint64(2), acct.PendingNonce())
+
+	// an address not in the grant is untouched
+	acct, err = accountutil.LoadAccount(sm, ungrant)
+	r.NoError(err)
+	r.Equal("0", acct.Balance.String())
+
+	// the height after is a no-op again -- a grant fires once, at its height
+	r.NoError(p.CreatePreStates(grantCtx(g, 101), sm))
+	acct, err = accountutil.LoadAccount(sm, fresh)
+	r.NoError(err)
+	r.Equal("500", acct.Balance.String())
+}
+
+func TestCreatePreStatesNoGrants(t *testing.T) {
+	r := require.New(t)
+	p := NewProtocol(rewarding.DepositGas)
+	sm := newGrantStateManager(t)
+	g := genesis.TestDefault()
+	for _, h := range []uint64{0, 1, 1000} {
+		r.NoError(p.CreatePreStates(grantCtx(g, h), sm))
+	}
+}
+
+// A malformed grant that somehow reached a running node -- ValidateTestnetGrants
+// should have caught it at startup -- must fail the block rather than panic and
+// take the node down.
+func TestCreatePreStatesGrantMalformed(t *testing.T) {
+	r := require.New(t)
+	p := NewProtocol(rewarding.DepositGas)
+	sm := newGrantStateManager(t)
+
+	g := genesis.TestDefault()
+	g.Account.TestnetGrants = []genesis.TestnetGrant{{
+		Height:     100,
+		Recipients: []genesis.GrantRecipient{{Address: "io1notavalidaddress", Amount: "1"}},
+	}}
+	r.Error(p.CreatePreStates(grantCtx(g, 100), sm))
+
+	g.Account.TestnetGrants = []genesis.TestnetGrant{{
+		Height:     100,
+		Recipients: []genesis.GrantRecipient{{Address: identityset.Address(10).String(), Amount: "not-a-number"}},
+	}}
+	r.Error(p.CreatePreStates(grantCtx(g, 100), sm))
+}
+
+// The protocol has to actually be picked up as a PreStatesCreator, otherwise
+// the hook above never runs and the grant silently does nothing.
+func TestProtocolIsPreStatesCreator(t *testing.T) {
+	var p interface{} = NewProtocol(rewarding.DepositGas)
+	_, ok := p.(protocol.PreStatesCreator)
+	require.True(t, ok)
+}

--- a/action/protocol/account/testnet_grant_test.go
+++ b/action/protocol/account/testnet_grant_test.go
@@ -23,8 +23,6 @@ import (
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_chainmanager"
 )
 
-// newGrantStateManager returns a state manager backed by an in-memory batch,
-// the same shape the other tests in this package use.
 func newGrantStateManager(t *testing.T) protocol.StateManager {
 	ctrl := gomock.NewController(t)
 	sm := mock_chainmanager.NewMockStateManager(ctrl)
@@ -84,13 +82,11 @@ func TestCreatePreStatesGrant(t *testing.T) {
 	r.NoError(g.ValidateTestnetGrants())
 
 	// `funded` already exists with a balance and a bumped nonce; the grant must
-	// add to it rather than replace it, which is the whole reason this goes
-	// through LoadOrCreateAccount instead of writing a fresh Account.
+	// add to it rather than replace it. Two bumps, so the expected nonce below
+	// is one a fresh account could not coincidentally have.
 	pre, err := accountutil.LoadOrCreateAccount(sm, funded)
 	r.NoError(err)
 	r.NoError(pre.AddBalance(big.NewInt(42)))
-	// two bumps, so the expected nonce below is one a fresh account could not
-	// coincidentally have
 	r.NoError(pre.SetPendingNonce(1))
 	r.NoError(pre.SetPendingNonce(2))
 	r.NoError(accountutil.StoreAccount(sm, funded, pre))
@@ -117,7 +113,7 @@ func TestCreatePreStatesGrant(t *testing.T) {
 	r.NoError(err)
 	r.Equal("0", acct.Balance.String())
 
-	// the height after is a no-op again -- a grant fires once, at its height
+	// a grant fires once, at its height
 	r.NoError(p.CreatePreStates(grantCtx(g, 101), sm))
 	acct, err = accountutil.LoadAccount(sm, fresh)
 	r.NoError(err)
@@ -134,9 +130,8 @@ func TestCreatePreStatesNoGrants(t *testing.T) {
 	}
 }
 
-// A malformed grant that somehow reached a running node -- ValidateTestnetGrants
-// should have caught it at startup -- must fail the block rather than panic and
-// take the node down.
+// A malformed grant that reached a running node must fail the block rather than
+// panic and take the node down.
 func TestCreatePreStatesGrantMalformed(t *testing.T) {
 	r := require.New(t)
 	p := NewProtocol(rewarding.DepositGas)
@@ -156,8 +151,7 @@ func TestCreatePreStatesGrantMalformed(t *testing.T) {
 	r.Error(p.CreatePreStates(grantCtx(g, 100), sm))
 }
 
-// The protocol has to actually be picked up as a PreStatesCreator, otherwise
-// the hook above never runs and the grant silently does nothing.
+// Without this the hook never runs and the grant silently does nothing.
 func TestProtocolIsPreStatesCreator(t *testing.T) {
 	var p interface{} = NewProtocol(rewarding.DepositGas)
 	_, ok := p.(protocol.PreStatesCreator)

--- a/action/protocol/account/testnet_grant_test.go
+++ b/action/protocol/account/testnet_grant_test.go
@@ -151,6 +151,45 @@ func TestCreatePreStatesGrantMalformed(t *testing.T) {
 	r.Error(p.CreatePreStates(grantCtx(g, 100), sm))
 }
 
+// A grant amount that passes ValidateTestnetGrants on its own can still push the
+// balance it lands on past what the Erigon secondary store holds -- the prior
+// balance is only known at the activation height. Over the bound the store
+// panics in uint256.MustFromBig, so the block has to be rejected here instead.
+func TestCreatePreStatesGrantOverflowsBalance(t *testing.T) {
+	r := require.New(t)
+
+	var (
+		rich = identityset.Address(10)
+		p    = NewProtocol(rewarding.DepositGas)
+		sm   = newGrantStateManager(t)
+		max  = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), genesis.MaxBalanceBits), big.NewInt(1))
+	)
+
+	pre, err := accountutil.LoadOrCreateAccount(sm, rich)
+	r.NoError(err)
+	r.NoError(pre.AddBalance(max))
+	r.NoError(accountutil.StoreAccount(sm, rich, pre))
+
+	g := genesis.TestDefault()
+	g.Account.TestnetGrants = []genesis.TestnetGrant{{
+		Height:     100,
+		Recipients: []genesis.GrantRecipient{{Address: rich.String(), Amount: "1"}},
+	}}
+	// the config itself is fine; only the sum is not
+	r.NoError(g.ValidateTestnetGrants())
+
+	err = p.CreatePreStates(grantCtx(g, 100), sm)
+	r.ErrorContains(err, "over 256 bits of balance")
+
+	// landing exactly on the bound is allowed
+	sm = newGrantStateManager(t)
+	g.Account.TestnetGrants[0].Recipients[0].Amount = max.String()
+	r.NoError(p.CreatePreStates(grantCtx(g, 100), sm))
+	acct, err := accountutil.LoadAccount(sm, rich)
+	r.NoError(err)
+	r.Equal(max.String(), acct.Balance.String())
+}
+
 // Without this the hook never runs and the grant silently does nothing.
 func TestProtocolIsPreStatesCreator(t *testing.T) {
 	var p interface{} = NewProtocol(rewarding.DepositGas)

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -6,6 +6,7 @@
 package genesis
 
 import (
+	"encoding/hex"
 	"math"
 	"math/big"
 	"sort"
@@ -28,9 +29,27 @@ import (
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 )
 
+// _mainnetGenesisHash is Hash() of the IoTeX mainnet genesis config, and the
+// guard that keeps TestnetGrants off mainnet.
+//
+// The grant list is deliberately not among the fields Hash() hashes over. That
+// is what makes this work: a mainnet genesis file still hashes to this value
+// after someone appends grants to it, so the check below still recognises it as
+// mainnet and refuses. Adding grants to the hashed set would let a mainnet file
+// hash to something else and slip past -- and would also change the p2p network
+// identity of every testnet node that schedules a grant.
+const _mainnetGenesisHash = "b337983730981c2d50f114eed5da9dd20b83c8c5e130beefdb3001dc858cfe8b"
+
 var (
 	// Default contains the default genesis config
 	Default = defaultConfig()
+
+	// _maxTestnetGrantTotal caps the sum of every grant in one genesis file. It
+	// bounds the blast radius of a mistyped amount -- the realistic mistake is
+	// an extra run of zeros, and this turns that into a startup error instead
+	// of an unrecoverable balance at the activation height. 1e9 IOTX is two
+	// orders of magnitude above what a full delegate set needs to self-stake.
+	_maxTestnetGrantTotal = unit.ConvertIotxToRau(1000000000)
 
 	_genesisTs     int64
 	_loadGenesisTs sync.Once
@@ -89,6 +108,10 @@ func defaultConfig() Genesis {
 		Account: Account{
 			InitBalanceMap:          map[string]string{},
 			ReplayDeployerWhitelist: []string{"0x3fab184622dc19b6109349b94811493bf2a45362"},
+			// empty, not nil: the YAML loader materialises an absent sequence
+			// as an empty slice, and config equality checks compare the loaded
+			// config against this literal
+			TestnetGrants: []TestnetGrant{},
 		},
 		Poll: Poll{
 			PollMode:                         "nativeMix",
@@ -420,6 +443,41 @@ type (
 		InitBalanceMap map[string]string `yaml:"initBalances"`
 		// ReplayDeployerWhitelist is the whitelist address for unprotected (pre-EIP155) transaction
 		ReplayDeployerWhitelist []string `yaml:"replayDeployerWhitelist"`
+		// TestnetGrants credits balance to a fixed set of addresses at a fixed
+		// height on a chain that is already running. It exists so a test
+		// network whose delegate owner keys have been lost can fund a
+		// replacement delegate set without restarting the chain, which
+		// InitBalanceMap cannot do -- that one only runs at height 0, and
+		// changing it changes the genesis state, the genesis hash and hence
+		// the network itself.
+		//
+		// It is rejected outright on mainnet; see ValidateTestnetGrants.
+		//
+		// A scheduled grant is consensus state. Every node has to carry the
+		// same genesis file before the activation height, or the ones that do
+		// not will fail the delta state digest check on that block and stop.
+		// Scheduling one is a hard fork and should be rolled out like one.
+		TestnetGrants []TestnetGrant `yaml:"testnetGrants"`
+	}
+	// TestnetGrant is one scheduled batch of balance credits. Recipients is a
+	// list rather than a map because it is applied in order and the order is
+	// part of consensus.
+	TestnetGrant struct {
+		// Height is the block height the credits are applied at, before any
+		// action in that block executes. It must be non-zero -- balances that
+		// exist from the start of the chain belong in InitBalanceMap.
+		Height uint64 `yaml:"height"`
+		// Recipients is the ordered list of addresses to credit.
+		Recipients []GrantRecipient `yaml:"recipients"`
+	}
+	// GrantRecipient is one address/amount pair of a TestnetGrant.
+	GrantRecipient struct {
+		// Address is the IoTeX bech32 address to credit.
+		Address string `yaml:"address"`
+		// Amount is the amount to add to the address' balance, in Rau, decimal.
+		// It is added to whatever the address already holds, so an address with
+		// history keeps its nonce and its existing balance.
+		Amount string `yaml:"amount"`
 	}
 	// Poll contains the configs for poll protocol
 	Poll struct {
@@ -598,6 +656,9 @@ func New(genesisPath string) (Genesis, error) {
 // inert rather than failing loudly. It runs on the YAML load path only: callers
 // that build a Genesis literal (tests, defaultConfig) are trusted.
 func (g *Genesis) validate() error {
+	if err := g.ValidateTestnetGrants(); err != nil {
+		return err
+	}
 	// IIP-59 shares ToBeEnabledBlockHeight with the other WIP features, so
 	// scheduling that height schedules voter reward distribution too. Until it
 	// is scheduled, the era length is never read and any value is acceptable.
@@ -665,6 +726,107 @@ func (g *Genesis) validate() error {
 		}
 	}
 	return nil
+}
+
+// IsMainnet reports whether this is the IoTeX mainnet genesis config.
+func (g *Genesis) IsMainnet() bool {
+	h := g.Hash()
+	return hex.EncodeToString(h[:]) == _mainnetGenesisHash
+}
+
+// ValidateTestnetGrants rejects a TestnetGrants list that is unusable or that
+// does not belong on this network. It is separate from validate() because the
+// YAML load path is not the only one that has to enforce it: a Genesis built as
+// a literal never reaches validate(), so chainservice re-runs this at build
+// time, where it also checks the chain ID.
+//
+// A nil or empty list is always fine -- that is every network except the one
+// being recovered.
+func (g *Genesis) ValidateTestnetGrants() error {
+	if len(g.TestnetGrants) == 0 {
+		return nil
+	}
+	if g.IsMainnet() {
+		return errors.New("genesis: testnetGrants must not be used on mainnet")
+	}
+	var (
+		total      = big.NewInt(0)
+		prevHeight uint64
+	)
+	for i, grant := range g.TestnetGrants {
+		if grant.Height == 0 {
+			return errors.Errorf(
+				"genesis: testnetGrants[%d] height must be non-zero, use initBalances for balances that exist at genesis", i)
+		}
+		if i > 0 && grant.Height <= prevHeight {
+			return errors.Errorf(
+				"genesis: testnetGrants heights must be strictly increasing, got %d after %d", grant.Height, prevHeight)
+		}
+		prevHeight = grant.Height
+		if len(grant.Recipients) == 0 {
+			return errors.Errorf("genesis: testnetGrants[%d] at height %d has no recipients", i, grant.Height)
+		}
+		seen := make(map[string]struct{}, len(grant.Recipients))
+		for j, r := range grant.Recipients {
+			addr, err := address.FromString(r.Address)
+			if err != nil {
+				return errors.Wrapf(err, "genesis: testnetGrants[%d].recipients[%d] has an invalid address %q", i, j, r.Address)
+			}
+			if _, dup := seen[addr.String()]; dup {
+				return errors.Errorf("genesis: testnetGrants[%d] credits %s more than once", i, addr.String())
+			}
+			seen[addr.String()] = struct{}{}
+			amount, ok := new(big.Int).SetString(r.Amount, 10)
+			if !ok {
+				return errors.Errorf("genesis: testnetGrants[%d].recipients[%d] has an unparsable amount %q", i, j, r.Amount)
+			}
+			if amount.Sign() <= 0 {
+				return errors.Errorf("genesis: testnetGrants[%d].recipients[%d] amount %q must be positive", i, j, r.Amount)
+			}
+			total.Add(total, amount)
+		}
+	}
+	if total.Cmp(_maxTestnetGrantTotal) > 0 {
+		return errors.Errorf(
+			"genesis: testnetGrants total %s Rau exceeds the cap of %s Rau", total, _maxTestnetGrantTotal)
+	}
+	return nil
+}
+
+// GrantsAtHeight returns the addresses and amounts of the grant scheduled at
+// the given height, in the order they are configured, or nil when no grant is
+// scheduled there -- which is every height on every network but one.
+//
+// The parsing here cannot fail on a node that came up: ValidateTestnetGrants
+// has already walked the same values. It still returns an error rather than
+// panicking, because CreatePreStates runs mid-block and a panic there takes the
+// node down instead of rejecting the block.
+func (a *Account) GrantsAtHeight(height uint64) ([]address.Address, []*big.Int, error) {
+	if height == 0 || len(a.TestnetGrants) == 0 {
+		return nil, nil, nil
+	}
+	for _, grant := range a.TestnetGrants {
+		if grant.Height != height {
+			continue
+		}
+		addrs := make([]address.Address, 0, len(grant.Recipients))
+		amounts := make([]*big.Int, 0, len(grant.Recipients))
+		for _, r := range grant.Recipients {
+			addr, err := address.FromString(r.Address)
+			if err != nil {
+				return nil, nil, errors.Wrapf(err, "invalid testnet grant address %q at height %d", r.Address, height)
+			}
+			amount, ok := new(big.Int).SetString(r.Amount, 10)
+			if !ok {
+				return nil, nil, errors.Errorf(
+					"invalid testnet grant amount %q for %s at height %d", r.Amount, r.Address, height)
+			}
+			addrs = append(addrs, addr)
+			amounts = append(amounts, amount)
+		}
+		return addrs, amounts, nil
+	}
+	return nil, nil, nil
 }
 
 // SetGenesisTimestamp sets the genesis timestamp

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -34,6 +34,15 @@ import (
 // after grants are appended to it and ValidateTestnetGrants still recognises it.
 const _mainnetGenesisHash = "b337983730981c2d50f114eed5da9dd20b83c8c5e130beefdb3001dc858cfe8b"
 
+// MaxBalanceBits is the width of the balance field in the Erigon secondary
+// store, which holds it as a uint256. Every other path that moves balance
+// conserves supply, so no account can approach the bound; a grant mints, so it
+// is the one place a configured number can cross it. Past the bound the write
+// panics in uint256.MustFromBig rather than failing, which takes the node down
+// instead of rejecting the block -- hence the check here and the one in
+// account.Protocol.CreatePreStates for the sum.
+const MaxBalanceBits = 256
+
 var (
 	// Default contains the default genesis config
 	Default = defaultConfig()
@@ -748,6 +757,11 @@ func (g *Genesis) ValidateTestnetGrants() error {
 			}
 			if amount.Sign() <= 0 {
 				return errors.Errorf("genesis: testnetGrants[%d].recipients[%d] amount %q must be positive", i, j, r.Amount)
+			}
+			if amount.BitLen() > MaxBalanceBits {
+				return errors.Errorf(
+					"genesis: testnetGrants[%d].recipients[%d] amount %q does not fit in %d bits",
+					i, j, r.Amount, MaxBalanceBits)
 			}
 		}
 	}

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -29,27 +29,14 @@ import (
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 )
 
-// _mainnetGenesisHash is Hash() of the IoTeX mainnet genesis config, and the
-// guard that keeps TestnetGrants off mainnet.
-//
-// The grant list is deliberately not among the fields Hash() hashes over. That
-// is what makes this work: a mainnet genesis file still hashes to this value
-// after someone appends grants to it, so the check below still recognises it as
-// mainnet and refuses. Adding grants to the hashed set would let a mainnet file
-// hash to something else and slip past -- and would also change the p2p network
-// identity of every testnet node that schedules a grant.
+// _mainnetGenesisHash is Hash() of the mainnet genesis config. TestnetGrants is
+// not among the fields Hash() covers, so a mainnet file still hashes to this
+// after grants are appended to it and ValidateTestnetGrants still recognises it.
 const _mainnetGenesisHash = "b337983730981c2d50f114eed5da9dd20b83c8c5e130beefdb3001dc858cfe8b"
 
 var (
 	// Default contains the default genesis config
 	Default = defaultConfig()
-
-	// _maxTestnetGrantTotal caps the sum of every grant in one genesis file. It
-	// bounds the blast radius of a mistyped amount -- the realistic mistake is
-	// an extra run of zeros, and this turns that into a startup error instead
-	// of an unrecoverable balance at the activation height. 1e9 IOTX is two
-	// orders of magnitude above what a full delegate set needs to self-stake.
-	_maxTestnetGrantTotal = unit.ConvertIotxToRau(1000000000)
 
 	_genesisTs     int64
 	_loadGenesisTs sync.Once
@@ -108,9 +95,8 @@ func defaultConfig() Genesis {
 		Account: Account{
 			InitBalanceMap:          map[string]string{},
 			ReplayDeployerWhitelist: []string{"0x3fab184622dc19b6109349b94811493bf2a45362"},
-			// empty, not nil: the YAML loader materialises an absent sequence
-			// as an empty slice, and config equality checks compare the loaded
-			// config against this literal
+			// empty, not nil: the YAML loader materialises an absent sequence as
+			// an empty slice, and config equality checks compare against this
 			TestnetGrants: []TestnetGrant{},
 		},
 		Poll: Poll{
@@ -443,41 +429,29 @@ type (
 		InitBalanceMap map[string]string `yaml:"initBalances"`
 		// ReplayDeployerWhitelist is the whitelist address for unprotected (pre-EIP155) transaction
 		ReplayDeployerWhitelist []string `yaml:"replayDeployerWhitelist"`
-		// TestnetGrants credits balance to a fixed set of addresses at a fixed
-		// height on a chain that is already running. It exists so a test
-		// network whose delegate owner keys have been lost can fund a
-		// replacement delegate set without restarting the chain, which
-		// InitBalanceMap cannot do -- that one only runs at height 0, and
-		// changing it changes the genesis state, the genesis hash and hence
-		// the network itself.
+		// TestnetGrants credits balance to a set of addresses at a given height
+		// on a chain that is already running, so a test network that has lost
+		// its delegate owner keys can fund a replacement set without restarting
+		// the chain. Rejected on mainnet, see ValidateTestnetGrants.
 		//
-		// It is rejected outright on mainnet; see ValidateTestnetGrants.
-		//
-		// A scheduled grant is consensus state. Every node has to carry the
-		// same genesis file before the activation height, or the ones that do
-		// not will fail the delta state digest check on that block and stop.
-		// Scheduling one is a hard fork and should be rolled out like one.
+		// A scheduled grant is consensus state: every node needs the same
+		// genesis file before the activation height, or it will fail the delta
+		// state digest check on that block and stop. Roll one out as a hard fork.
 		TestnetGrants []TestnetGrant `yaml:"testnetGrants"`
 	}
 	// TestnetGrant is one scheduled batch of balance credits. Recipients is a
-	// list rather than a map because it is applied in order and the order is
-	// part of consensus.
+	// list rather than a map because the apply order is part of consensus.
 	TestnetGrant struct {
-		// Height is the block height the credits are applied at, before any
-		// action in that block executes. It must be non-zero -- balances that
-		// exist from the start of the chain belong in InitBalanceMap.
-		Height uint64 `yaml:"height"`
-		// Recipients is the ordered list of addresses to credit.
+		// Height is applied before any action in that block. Must be non-zero;
+		// balances that exist from the start of the chain go in InitBalanceMap.
+		Height     uint64           `yaml:"height"`
 		Recipients []GrantRecipient `yaml:"recipients"`
 	}
-	// GrantRecipient is one address/amount pair of a TestnetGrant.
+	// GrantRecipient is one address/amount pair of a TestnetGrant. Amount is in
+	// Rau and is added to whatever the address already holds.
 	GrantRecipient struct {
-		// Address is the IoTeX bech32 address to credit.
 		Address string `yaml:"address"`
-		// Amount is the amount to add to the address' balance, in Rau, decimal.
-		// It is added to whatever the address already holds, so an address with
-		// history keeps its nonce and its existing balance.
-		Amount string `yaml:"amount"`
+		Amount  string `yaml:"amount"`
 	}
 	// Poll contains the configs for poll protocol
 	Poll struct {
@@ -728,20 +702,15 @@ func (g *Genesis) validate() error {
 	return nil
 }
 
-// IsMainnet reports whether this is the IoTeX mainnet genesis config.
+// IsMainnet reports whether this is the mainnet genesis config.
 func (g *Genesis) IsMainnet() bool {
 	h := g.Hash()
 	return hex.EncodeToString(h[:]) == _mainnetGenesisHash
 }
 
-// ValidateTestnetGrants rejects a TestnetGrants list that is unusable or that
-// does not belong on this network. It is separate from validate() because the
-// YAML load path is not the only one that has to enforce it: a Genesis built as
-// a literal never reaches validate(), so chainservice re-runs this at build
-// time, where it also checks the chain ID.
-//
-// A nil or empty list is always fine -- that is every network except the one
-// being recovered.
+// ValidateTestnetGrants rejects a grant list that is unusable or does not belong
+// on this network. It is separate from validate() because a Genesis built as a
+// literal never reaches validate(), so chainservice re-runs it at build time.
 func (g *Genesis) ValidateTestnetGrants() error {
 	if len(g.TestnetGrants) == 0 {
 		return nil
@@ -749,10 +718,7 @@ func (g *Genesis) ValidateTestnetGrants() error {
 	if g.IsMainnet() {
 		return errors.New("genesis: testnetGrants must not be used on mainnet")
 	}
-	var (
-		total      = big.NewInt(0)
-		prevHeight uint64
-	)
+	var prevHeight uint64
 	for i, grant := range g.TestnetGrants {
 		if grant.Height == 0 {
 			return errors.Errorf(
@@ -783,24 +749,15 @@ func (g *Genesis) ValidateTestnetGrants() error {
 			if amount.Sign() <= 0 {
 				return errors.Errorf("genesis: testnetGrants[%d].recipients[%d] amount %q must be positive", i, j, r.Amount)
 			}
-			total.Add(total, amount)
 		}
-	}
-	if total.Cmp(_maxTestnetGrantTotal) > 0 {
-		return errors.Errorf(
-			"genesis: testnetGrants total %s Rau exceeds the cap of %s Rau", total, _maxTestnetGrantTotal)
 	}
 	return nil
 }
 
-// GrantsAtHeight returns the addresses and amounts of the grant scheduled at
-// the given height, in the order they are configured, or nil when no grant is
-// scheduled there -- which is every height on every network but one.
-//
-// The parsing here cannot fail on a node that came up: ValidateTestnetGrants
-// has already walked the same values. It still returns an error rather than
-// panicking, because CreatePreStates runs mid-block and a panic there takes the
-// node down instead of rejecting the block.
+// GrantsAtHeight returns the grant scheduled at the given height in configured
+// order, or nil when there is none. It returns an error rather than panicking on
+// unparsable values -- ValidateTestnetGrants has already walked them, but this
+// runs mid-block, where a panic takes the node down instead of rejecting a block.
 func (a *Account) GrantsAtHeight(height uint64) ([]address.Address, []*big.Int, error) {
 	if height == 0 || len(a.TestnetGrants) == 0 {
 		return nil, nil, nil

--- a/blockchain/genesis/testnet_grant_test.go
+++ b/blockchain/genesis/testnet_grant_test.go
@@ -7,6 +7,7 @@ package genesis
 
 import (
 	"encoding/hex"
+	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -60,6 +61,9 @@ func testnetGenesis(grants ...TestnetGrant) Genesis {
 
 func TestValidateTestnetGrants(t *testing.T) {
 	oneIotx := unit.ConvertIotxToRau(1).String()
+	// The widest balance the Erigon secondary store can hold, and one past it.
+	maxBalance := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), MaxBalanceBits), big.NewInt(1))
+	overMaxBalance := new(big.Int).Add(maxBalance, big.NewInt(1))
 
 	for _, c := range []struct {
 		name   string
@@ -125,6 +129,15 @@ func TestValidateTestnetGrants(t *testing.T) {
 			name:   "negative amount",
 			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: "-1"}}}},
 			errMsg: "must be positive",
+		},
+		{
+			name:   "amount at the balance bound",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: maxBalance.String()}}}},
+		},
+		{
+			name:   "amount over the balance bound",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: overMaxBalance.String()}}}},
+			errMsg: "does not fit in 256 bits",
 		},
 	} {
 		t.Run(c.name, func(t *testing.T) {

--- a/blockchain/genesis/testnet_grant_test.go
+++ b/blockchain/genesis/testnet_grant_test.go
@@ -1,0 +1,286 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package genesis
+
+import (
+	"encoding/hex"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+)
+
+const (
+	_addrA = "io1uqhmnttmv0pg8prugxxn7d8ex9angrvfjfthxa"
+	_addrB = "io1v3gkc49d5vwtdfdka2ekjl3h468egun8e43r7z"
+	_addrC = "io1vrl48nsdm8jaujccd9cx4ve23cskr0ys6urx92"
+)
+
+// The in-repo defaults are the mainnet genesis config -- New("") and
+// iotex-bootstrap's genesis_mainnet.yaml produce the same Hash(). That is what
+// lets _mainnetGenesisHash be pinned without shipping a copy of the mainnet
+// YAML, and it is what this test guards: if a future change to defaultConfig
+// touches a field Hash() covers, the pinned constant stops matching mainnet and
+// the guard silently stops guarding.
+func TestMainnetGenesisHashIsPinned(t *testing.T) {
+	r := require.New(t)
+	cfg, err := New("")
+	r.NoError(err)
+	h := cfg.Hash()
+	r.Equal(_mainnetGenesisHash, hex.EncodeToString(h[:]))
+	r.True(cfg.IsMainnet())
+}
+
+func TestTestnetGrantsRejectedOnMainnet(t *testing.T) {
+	r := require.New(t)
+	cfg, err := New("")
+	r.NoError(err)
+	// no grants: mainnet loads as usual
+	r.NoError(cfg.ValidateTestnetGrants())
+
+	cfg.TestnetGrants = []TestnetGrant{{
+		Height:     100,
+		Recipients: []GrantRecipient{{Address: _addrA, Amount: "1"}},
+	}}
+	// The grant list is not part of Hash(), so mainnet is still recognisable
+	// after the list is appended -- that is the whole point of leaving it out.
+	r.True(cfg.IsMainnet())
+	r.ErrorContains(cfg.ValidateTestnetGrants(), "must not be used on mainnet")
+}
+
+func testnetGenesis(grants ...TestnetGrant) Genesis {
+	g := TestDefault()
+	g.TestnetGrants = grants
+	return g
+}
+
+func TestValidateTestnetGrants(t *testing.T) {
+	oneIotx := unit.ConvertIotxToRau(1).String()
+	overCap := new(big.Int).Add(_maxTestnetGrantTotal, big.NewInt(1)).String()
+
+	for _, c := range []struct {
+		name   string
+		grants []TestnetGrant
+		errMsg string
+	}{
+		{
+			name:   "no grants",
+			grants: nil,
+		},
+		{
+			name: "valid",
+			grants: []TestnetGrant{
+				{Height: 100, Recipients: []GrantRecipient{
+					{Address: _addrA, Amount: oneIotx},
+					{Address: _addrB, Amount: oneIotx},
+				}},
+				{Height: 200, Recipients: []GrantRecipient{{Address: _addrC, Amount: oneIotx}}},
+			},
+		},
+		{
+			name:   "zero height",
+			grants: []TestnetGrant{{Height: 0, Recipients: []GrantRecipient{{Address: _addrA, Amount: oneIotx}}}},
+			errMsg: "height must be non-zero",
+		},
+		{
+			name: "heights not increasing",
+			grants: []TestnetGrant{
+				{Height: 200, Recipients: []GrantRecipient{{Address: _addrA, Amount: oneIotx}}},
+				{Height: 200, Recipients: []GrantRecipient{{Address: _addrB, Amount: oneIotx}}},
+			},
+			errMsg: "strictly increasing",
+		},
+		{
+			name:   "no recipients",
+			grants: []TestnetGrant{{Height: 100}},
+			errMsg: "has no recipients",
+		},
+		{
+			name: "duplicate recipient",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{
+				{Address: _addrA, Amount: oneIotx},
+				{Address: _addrA, Amount: oneIotx},
+			}}},
+			errMsg: "more than once",
+		},
+		{
+			name:   "bad address",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: "not-an-address", Amount: oneIotx}}}},
+			errMsg: "invalid address",
+		},
+		{
+			name:   "unparsable amount",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: "1.5"}}}},
+			errMsg: "unparsable amount",
+		},
+		{
+			name:   "zero amount",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: "0"}}}},
+			errMsg: "must be positive",
+		},
+		{
+			name:   "negative amount",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: "-1"}}}},
+			errMsg: "must be positive",
+		},
+		{
+			name:   "over the cap in one grant",
+			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: overCap}}}},
+			errMsg: "exceeds the cap",
+		},
+		{
+			name: "over the cap across grants",
+			grants: []TestnetGrant{
+				{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: _maxTestnetGrantTotal.String()}}},
+				{Height: 200, Recipients: []GrantRecipient{{Address: _addrB, Amount: oneIotx}}},
+			},
+			errMsg: "exceeds the cap",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
+			g := testnetGenesis(c.grants...)
+			err := g.ValidateTestnetGrants()
+			if c.errMsg == "" {
+				r.NoError(err)
+				return
+			}
+			r.ErrorContains(err, c.errMsg)
+		})
+	}
+}
+
+func TestGrantsAtHeight(t *testing.T) {
+	r := require.New(t)
+	g := testnetGenesis(
+		[]TestnetGrant{
+			// deliberately not in sorted address order: the configured order is
+			// the applied order, and callers must not re-sort it
+			{Height: 100, Recipients: []GrantRecipient{
+				{Address: _addrC, Amount: "3"},
+				{Address: _addrA, Amount: "1"},
+			}},
+			{Height: 200, Recipients: []GrantRecipient{{Address: _addrB, Amount: "2"}}},
+		}...,
+	)
+	r.NoError(g.ValidateTestnetGrants())
+
+	addrs, amounts, err := g.GrantsAtHeight(100)
+	r.NoError(err)
+	r.Len(addrs, 2)
+	r.Equal(_addrC, addrs[0].String())
+	r.Equal(_addrA, addrs[1].String())
+	r.Equal("3", amounts[0].String())
+	r.Equal("1", amounts[1].String())
+
+	addrs, amounts, err = g.GrantsAtHeight(200)
+	r.NoError(err)
+	r.Len(addrs, 1)
+	r.Equal(_addrB, addrs[0].String())
+	r.Equal("2", amounts[0].String())
+
+	for _, h := range []uint64{0, 1, 99, 101, 199, 201} {
+		addrs, amounts, err = g.GrantsAtHeight(h)
+		r.NoError(err)
+		r.Nil(addrs)
+		r.Nil(amounts)
+	}
+
+	// a genesis with no grants -- the case on every network but the one being
+	// recovered -- never allocates or parses anything
+	noGrants := TestDefault()
+	addrs, amounts, err = noGrants.GrantsAtHeight(100)
+	r.NoError(err)
+	r.Nil(addrs)
+	r.Nil(amounts)
+}
+
+// The whole feature is driven from a YAML file an operator edits, so the tags
+// have to actually round-trip. This also pins that a genesis file without the
+// key still loads, and that a bad one is rejected by New() rather than at the
+// activation height.
+func TestTestnetGrantsFromYAML(t *testing.T) {
+	r := require.New(t)
+	write := func(body string) string {
+		p := filepath.Join(t.TempDir(), "genesis.yaml")
+		r.NoError(os.WriteFile(p, []byte(body), 0600))
+		return p
+	}
+
+	// a testnet-shaped genesis: anything that moves it off the mainnet hash
+	// works, and a different timestamp is the smallest such change
+	const header = "blockchain:\n  timestamp: 1571036400\n"
+
+	t.Run("absent", func(t *testing.T) {
+		cfg, err := New(write(header))
+		r.NoError(err)
+		r.Empty(cfg.TestnetGrants)
+	})
+
+	t.Run("parsed", func(t *testing.T) {
+		cfg, err := New(write(header + `account:
+  testnetGrants:
+    - height: 44500000
+      recipients:
+        - address: ` + _addrA + `
+          amount: "1200100000000000000000000"
+        - address: ` + _addrB + `
+          amount: "100000000000000000000"
+`))
+		r.NoError(err)
+		r.Len(cfg.TestnetGrants, 1)
+		r.EqualValues(44500000, cfg.TestnetGrants[0].Height)
+		r.Equal([]GrantRecipient{
+			{Address: _addrA, Amount: "1200100000000000000000000"},
+			{Address: _addrB, Amount: "100000000000000000000"},
+		}, cfg.TestnetGrants[0].Recipients)
+
+		addrs, amounts, err := cfg.GrantsAtHeight(44500000)
+		r.NoError(err)
+		r.Len(addrs, 2)
+		r.Equal("1200100000000000000000000", amounts[0].String())
+	})
+
+	t.Run("invalid is rejected at load", func(t *testing.T) {
+		_, err := New(write(header + `account:
+  testnetGrants:
+    - height: 0
+      recipients:
+        - address: ` + _addrA + `
+          amount: "1"
+`))
+		r.ErrorContains(err, "height must be non-zero")
+	})
+
+	t.Run("mainnet is rejected at load", func(t *testing.T) {
+		_, err := New(write(`account:
+  testnetGrants:
+    - height: 44500000
+      recipients:
+        - address: ` + _addrA + `
+          amount: "1"
+`))
+		r.ErrorContains(err, "must not be used on mainnet")
+	})
+}
+
+// A grant must not change the genesis hash: nodes that carry the grant and
+// nodes that do not have to stay on the same p2p network, so that the ones
+// missing it fail loudly on the delta state digest at the activation height
+// rather than quietly forming a second network at startup.
+func TestTestnetGrantsDoNotChangeGenesisHash(t *testing.T) {
+	r := require.New(t)
+	plain := TestDefault()
+	withGrant := testnetGenesis(TestnetGrant{
+		Height:     100,
+		Recipients: []GrantRecipient{{Address: _addrA, Amount: "1"}},
+	})
+	r.Equal(plain.Hash(), withGrant.Hash())
+}

--- a/blockchain/genesis/testnet_grant_test.go
+++ b/blockchain/genesis/testnet_grant_test.go
@@ -7,7 +7,6 @@ package genesis
 
 import (
 	"encoding/hex"
-	"math/big"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,12 +22,10 @@ const (
 	_addrC = "io1vrl48nsdm8jaujccd9cx4ve23cskr0ys6urx92"
 )
 
-// The in-repo defaults are the mainnet genesis config -- New("") and
-// iotex-bootstrap's genesis_mainnet.yaml produce the same Hash(). That is what
-// lets _mainnetGenesisHash be pinned without shipping a copy of the mainnet
-// YAML, and it is what this test guards: if a future change to defaultConfig
-// touches a field Hash() covers, the pinned constant stops matching mainnet and
-// the guard silently stops guarding.
+// The in-repo defaults are the mainnet genesis config: New("") and
+// iotex-bootstrap's genesis_mainnet.yaml produce the same Hash(). If a change to
+// defaultConfig touches a field Hash() covers, the pinned constant stops
+// matching mainnet and the guard silently stops guarding.
 func TestMainnetGenesisHashIsPinned(t *testing.T) {
 	r := require.New(t)
 	cfg, err := New("")
@@ -49,8 +46,8 @@ func TestTestnetGrantsRejectedOnMainnet(t *testing.T) {
 		Height:     100,
 		Recipients: []GrantRecipient{{Address: _addrA, Amount: "1"}},
 	}}
-	// The grant list is not part of Hash(), so mainnet is still recognisable
-	// after the list is appended -- that is the whole point of leaving it out.
+	// still recognisable as mainnet after appending grants, which is the point
+	// of leaving them out of Hash()
 	r.True(cfg.IsMainnet())
 	r.ErrorContains(cfg.ValidateTestnetGrants(), "must not be used on mainnet")
 }
@@ -63,7 +60,6 @@ func testnetGenesis(grants ...TestnetGrant) Genesis {
 
 func TestValidateTestnetGrants(t *testing.T) {
 	oneIotx := unit.ConvertIotxToRau(1).String()
-	overCap := new(big.Int).Add(_maxTestnetGrantTotal, big.NewInt(1)).String()
 
 	for _, c := range []struct {
 		name   string
@@ -130,19 +126,6 @@ func TestValidateTestnetGrants(t *testing.T) {
 			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: "-1"}}}},
 			errMsg: "must be positive",
 		},
-		{
-			name:   "over the cap in one grant",
-			grants: []TestnetGrant{{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: overCap}}}},
-			errMsg: "exceeds the cap",
-		},
-		{
-			name: "over the cap across grants",
-			grants: []TestnetGrant{
-				{Height: 100, Recipients: []GrantRecipient{{Address: _addrA, Amount: _maxTestnetGrantTotal.String()}}},
-				{Height: 200, Recipients: []GrantRecipient{{Address: _addrB, Amount: oneIotx}}},
-			},
-			errMsg: "exceeds the cap",
-		},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			r := require.New(t)
@@ -161,8 +144,7 @@ func TestGrantsAtHeight(t *testing.T) {
 	r := require.New(t)
 	g := testnetGenesis(
 		[]TestnetGrant{
-			// deliberately not in sorted address order: the configured order is
-			// the applied order, and callers must not re-sort it
+			// not in sorted address order: configured order is applied order
 			{Height: 100, Recipients: []GrantRecipient{
 				{Address: _addrC, Amount: "3"},
 				{Address: _addrA, Amount: "1"},
@@ -193,8 +175,6 @@ func TestGrantsAtHeight(t *testing.T) {
 		r.Nil(amounts)
 	}
 
-	// a genesis with no grants -- the case on every network but the one being
-	// recovered -- never allocates or parses anything
 	noGrants := TestDefault()
 	addrs, amounts, err = noGrants.GrantsAtHeight(100)
 	r.NoError(err)
@@ -202,9 +182,8 @@ func TestGrantsAtHeight(t *testing.T) {
 	r.Nil(amounts)
 }
 
-// The whole feature is driven from a YAML file an operator edits, so the tags
-// have to actually round-trip. This also pins that a genesis file without the
-// key still loads, and that a bad one is rejected by New() rather than at the
+// The feature is driven from a YAML file an operator edits, so the tags have to
+// round-trip, and a bad file has to be rejected by New() rather than at the
 // activation height.
 func TestTestnetGrantsFromYAML(t *testing.T) {
 	r := require.New(t)
@@ -214,8 +193,8 @@ func TestTestnetGrantsFromYAML(t *testing.T) {
 		return p
 	}
 
-	// a testnet-shaped genesis: anything that moves it off the mainnet hash
-	// works, and a different timestamp is the smallest such change
+	// a different timestamp is the smallest change that moves a config off the
+	// mainnet hash
 	const header = "blockchain:\n  timestamp: 1571036400\n"
 
 	t.Run("absent", func(t *testing.T) {
@@ -271,9 +250,8 @@ func TestTestnetGrantsFromYAML(t *testing.T) {
 	})
 }
 
-// A grant must not change the genesis hash: nodes that carry the grant and
-// nodes that do not have to stay on the same p2p network, so that the ones
-// missing it fail loudly on the delta state digest at the activation height
+// Nodes with and without the grant must stay on the same p2p network, so the
+// ones missing it fail loudly on the delta state digest at the activation height
 // rather than quietly forming a second network at startup.
 func TestTestnetGrantsDoNotChangeGenesisHash(t *testing.T) {
 	r := require.New(t)

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -923,7 +923,50 @@ func (builder *Builder) buildConsensusComponent() error {
 	return nil
 }
 
+// Mainnet's chain ID and EVM network ID. They back the second of the two gates
+// on genesis.TestnetGrants; the first is the mainnet genesis hash check inside
+// genesis.ValidateTestnetGrants. This one catches the case that one misses: a
+// config derived from mainnet's but with a hashed field edited, which no longer
+// matches the mainnet genesis hash but is still pointed at mainnet.
+const (
+	_mainnetChainID      uint32 = 1
+	_mainnetEVMNetworkID uint32 = 4689
+)
+
+// checkTestnetGrants re-validates any scheduled balance grant at node build
+// time and refuses to run one on mainnet.
+//
+// genesis.New() already validates on the YAML path, but a Genesis built as a
+// literal never goes through it -- server/main.go assigns cfg.Genesis after
+// config.New has run its validators, and tests build one directly. This is the
+// choke point every node passes through.
+func (builder *Builder) checkTestnetGrants() error {
+	g := builder.cfg.Genesis
+	if len(g.TestnetGrants) == 0 {
+		return nil
+	}
+	if err := g.ValidateTestnetGrants(); err != nil {
+		return err
+	}
+	if builder.cfg.Chain.ID == _mainnetChainID || builder.cfg.Chain.EVMNetworkID == _mainnetEVMNetworkID {
+		return errors.Errorf(
+			"genesis testnetGrants must not be used on mainnet (chain ID %d, EVM network ID %d)",
+			builder.cfg.Chain.ID, builder.cfg.Chain.EVMNetworkID,
+		)
+	}
+	for _, grant := range g.TestnetGrants {
+		log.L().Warn("testnet balance grant is scheduled",
+			zap.Uint64("height", grant.Height),
+			zap.Int("recipients", len(grant.Recipients)),
+		)
+	}
+	return nil
+}
+
 func (builder *Builder) build(forSubChain, forTest bool) (*ChainService, error) {
+	if err := builder.checkTestnetGrants(); err != nil {
+		return nil, err
+	}
 	builder.cs.registry = protocol.NewRegistry()
 	if builder.cs.p2pAgent == nil {
 		builder.cs.p2pAgent = p2p.NewDummyAgent()

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -923,23 +923,19 @@ func (builder *Builder) buildConsensusComponent() error {
 	return nil
 }
 
-// Mainnet's chain ID and EVM network ID. They back the second of the two gates
-// on genesis.TestnetGrants; the first is the mainnet genesis hash check inside
-// genesis.ValidateTestnetGrants. This one catches the case that one misses: a
-// config derived from mainnet's but with a hashed field edited, which no longer
-// matches the mainnet genesis hash but is still pointed at mainnet.
 const (
 	_mainnetChainID      uint32 = 1
 	_mainnetEVMNetworkID uint32 = 4689
 )
 
-// checkTestnetGrants re-validates any scheduled balance grant at node build
-// time and refuses to run one on mainnet.
+// checkTestnetGrants is the second gate on genesis.TestnetGrants, after the
+// mainnet genesis hash check in ValidateTestnetGrants. It catches what that one
+// misses: a config derived from mainnet's with a hashed field edited, so the
+// hash no longer matches but the node still points at mainnet.
 //
-// genesis.New() already validates on the YAML path, but a Genesis built as a
-// literal never goes through it -- server/main.go assigns cfg.Genesis after
-// config.New has run its validators, and tests build one directly. This is the
-// choke point every node passes through.
+// It also re-runs ValidateTestnetGrants, because a Genesis built as a literal
+// never reaches genesis.New() -- server/main.go assigns cfg.Genesis after
+// config.New has run its validators.
 func (builder *Builder) checkTestnetGrants() error {
 	g := builder.cfg.Genesis
 	if len(g.TestnetGrants) == 0 {

--- a/chainservice/testnet_grant_test.go
+++ b/chainservice/testnet_grant_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package chainservice
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+)
+
+func TestCheckTestnetGrants(t *testing.T) {
+	grants := []genesis.TestnetGrant{{
+		Height:     100,
+		Recipients: []genesis.GrantRecipient{{Address: identityset.Address(1).String(), Amount: "1"}},
+	}}
+
+	for _, c := range []struct {
+		name         string
+		chainID      uint32
+		evmNetworkID uint32
+		grants       []genesis.TestnetGrant
+		mainnetCfg   bool
+		errMsg       string
+	}{
+		{
+			name:         "no grants on mainnet ids",
+			chainID:      1,
+			evmNetworkID: 4689,
+		},
+		{
+			name:         "grants on testnet ids",
+			chainID:      2,
+			evmNetworkID: 4690,
+			grants:       grants,
+		},
+		{
+			name:         "grants on mainnet chain id",
+			chainID:      1,
+			evmNetworkID: 4690,
+			grants:       grants,
+			errMsg:       "must not be used on mainnet",
+		},
+		{
+			name:         "grants on mainnet evm network id",
+			chainID:      2,
+			evmNetworkID: 4689,
+			grants:       grants,
+			errMsg:       "must not be used on mainnet",
+		},
+		{
+			// Genesis built as a literal never passes through genesis.New's
+			// validate(), so the build-time check has to re-run it.
+			name:         "invalid grant on testnet ids",
+			chainID:      2,
+			evmNetworkID: 4690,
+			grants: []genesis.TestnetGrant{{
+				Height:     0,
+				Recipients: []genesis.GrantRecipient{{Address: identityset.Address(1).String(), Amount: "1"}},
+			}},
+			errMsg: "height must be non-zero",
+		},
+		{
+			// Even with testnet IDs, the mainnet genesis config itself is
+			// refused -- this is the gate that catches a mainnet genesis file
+			// deployed with a doctored node config.
+			name:         "mainnet genesis with testnet ids",
+			chainID:      2,
+			evmNetworkID: 4690,
+			grants:       grants,
+			mainnetCfg:   true,
+			errMsg:       "must not be used on mainnet",
+		},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			r := require.New(t)
+			cfg := config.Default
+			cfg.Chain.ID = c.chainID
+			cfg.Chain.EVMNetworkID = c.evmNetworkID
+			if c.mainnetCfg {
+				mainnet, err := genesis.New("")
+				r.NoError(err)
+				r.True(mainnet.IsMainnet())
+				cfg.Genesis = mainnet
+			} else {
+				cfg.Genesis = genesis.TestDefault()
+			}
+			cfg.Genesis.Account.TestnetGrants = c.grants
+
+			err := (&Builder{cfg: cfg}).checkTestnetGrants()
+			if c.errMsg == "" {
+				r.NoError(err)
+				return
+			}
+			r.ErrorContains(err, c.errMsg)
+		})
+	}
+}

--- a/chainservice/testnet_grant_test.go
+++ b/chainservice/testnet_grant_test.go
@@ -55,8 +55,7 @@ func TestCheckTestnetGrants(t *testing.T) {
 			errMsg:       "must not be used on mainnet",
 		},
 		{
-			// Genesis built as a literal never passes through genesis.New's
-			// validate(), so the build-time check has to re-run it.
+			// a Genesis literal never reaches genesis.New's validate()
 			name:         "invalid grant on testnet ids",
 			chainID:      2,
 			evmNetworkID: 4690,
@@ -67,9 +66,7 @@ func TestCheckTestnetGrants(t *testing.T) {
 			errMsg: "height must be non-zero",
 		},
 		{
-			// Even with testnet IDs, the mainnet genesis config itself is
-			// refused -- this is the gate that catches a mainnet genesis file
-			// deployed with a doctored node config.
+			// mainnet genesis is refused even under a doctored node config
 			name:         "mainnet genesis with testnet ids",
 			chainID:      2,
 			evmNetworkID: 4690,

--- a/e2etest/testnet_grant_test.go
+++ b/e2etest/testnet_grant_test.go
@@ -1,0 +1,171 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package e2etest
+
+import (
+	"context"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+// TestTestnetGrant runs a scheduled balance grant on a live chain across two
+// nodes: one mints the blocks, the other independently validates and commits
+// them. The second node is the point of the test -- it recomputes the delta
+// state digest from its own working set, so if the grant did not reproduce
+// identically there, ValidateBlock would fail with ErrDeltaStateMismatch
+// instead of the balances lining up.
+func TestTestnetGrant(t *testing.T) {
+	var (
+		sender   = identityset.Address(10)
+		senderSK = identityset.PrivateKey(10)
+		// an address with no genesis balance, and no role in the genesis
+		// delegate set -- what a replacement delegate owner key looks like
+		fresh = mustNoErr(address.FromHex("0x00000000000000000000000000000000000c0ffe"))
+		// an address that already holds a genesis balance, to prove the grant
+		// adds rather than overwrites
+		funded      = identityset.Address(1)
+		fundedInit  = unit.ConvertIotxToRau(100000000)
+		grantHeight = uint64(3)
+		freshGrant  = unit.ConvertIotxToRau(1200100) // min self-stake plus the registration fee
+		fundedGrant = unit.ConvertIotxToRau(5)
+		gasLimit    = uint64(1000000)
+	)
+
+	newCfg := func(r *require.Assertions, withGrant bool) config.Config {
+		cfg := initCfg(r)
+		// A grant is refused on mainnet's chain ID and EVM network ID, so a
+		// test that schedules one has to declare a testnet identity.
+		cfg.Chain.ID = 2
+		cfg.Chain.EVMNetworkID = 4690
+		cfg.Network.Port = testutil.RandomPort()
+		cfg.API.GRPCPort = testutil.RandomPort()
+		cfg.API.HTTPPort = testutil.RandomPort()
+		cfg.API.WebSocketPort = 0
+		cfg.Genesis.InitBalanceMap[sender.String()] = unit.ConvertIotxToRau(10000).String()
+		cfg.Genesis.InitBalanceMap[funded.String()] = fundedInit.String()
+		if withGrant {
+			cfg.Genesis.Account.TestnetGrants = []genesis.TestnetGrant{{
+				Height: grantHeight,
+				Recipients: []genesis.GrantRecipient{
+					{Address: fresh.String(), Amount: freshGrant.String()},
+					{Address: funded.String(), Amount: fundedGrant.String()},
+				},
+			}}
+		}
+		return cfg
+	}
+
+	// a plain self-transfer per block, purely to have something to mint
+	newTransfer := func(chainID uint32, nonce uint64) *actionWithTime {
+		tx := action.NewLegacyTx(chainID, nonce, gasLimit, big.NewInt(unit.Qev))
+		elp := action.NewEnvelope(tx, action.NewTransfer(big.NewInt(1), sender.String(), nil))
+		return &actionWithTime{mustNoErr(action.Sign(elp, senderSK)), time.Now()}
+	}
+
+	t.Run("both nodes carry the grant", func(t *testing.T) {
+		r := require.New(t)
+		cfgA, cfgB := newCfg(r, true), newCfg(r, true)
+		// the two nodes differ only in their local paths and ports -- the
+		// genesis, including the grant, has to be identical to agree
+		r.Equal(cfgA.Genesis.Hash(), cfgB.Genesis.Hash())
+
+		producer := newE2ETest(t, cfgA)
+		defer producer.teardown()
+		validator := newE2ETest(t, cfgB)
+		defer validator.teardown()
+
+		var (
+			ctx              = context.Background()
+			bcA              = producer.cs.Blockchain()
+			apA              = producer.cs.ActionPool()
+			bcB              = validator.cs.Blockchain()
+			balanceA         = balanceReader(r, producer.cs.StateFactory(), cfgA.Genesis)
+			balanceB         = balanceReader(r, validator.cs.StateFactory(), cfgB.Genesis)
+			fundedAfterGrant = new(big.Int).Add(fundedInit, fundedGrant).String()
+		)
+
+		for h := uint64(1); h <= 5; h++ {
+			tx := newTransfer(cfgA.Chain.ID, producer.nonceMgr.pop(sender.String()))
+			_, _, blk, err := addOneTx(ctx, apA, bcA, tx)
+			r.NoErrorf(err, "failed to mint block %d", h)
+			r.Equal(h, blk.Height())
+
+			// the second node reproduces the block from scratch; ValidateBlock
+			// is what compares its own digest against the one in the header
+			r.NoErrorf(bcB.ValidateBlock(blk), "node B failed to validate block %d", h)
+			r.NoErrorf(bcB.CommitBlock(blk), "node B failed to commit block %d", h)
+
+			wantFresh, wantFunded := "0", fundedInit.String()
+			if h >= grantHeight {
+				wantFresh, wantFunded = freshGrant.String(), fundedAfterGrant
+			}
+			for _, b := range []func(address.Address) string{balanceA, balanceB} {
+				r.Equalf(wantFresh, b(fresh), "unexpected fresh balance at height %d", h)
+				r.Equalf(wantFunded, b(funded), "unexpected funded balance at height %d", h)
+			}
+		}
+	})
+
+	// The operational failure mode, pinned so it stays the loud one. A node
+	// that did not get the updated genesis file stays on the same p2p network
+	// -- the grant is not part of the genesis hash -- and follows the chain
+	// normally right up to the activation height, where its own digest no
+	// longer matches the block header and it stops. It does not silently fork.
+	t.Run("node missing the grant rejects the block", func(t *testing.T) {
+		r := require.New(t)
+		cfgA, cfgB := newCfg(r, true), newCfg(r, false)
+		r.Equal(cfgA.Genesis.Hash(), cfgB.Genesis.Hash())
+
+		producer := newE2ETest(t, cfgA)
+		defer producer.teardown()
+		stale := newE2ETest(t, cfgB)
+		defer stale.teardown()
+
+		var (
+			ctx = context.Background()
+			bcA = producer.cs.Blockchain()
+			apA = producer.cs.ActionPool()
+			bcB = stale.cs.Blockchain()
+		)
+
+		for h := uint64(1); h <= grantHeight; h++ {
+			tx := newTransfer(cfgA.Chain.ID, producer.nonceMgr.pop(sender.String()))
+			_, _, blk, err := addOneTx(ctx, apA, bcA, tx)
+			r.NoErrorf(err, "failed to mint block %d", h)
+
+			err = bcB.ValidateBlock(blk)
+			if h < grantHeight {
+				r.NoErrorf(err, "stale node should still follow block %d", h)
+				r.NoError(bcB.CommitBlock(blk))
+				continue
+			}
+			r.ErrorIs(err, block.ErrDeltaStateMismatch)
+		}
+	})
+}
+
+func balanceReader(r *require.Assertions, sf factory.Factory, g genesis.Genesis) func(address.Address) string {
+	ctx := genesis.WithGenesisContext(context.Background(), g)
+	return func(addr address.Address) string {
+		acct, err := accountutil.AccountState(ctx, sf, addr)
+		r.NoError(err)
+		return acct.Balance.String()
+	}
+}

--- a/e2etest/testnet_grant_test.go
+++ b/e2etest/testnet_grant_test.go
@@ -11,7 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/v2/action"
@@ -34,9 +36,11 @@ func TestTestnetGrant(t *testing.T) {
 	var (
 		sender   = identityset.Address(10)
 		senderSK = identityset.PrivateKey(10)
-		// no genesis balance, no role in the genesis delegate set -- what a
-		// replacement delegate owner key looks like
-		fresh = mustNoErr(address.FromHex("0x00000000000000000000000000000000000c0ffe"))
+		// index 25 is outside the genesis delegate set (NumDelegates is 24) and
+		// its init balance is dropped below, so it does not exist until the
+		// grant creates it -- what a replacement delegate owner key looks like
+		fresh   = identityset.Address(25)
+		freshSK = identityset.PrivateKey(25)
 		// already holds a genesis balance, to prove the grant adds to it
 		funded      = identityset.Address(1)
 		fundedInit  = unit.ConvertIotxToRau(100000000)
@@ -57,6 +61,7 @@ func TestTestnetGrant(t *testing.T) {
 		cfg.API.WebSocketPort = 0
 		cfg.Genesis.InitBalanceMap[sender.String()] = unit.ConvertIotxToRau(10000).String()
 		cfg.Genesis.InitBalanceMap[funded.String()] = fundedInit.String()
+		delete(cfg.Genesis.InitBalanceMap, fresh.String())
 		if withGrant {
 			cfg.Genesis.Account.TestnetGrants = []genesis.TestnetGrant{{
 				Height: grantHeight,
@@ -69,11 +74,14 @@ func TestTestnetGrant(t *testing.T) {
 		return cfg
 	}
 
+	newTransferFrom := func(chainID uint32, nonce uint64, sk crypto.PrivateKey, to address.Address) *actionWithTime {
+		tx := action.NewLegacyTx(chainID, nonce, gasLimit, big.NewInt(unit.Qev))
+		elp := action.NewEnvelope(tx, action.NewTransfer(big.NewInt(1), to.String(), nil))
+		return &actionWithTime{mustNoErr(action.Sign(elp, sk)), time.Now()}
+	}
 	// purely to have something to mint
 	newTransfer := func(chainID uint32, nonce uint64) *actionWithTime {
-		tx := action.NewLegacyTx(chainID, nonce, gasLimit, big.NewInt(unit.Qev))
-		elp := action.NewEnvelope(tx, action.NewTransfer(big.NewInt(1), sender.String(), nil))
-		return &actionWithTime{mustNoErr(action.Sign(elp, senderSK)), time.Now()}
+		return newTransferFrom(chainID, nonce, senderSK, sender)
 	}
 
 	t.Run("both nodes carry the grant", func(t *testing.T) {
@@ -116,6 +124,17 @@ func TestTestnetGrant(t *testing.T) {
 				r.Equalf(wantFunded, b(funded), "unexpected funded balance at height %d", h)
 			}
 		}
+
+		// The granted account has to be able to spend, or the grant is useless:
+		// a replacement delegate owner's first act is CandidateRegister. Note
+		// this runs at a pre-Okhotsk height under TestDefault, so it also covers
+		// the account type the grant creates being usable there.
+		spend := newTransferFrom(cfgA.Chain.ID, 0, freshSK, sender)
+		_, receipt, blk, err := addOneTx(ctx, apA, bcA, spend)
+		r.NoError(err)
+		r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+		r.NoError(bcB.ValidateBlock(blk))
+		r.NoError(bcB.CommitBlock(blk))
 	})
 
 	// The operational failure mode, pinned so it stays the loud one: a node that

--- a/e2etest/testnet_grant_test.go
+++ b/e2etest/testnet_grant_test.go
@@ -25,21 +25,19 @@ import (
 	"github.com/iotexproject/iotex-core/v2/testutil"
 )
 
-// TestTestnetGrant runs a scheduled balance grant on a live chain across two
-// nodes: one mints the blocks, the other independently validates and commits
-// them. The second node is the point of the test -- it recomputes the delta
-// state digest from its own working set, so if the grant did not reproduce
-// identically there, ValidateBlock would fail with ErrDeltaStateMismatch
-// instead of the balances lining up.
+// TestTestnetGrant runs a grant across two nodes: one mints, the other
+// independently validates and commits. The second node is the point of the test
+// -- it recomputes the delta state digest from its own working set, so a grant
+// that did not reproduce identically there fails ValidateBlock rather than
+// quietly producing different balances.
 func TestTestnetGrant(t *testing.T) {
 	var (
 		sender   = identityset.Address(10)
 		senderSK = identityset.PrivateKey(10)
-		// an address with no genesis balance, and no role in the genesis
-		// delegate set -- what a replacement delegate owner key looks like
+		// no genesis balance, no role in the genesis delegate set -- what a
+		// replacement delegate owner key looks like
 		fresh = mustNoErr(address.FromHex("0x00000000000000000000000000000000000c0ffe"))
-		// an address that already holds a genesis balance, to prove the grant
-		// adds rather than overwrites
+		// already holds a genesis balance, to prove the grant adds to it
 		funded      = identityset.Address(1)
 		fundedInit  = unit.ConvertIotxToRau(100000000)
 		grantHeight = uint64(3)
@@ -50,8 +48,7 @@ func TestTestnetGrant(t *testing.T) {
 
 	newCfg := func(r *require.Assertions, withGrant bool) config.Config {
 		cfg := initCfg(r)
-		// A grant is refused on mainnet's chain ID and EVM network ID, so a
-		// test that schedules one has to declare a testnet identity.
+		// a grant is refused on mainnet's chain ID and EVM network ID
 		cfg.Chain.ID = 2
 		cfg.Chain.EVMNetworkID = 4690
 		cfg.Network.Port = testutil.RandomPort()
@@ -72,7 +69,7 @@ func TestTestnetGrant(t *testing.T) {
 		return cfg
 	}
 
-	// a plain self-transfer per block, purely to have something to mint
+	// purely to have something to mint
 	newTransfer := func(chainID uint32, nonce uint64) *actionWithTime {
 		tx := action.NewLegacyTx(chainID, nonce, gasLimit, big.NewInt(unit.Qev))
 		elp := action.NewEnvelope(tx, action.NewTransfer(big.NewInt(1), sender.String(), nil))
@@ -82,8 +79,6 @@ func TestTestnetGrant(t *testing.T) {
 	t.Run("both nodes carry the grant", func(t *testing.T) {
 		r := require.New(t)
 		cfgA, cfgB := newCfg(r, true), newCfg(r, true)
-		// the two nodes differ only in their local paths and ports -- the
-		// genesis, including the grant, has to be identical to agree
 		r.Equal(cfgA.Genesis.Hash(), cfgB.Genesis.Hash())
 
 		producer := newE2ETest(t, cfgA)
@@ -107,8 +102,8 @@ func TestTestnetGrant(t *testing.T) {
 			r.NoErrorf(err, "failed to mint block %d", h)
 			r.Equal(h, blk.Height())
 
-			// the second node reproduces the block from scratch; ValidateBlock
-			// is what compares its own digest against the one in the header
+			// node B reproduces the block from scratch and compares its own
+			// digest against the one in the header
 			r.NoErrorf(bcB.ValidateBlock(blk), "node B failed to validate block %d", h)
 			r.NoErrorf(bcB.CommitBlock(blk), "node B failed to commit block %d", h)
 
@@ -123,11 +118,9 @@ func TestTestnetGrant(t *testing.T) {
 		}
 	})
 
-	// The operational failure mode, pinned so it stays the loud one. A node
-	// that did not get the updated genesis file stays on the same p2p network
-	// -- the grant is not part of the genesis hash -- and follows the chain
-	// normally right up to the activation height, where its own digest no
-	// longer matches the block header and it stops. It does not silently fork.
+	// The operational failure mode, pinned so it stays the loud one: a node that
+	// missed the genesis update stays on the same p2p network, follows the chain
+	// normally, then stops at the activation height. It does not silently fork.
 	t.Run("node missing the grant rejects the block", func(t *testing.T) {
 		r := require.New(t)
 		cfgA, cfgB := newCfg(r, true), newCfg(r, false)


### PR DESCRIPTION
## Problem

A test network that has lost the owner keys of its delegate set cannot recover on its own. The old delegates' stake is unreachable — every path that could move it (`CandidateUpdate`, `CandidateTransferOwnership`, unstake, `CandidateActivate`) requires an owner signature — and no remaining account holds enough balance to register replacements. Registering a full 24-delegate set needs roughly 28.8M IOTX of self-stake.

Neither existing mechanism helps:

- **`genesis.initBalances`** runs only at height 0 (`account.Protocol.CreateGenesisStates` asserts it, and `createAccount` rejects addresses that already exist). Changing it changes the genesis state *and* `Genesis.Hash()`, which is the p2p network identity — that is starting a new chain, not continuing one.
- **The staking patch store** (`stakingPatchDir/{height}.patch`) only feeds the candidate name/operator/owner maps into the in-memory view at `Protocol.Start()`, on the legacy pre-Greenland path where `candsMap` is not in the state DB. It writes no state and touches no balances.

`chain.trieDBPatchFile` *can* do it — it PUTs arbitrary bytes into the `Account` namespace at a given height — but it writes past the state manager (so the Erigon secondary store never sees it, and archive nodes diverge), it overwrites the whole account object rather than adding to it, and it is an out-of-band file every operator has to place by hand.

## What this adds

`genesis.Account.TestnetGrants`: a list of `{height, recipients}` applied by a new `account.Protocol.CreatePreStates`, before any action in that block.

```yaml
account:
  testnetGrants:
    - height: 44500000
      recipients:
        - address: io1...
          amount: "1200100000000000000000000"   # Rau
        - address: io1...
          amount: "1200100000000000000000000"
```

Credits go through the state manager (`LoadOrCreateAccount` → `AddBalance` → `StoreAccount`), so they reach the Erigon secondary store as well as the trie, and they **add** to an existing account rather than overwriting it — nonce and prior balance are preserved. Delegate registration then proceeds through the ordinary `CandidateRegister` path with real keys, real receipts and real transaction logs.

`Recipients` is a list rather than a map because the apply order is part of consensus.

## Mainnet is gated twice

1. **Genesis hash.** `ValidateTestnetGrants` refuses a config whose `Hash()` equals the pinned mainnet genesis hash. The grant list is *deliberately* kept out of the fields `Hash()` covers — that is what makes the gate work, because a mainnet genesis file still hashes to that value after grants are appended to it and is still recognised. Putting grants into the hashed set would let a doctored mainnet file hash to something else and slip past. `TestMainnetGenesisHashIsPinned` asserts `New("")` still hashes to the constant, so the gate cannot silently stop guarding.
2. **Chain ID.** `chainservice` refuses to build a node whose chain ID is `1` or whose EVM network ID is `4689`. This catches what the first gate misses: a config derived from mainnet's with a hashed field edited.

The build-time check re-runs the genesis validation, because a `Genesis` built as a literal never reaches `genesis.New()` — `server/main.go` assigns `cfg.Genesis` *after* `config.New` has run its validators.

`ValidateTestnetGrants` also rejects height 0, non-increasing heights, empty recipient lists, duplicate addresses, and unparsable or non-positive amounts.

There is no cap on the amount. An earlier revision had one at 1e9 IOTX; it was removed as an invented policy number that bought nothing — a grant lands through a coordinated hard fork with a reviewed genesis file, and a wrong-but-under-cap amount is just as bad as one over it. What is left is the amount's **value domain**, which is not a policy question: the Erigon secondary store holds balance as a uint256 and writes it with `uint256.MustFromBig`, which *panics* past 2^256. Nothing guarded that before, because every other path that moves balance conserves supply, so no account could approach the bound — a grant mints, so it is the first way a configured number can cross it, and a panic in the account write takes down every node at the activation height rather than rejecting one block. So:

- `ValidateTestnetGrants` rejects an amount wider than 256 bits — a startup error.
- `CreatePreStates` rejects a credit whose *resulting* balance is over the bound. The balance a grant lands on is only known at the activation height, so config validation cannot see this case; here it degrades to a rejected block instead of a crash.

Guarding against a wrong-but-representable amount is left to review of the genesis file, which is where it belongs.

## Rollout is a hard fork

A grant is part of the delta state digest, so every node needs the same genesis file before the activation height. Keeping the grant out of the genesis hash is what makes the failure **loud rather than silent**: a node that missed the update stays on the same p2p network, follows the chain normally, and then stops at the activation height with `ErrDeltaStateMismatch`. It does not fork quietly. `TestTestnetGrant/node_missing_the_grant_rejects_the_block` pins exactly that.

## Known limitation

There is no transaction log — nothing spends, so there is no sender to record. Indexers that derive balances from transfer logs alone will not see the credit. This is noted in the code and is the one externally visible cost of the mechanism.

## Tests

- `blockchain/genesis/testnet_grant_test.go` — pinned mainnet hash, mainnet refusal, 12 validation cases, configured order preserved, **YAML round-trip** (the tags actually parse, and a bad file is rejected at `New()` rather than at the activation height), and that grants do not change the genesis hash.
- `action/protocol/account/testnet_grant_test.go` — fresh account, existing account (balance added, nonce preserved), no-op at non-grant heights, malformed config returns an error instead of panicking mid-block, a credit that overflows the balance bound is rejected while one landing exactly on it is not, and that the protocol is actually picked up as a `PreStatesCreator`.
- `chainservice/testnet_grant_test.go` — the two gates across 6 combinations.
- `e2etest/testnet_grant_test.go` — **two nodes**. One mints, the other independently `ValidateBlock`s and commits, recomputing the delta state digest from its own working set. Plus the divergence case above, and that a recipient can spend the credited balance in a later block.

Verified the e2e test is load-bearing: stubbing `CreatePreStates` to a no-op makes it fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

