### PR TITLE
fix(staking): correct migrate-stake receipt gas accounting

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -260,6 +260,38 @@ type (
 		// An update that omits both leaves any previously registered key
 		// untouched.
 		OptionalCandidateBLSPublicKey bool
+		// CorrectStakeMigrationGas budgets the contract call a stake migration
+		// makes with the action's gas limit minus the migration's own intrinsic
+		// gas, instead of the full gas limit.
+		//
+		// The migration receipt reports the intrinsic gas plus whatever the
+		// contract call consumed. While the call is budgeted with the whole gas
+		// limit, that sum can exceed the gas limit the action declared -- and
+		// the gas limit is what the block gas budget was reserved against, so a
+		// receipt reporting beyond it reports gas the block never had. Taking
+		// the intrinsic gas out of the call's budget bounds the reported total
+		// by the declared limit, which is also what the gas estimator has always
+		// assumed (it quotes contract gas + intrinsic gas).
+		//
+		// Both the budget handed to the EVM and the gas on the receipt are
+		// consensus data, so this needs its own height: a chain that has already
+		// executed migrations under the old budget would recompute different
+		// receipts for those blocks. Wired to IsToBeEnabled until the named
+		// height is assigned.
+		CorrectStakeMigrationGas bool
+		// CheckedBlockGasDeduction subtracts a receipt's gas from the remaining
+		// block gas budget without letting the unsigned counter wrap: a receipt
+		// reporting more gas than is left saturates the budget at zero rather
+		// than rolling it over to near 2^64, which would let the rest of the
+		// block run as if the budget were untouched.
+		//
+		// Saturating is deterministic -- every node lands on the same remaining
+		// budget -- and the following action is then rejected for want of gas,
+		// so the condition is never absorbed silently. Changing the remaining
+		// budget changes which actions a block may carry, so this is gated at
+		// its own height. Wired to IsToBeEnabled until the named height is
+		// assigned.
+		CheckedBlockGasDeduction bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -448,6 +480,11 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixEpochSettlementFaultHandling:  g.IsZanzibarBeta(height),
 			RequireProfileForHermesMigration: g.IsZanzibarBeta(height),
 			EmitEraFreezeLog:                 g.IsZanzibarBeta(height),
+			// Zanzibar Gamma: both were found after Beta was scheduled, so
+			// folding them into Beta would rewrite blocks a chain that
+			// activated Beta has already committed.
+			CorrectStakeMigrationGas: g.IsZanzibarGamma(height),
+			CheckedBlockGasDeduction: g.IsZanzibarGamma(height),
 		},
 	)
 }

