### PR TITLE
fix(blockchain): validate header gas fields against receipts

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -464,9 +464,10 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixEpochSettlementFaultHandling:  g.IsZanzibarBeta(height),
 			RequireProfileForHermesMigration: g.IsZanzibarBeta(height),
 			EmitEraFreezeLog:                 g.IsZanzibarBeta(height),
-			// Same batch: a correction that did not exist in rc0, so it rides
-			// Beta for the same reason the three above do.
-			ValidateHeaderGasUsed: g.IsZanzibarBeta(height),
+			// Zanzibar Gamma: found after Beta was scheduled, so folding it into
+			// Beta would rewrite blocks a chain that activated Beta has
+			// already committed.
+			ValidateHeaderGasUsed: g.IsZanzibarGamma(height),
 		},
 	)
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -260,6 +260,22 @@ type (
 		// An update that omits both leaves any previously registered key
 		// untouched.
 		OptionalCandidateBLSPublicKey bool
+		// ValidateHeaderGasUsed makes a validating node recompute the header's
+		// gasUsed and blobGasUsed from the receipts it produced while executing
+		// the block, and reject the block when either disagrees with the value
+		// the proposer put in the header.
+		//
+		// The proposer fills both fields from its own receipts (see
+		// workingSet.CreateBuilder), but until now nothing on the validating
+		// side re-derived them, so the two header fields were accepted as
+		// given. gasUsed feeds the EIP-1559 base fee of the next block and
+		// blobGasUsed feeds its excessBlobGas, and both are served over the
+		// API, so they need to agree with the executed block.
+		//
+		// Needs its own height: a chain that has already committed blocks whose
+		// header gas fields do not match their receipts must keep accepting
+		// them on replay, so the check may only start at a fork boundary.
+		ValidateHeaderGasUsed bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -448,6 +464,9 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixEpochSettlementFaultHandling:  g.IsZanzibarBeta(height),
 			RequireProfileForHermesMigration: g.IsZanzibarBeta(height),
 			EmitEraFreezeLog:                 g.IsZanzibarBeta(height),
+			// Same batch: a correction that did not exist in rc0, so it rides
+			// Beta for the same reason the three above do.
+			ValidateHeaderGasUsed: g.IsZanzibarBeta(height),
 		},
 	)
 }

--- a/blockchain/block/header.go
+++ b/blockchain/block/header.go
@@ -48,6 +48,8 @@ var (
 	ErrTxRootMismatch      = errors.New("transaction merkle root does not match")
 	ErrDeltaStateMismatch  = errors.New("delta state digest doesn't match")
 	ErrReceiptRootMismatch = errors.New("receipt root hash does not match")
+	ErrGasUsedMismatch     = errors.New("gas used does not match")
+	ErrBlobGasUsedMismatch = errors.New("blob gas used does not match")
 )
 
 // Version returns the version of this block.