--- a/action/protocol/staking/handler_stake_migrate.go
+++ b/action/protocol/staking/handler_stake_migrate.go
@@ -51,7 +51,20 @@ func (p *Protocol) handleStakeMigrate(ctx context.Context, elp action.Envelope, 
 	if candidate == nil {
 		return nil, nil, gasConsumed, gasToBeDeducted, errCandNotExist
 	}
-	exec, err := p.constructExecution(ctx, candidate.GetIdentifier(), bucket.StakedAmount, bucket.StakedDuration, elp.Nonce(), elp.Gas(), elp.GasPrice())
+	// the receipt reports insGas on top of whatever the contract call consumes,
+	// so the call only gets what is left of the action's gas limit after the
+	// intrinsic gas; otherwise the two together can exceed the declared limit
+	execGas := elp.Gas()
+	if protocol.MustGetFeatureCtx(ctx).CorrectStakeMigrationGas {
+		if execGas < insGas {
+			// an action whose gas limit does not cover its own intrinsic gas is
+			// rejected before it gets here; leave the call with nothing to spend
+			execGas = 0
+		} else {
+			execGas -= insGas
+		}
+	}
+	exec, err := p.constructExecution(ctx, candidate.GetIdentifier(), bucket.StakedAmount, bucket.StakedDuration, elp.Nonce(), execGas, elp.GasPrice())
 	if err != nil {
 		return nil, nil, gasConsumed, gasToBeDeducted, errors.Wrap(err, "failed to construct execution")
 	}
@@ -79,6 +92,19 @@ func (p *Protocol) handleStakeMigrate(ctx context.Context, elp action.Envelope, 
 	excReceipt, err := p.createNFTBucket(ctx, exec, csm.SM())
 	if err != nil {
 		revertSM()
+		if protocol.MustGetFeatureCtx(ctx).CorrectStakeMigrationGas && isCallNeverStartedError(err) {
+			// The call was refused before it ran, for want of gas. The
+			// execution protocol reports that as a plain error rather than a
+			// failed receipt, and a plain error out of a handler abandons the
+			// whole block being built or validated. Settle a receipt instead,
+			// so an underfunded migration costs its sender a failed action and
+			// nothing more.
+			gasToBeDeducted = gasConsumed
+			return nil, nil, gasConsumed, gasToBeDeducted, &handleError{
+				err:           errors.Wrapf(err, "staking contract call could not start with %d gas of the %d declared", execGas, elp.Gas()),
+				failureStatus: iotextypes.ReceiptStatus_ErrOutOfGas,
+			}
+		}
 		return nil, nil, gasConsumed, gasToBeDeducted, errors.Wrap(err, "failed to handle execution action")
 	}
 	gasConsumed += excReceipt.GasConsumed
@@ -202,6 +228,25 @@ func (p *Protocol) constructExecution(ctx context.Context, candidate address.Add
 	}
 	return (&action.EnvelopeBuilder{}).SetAction(action.NewExecution(contractAddress, amount, data)).
 		SetNonce(nonce).SetGasLimit(gasLimit).SetGasPrice(gasPrice).Build(), nil
+}
+
+// isCallNeverStartedError reports the refusals the EVM raises before a call
+// executes at all, because the gas it was handed does not cover what the call
+// costs just to begin: the intrinsic cost, the EIP-7623 data floor that Prague
+// added on top of it, and the balance needed to pay for either.
+//
+// They are named rather than derived. The arithmetic behind each lives in the
+// EVM, is gated on its own fork, and has grown once already, so a handler that
+// recomputed it would go stale without anything failing loudly. Reading the
+// verdict off the error keeps this correct as that set grows.
+//
+// ErrInsufficientFunds is in the set because the EVM currently reports the
+// intrinsic shortfall with it as well as the genuine balance shortfall. Either
+// way the call never ran, and neither should cost a block draft.
+func isCallNeverStartedError(err error) bool {
+	return errors.Is(err, action.ErrIntrinsicGas) ||
+		errors.Is(err, action.ErrFloorDataGas) ||
+		errors.Is(err, action.ErrInsufficientFunds)
 }
 
 func (p *Protocol) createNFTBucket(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {

--- a/action/protocol/staking/handler_stake_migrate_test.go
+++ b/action/protocol/staking/handler_stake_migrate_test.go
@@ -351,6 +351,195 @@ func TestHandleStakeMigrate(t *testing.T) {
 
 }
 
+// TestHandleStakeMigrateGasAccounting pins the two gas figures a stake
+// migration produces: the gas limit handed to the inner contract call, and the
+// total gas reported on the migration receipt.
+//
+// Before the fix height the inner call is budgeted with the whole declared gas
+// limit of the migration and the migration's own intrinsic gas is reported on
+// top of it, so the receipt can report more gas than the action ever declared.
+// From the fix height on the intrinsic gas is taken out of the inner call's
+// budget, so the reported total is bounded by the declared gas limit.
+func TestHandleStakeMigrateGasAccounting(t *testing.T) {
+	var (
+		gasPrice   = big.NewInt(10)
+		gasLimit   = uint64(1000000)
+		migrateHgt = uint64(3)
+	)
+	for _, tt := range []struct {
+		name string
+		// height from which the corrected accounting takes effect
+		gateHeight uint64
+		// gas limit the inner contract call is expected to run under
+		wantExecGasLimit uint64
+		// gas the migration receipt is expected to report
+		wantReceiptGas uint64
+	}{
+		{
+			name:             "before fix height",
+			gateHeight:       math.MaxUint64,
+			wantExecGasLimit: gasLimit,
+			wantReceiptGas:   gasLimit + action.MigrateStakeBaseIntrinsicGas,
+		},
+		{
+			name:             "from fix height",
+			gateHeight:       migrateHgt,
+			wantExecGasLimit: gasLimit - action.MigrateStakeBaseIntrinsicGas,
+			wantReceiptGas:   gasLimit,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			ctrl := gomock.NewController(t)
+			sm := testdb.NewMockStateManager(ctrl)
+			g := genesis.TestDefault()
+			p, err := NewProtocol(
+				HelperCtx{getBlockInterval, depositGas},
+				&BuilderConfig{
+					Staking:                       g.Staking,
+					PersistStakingPatchBlock:      math.MaxUint64,
+					SkipContractStakingViewHeight: math.MaxUint64,
+					Revise: ReviseConfig{
+						VoteWeight: g.Staking.VoteWeightCalConsts,
+					},
+				},
+				nil, nil, nil, nil)
+			r.NoError(err)
+			cfg := deepcopy.Copy(genesis.TestDefault()).(genesis.Genesis)
+			cfg.PacificBlockHeight = 1
+			cfg.AleutianBlockHeight = 1
+			cfg.BeringBlockHeight = 1
+			cfg.CookBlockHeight = 1
+			cfg.DardanellesBlockHeight = 1
+			cfg.DaytonaBlockHeight = 1
+			cfg.EasterBlockHeight = 1
+			cfg.FbkMigrationBlockHeight = 1
+			cfg.FairbankBlockHeight = 1
+			cfg.GreenlandBlockHeight = 1
+			cfg.HawaiiBlockHeight = 1
+			cfg.IcelandBlockHeight = 1
+			cfg.JutlandBlockHeight = 1
+			cfg.KamchatkaBlockHeight = 1
+			cfg.LordHoweBlockHeight = 1
+			cfg.MidwayBlockHeight = 1
+			cfg.NewfoundlandBlockHeight = 1
+			cfg.OkhotskBlockHeight = 1
+			cfg.PalauBlockHeight = 1
+			cfg.QuebecBlockHeight = 1
+			cfg.RedseaBlockHeight = 1
+			cfg.SumatraBlockHeight = 1
+			cfg.TsunamiBlockHeight = 1
+			cfg.UpernavikBlockHeight = 1
+			// The corrections ride Zanzibar Gamma; a chain that has activated
+			// none of the family carries the heights equal, so set all three
+			// rather than leaving a partial-family genesis in a test.
+			cfg.ZanzibarBlockHeight = tt.gateHeight
+			cfg.ZanzibarBetaBlockHeight = tt.gateHeight
+			cfg.ZanzibarGammaBlockHeight = tt.gateHeight
+
+			ctx := genesis.WithGenesisContext(context.Background(), cfg)
+			ctx = protocol.WithFeatureWithHeightCtx(ctx)
+			ctx = protocol.WithFeatureCtx(protocol.WithBlockCtx(ctx, protocol.BlockCtx{}))
+			view, err := p.Start(ctx, sm)
+			r.NoError(err)
+			r.NoError(sm.WriteView(p.Name(), view))
+			r.NoError(p.CreateGenesisStates(ctx, sm))
+			r.NoError(p.PreCommit(ctx, sm))
+			r.NoError(p.Commit(ctx, sm))
+
+			excPrtl := execution.NewProtocol(
+				func(u uint64) (hash.Hash256, error) { return hash.ZeroHash256, nil },
+				func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
+					return nil, nil
+				},
+				func(uint64) (time.Time, error) { return time.Now(), nil },
+				nil,
+			)
+			reg := protocol.NewRegistry()
+			r.NoError(excPrtl.Register(reg))
+			ctx = protocol.WithRegistry(ctx, reg)
+
+			runBlock := func(height uint64, acts ...*action.SealedEnvelope) []*action.Receipt {
+				blkCtx := protocol.WithBlockCtx(ctx, protocol.BlockCtx{
+					BlockHeight:    height,
+					BlockTimeStamp: timeBlock,
+					GasLimit:       gasLimit,
+				})
+				blkCtx = protocol.WithBlockchainCtx(blkCtx, protocol.BlockchainCtx{
+					Tip: protocol.TipInfo{Height: height},
+				})
+				blkCtx = protocol.WithFeatureCtx(blkCtx)
+				r.NoError(p.CreatePreStates(blkCtx, sm))
+				receipts := make([]*action.Receipt, 0, len(acts))
+				for _, act := range acts {
+					h, err := act.Hash()
+					r.NoError(err)
+					insGas, err := act.IntrinsicGas()
+					r.NoError(err)
+					actCtx := protocol.WithActionCtx(blkCtx, protocol.ActionCtx{
+						Caller:       act.SenderAddress(),
+						ActionHash:   h,
+						GasPrice:     gasPrice,
+						IntrinsicGas: insGas,
+						Nonce:        act.Nonce(),
+					})
+					r.NoError(p.Validate(actCtx, act.Envelope, sm))
+					receipt, err := p.Handle(actCtx, act.Envelope, sm)
+					r.NoError(err)
+					receipts = append(receipts, receipt)
+				}
+				r.NoError(p.PreCommit(blkCtx, sm))
+				r.NoError(p.Commit(blkCtx, sm))
+				return receipts
+			}
+
+			var (
+				candOwnerID       = 1
+				stakerID          = 2
+				balance, _        = big.NewInt(0).SetString("100000000000000000000000000", 10)
+				registerAmount, _ = big.NewInt(0).SetString("1200000000000000000000000", 10)
+				stakeAmount, _    = big.NewInt(0).SetString("1000000000000000000000", 10)
+			)
+			r.NoError(initAccountBalance(sm, identityset.Address(candOwnerID), balance))
+			r.NoError(initAccountBalance(sm, identityset.Address(stakerID), balance))
+			receipts := runBlock(1,
+				assertions.MustNoErrorV(action.SignedCandidateRegister(0, "cand1", identityset.Address(1).String(), identityset.Address(1).String(), identityset.Address(candOwnerID).String(), registerAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(candOwnerID))),
+			)
+			r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[0].Status)
+			bktIdx := uint64(1)
+			receipts = runBlock(2,
+				assertions.MustNoErrorV(action.SignedCreateStake(0, "cand1", stakeAmount.String(), 1, true, nil, gasLimit, gasPrice, identityset.PrivateKey(stakerID))),
+			)
+			r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[0].Status)
+
+			// the inner contract call burns every unit of gas it is given
+			var execGasLimit uint64
+			pa := NewPatches()
+			defer pa.Reset()
+			sm.EXPECT().Revert(gomock.Any()).Return(nil).AnyTimes()
+			pa.ApplyMethodFunc(excPrtl, "Handle", func(_ context.Context, elp action.Envelope, _ protocol.StateManager) (*action.Receipt, error) {
+				execGasLimit = elp.Gas()
+				return &action.Receipt{
+					Status:      uint64(iotextypes.ReceiptStatus_Success),
+					BlockHeight: migrateHgt,
+					GasConsumed: elp.Gas(),
+				}, nil
+			})
+			act := assertions.MustNoErrorV(action.SignedMigrateStake(1, bktIdx, gasLimit, gasPrice, identityset.PrivateKey(stakerID)))
+			receipts = runBlock(migrateHgt, act)
+			r.Len(receipts, 1)
+			r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[0].Status)
+			r.Equal(tt.wantExecGasLimit, execGasLimit)
+			r.Equal(tt.wantReceiptGas, receipts[0].GasConsumed)
+			// the declared gas limit is the ceiling the block budget was
+			// reserved against, so the receipt must never report beyond it
+			if tt.gateHeight <= migrateHgt {
+				r.LessOrEqual(receipts[0].GasConsumed, act.Gas())
+			}
+		})
+	}
+}
+
 func initAccountBalance(sm protocol.StateManager, addr address.Address, initBalance *big.Int) error {
 	acc, err := accountutil.LoadAccount(sm, addr)
 	if err != nil {
@@ -358,4 +547,241 @@ func initAccountBalance(sm protocol.StateManager, addr address.Address, initBala
 	}
 	acc.Balance = initBalance
 	return accountutil.StoreAccount(sm, addr, acc)
+}
+
+// TestHandleStakeMigrateUnderfundedContractCall covers a migration whose gas
+// limit clears its own intrinsic gas but leaves the staking contract call short
+// of what that call needs just to start. The execution protocol reports those
+// refusals as plain errors rather than failed receipts, and a plain error out
+// of a handler abandons the block being built or validated. From the fix height
+// the migration settles a failed receipt instead, so an underfunded action
+// costs its sender a failed action and nothing more.
+//
+// There are two such refusals and they sit at different gas limits, which is
+// why both are exercised. The contract call packs 68 bytes, so it needs 16,800
+// intrinsic gas (10,000 base + 68x100) and, once Prague is active, an EIP-7623
+// data floor of 27,000 (10,000 + 68x250) checked after it. Past the fix the
+// call is handed the declared limit less the migration 10,000, so the two
+// refusals answer for declared limits below 26,800 and below 37,000.
+func TestHandleStakeMigrateUnderfundedContractCall(t *testing.T) {
+	var (
+		gasPrice   = big.NewInt(10)
+		blockGas   = uint64(1000000)
+		migrateHgt = uint64(3)
+	)
+	for _, tt := range []struct {
+		name       string
+		gateHeight uint64
+		// declared gas limit of the migration
+		actGasLimit uint64
+		// whether Handle reports a plain error instead of a receipt
+		wantErr    bool
+		wantErrIs  error
+		wantStatus uint64
+	}{
+		{
+			name:        "intrinsic shortfall before fix height",
+			gateHeight:  math.MaxUint64,
+			actGasLimit: 12000,
+			wantErr:     true,
+			wantErrIs:   action.ErrInsufficientFunds,
+		},
+		{
+			name:        "intrinsic shortfall from fix height",
+			gateHeight:  migrateHgt,
+			actGasLimit: 12000,
+			wantStatus:  uint64(iotextypes.ReceiptStatus_ErrOutOfGas),
+		},
+		{
+			// 20,000 clears the intrinsic cost and still falls under the data
+			// floor, so this band costs a draft on the current code too -- the
+			// fix does not open it, it only moves it
+			name:        "data floor shortfall before fix height",
+			gateHeight:  math.MaxUint64,
+			actGasLimit: 20000,
+			wantErr:     true,
+			wantErrIs:   action.ErrFloorDataGas,
+		},
+		{
+			// past the fix the call is handed 30,000 less the migration
+			// 10,000, which lands in the same band one 10,000 higher
+			name:        "data floor shortfall from fix height",
+			gateHeight:  migrateHgt,
+			actGasLimit: 30000,
+			wantStatus:  uint64(iotextypes.ReceiptStatus_ErrOutOfGas),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			ctrl := gomock.NewController(t)
+			sm := testdb.NewMockStateManager(ctrl)
+			g := genesis.TestDefault()
+			p, err := NewProtocol(
+				HelperCtx{getBlockInterval, depositGas},
+				&BuilderConfig{
+					Staking:                       g.Staking,
+					PersistStakingPatchBlock:      math.MaxUint64,
+					SkipContractStakingViewHeight: math.MaxUint64,
+					Revise: ReviseConfig{
+						VoteWeight: g.Staking.VoteWeightCalConsts,
+					},
+				},
+				nil, nil, nil, nil)
+			r.NoError(err)
+			cfg := deepcopy.Copy(genesis.TestDefault()).(genesis.Genesis)
+			cfg.PacificBlockHeight = 1
+			cfg.AleutianBlockHeight = 1
+			cfg.BeringBlockHeight = 1
+			cfg.CookBlockHeight = 1
+			cfg.DardanellesBlockHeight = 1
+			cfg.DaytonaBlockHeight = 1
+			cfg.EasterBlockHeight = 1
+			cfg.FbkMigrationBlockHeight = 1
+			cfg.FairbankBlockHeight = 1
+			cfg.GreenlandBlockHeight = 1
+			cfg.HawaiiBlockHeight = 1
+			cfg.IcelandBlockHeight = 1
+			cfg.JutlandBlockHeight = 1
+			cfg.KamchatkaBlockHeight = 1
+			cfg.LordHoweBlockHeight = 1
+			cfg.MidwayBlockHeight = 1
+			cfg.NewfoundlandBlockHeight = 1
+			cfg.OkhotskBlockHeight = 1
+			cfg.PalauBlockHeight = 1
+			cfg.QuebecBlockHeight = 1
+			cfg.RedseaBlockHeight = 1
+			cfg.SumatraBlockHeight = 1
+			cfg.TsunamiBlockHeight = 1
+			cfg.UpernavikBlockHeight = 1
+			// The corrections ride Zanzibar Gamma; a chain that has activated
+			// none of the family carries the heights equal, so set all three
+			// rather than leaving a partial-family genesis in a test.
+			cfg.ZanzibarBlockHeight = tt.gateHeight
+			cfg.ZanzibarBetaBlockHeight = tt.gateHeight
+			cfg.ZanzibarGammaBlockHeight = tt.gateHeight
+
+			ctx := genesis.WithGenesisContext(context.Background(), cfg)
+			ctx = protocol.WithFeatureWithHeightCtx(ctx)
+			ctx = protocol.WithFeatureCtx(protocol.WithBlockCtx(ctx, protocol.BlockCtx{}))
+			view, err := p.Start(ctx, sm)
+			r.NoError(err)
+			r.NoError(sm.WriteView(p.Name(), view))
+			r.NoError(p.CreateGenesisStates(ctx, sm))
+			r.NoError(p.PreCommit(ctx, sm))
+			r.NoError(p.Commit(ctx, sm))
+
+			excPrtl := execution.NewProtocol(
+				func(u uint64) (hash.Hash256, error) { return hash.ZeroHash256, nil },
+				func(context.Context, protocol.StateManager, *big.Int, ...protocol.DepositOption) ([]*action.TransactionLog, error) {
+					return nil, nil
+				},
+				func(uint64) (time.Time, error) { return time.Now(), nil },
+				nil,
+			)
+			reg := protocol.NewRegistry()
+			r.NoError(excPrtl.Register(reg))
+			ctx = protocol.WithRegistry(ctx, reg)
+
+			runBlock := func(height uint64, acts ...*action.SealedEnvelope) ([]*action.Receipt, error) {
+				blkCtx := protocol.WithBlockCtx(ctx, protocol.BlockCtx{
+					BlockHeight:    height,
+					BlockTimeStamp: timeBlock,
+					GasLimit:       blockGas,
+				})
+				blkCtx = protocol.WithBlockchainCtx(blkCtx, protocol.BlockchainCtx{
+					Tip: protocol.TipInfo{Height: height},
+				})
+				blkCtx = protocol.WithFeatureCtx(blkCtx)
+				r.NoError(p.CreatePreStates(blkCtx, sm))
+				receipts := make([]*action.Receipt, 0, len(acts))
+				for _, act := range acts {
+					h, err := act.Hash()
+					r.NoError(err)
+					insGas, err := act.IntrinsicGas()
+					r.NoError(err)
+					actCtx := protocol.WithActionCtx(blkCtx, protocol.ActionCtx{
+						Caller:       act.SenderAddress(),
+						ActionHash:   h,
+						GasPrice:     gasPrice,
+						IntrinsicGas: insGas,
+						Nonce:        act.Nonce(),
+					})
+					r.NoError(p.Validate(actCtx, act.Envelope, sm))
+					receipt, err := p.Handle(actCtx, act.Envelope, sm)
+					if err != nil {
+						return nil, err
+					}
+					receipts = append(receipts, receipt)
+				}
+				r.NoError(p.PreCommit(blkCtx, sm))
+				r.NoError(p.Commit(blkCtx, sm))
+				return receipts, nil
+			}
+
+			var (
+				candOwnerID       = 1
+				stakerID          = 2
+				balance, _        = big.NewInt(0).SetString("100000000000000000000000000", 10)
+				registerAmount, _ = big.NewInt(0).SetString("1200000000000000000000000", 10)
+				stakeAmount, _    = big.NewInt(0).SetString("1000000000000000000000", 10)
+			)
+			r.NoError(initAccountBalance(sm, identityset.Address(candOwnerID), balance))
+			r.NoError(initAccountBalance(sm, identityset.Address(stakerID), balance))
+			receipts, err := runBlock(1,
+				assertions.MustNoErrorV(action.SignedCandidateRegister(0, "cand1", identityset.Address(1).String(), identityset.Address(1).String(), identityset.Address(candOwnerID).String(), registerAmount.String(), 1, true, nil, blockGas, gasPrice, identityset.PrivateKey(candOwnerID))),
+			)
+			r.NoError(err)
+			r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[0].Status)
+			bktIdx := uint64(1)
+			receipts, err = runBlock(2,
+				assertions.MustNoErrorV(action.SignedCreateStake(0, "cand1", stakeAmount.String(), 1, true, nil, blockGas, gasPrice, identityset.PrivateKey(stakerID))),
+			)
+			r.NoError(err)
+			r.Equal(uint64(iotextypes.ReceiptStatus_Success), receipts[0].Status)
+
+			pa := NewPatches()
+			defer pa.Reset()
+			sm.EXPECT().Revert(gomock.Any()).Return(nil).AnyTimes()
+			// mirrors the execution protocol, in the order it applies them: a
+			// call whose gas limit is below its own intrinsic cost, or below
+			// the EIP-7623 data floor checked after it, is reported as an
+			// error rather than a receipt
+			pa.ApplyMethodFunc(excPrtl, "Handle", func(_ context.Context, elp action.Envelope, _ protocol.StateManager) (*action.Receipt, error) {
+				innerInsGas, err := elp.IntrinsicGas()
+				if err != nil {
+					return nil, err
+				}
+				if elp.Gas() < innerInsGas {
+					return nil, errors.Wrap(action.ErrInsufficientFunds, "failed to execute contract")
+				}
+				exc, ok := elp.Action().(*action.Execution)
+				r.True(ok, "the migration must hand the execution protocol an execution")
+				floor, err := action.FloorDataGas(exc.Data())
+				if err != nil {
+					return nil, err
+				}
+				if elp.Gas() < floor {
+					return nil, errors.Wrapf(action.ErrFloorDataGas, "have %d, want %d", elp.Gas(), floor)
+				}
+				return &action.Receipt{
+					Status:      uint64(iotextypes.ReceiptStatus_Success),
+					BlockHeight: migrateHgt,
+					GasConsumed: elp.Gas(),
+				}, nil
+			})
+			act := assertions.MustNoErrorV(action.SignedMigrateStake(1, bktIdx, tt.actGasLimit, gasPrice, identityset.PrivateKey(stakerID)))
+			receipts, err = runBlock(migrateHgt, act)
+			if tt.wantErr {
+				r.Error(err)
+				r.ErrorIs(err, tt.wantErrIs)
+				return
+			}
+			r.NoError(err)
+			r.Len(receipts, 1)
+			r.Equal(tt.wantStatus, receipts[0].Status)
+			// the failed migration still charges its sender, and never more
+			// than the gas limit it declared
+			r.LessOrEqual(receipts[0].GasConsumed, act.Gas())
+		})
+	}
 }

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -68,6 +68,20 @@ func init() {
 	prometheus.MustRegister(_mintAbility)
 }
 
+// deductBlockGas takes the gas reported by a receipt out of the gas a block has
+// left. The counter is unsigned, so before the fix height the subtraction wraps
+// around when a receipt reports more gas than remains; from that height on it
+// saturates at zero, which keeps the remaining budget monotonic and makes the
+// next action in the block run out of gas instead of being waved through.
+func deductBlockGas(fCtx protocol.FeatureCtx, remaining, consumed uint64) uint64 {
+	if fCtx.CheckedBlockGasDeduction && remaining < consumed {
+		log.L().Warn("receipt reports more gas than the block has left",
+			zap.Uint64("remaining", remaining), zap.Uint64("consumed", consumed))
+		return 0
+	}
+	return remaining - consumed
+}
+
 type (
 	// WorkingSetStoreFactory is the factory to create working set store
 	WorkingSetStoreFactory interface {
@@ -650,7 +664,7 @@ func (ws *workingSet) process(ctx context.Context, actions []*action.SealedEnvel
 		}
 		receipts = append(receipts, receipt)
 		if !action.IsSystemAction(act) {
-			blkCtx.GasLimit -= receipt.GasConsumed
+			blkCtx.GasLimit = deductBlockGas(fCtx, blkCtx.GasLimit, receipt.GasConsumed)
 			if fCtx.EnableDynamicFeeTx && receipt.PriorityFee() != nil {
 				(&blkCtx.AccumulatedTips).Add(&blkCtx.AccumulatedTips, receipt.PriorityFee())
 			}
@@ -907,7 +921,7 @@ func (ws *workingSet) pickAndRunActions(
 							}
 							return errors.Errorf("receipt is nil for transaction %x", h)
 						}
-						bGasLimit -= receipt.GasConsumed
+						bGasLimit = deductBlockGas(fCtx, bGasLimit, receipt.GasConsumed)
 						if fCtx.EnableDynamicFeeTx && receipt.PriorityFee() != nil {
 							(&bBlkCtx.AccumulatedTips).Add(&bBlkCtx.AccumulatedTips, receipt.PriorityFee())
 						}
@@ -924,7 +938,7 @@ func (ws *workingSet) pickAndRunActions(
 						continue
 					}
 					for _, receipt := range bReceipts {
-						blkCtx.GasLimit -= receipt.GasConsumed
+						blkCtx.GasLimit = deductBlockGas(fCtx, blkCtx.GasLimit, receipt.GasConsumed)
 						if fCtx.EnableDynamicFeeTx && receipt.PriorityFee() != nil {
 							(&blkCtx.AccumulatedTips).Add(&blkCtx.AccumulatedTips, receipt.PriorityFee())
 						}
@@ -970,7 +984,7 @@ func (ws *workingSet) pickAndRunActions(
 			if receipt == nil {
 				continue
 			}
-			blkCtx.GasLimit -= receipt.GasConsumed
+			blkCtx.GasLimit = deductBlockGas(fCtx, blkCtx.GasLimit, receipt.GasConsumed)
 			if fCtx.EnableDynamicFeeTx && receipt.PriorityFee() != nil {
 				(&blkCtx.AccumulatedTips).Add(&blkCtx.AccumulatedTips, receipt.PriorityFee())
 			}

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -7,6 +7,7 @@ package factory
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 	"time"
@@ -408,6 +409,128 @@ func TestWorkingSet_ValidateBlock_SystemAction(t *testing.T) {
 			require.ErrorIs(f.Validate(zctx, block), errInvalidSystemActionLayout)
 		}
 	})
+}
+
+// gasReportingProtocol is a post-action handler that rewrites the gas reported
+// by the receipt of the action carrying a given nonce. It lets a test drive
+// the remaining-block-gas bookkeeping with a receipt that reports more gas
+// than the block has left.
+type gasReportingProtocol struct {
+	nonce       uint64
+	gasConsumed uint64
+}
+
+func (p *gasReportingProtocol) Handle(context.Context, action.Envelope, protocol.StateManager) (*action.Receipt, error) {
+	return nil, nil
+}
+
+func (p *gasReportingProtocol) HandleReceipt(_ context.Context, elp action.Envelope, _ protocol.StateManager, receipt *action.Receipt) error {
+	if elp.Nonce() == p.nonce {
+		receipt.GasConsumed = p.gasConsumed
+	}
+	return nil
+}
+
+func (p *gasReportingProtocol) ReadState(context.Context, protocol.StateReader, []byte, ...[]byte) ([]byte, uint64, error) {
+	return nil, 0, protocol.ErrUnimplemented
+}
+
+func (p *gasReportingProtocol) Register(r *protocol.Registry) error {
+	return r.Register(p.Name(), p)
+}
+
+func (p *gasReportingProtocol) ForceRegister(r *protocol.Registry) error {
+	return r.ForceRegister(p.Name(), p)
+}
+
+func (p *gasReportingProtocol) Name() string { return "gasReporting" }
+
+// TestWorkingSet_RemainingBlockGas covers what happens when a receipt reports
+// more gas than the block has left. The remaining budget is an unsigned
+// counter: before the fix height the subtraction is unchecked and wraps to a
+// huge value, so the rest of the block is processed as if the budget were
+// untouched; from the fix height on it saturates at zero and the next action
+// is rejected for want of gas.
+func TestWorkingSet_RemainingBlockGas(t *testing.T) {
+	const blkGasLimit = uint64(15000)
+	for _, tt := range []struct {
+		name string
+		// height from which the checked subtraction takes effect
+		gateHeight uint64
+		// whether the action following the over-reporting one is refused
+		wantNextActionOutOfGas bool
+	}{
+		{
+			name:                   "before fix height",
+			gateHeight:             math.MaxUint64,
+			wantNextActionOutOfGas: false,
+		},
+		{
+			name:                   "from fix height",
+			gateHeight:             1,
+			wantNextActionOutOfGas: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			cfg := Config{
+				Chain:   blockchain.DefaultConfig,
+				Genesis: genesis.TestDefault(),
+			}
+			cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100000000"
+			// the remaining budget is only carried across actions on the
+			// post-Vanuatu processing path
+			cfg.Genesis.VanuatuBlockHeight = 1
+			// The corrections ride Zanzibar Gamma; a chain that has activated
+			// none of the family carries the heights equal, so set all three
+			// rather than leaving a partial-family genesis in a test.
+			cfg.Genesis.ZanzibarBlockHeight = tt.gateHeight
+			cfg.Genesis.ZanzibarBetaBlockHeight = tt.gateHeight
+			cfg.Genesis.ZanzibarGammaBlockHeight = tt.gateHeight
+			registry := protocol.NewRegistry()
+			require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+			// makes the first transfer report one unit more gas than the block
+			// has to give
+			require.NoError((&gasReportingProtocol{nonce: 0, gasConsumed: blkGasLimit + 1}).Register(registry))
+			f, err := NewStateDB(cfg, db.NewMemKVStore(), RegistryStateDBOption(registry))
+			require.NoError(err)
+
+			startCtx := protocol.WithBlockCtx(
+				genesis.WithGenesisContext(context.Background(), cfg.Genesis),
+				protocol.BlockCtx{},
+			)
+			require.NoError(f.Start(startCtx))
+			defer func() {
+				require.NoError(f.Stop(startCtx))
+			}()
+
+			blk := makeBlock(t, hash.ZeroHash256, hash.ZeroHash256, hash.ZeroHash256,
+				makeTransferAction(t, 0), makeTransferAction(t, 1))
+
+			zctx := protocol.WithBlockCtx(context.Background(),
+				protocol.BlockCtx{
+					BlockHeight: uint64(1),
+					Producer:    identityset.Address(27),
+					GasLimit:    blkGasLimit,
+				})
+			zctx = genesis.WithGenesisContext(zctx, cfg.Genesis)
+			zctx = protocol.WithFeatureCtx(protocol.WithBlockchainCtx(zctx, protocol.BlockchainCtx{
+				ChainID: 1,
+			}))
+			zctx = protocol.WithFeatureWithHeightCtx(zctx)
+
+			err = f.Validate(zctx, blk)
+			require.Error(err)
+			if tt.wantNextActionOutOfGas {
+				require.ErrorIs(err, action.ErrGasLimit)
+			} else {
+				// the budget wrapped around, so the second action was run
+				// anyway and the block only failed later, on the state digest
+				require.NotErrorIs(err, action.ErrGasLimit)
+				require.ErrorIs(err, block.ErrDeltaStateMismatch)
+			}
+		})
+	}
 }
 
 func makeTransferAction(t *testing.T, nonce uint64) *action.SealedEnvelope {


### PR DESCRIPTION
## What this changes

Three related corrections in how stake migration reports gas, how an underfunded migration fails, and how the block gas budget consumes a receipt.

**1. Inner call budget.** A `MigrateStake` charges its own intrinsic gas and then runs a staking contract call. The contract call was budgeted with the full gas limit of the action, and the receipt then reported the sum of both, so the reported total could exceed the limit the action itself declared. The block gas budget is reserved against that declared limit, so such a receipt reports gas the block never had. The inner call is now budgeted with `elp.Gas() - insGas`, which bounds the reported total by the declared limit and matches what `estimateMigrateStakeGasConsumptionAt` has always quoted (contract gas + intrinsic gas).

**2. A call that never starts.** The EVM refuses a call whose gas does not cover what the call costs just to begin, and reports that as a plain error rather than a failed receipt. `ExecuteContract` propagates it, a plain error out of a staking handler is not a `ReceiptError`, so it leaves `handle()` as an error and `validateAndRun` routes it to its `default` case, which abandons the block draft.

There are two such refusals, at different gas limits. The `stake0(uint256,address)` call packs 68 bytes, so it needs `10,000 + 68*100 = 16,800` intrinsic gas (`evm.go:706`) and, once Prague is active, an EIP-7623 data floor of `10,000 + 68*250 = 27,000` checked after it (`evm.go:722`). `MigrateStake` intrinsic gas is 10,000, and admission only requires the action to cover that.

So `[10000, 27000)` already costs a block draft on the current code. Change 1 hands the call the declared limit less the migration's own 10,000, which moves that band up to `[10000, 37000)` rather than creating it.

Rather than recompute either bound in the handler, `handleStakeMigrate` reads the verdict off the error the call returns and settles an `ErrOutOfGas` receipt for it. The arithmetic behind both bounds lives in the EVM, is gated on its own fork, and has grown once already; a handler that recomputed it would go stale without anything failing loudly. `ErrInsufficientFunds` is in the set alongside `ErrIntrinsicGas` and `ErrFloorDataGas` because the EVM currently reports the intrinsic shortfall with it as well as a genuine balance shortfall -- either way the call never ran, and neither should cost a draft. #5007 narrows that first one. Gated with change 1, so the pre-gate bands keep their current behaviour.

**3. Budget subtraction.** The remaining block gas budget is an unsigned counter and the per-receipt subtraction was unchecked, so a receipt reporting more gas than was left wrapped the counter and the rest of the block ran as if the budget were untouched. The four subtraction sites in `workingset.go` now route through a `deductBlockGas` helper that saturates at zero. Every node lands on the same remaining budget, and the next action is then rejected for want of gas rather than admitted.

## Fork gating

All of it is consensus data: the EVM budget, the receipt gas and status, and which actions a block may carry. Changes 1 and 2 are gated on `CorrectStakeMigrationGas`, change 3 on `CheckedBlockGasDeduction`, both wired to `IsZanzibarGamma(height)`. They were found after Zanzibar Beta had been scheduled, so folding them into Beta would rewrite the semantics of blocks a chain that activated Beta has already committed -- the same argument that gave Beta a height of its own, one level up. Below the gate the arithmetic and the error handling are byte-for-byte what they were, so historical blocks replay identically.

## Tests

`TestHandleStakeMigrateGasAccounting` pins the inner call budget and the reported receipt gas, pre- and post-gate.

`TestHandleStakeMigrateUnderfundedContractCall` covers change 2 against both refusals, since they sit at different gas limits: 12,000 for the intrinsic shortfall and 20,000 (pre-gate) / 30,000 (post-gate) for the data floor. Pre-gate the handler reports a plain error wrapping the matching sentinel; post-gate it settles an `ErrOutOfGas` receipt bounded by the declared limit. The execution stub mirrors both real checks in the order the EVM applies them, so the pre-gate paths exercise the same error classes the EVM produces.

`TestWorkingSet_RemainingBlockGas` covers change 3, with a `gasReportingProtocol` post-action-handler stub. Note this test must set `VanuatuBlockHeight = 1`: with the default test genesis, `Process` dispatches to `processLegacy`, which carries no per-action gas budget, and the test would silently exercise nothing.

Each change was verified in both directions, by neutering it and confirming the relevant subtest flips back to failing while the pre-gate subtest keeps passing.

`gofmt` clean. `go build ./...` and `go vet` pass. `go test -count=1` passes across `action/protocol`, `action/protocol/staking/...` and `state/factory/...` (669 tests, 14 packages).

## For reviewers

**Fork heights.** Both flags ride Zanzibar Gamma, which is unscheduled. They are logically independent, and if they are ever split, `CheckedBlockGasDeduction` has to activate at or before `CorrectStakeMigrationGas` so the guard is in place when the reporting change lands. On one shared height that ordering holds trivially. Per AGENTS.md the height needs maintainer sign-off.

**Receipt status choice.** Change 2 settles `ReceiptStatus_ErrOutOfGas`. It is the closest existing status for a gas shortfall; there is no dedicated intrinsic-gas status. Worth confirming that reads correctly for integrators.

**`ErrInsufficientFunds` at `evm.go:706` is a misnomer** and is left alone here. That line checks `remainingGas < intriGas` and touches no balance, while the branch below it does the real funds check. #5007 renames it and decides where both refusals belong in the `validateAndRun` switch; this PR only stops them costing a draft on the migration path, and does not depend on that one landing.

**Saturate or reject.** Change 3 saturates at zero rather than returning an error at the subtraction. It is deterministic and uniform, and the next action then fails with `ErrGasLimit`. The one gap: if the over-reporting action is the last in the block, the block is accepted with a zero remaining budget. If the intended policy is to always fail the block, that is a different call and should be stated explicitly.

**Fee change on the failure path.** On the contract-failure branch `gasToBeDeducted` becomes the full `gasConsumed`, so post-gate a failing migration is charged at most the declared limit rather than potentially more. Intended, but user visible, and worth a release note.

**Related.** A sibling branch adds validator-side recomputation of the header gas fields. `calculateGasUsed` sums `receipt.GasConsumed`, and change 1 changes that sum, so post-gate a block containing a `MigrateStake` reports a smaller `header.gasUsed`. Both branches touch `action/protocol/context.go` and `state/factory/workingset.go` and will need a trivial merge.

---

Do not merge until the Zanzibar Gamma height is assigned.

Generated with [Claude Code](https://claude.com/claude-code)