@@ -238,6 +240,16 @@ func (h *Header) VerifyReceiptRoot(root hash.Hash256) bool {
 // VerifyTransactionRoot verifies the delta state digest in header
 func (h *Header) VerifyTransactionRoot(root hash.Hash256) bool {
 	return h.txRoot == root
+}
+
+// VerifyGasUsed verifies the gas used in header
+func (h *Header) VerifyGasUsed(gasUsed uint64) bool {
+	return h.gasUsed == gasUsed
+}
+
+// VerifyBlobGasUsed verifies the blob gas used in header
+func (h *Header) VerifyBlobGasUsed(blobGasUsed uint64) bool {
+	return h.blobGasUsed == blobGasUsed
 }
 
 // ProducerAddress returns the address of producer

--- a/blockchain/block/header_test.go
+++ b/blockchain/block/header_test.go
@@ -88,3 +88,39 @@ func isEqual(expected string, hash hash.Hash256) bool {
 	h := fmt.Sprintf("%x", hash[:])
 	return strings.EqualFold(expected, h)
 }
+
+// TestHeaderVerifyGasUsed covers the two header comparisons a validating node
+// makes against the gas figures it re-derived from the receipts it produced.
+func TestHeaderVerifyGasUsed(t *testing.T) {
+	require := require.New(t)
+
+	t.Run("gas used", func(t *testing.T) {
+		h := getHeader(true)
+		require.EqualValues(189000, h.gasUsed, "fixture must carry a non-zero value")
+		require.True(h.VerifyGasUsed(189000))
+		require.False(h.VerifyGasUsed(188999))
+		require.False(h.VerifyGasUsed(189001))
+		require.False(h.VerifyGasUsed(0), "a zero recomputation must not pass a non-zero header")
+	})
+
+	t.Run("blob gas used", func(t *testing.T) {
+		h := getHeader(true)
+		h.blobGasUsed = 262144
+		require.True(h.VerifyBlobGasUsed(262144))
+		require.False(h.VerifyBlobGasUsed(262143))
+		require.False(h.VerifyBlobGasUsed(524288))
+		require.False(h.VerifyBlobGasUsed(0))
+	})
+
+	t.Run("unset fields verify as zero", func(t *testing.T) {
+		// The proposer only writes these under their own feature gates, so a
+		// header that never carried them has to agree with a zero recompute.
+		h := getHeader(false)
+		require.Zero(h.gasUsed)
+		require.Zero(h.blobGasUsed)
+		require.True(h.VerifyGasUsed(0))
+		require.True(h.VerifyBlobGasUsed(0))
+		require.False(h.VerifyGasUsed(1))
+		require.False(h.VerifyBlobGasUsed(1))
+	})
+}

--- a/e2etest/header_gas_test.go
+++ b/e2etest/header_gas_test.go
@@ -1,0 +1,166 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided as is and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package e2etest
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+
+	"github.com/iotexproject/go-pkgs/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/execution"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/poll"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
+	"github.com/iotexproject/iotex-core/v2/actpool"
+	"github.com/iotexproject/iotex-core/v2/blockchain"
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/blockdao"
+	"github.com/iotexproject/iotex-core/v2/blockchain/filedao"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/config"
+	"github.com/iotexproject/iotex-core/v2/db"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+// TestHeaderGasFieldsThroughBlockchainValidate drives the header gas check
+// through blockchain.ValidateBlock, the entry point a node actually uses for a
+// block it received, rather than through the state factory directly. It is the
+// end of the chain the mismatch has to travel: workingSet.ValidateBlock ->
+// stateDB.Validate -> block.Validator -> blockchain.ValidateBlock.
+func TestHeaderGasFieldsThroughBlockchainValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		gateHeight uint64
+		wantErr    error
+	}{
+		{"pre-fork mismatch accepted", math.MaxUint64, nil},
+		{"post-fork mismatch rejected", 1, block.ErrGasUsedMismatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			bc, ap, producerKey, cfg := newHeaderGasChain(t, tc.gateHeight)
+
+			sender := identityset.Address(28)
+			tsf := action.NewTransfer(big.NewInt(1), identityset.Address(29).String(), nil)
+			elp := (&action.EnvelopeBuilder{}).
+				SetAction(tsf).
+				SetNonce(0).
+				SetGasLimit(100000).
+				SetGasPrice(big.NewInt(action.InitialBaseFee)).
+				SetChainID(cfg.Chain.ID).
+				SetVersion(1).
+				Build()
+			selp, err := action.Sign(elp, identityset.PrivateKey(28))
+			r.NoError(err)
+			r.NoError(ap.Add(context.Background(), selp))
+			r.NotNil(sender)
+
+			blk, err := bc.MintNewBlock(testutil.TimestampNow())
+			r.NoError(err)
+			minted := false
+			for _, act := range blk.Actions {
+				if _, ok := act.Action().(*action.Transfer); ok {
+					minted = true
+				}
+			}
+			r.True(minted, "the transfer must have been minted into the block")
+			r.NotZero(blk.GasUsed(), "the mismatch below has to be distinguishable from a zero value")
+
+			// The untampered block is the control: whatever else the validator
+			// checks, it has to pass before a gas-field verdict means anything.
+			blk.Receipts = nil
+			r.NoError(bc.ValidateBlock(blk))
+
+			tampered := rebuildBlockWithGasUsed(t, blk, blk.GasUsed()+1, producerKey)
+			err = bc.ValidateBlock(tampered)
+			if tc.wantErr == nil {
+				r.NoError(err)
+			} else {
+				r.ErrorIs(err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func newHeaderGasChain(t *testing.T, gateHeight uint64) (blockchain.Blockchain, actpool.ActPool, crypto.PrivateKey, config.Config) {
+	r := require.New(t)
+	cfg := config.Default
+	cfg.Chain.EnableAsyncIndexWrite = false
+	cfg.Genesis.EnableGravityChainVoting = false
+	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100000000000000000000000"
+	cfg.Genesis.YapBetaBlockHeight = 1
+	// The check rides Zanzibar Gamma; a chain that has activated none of the
+	// family carries them equal, so set all three rather than Gamma alone.
+	cfg.Genesis.ZanzibarBlockHeight = gateHeight
+	cfg.Genesis.ZanzibarBetaBlockHeight = gateHeight
+	cfg.Genesis.ZanzibarGammaBlockHeight = gateHeight
+	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+
+	registry := protocol.NewRegistry()
+	r.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+	r.NoError(rolldpos.NewProtocol(
+		cfg.Genesis.NumCandidateDelegates, cfg.Genesis.NumDelegates, cfg.Genesis.NumSubEpochs,
+	).Register(registry))
+
+	factoryCfg := factory.GenerateConfig(cfg.Chain, cfg.Genesis)
+	sf, err := factory.NewStateDB(factoryCfg, db.NewMemKVStore(), factory.RegistryStateDBOption(registry))
+	r.NoError(err)
+	genericValidator := protocol.NewGenericValidator(sf, accountutil.AccountState)
+	ap, err := actpool.NewActPool(cfg.Genesis, sf, cfg.ActPool)
+	r.NoError(err)
+	ap.AddActionEnvelopeValidators(genericValidator)
+
+	store, err := filedao.NewFileDAOInMemForTest()
+	r.NoError(err)
+	dao := blockdao.NewBlockDAOWithIndexersAndCache(store, []blockdao.BlockIndexer{sf}, cfg.DB.MaxCacheSize)
+	bc := blockchain.NewBlockchain(
+		cfg.Chain, cfg.Genesis, dao, factory.NewMinter(sf, ap),
+		blockchain.BlockValidatorOption(block.NewValidator(sf, genericValidator)),
+	)
+	r.NotNil(bc)
+	r.NoError(rewarding.NewProtocol(cfg.Genesis.Rewarding).Register(registry))
+	r.NoError(execution.NewProtocol(dao.GetBlockHash, rewarding.DepositGas, fakeGetBlockTime, nil).Register(registry))
+	r.NoError(poll.NewLifeLongDelegatesProtocol(cfg.Genesis.Delegates).Register(registry))
+
+	ctx := genesis.WithGenesisContext(context.Background(), cfg.Genesis)
+	r.NoError(bc.Start(ctx))
+	t.Cleanup(func() { r.NoError(bc.Stop(ctx)) })
+	r.NoError(sf.Start(ctx))
+
+	keys := cfg.Chain.ProducerPrivateKeys()
+	r.NotEmpty(keys)
+	return bc, ap, keys[0], cfg
+}
+
+// rebuildBlockWithGasUsed re-signs a copy of blk carrying a header gasUsed that
+// does not follow from its receipts, standing in for a block a peer published.
+func rebuildBlockWithGasUsed(t *testing.T, blk *block.Block, gasUsed uint64, key crypto.PrivateKey) *block.Block {
+	tampered, err := block.NewBuilder(blk.RunnableActions()).
+		SetVersion(blk.Version()).
+		SetHeight(blk.Height()).
+		SetTimestamp(blk.Timestamp()).
+		SetPrevBlockHash(blk.PrevHash()).
+		SetDeltaStateDigest(blk.DeltaStateDigest()).
+		SetReceiptRoot(blk.ReceiptRoot()).
+		SetLogsBloom(blk.LogsBloomfilter()).
+		SetBaseFee(blk.BaseFee()).
+		SetExcessBlobGas(blk.ExcessBlobGas()).
+		SetGasUsed(gasUsed).
+		SetBlobGasUsed(blk.BlobGasUsed()).
+		SignAndBuild(key)
+	require.NoError(t, err)
+	return &tampered
+}

--- a/state/factory/util_test.go
+++ b/state/factory/util_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+package factory
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+)
+
+// TestCalculateGasUsedFromReceipts pins the two sums a validating node
+// re-derives from its receipts and compares against the header. They are the
+// same helpers the proposer uses in CreateBuilder, so the pair cannot drift,
+// and the non-zero blob case is the one a header carrying blob gas has to
+// agree with.
+func TestCalculateGasUsedFromReceipts(t *testing.T) {
+	r := require.New(t)
+	const perBlob = uint64(params.BlobTxBlobGasPerBlob)
+
+	t.Run("no receipts sums to zero", func(t *testing.T) {
+		r.Zero(calculateGasUsed(nil))
+		r.Zero(calculateBlobGasUsed(nil))
+		r.Zero(calculateGasUsed([]*action.Receipt{}))
+		r.Zero(calculateBlobGasUsed([]*action.Receipt{}))
+	})
+
+	t.Run("gas is summed across receipts", func(t *testing.T) {
+		receipts := []*action.Receipt{
+			{GasConsumed: 21000},
+			{GasConsumed: 100000},
+			{GasConsumed: 0},
+		}
+		r.EqualValues(121000, calculateGasUsed(receipts))
+		// none of them carried a blob
+		r.Zero(calculateBlobGasUsed(receipts))
+	})
+
+	t.Run("blob gas is summed independently of gas", func(t *testing.T) {
+		receipts := []*action.Receipt{
+			{GasConsumed: 21000, BlobGasUsed: perBlob},
+			{GasConsumed: 21000},
+			{GasConsumed: 50000, BlobGasUsed: 2 * perBlob},
+		}
+		r.EqualValues(92000, calculateGasUsed(receipts))
+		r.Equal(3*perBlob, calculateBlobGasUsed(receipts))
+
+		// A header carrying exactly this much blob gas is what the validator
+		// has to accept, and one unit off is what it has to reject.
+		h := block.Header{}
+		r.False(h.VerifyBlobGasUsed(calculateBlobGasUsed(receipts)),
+			"an unset header must not match a non-zero recompute")
+	})
+}

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -1211,6 +1211,25 @@ func (ws *workingSet) ValidateBlock(ctx context.Context, blk *block.Block) (err 
 	if !blk.VerifyReceiptRoot(receiptRoot) {
 		return errors.Wrapf(block.ErrReceiptRootMismatch, "receipt root in block '%x' vs receipt root in workingset '%x'", blk.ReceiptRoot(), receiptRoot)
 	}
+	// The proposer derives the header's gasUsed/blobGasUsed from its own
+	// receipts in CreateBuilder; re-derive them here from the receipts this
+	// node produced and reject a header that disagrees. Each field is checked
+	// only when the feature that makes the proposer set it is active, so the
+	// validator never demands a value the proposer never wrote.
+	if fCtx.ValidateHeaderGasUsed {
+		if fCtx.EnableDynamicFeeTx {
+			gasUsed := calculateGasUsed(ws.receipts)
+			if !blk.VerifyGasUsed(gasUsed) {
+				return errors.Wrapf(block.ErrGasUsedMismatch, "gas used in block %d vs gas used in workingset %d at height %d", blk.GasUsed(), gasUsed, blk.Height())
+			}
+		}
+		if fCtx.EnableBlobTransaction {
+			blobGasUsed := calculateBlobGasUsed(ws.receipts)
+			if !blk.VerifyBlobGasUsed(blobGasUsed) {
+				return errors.Wrapf(block.ErrBlobGasUsedMismatch, "blob gas used in block %d vs blob gas used in workingset %d at height %d", blk.BlobGasUsed(), blobGasUsed, blk.Height())
+			}
+		}
+	}
 
 	return nil
 }

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -422,9 +422,9 @@ func TestWorkingSet_ValidateBlock_SystemAction(t *testing.T) {
 func TestWorkingSet_ValidateBlock_HeaderGasFields(t *testing.T) {
 	tests := []struct {
 		name string
-		// toBeEnabled is the fork height the check is wired to; math.MaxUint64
-		// is the shipped default, i.e. the check is off
-		toBeEnabled  uint64
+		// gateHeight is the Zanzibar Gamma height the check is wired to;
+		// math.MaxUint64 is the shipped default, i.e. the check is off
+		gateHeight   uint64
 		gasUsedDelta uint64
 		blobGasUsed  uint64
 		expectedErr  error
@@ -438,7 +438,7 @@ func TestWorkingSet_ValidateBlock_HeaderGasFields(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require := require.New(t)
-			cfg := gasFieldTestConfig(test.toBeEnabled)
+			cfg := gasFieldTestConfig(test.gateHeight)
 			minter, ctx := newGasFieldTestFactory(t, cfg)
 			validator, _ := newGasFieldTestFactory(t, cfg)
 
@@ -471,13 +471,18 @@ func TestWorkingSet_ValidateBlock_HeaderGasFields(t *testing.T) {
 // gasFieldTestConfig returns a config where every fork but the one gating the
 // header gas check is active at height 1, so the two cases differ only by that
 // gate.
-func gasFieldTestConfig(toBeEnabled uint64) Config {
+func gasFieldTestConfig(gateHeight uint64) Config {
 	cfg := Config{
 		Chain:   blockchain.DefaultConfig,
 		Genesis: genesis.TestDefault(),
 	}
 	cfg.Genesis.YapBetaBlockHeight = 1
-	cfg.Genesis.ToBeEnabledBlockHeight = toBeEnabled
+	// All three at one height: the check rides Zanzibar Gamma, and a chain
+	// that has activated none of the family carries them equal. Setting the
+	// later ones alone would bake a partial-family genesis into the test.
+	cfg.Genesis.ZanzibarBlockHeight = gateHeight
+	cfg.Genesis.ZanzibarBetaBlockHeight = gateHeight
+	cfg.Genesis.ZanzibarGammaBlockHeight = gateHeight
 	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
 	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100000000000000000000"
 	return cfg
@@ -487,7 +492,19 @@ func newGasFieldTestFactory(t *testing.T, cfg Config) (Factory, context.Context)
 	require := require.New(t)
 	registry := protocol.NewRegistry()
 	require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
-	f, err := NewStateDB(cfg, db.NewMemKVStore(), RegistryStateDBOption(registry))
+	// A real KV store rather than db.NewMemKVStore(): committing a block range
+	// scans, which the in-memory store does not support, and the fork-boundary
+	// case has to commit one block to reach the next height.
+	dbPath, err := testutil.PathOfTempFile("gas-field-statedb")
+	require.NoError(err)
+	t.Cleanup(func() { testutil.CleanupPath(dbPath) })
+	chainCfg := cfg.Chain
+	chainCfg.TrieDBPath = dbPath
+	chainCfg.TrieDBPatchFile = ""
+	cfg.Chain = chainCfg
+	kv, err := db.CreateKVStoreWithCache(db.DefaultConfig, dbPath, cfg.Chain.StateDBCacheSize)
+	require.NoError(err)
+	f, err := NewStateDB(cfg, kv, RegistryStateDBOption(registry))
 	require.NoError(err)
 	startCtx := protocol.WithBlockCtx(
 		genesis.WithGenesisContext(context.Background(), cfg.Genesis),
@@ -498,18 +515,27 @@ func newGasFieldTestFactory(t *testing.T, cfg Config) (Factory, context.Context)
 		require.NoError(f.Stop(startCtx))
 	})
 
+	return f, gasFieldCtx(cfg, protocol.TipInfo{})
+}
+
+// gasFieldCtx builds the context for the block that follows tip. Mint derives
+// the height it is being asked for from the tip it is handed, so the
+// fork-boundary case advances the tip to cross an activation height, and the
+// feature context follows from the same height.
+func gasFieldCtx(cfg Config, tip protocol.TipInfo) context.Context {
+	height := tip.Height + 1
 	ctx := protocol.WithBlockCtx(context.Background(), protocol.BlockCtx{
-		BlockHeight:    1,
-		BlockTimeStamp: time.Unix(cfg.Genesis.Timestamp, 0),
+		BlockHeight:    height,
+		BlockTimeStamp: time.Unix(cfg.Genesis.Timestamp, 0).Add(time.Duration(height) * time.Second),
 		Producer:       identityset.Address(27),
 		GasLimit:       testutil.TestGasLimit * 100000,
 		BaseFee:        big.NewInt(action.InitialBaseFee),
 	})
 	ctx = protocol.WithBlockchainCtx(
 		genesis.WithGenesisContext(ctx, cfg.Genesis),
-		protocol.BlockchainCtx{ChainID: 1},
+		protocol.BlockchainCtx{ChainID: 1, Tip: tip},
 	)
-	return f, protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
+	return protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
 }
 
 func makeGasFieldTransferAction(t *testing.T, nonce uint64) *action.SealedEnvelope {
@@ -586,4 +612,62 @@ func makeBlock(t *testing.T, prevHash hash.Hash256, receiptRoot hash.Hash256, di
 		SignAndBuild(identityset.PrivateKey(0))
 	require.NoError(t, err)
 	return &blk
+}
+
+// TestWorkingSet_ValidateBlock_HeaderGasFieldsForkBoundary walks the activation
+// height itself rather than comparing a gate that is off against one that has
+// been on all along. The same tampering is applied to the block at fork-1 and
+// to the block at fork, against one config and one pair of factories, so the
+// only thing that differs between the two outcomes is the height the block
+// lands on.
+func TestWorkingSet_ValidateBlock_HeaderGasFieldsForkBoundary(t *testing.T) {
+	require := require.New(t)
+	const forkHeight = uint64(2)
+	cfg := gasFieldTestConfig(forkHeight)
+	minter, _ := newGasFieldTestFactory(t, cfg)
+	validator, _ := newGasFieldTestFactory(t, cfg)
+
+	// mintTamperValidate mints the block at height, hands the validator a copy
+	// whose gasUsed does not follow from its receipts, and then commits the
+	// untampered block on both factories so the next height can be minted.
+	tip := protocol.TipInfo{}
+	mintTamperValidate := func(height, nonce uint64) error {
+		ctx := gasFieldCtx(cfg, tip)
+		ctrl := gomock.NewController(t)
+		ap := mock_actpool.NewMockActPool(ctrl)
+		ap.EXPECT().BundlePool().Return(nil).Times(1)
+		ap.EXPECT().PendingActionMap().Return(map[string][]*action.SealedEnvelope{
+			identityset.Address(28).String(): {makeGasFieldTransferAction(t, nonce)},
+		}).Times(1)
+
+		blk, err := minter.Mint(ctx, ap, identityset.PrivateKey(27))
+		require.NoError(err)
+		require.Equal(height, blk.Height())
+		require.NotZero(blk.GasUsed(), "the mismatch below has to be distinguishable from a zero value")
+
+		verr := validator.Validate(ctx, rebuildWithGasFields(t, blk, blk.GasUsed()+1, 0))
+
+		require.NoError(minter.PutBlock(ctx, blk))
+		require.NoError(validator.PutBlock(ctx, blk))
+		// EIP-1559 header verification derives the next base fee from the
+		// parent, so the tip has to carry the whole gas picture, not just the
+		// height and hash.
+		tip = protocol.TipInfo{
+			Height:        blk.Height(),
+			Hash:          blk.HashBlock(),
+			Timestamp:     blk.Timestamp(),
+			GasUsed:       blk.GasUsed(),
+			BaseFee:       blk.BaseFee(),
+			BlobGasUsed:   blk.BlobGasUsed(),
+			ExcessBlobGas: blk.ExcessBlobGas(),
+		}
+		return verr
+	}
+
+	// At fork-1 the check is still off, so a header that disagrees with its
+	// receipts has to be accepted: committed history must keep replaying.
+	require.NoError(mintTamperValidate(forkHeight-1, 0))
+
+	// At the activation height exactly, the same tampering is rejected.
+	require.ErrorIs(mintTamperValidate(forkHeight, 1), block.ErrGasUsedMismatch)
 }

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -624,6 +624,10 @@ func TestWorkingSet_ValidateBlock_HeaderGasFieldsForkBoundary(t *testing.T) {
 	require := require.New(t)
 	const forkHeight = uint64(2)
 	cfg := gasFieldTestConfig(forkHeight)
+	// Keep the earlier Zanzibar family members active at fork-1. This pins
+	// the header check to Gamma rather than merely testing a family-wide gate.
+	cfg.Genesis.ZanzibarBlockHeight = forkHeight - 1
+	cfg.Genesis.ZanzibarBetaBlockHeight = forkHeight - 1
 	minter, _ := newGasFieldTestFactory(t, cfg)
 	validator, _ := newGasFieldTestFactory(t, cfg)
 

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -7,10 +7,12 @@ package factory
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/params"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
@@ -408,6 +410,142 @@ func TestWorkingSet_ValidateBlock_SystemAction(t *testing.T) {
 			require.ErrorIs(f.Validate(zctx, block), errInvalidSystemActionLayout)
 		}
 	})
+}
+
+// TestWorkingSet_ValidateBlock_HeaderGasFields checks that a validating node
+// re-derives the header's gasUsed and blobGasUsed from the receipts it produced
+// while executing the block, and rejects a header whose values disagree.
+//
+// The check is gated: before the fork height a header carrying gas fields that
+// do not match its receipts must still be accepted, so that already-committed
+// blocks keep replaying.
+func TestWorkingSet_ValidateBlock_HeaderGasFields(t *testing.T) {
+	tests := []struct {
+		name string
+		// toBeEnabled is the fork height the check is wired to; math.MaxUint64
+		// is the shipped default, i.e. the check is off
+		toBeEnabled  uint64
+		gasUsedDelta uint64
+		blobGasUsed  uint64
+		expectedErr  error
+	}{
+		{"pre-fork gas used mismatch accepted", math.MaxUint64, 1, 0, nil},
+		{"pre-fork blob gas used mismatch accepted", math.MaxUint64, 0, params.BlobTxBlobGasPerBlob, nil},
+		{"post-fork matching header accepted", 1, 0, 0, nil},
+		{"post-fork gas used mismatch rejected", 1, 1, 0, block.ErrGasUsedMismatch},
+		{"post-fork blob gas used mismatch rejected", 1, 0, params.BlobTxBlobGasPerBlob, block.ErrBlobGasUsedMismatch},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+			cfg := gasFieldTestConfig(test.toBeEnabled)
+			minter, ctx := newGasFieldTestFactory(t, cfg)
+			validator, _ := newGasFieldTestFactory(t, cfg)
+
+			ctrl := gomock.NewController(t)
+			ap := mock_actpool.NewMockActPool(ctrl)
+			ap.EXPECT().BundlePool().Return(nil).Times(1)
+			ap.EXPECT().PendingActionMap().Return(map[string][]*action.SealedEnvelope{
+				identityset.Address(28).String(): {makeGasFieldTransferAction(t, 0)},
+			}).Times(1)
+
+			blk, err := minter.Mint(ctx, ap, identityset.PrivateKey(27))
+			require.NoError(err)
+			// the proposer must have put a non-zero gas used in the header,
+			// otherwise the mismatch below would be indistinguishable from the
+			// zero value
+			require.NotZero(blk.GasUsed())
+			require.Zero(blk.BlobGasUsed())
+
+			tampered := rebuildWithGasFields(t, blk, blk.GasUsed()+test.gasUsedDelta, test.blobGasUsed)
+			err = validator.Validate(ctx, tampered)
+			if test.expectedErr == nil {
+				require.NoError(err)
+			} else {
+				require.ErrorIs(err, test.expectedErr)
+			}
+		})
+	}
+}
+
+// gasFieldTestConfig returns a config where every fork but the one gating the
+// header gas check is active at height 1, so the two cases differ only by that
+// gate.
+func gasFieldTestConfig(toBeEnabled uint64) Config {
+	cfg := Config{
+		Chain:   blockchain.DefaultConfig,
+		Genesis: genesis.TestDefault(),
+	}
+	cfg.Genesis.YapBetaBlockHeight = 1
+	cfg.Genesis.ToBeEnabledBlockHeight = toBeEnabled
+	testutil.NormalizeGenesisHeights(&cfg.Genesis.Blockchain)
+	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100000000000000000000"
+	return cfg
+}
+
+func newGasFieldTestFactory(t *testing.T, cfg Config) (Factory, context.Context) {
+	require := require.New(t)
+	registry := protocol.NewRegistry()
+	require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+	f, err := NewStateDB(cfg, db.NewMemKVStore(), RegistryStateDBOption(registry))
+	require.NoError(err)
+	startCtx := protocol.WithBlockCtx(
+		genesis.WithGenesisContext(context.Background(), cfg.Genesis),
+		protocol.BlockCtx{},
+	)
+	require.NoError(f.Start(startCtx))
+	t.Cleanup(func() {
+		require.NoError(f.Stop(startCtx))
+	})
+
+	ctx := protocol.WithBlockCtx(context.Background(), protocol.BlockCtx{
+		BlockHeight:    1,
+		BlockTimeStamp: time.Unix(cfg.Genesis.Timestamp, 0),
+		Producer:       identityset.Address(27),
+		GasLimit:       testutil.TestGasLimit * 100000,
+		BaseFee:        big.NewInt(action.InitialBaseFee),
+	})
+	ctx = protocol.WithBlockchainCtx(
+		genesis.WithGenesisContext(ctx, cfg.Genesis),
+		protocol.BlockchainCtx{ChainID: 1},
+	)
+	return f, protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
+}
+
+func makeGasFieldTransferAction(t *testing.T, nonce uint64) *action.SealedEnvelope {
+	tsf := action.NewTransfer(big.NewInt(1), identityset.Address(29).String(), nil)
+	evlp := (&action.EnvelopeBuilder{}).
+		SetAction(tsf).
+		SetGasLimit(testutil.TestGasLimit).
+		SetGasPrice(big.NewInt(action.InitialBaseFee)).
+		SetNonce(nonce).
+		SetChainID(1).
+		SetVersion(1).
+		Build()
+	sevlp, err := action.Sign(evlp, identityset.PrivateKey(28))
+	require.NoError(t, err)
+	return sevlp
+}
+
+// rebuildWithGasFields re-signs a copy of blk that carries the given gas fields
+// and is otherwise identical, standing in for a header a proposer published
+// with gas fields that do not follow from its receipts.
+func rebuildWithGasFields(t *testing.T, blk *block.Block, gasUsed, blobGasUsed uint64) *block.Block {
+	tampered, err := block.NewBuilder(blk.RunnableActions()).
+		SetVersion(blk.Version()).
+		SetHeight(blk.Height()).
+		SetTimestamp(blk.Timestamp()).
+		SetPrevBlockHash(blk.PrevHash()).
+		SetDeltaStateDigest(blk.DeltaStateDigest()).
+		SetReceiptRoot(blk.ReceiptRoot()).
+		SetLogsBloom(blk.LogsBloomfilter()).
+		SetBaseFee(blk.BaseFee()).
+		SetExcessBlobGas(blk.ExcessBlobGas()).
+		SetGasUsed(gasUsed).
+		SetBlobGasUsed(blobGasUsed).
+		SignAndBuild(identityset.PrivateKey(27))
+	require.NoError(t, err)
+	return &tampered
 }
 
 func makeTransferAction(t *testing.T, nonce uint64) *action.SealedEnvelope {


### PR DESCRIPTION
## What this changes

The block header carries `gasUsed` and `blobGasUsed`. The proposer derives both from the execution receipts in `CreateBuilder`, but validators accept whatever the header says without recomputing them. This adds the validator-side check.

`workingSet.ValidateBlock` now recomputes both values from `ws.receipts` and compares them against the header, immediately after the existing receipt-root check. It reuses `calculateGasUsed` and `calculateBlobGasUsed`, the same helpers the proposer uses, so the two sides cannot drift.

Two sentinel errors are added alongside `ErrReceiptRootMismatch`: `ErrGasUsedMismatch` and `ErrBlobGasUsedMismatch`, with `Header.VerifyGasUsed` / `Header.VerifyBlobGasUsed` mirroring the existing `VerifyReceiptRoot` helper.

## Fork gating

Rejecting a block that would previously have been accepted changes block acceptance, so the check is gated on a new `FeatureCtx.ValidateHeaderGasUsed` flag wired to `IsZanzibarGamma(height)`. It was found after Zanzibar Beta had been scheduled, so folding it into Beta would rewrite the semantics of blocks a chain that activated Beta has already committed -- the same argument that gave Beta a height of its own, one level up. Gamma is `math.MaxUint64` everywhere today, so this is inert: below the gate the validator behaves exactly as before and historical blocks replay unchanged.

The inner conditions mirror `CreateBuilder` exactly. The `gasUsed` comparison runs under `EnableDynamicFeeTx` and the `blobGasUsed` comparison under `EnableBlobTransaction`, because the proposer only writes those fields under the same flags. The validator therefore never demands a field the proposer never wrote.

## Tests

**`TestWorkingSet_ValidateBlock_HeaderGasFields`** -- table driven, using a real mint/validate round trip rather than synthetic receipts. A block is minted through `stateDB.Mint`, rebuilt and re-signed with tampered header gas fields via `block.NewBuilder`, then validated on a separate factory instance so the working-set cache cannot short-circuit it. Pre-gate and post-gate configurations differ only in the Zanzibar heights.

- pre-fork gas used mismatch accepted
- pre-fork blob gas used mismatch accepted
- post-fork matching header accepted
- post-fork gas used mismatch rejected
- post-fork blob gas used mismatch rejected

**`TestWorkingSet_ValidateBlock_HeaderGasFieldsForkBoundary`** -- the case above compares a gate that is off against one that has been on since height one, which never crosses an activation height. This one mints at `fork - 1` and at `fork` against a single config and a single pair of factories, applying the same tampering to both, so the height the block lands on is the only thing that differs between accepted and rejected. Reaching the second height means committing the first block, so the fixture runs on a real key-value store (the in-memory one cannot range scan) and threads the tip through: `Mint` derives the height it is asked for from the tip it is handed, and EIP-1559 header verification derives the next base fee from the parent, so the tip carries the whole gas picture rather than just a height and a hash.

**`TestHeaderVerifyGasUsed`** (in `blockchain/block`) -- direct unit tests for the two comparisons, including that a header which never carried either field agrees with a zero recomputation. The proposer only writes those fields under their own feature gates, so that is the case a validator meets first.

**`TestCalculateGasUsedFromReceipts`** (in `state/factory`) -- unit tests for the two sums the validator re-derives, covering the non-zero blob sum that a header carrying blob gas has to agree with. The end-to-end cases only reach the blob comparison in the mismatching direction, since minting a block that genuinely carries blob gas needs a blob transaction with a sidecar; this covers the positive direction of the same arithmetic.

**`TestHeaderGasFieldsThroughBlockchainValidate`** (in `e2etest`) -- drives the mismatch through `blockchain.ValidateBlock`, the entry point a node uses for a block it received, rather than through the state factory alone. It is the end of the path the error has to travel: `workingSet.ValidateBlock` -> `stateDB.Validate` -> `block.Validator` -> `blockchain.ValidateBlock`. The untampered block is validated first, so that a gas-field verdict means something.

Each case was checked by neutering the gate and confirming the post-fork assertions flip to failing while the pre-fork ones keep passing.

`go build ./...`, `go vet`, and `go test` pass on `state/factory`, `action/protocol`, `blockchain/block`, `blockchain`, `chainservice` and `e2etest`.

## For reviewers

**Fork height.** Gamma is unscheduled. Per AGENTS.md the height needs maintainer sign-off, and assigning it is what lets a fork-at-height devnet run attribute behaviour to this batch rather than to the eight unrelated WIP features that used to share a gate with it.

**Lockstep requirement.** This makes proposer and validator permanently coupled on how `header.gasUsed` is derived. Both call `calculateGasUsed(receipts)` today. Any future change to the proposer side must update the validator in the same fork, where previously only the proposer mattered.

**Related.** A sibling branch changes how stake migration reports receipt gas. Both sides here sum the same `receipt.GasConsumed`, so the two move together, but the branches touch the same two files and will need a trivial merge.

---

Do not merge until the Zanzibar Gamma height is assigned.

Generated with [Claude Code](https://claude.com/claude-code)


