### PR TITLE
fix(staking): revert state manager writes on failed receipts

### DIFF
--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -260,6 +260,26 @@ type (
 		// An update that omits both leaves any previously registered key
 		// untouched.
 		OptionalCandidateBLSPublicKey bool
+		// RevertStakingStateOnFailedReceipt makes a staking action that ends in
+		// a failure receipt discard every state-manager write it made before
+		// the failure, instead of only rolling back the protocol view.
+		//
+		// The handlers mutate the state manager as they go -- a bucket is
+		// written, then the bucket pool is debited, then the caller's account
+		// is stored -- and a verdict raised part way through is reported as a
+		// failure receipt rather than an error. Without this, whatever the
+		// handler had already written stays in committed state under a receipt
+		// that says the action did nothing.
+		//
+		// The rollback runs before gas is deposited and the nonce is bumped, so
+		// a failed action still charges its caller exactly as it does today;
+		// what it no longer keeps is the half-applied state.
+		//
+		// Needs its own height: what state a failed action leaves behind is
+		// part of the state root, so a chain that has already committed such
+		// blocks would recompute different roots for them on replay. Wired to
+		// IsToBeEnabled until the named height is assigned.
+		RevertStakingStateOnFailedReceipt bool
 	}
 
 	// FeatureWithHeightCtx provides feature check functions.
@@ -448,6 +468,10 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixEpochSettlementFaultHandling:  g.IsZanzibarBeta(height),
 			RequireProfileForHermesMigration: g.IsZanzibarBeta(height),
 			EmitEraFreezeLog:                 g.IsZanzibarBeta(height),
+			// Same batch: a correction that did not exist in rc0. Note this
+			// lands later than EnforceBLSPoP on any chain where Beta trails
+			// Zanzibar, which is the case testnet is already in.
+			RevertStakingStateOnFailedReceipt: g.IsZanzibarBeta(height),
 		},
 	)
 }

--- a/action/protocol/context.go
+++ b/action/protocol/context.go
@@ -468,10 +468,10 @@ func WithFeatureCtx(ctx context.Context) context.Context {
 			FixEpochSettlementFaultHandling:  g.IsZanzibarBeta(height),
 			RequireProfileForHermesMigration: g.IsZanzibarBeta(height),
 			EmitEraFreezeLog:                 g.IsZanzibarBeta(height),
-			// Same batch: a correction that did not exist in rc0. Note this
-			// lands later than EnforceBLSPoP on any chain where Beta trails
+			// Zanzibar Gamma: found after Beta was scheduled. Note this lands
+			// later than EnforceBLSPoP on any chain where Gamma trails
 			// Zanzibar, which is the case testnet is already in.
-			RevertStakingStateOnFailedReceipt: g.IsZanzibarBeta(height),
+			RevertStakingStateOnFailedReceipt: g.IsZanzibarGamma(height),
 		},
 	)
 }

--- a/action/protocol/staking/handler_failure_revert_test.go
+++ b/action/protocol/staking/handler_failure_revert_test.go
@@ -81,17 +81,24 @@ func testDepositGas(ctx context.Context, sm protocol.StateManager, gasFee *big.I
 // newStakingEnv boots a state factory whose genesis turns the corrected
 // rollback on at toBeEnabledHeight. math.MaxUint64 leaves it off, which is what
 // mainnet runs today.
-func newStakingEnv(t *testing.T, toBeEnabledHeight uint64) *stakingEnv {
-	return newStakingEnvWith(t, toBeEnabledHeight)
+func newStakingEnv(t *testing.T, gateHeight uint64) *stakingEnv {
+	return newStakingEnvWith(t, gateHeight)
 }
 
 // newStakingEnvWith is newStakingEnv with room to adjust the genesis before the
 // factory is built, for cases that need a feature the default heights leave off.
-func newStakingEnvWith(t *testing.T, toBeEnabledHeight uint64, tweaks ...func(*genesis.Genesis)) *stakingEnv {
+func newStakingEnvWith(t *testing.T, gateHeight uint64, tweaks ...func(*genesis.Genesis)) *stakingEnv {
 	r := require.New(t)
 
 	g := genesis.TestDefault()
-	g.ToBeEnabledBlockHeight = toBeEnabledHeight
+	// The rollback rides Zanzibar Gamma. All three heights are set together
+	// because a chain that has activated none of the family carries them
+	// equal; leaving the earlier ones off would be a partial-family genesis,
+	// and the register case below also needs EnforceBLSPoP, which Zanzibar
+	// carries.
+	g.ZanzibarBlockHeight = gateHeight
+	g.ZanzibarBetaBlockHeight = gateHeight
+	g.ZanzibarGammaBlockHeight = gateHeight
 	for _, tweak := range tweaks {
 		tweak(&g)
 	}

--- a/action/protocol/staking/handler_failure_revert_test.go
+++ b/action/protocol/staking/handler_failure_revert_test.go
@@ -15,6 +15,7 @@ package staking_test
 
 import (
 	"context"
+	"crypto/sha256"
 	"math"
 	"math/big"
 	"testing"
@@ -22,6 +23,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/iotexproject/go-pkgs/crypto"
 	"github.com/iotexproject/go-pkgs/hash"
 	"github.com/iotexproject/iotex-address/address"
 	"github.com/iotexproject/iotex-proto/golang/iotextypes"
@@ -45,6 +47,8 @@ var (
 	// the ordinary (non self-stake) bucket the withdraw acts on.
 	_candOwner = identityset.Address(27)
 	_staker    = identityset.Address(28)
+	// owner of the candidate the proof-of-possession case registers
+	_popOwner = identityset.Address(29)
 
 	_selfStakeAmount = unit.ConvertIotxToRau(1200000)
 	_stakeAmount     = unit.ConvertIotxToRau(100)
@@ -78,11 +82,20 @@ func testDepositGas(ctx context.Context, sm protocol.StateManager, gasFee *big.I
 // rollback on at toBeEnabledHeight. math.MaxUint64 leaves it off, which is what
 // mainnet runs today.
 func newStakingEnv(t *testing.T, toBeEnabledHeight uint64) *stakingEnv {
+	return newStakingEnvWith(t, toBeEnabledHeight)
+}
+
+// newStakingEnvWith is newStakingEnv with room to adjust the genesis before the
+// factory is built, for cases that need a feature the default heights leave off.
+func newStakingEnvWith(t *testing.T, toBeEnabledHeight uint64, tweaks ...func(*genesis.Genesis)) *stakingEnv {
 	r := require.New(t)
 
 	g := genesis.TestDefault()
 	g.ToBeEnabledBlockHeight = toBeEnabledHeight
-	for _, addr := range []address.Address{_candOwner, _staker} {
+	for _, tweak := range tweaks {
+		tweak(&g)
+	}
+	for _, addr := range []address.Address{_candOwner, _staker, _popOwner} {
 		g.InitBalanceMap[addr.String()] = unit.ConvertIotxToRau(100000000).String()
 	}
 
@@ -372,4 +385,156 @@ func TestSnapshotCoversStakingView(t *testing.T) {
 	r.NoError(e.csm(t).Commit(commitCtx))
 	votes = zeroOutVotes()
 	r.Equal(votes, e.csm(t).GetByName("cand1").Votes)
+}
+
+// blsKey derives a deterministic BLS keypair so the case does not depend on
+// randomness across runs.
+func blsKey(t *testing.T, seed string) *crypto.BLS12381PrivateKey {
+	t.Helper()
+	h := sha256.Sum256([]byte(seed))
+	sk, err := crypto.GenerateBLS12381PrivateKey(h[:])
+	require.NoError(t, err)
+	return sk
+}
+
+// TestCandidateRegisterPoPFailureLeavesNoBucket covers the ordering that makes
+// this rollback matter beyond the withdraw case: handleCandidateRegister writes
+// the self-stake bucket and its indexes and only then verifies the BLS
+// proof-of-possession, and a rejected proof settles a failure receipt rather
+// than an error. Without the rollback the bucket stays behind, owned by an
+// address that has no candidate record but still counted against the bucket
+// total.
+//
+// EnforceBLSPoP rides the same height as the corrected rollback, so there is no
+// pre-gate half to compare against: below the gate the proof is not checked at
+// all and the registration simply succeeds. The case is therefore post-gate
+// only, and its teeth were confirmed by removing the rollback and watching the
+// orphan bucket reappear.
+func TestCandidateRegisterPoPFailureLeavesNoBucket(t *testing.T) {
+	r := require.New(t)
+	// XinguBlockHeight reaches the BLS register path; the CandidateBLSPublicKey
+	// feature is gated on it and TestDefault leaves it out of range.
+	e := newStakingEnvWith(t, 1, func(g *genesis.Genesis) { g.XinguBlockHeight = 0 })
+	genesisTime := time.Unix(e.g.Timestamp, 0)
+
+	// buckets 0 and 1 belong to the fixture candidate and _staker, so a
+	// self-stake bucket written by the register below would land at index 2.
+	e.setupBucket(t)
+	const orphanIdx = uint64(2)
+	_, err := e.csm(t).NativeBucket(orphanIdx)
+	r.ErrorIs(err, state.ErrStateNotExist, "fixture must not have used the index yet")
+
+	balanceBefore := new(big.Int).Set(e.account(t, _popOwner).Balance)
+	nonceBefore := e.account(t, _popOwner).PendingNonce()
+
+	// A pubkey with no proof at all: the shape the gate exists to reject.
+	pk := blsKey(t, "register-pop-failure").PublicKey().Bytes()
+	reg, err := action.NewCandidateRegisterWithBLS(
+		"cand2", _popOwner.String(), _popOwner.String(), _popOwner.String(),
+		_selfStakeAmount.String(), 0, false, pk, nil, nil)
+	r.NoError(err)
+
+	receipt := e.run(t, _popOwner, 1, envelope(1).SetAction(reg).Build(), genesisTime)
+	r.EqualValues(iotextypes.ReceiptStatus_ErrUnauthorizedOperator, receipt.Status)
+
+	// The self-stake bucket the handler wrote before it reached the proof is
+	// gone, so nothing is left owned by a candidate that was never recorded.
+	_, err = e.csm(t).NativeBucket(orphanIdx)
+	r.ErrorIs(err, state.ErrStateNotExist)
+	r.Nil(e.csm(t).GetByName("cand2"), "the rejected candidate must not be registered")
+	r.Nil(e.csm(t).GetByOwner(_popOwner), "the rejected candidate must not be registered")
+
+	// The self-stake was not taken either: only the gas left the account, and
+	// the nonce still advanced, which is what a failure receipt owes its caller.
+	acc := e.account(t, _popOwner)
+	gasFee := new(big.Int).Mul(_testGasPrice, new(big.Int).SetUint64(receipt.GasConsumed))
+	r.Equal(new(big.Int).Sub(balanceBefore, gasFee), acc.Balance)
+	r.Equal(nonceBefore+1, acc.PendingNonce())
+}
+
+// runExpectingError sends one staking action through Handle and returns the
+// error it reports instead of a receipt.
+func (e *stakingEnv) runExpectingError(t *testing.T, caller address.Address, nonce uint64, elp action.Envelope, blkTime time.Time) error {
+	r := require.New(t)
+	intrinsicGas, err := elp.IntrinsicGas()
+	r.NoError(err)
+	receipt, err := e.p.Handle(e.actionCtx(caller, nonce, intrinsicGas, blkTime), elp, e.ws)
+	r.Error(err)
+	r.Nil(receipt)
+	return err
+}
+
+// setupMigratableBucket opens an auto-staked, still-staked bucket for _staker,
+// which is what validateStakeMigrate requires, and returns its index.
+func (e *stakingEnv) setupMigratableBucket(t *testing.T) uint64 {
+	r := require.New(t)
+	genesisTime := time.Unix(e.g.Timestamp, 0)
+
+	cs, err := action.NewCreateStake("cand1", _stakeAmount.String(), 91, true, nil)
+	r.NoError(err)
+	receipt := e.run(t, _staker, 3, envelope(3).SetAction(cs).Build(), genesisTime)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+
+	const bucketIdx = uint64(2)
+	bucket, err := e.csm(t).NativeBucket(bucketIdx)
+	r.NoError(err)
+	r.True(bucket.AutoStake)
+	r.Equal(_staker.String(), bucket.Owner.String())
+	return bucketIdx
+}
+
+// TestStakeMigrateFailureRevertsNested covers the one handler that snapshots on
+// its own: handleStakeMigrate withdraws the native bucket, then calls the
+// staking contract, and reverts to its own inner snapshot if that call fails.
+// The rollback added here takes an outer snapshot around the same action, so
+// the two have to compose -- the inner revert must not leave the outer index
+// unusable, and neither may leave the withdrawn bucket destroyed.
+//
+// The contract call is made to fail by handing the action a context whose
+// registry carries no execution protocol, which is the shortest way to reach
+// the failure branch after withdrawBucket has already written. That branch
+// returns a plain error rather than a ReceiptError, so it is also the
+// hard-error path: no receipt is settled, and nothing may survive the action.
+func TestStakeMigrateFailureRevertsNested(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		toBeEnabled uint64
+	}{
+		{"pre-gate", math.MaxUint64},
+		{"post-gate", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			e := newStakingEnv(t, tc.toBeEnabled)
+			e.setupBucket(t)
+			bucketIdx := e.setupMigratableBucket(t)
+
+			before, err := e.csm(t).NativeBucket(bucketIdx)
+			r.NoError(err)
+			votesBefore := new(big.Int).Set(e.csm(t).GetByName("cand1").Votes)
+			balanceBefore := new(big.Int).Set(e.account(t, _staker).Balance)
+			nonceBefore := e.account(t, _staker).PendingNonce()
+
+			err = e.runExpectingError(t, _staker, 4,
+				envelope(4).SetAction(action.NewMigrateStake(bucketIdx)).Build(),
+				time.Unix(e.g.Timestamp, 0))
+			r.ErrorContains(err, "execution protocol is not registered")
+
+			// The bucket the migration withdrew before the contract call failed
+			// is back, with its stake and its candidate intact.
+			after, err := e.csm(t).NativeBucket(bucketIdx)
+			r.NoError(err)
+			r.Equal(before.StakedAmount, after.StakedAmount)
+			r.Equal(before.Candidate.String(), after.Candidate.String())
+			r.Equal(before.Owner.String(), after.Owner.String())
+			r.True(after.AutoStake)
+
+			// The candidate keeps the votes the withdraw had taken off it, and
+			// a hard error settles no receipt, so neither gas nor nonce moved.
+			r.Equal(votesBefore, e.csm(t).GetByName("cand1").Votes)
+			acc := e.account(t, _staker)
+			r.Equal(balanceBefore, acc.Balance)
+			r.Equal(nonceBefore, acc.PendingNonce())
+		})
+	}
 }

--- a/action/protocol/staking/handler_failure_revert_test.go
+++ b/action/protocol/staking/handler_failure_revert_test.go
@@ -1,0 +1,375 @@
+// Copyright (c) 2026 IoTeX Foundation
+// This source code is provided 'as is' and no warranties are given as to title or non-infringement, merchantability
+// or fitness for purpose and, to the extent permitted by law, all liability for your use of the code is disclaimed.
+// This source code is governed by Apache License 2.0 that can be found in the LICENSE file.
+
+// The tests in this file are the only ones in the package that drive the
+// staking handlers against a real working set instead of
+// testdb.NewMockStateManager. The mock keeps no undo log -- its Snapshot()
+// returns a constant and testdb.AllowRevert stubs Revert() to a no-op -- so a
+// unit-level version of these cases would pass whether or not the state
+// manager is actually rolled back. Only a working set reverts, which is why
+// this file lives in the external test package and builds a state factory.
+
+package staking_test
+
+import (
+	"context"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/iotexproject/go-pkgs/hash"
+	"github.com/iotexproject/iotex-address/address"
+	"github.com/iotexproject/iotex-proto/golang/iotextypes"
+
+	"github.com/iotexproject/iotex-core/v2/action"
+	"github.com/iotexproject/iotex-core/v2/action/protocol"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/account"
+	accountutil "github.com/iotexproject/iotex-core/v2/action/protocol/account/util"
+	"github.com/iotexproject/iotex-core/v2/action/protocol/staking"
+	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
+	"github.com/iotexproject/iotex-core/v2/db"
+	"github.com/iotexproject/iotex-core/v2/pkg/unit"
+	"github.com/iotexproject/iotex-core/v2/state"
+	"github.com/iotexproject/iotex-core/v2/state/factory"
+	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil"
+)
+
+var (
+	// candidate owner / operator / reward address, and the account that opens
+	// the ordinary (non self-stake) bucket the withdraw acts on.
+	_candOwner = identityset.Address(27)
+	_staker    = identityset.Address(28)
+
+	_selfStakeAmount = unit.ConvertIotxToRau(1200000)
+	_stakeAmount     = unit.ConvertIotxToRau(100)
+	_testGasPrice    = big.NewInt(unit.Qev)
+)
+
+// stakingEnv drives staking actions through Protocol.Handle against a working
+// set produced by a real state factory.
+type stakingEnv struct {
+	p  *staking.Protocol
+	ws protocol.StateManagerWithCloser
+	g  genesis.Genesis
+}
+
+// testDepositGas mirrors the package's own test deposit function: it takes the
+// fee out of the caller's balance so a settled receipt is observable as a
+// balance change, without pulling the rewarding protocol into the fixture.
+func testDepositGas(ctx context.Context, sm protocol.StateManager, gasFee *big.Int, _ ...protocol.DepositOption) ([]*action.TransactionLog, error) {
+	actionCtx := protocol.MustGetActionCtx(ctx)
+	acc, err := accountutil.LoadAccount(sm, actionCtx.Caller)
+	if err != nil {
+		return nil, err
+	}
+	if err := acc.SubBalance(gasFee); err != nil {
+		return nil, err
+	}
+	return nil, accountutil.StoreAccount(sm, actionCtx.Caller, acc)
+}
+
+// newStakingEnv boots a state factory whose genesis turns the corrected
+// rollback on at toBeEnabledHeight. math.MaxUint64 leaves it off, which is what
+// mainnet runs today.
+func newStakingEnv(t *testing.T, toBeEnabledHeight uint64) *stakingEnv {
+	r := require.New(t)
+
+	g := genesis.TestDefault()
+	g.ToBeEnabledBlockHeight = toBeEnabledHeight
+	for _, addr := range []address.Address{_candOwner, _staker} {
+		g.InitBalanceMap[addr.String()] = unit.ConvertIotxToRau(100000000).String()
+	}
+
+	registry := protocol.NewRegistry()
+	r.NoError(account.NewProtocol(testDepositGas).Register(registry))
+	p, err := staking.NewProtocol(
+		staking.HelperCtx{
+			DepositGas:    testDepositGas,
+			BlockInterval: func(uint64) time.Duration { return 5 * time.Second },
+		},
+		&staking.BuilderConfig{
+			Staking:                       g.Staking,
+			PersistStakingPatchBlock:      math.MaxUint64,
+			SkipContractStakingViewHeight: math.MaxUint64,
+			Revise: staking.ReviseConfig{
+				VoteWeight: g.Staking.VoteWeightCalConsts,
+			},
+		},
+		nil, nil, nil, nil,
+	)
+	r.NoError(err)
+	r.NoError(p.Register(registry))
+
+	// A real KV store, not db.NewMemKVStore(): the candidate center is built
+	// with a range scan and the in-memory store does not implement Filter().
+	dbPath, err := testutil.PathOfTempFile("staking-failed-receipt")
+	r.NoError(err)
+	t.Cleanup(func() { testutil.CleanupPath(dbPath) })
+
+	cfg := factory.DefaultConfig
+	cfg.Genesis = g
+	cfg.Chain.TrieDBPath = dbPath
+	cfg.Chain.TrieDBPatchFile = ""
+	kv, err := db.CreateKVStoreWithCache(db.DefaultConfig, dbPath, cfg.Chain.StateDBCacheSize)
+	r.NoError(err)
+	sdb, err := factory.NewStateDB(cfg, kv, factory.RegistryStateDBOption(registry))
+	r.NoError(err)
+
+	base := protocol.WithRegistry(genesis.WithGenesisContext(context.Background(), g), registry)
+	startCtx := protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(
+		protocol.WithBlockCtx(base, protocol.BlockCtx{})))
+	r.NoError(sdb.Start(startCtx))
+	t.Cleanup(func() { r.NoError(sdb.Stop(startCtx)) })
+
+	// The working set builds its protocol views lazily from the context handed
+	// to it, so that context needs the same block height the actions run at.
+	wsCtx := protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(
+		protocol.WithBlockCtx(base, protocol.BlockCtx{BlockHeight: 1})))
+	ws, err := sdb.WorkingSet(wsCtx)
+	r.NoError(err)
+	t.Cleanup(func() { ws.Close() })
+
+	return &stakingEnv{p: p, ws: ws, g: g}
+}
+
+// actionCtx builds the per-action context Handle expects.
+func (e *stakingEnv) actionCtx(caller address.Address, nonce uint64, intrinsicGas uint64, blkTime time.Time) context.Context {
+	ctx := protocol.WithRegistry(genesis.WithGenesisContext(context.Background(), e.g), protocol.NewRegistry())
+	ctx = protocol.WithActionCtx(ctx, protocol.ActionCtx{
+		Caller:       caller,
+		Nonce:        nonce,
+		ActionHash:   hash.Hash256b([]byte{byte(nonce), caller.Bytes()[0]}),
+		GasPrice:     _testGasPrice,
+		IntrinsicGas: intrinsicGas,
+	})
+	ctx = protocol.WithBlockCtx(ctx, protocol.BlockCtx{
+		BlockHeight:    1,
+		BlockTimeStamp: blkTime,
+		GasLimit:       10000000,
+	})
+	ctx = protocol.WithBlockchainCtx(ctx, protocol.BlockchainCtx{Tip: protocol.TipInfo{Height: 0}})
+	return protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
+}
+
+// envelope starts an envelope carrying the fixture's gas settings. SetAction
+// takes an unexported interface, so the concrete action has to be supplied at
+// the call site rather than passed around as action.Action.
+func envelope(nonce uint64) *action.EnvelopeBuilder {
+	return (&action.EnvelopeBuilder{}).SetNonce(nonce).SetGasLimit(1000000).SetGasPrice(_testGasPrice)
+}
+
+// run sends one staking action through Handle and returns its receipt.
+func (e *stakingEnv) run(t *testing.T, caller address.Address, nonce uint64, elp action.Envelope, blkTime time.Time) *action.Receipt {
+	r := require.New(t)
+	intrinsicGas, err := elp.IntrinsicGas()
+	r.NoError(err)
+	receipt, err := e.p.Handle(e.actionCtx(caller, nonce, intrinsicGas, blkTime), elp, e.ws)
+	r.NoError(err)
+	r.NotNil(receipt)
+	return receipt
+}
+
+func (e *stakingEnv) csm(t *testing.T) staking.CandidateStateManager {
+	csm, err := staking.NewCandidateStateManagerWithContext(e.actionCtx(_staker, 1, 0, time.Unix(e.g.Timestamp, 0)), e.ws)
+	require.NoError(t, err)
+	return csm
+}
+
+func (e *stakingEnv) account(t *testing.T, addr address.Address) *state.Account {
+	acc, err := accountutil.LoadAccount(e.ws, addr)
+	require.NoError(t, err)
+	return acc
+}
+
+// setupBucket registers a candidate, opens an ordinary bucket for _staker
+// against it, and unstakes that bucket so it is ready to be withdrawn. It
+// returns the bucket index and the block time at which the withdraw matures.
+func (e *stakingEnv) setupBucket(t *testing.T) (uint64, time.Time) {
+	r := require.New(t)
+	genesisTime := time.Unix(e.g.Timestamp, 0)
+
+	reg, err := action.NewCandidateRegister(
+		"cand1", _candOwner.String(), _candOwner.String(), _candOwner.String(),
+		_selfStakeAmount.String(), 0, false, nil)
+	r.NoError(err)
+	receipt := e.run(t, _candOwner, 1, envelope(1).SetAction(reg).Build(), genesisTime)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+
+	cs, err := action.NewCreateStake("cand1", _stakeAmount.String(), 0, false, nil)
+	r.NoError(err)
+	receipt = e.run(t, _staker, 1, envelope(1).SetAction(cs).Build(), genesisTime)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+
+	// bucket 0 is the candidate's self-stake, bucket 1 is _staker's.
+	const bucketIdx = uint64(1)
+	bucket, err := e.csm(t).NativeBucket(bucketIdx)
+	r.NoError(err)
+	r.Equal(_staker.String(), bucket.Owner.String())
+
+	unstakeTime := genesisTime.Add(time.Hour)
+	receipt = e.run(t, _staker, 2, envelope(2).SetAction(action.NewUnstake(bucketIdx, nil)).Build(), unstakeTime)
+	r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+
+	bucket, err = e.csm(t).NativeBucket(bucketIdx)
+	r.NoError(err)
+	r.False(bucket.UnstakeStartTime.IsZero())
+
+	// Well past any withdraw waiting period the feature set may pick.
+	return bucketIdx, unstakeTime.Add(30 * 24 * time.Hour)
+}
+
+// breakBucketPool drives the bucket pool's bucket count to zero while leaving
+// the buckets themselves in place. Nothing a user can send produces this state;
+// it is the shortest way to make a handler fail *after* it has already written,
+// which is the shape this file is about. handleWithdrawStake deletes the bucket
+// and its indexes first and only then credits the pool, and a pool with no
+// buckets left to release rejects the credit with a failure receipt.
+func (e *stakingEnv) breakBucketPool(t *testing.T, buckets int) {
+	r := require.New(t)
+	csm := e.csm(t)
+	for i := 0; i < buckets; i++ {
+		r.NoError(csm.CreditBucketPool(big.NewInt(0), true))
+	}
+	r.NoError(csm.Commit(e.actionCtx(_staker, 1, 0, time.Unix(e.g.Timestamp, 0))))
+}
+
+// TestWithdrawStakeFailureLeavesNoPartialState is the reproduction and the
+// fix. Before the gate height a withdraw that settles a failure receipt still
+// leaves the bucket deleted; after it, the bucket survives untouched while the
+// gas charge and the nonce bump the receipt is supposed to keep still land.
+func TestWithdrawStakeFailureLeavesNoPartialState(t *testing.T) {
+	t.Run("pre-gate keeps today's behaviour", func(t *testing.T) {
+		r := require.New(t)
+		e := newStakingEnv(t, math.MaxUint64)
+		bucketIdx, withdrawTime := e.setupBucket(t)
+		e.breakBucketPool(t, 2)
+
+		balanceBefore := new(big.Int).Set(e.account(t, _staker).Balance)
+		nonceBefore := e.account(t, _staker).PendingNonce()
+
+		receipt := e.run(t, _staker, 3, envelope(3).SetAction(action.NewWithdrawStake(bucketIdx, nil)).Build(), withdrawTime)
+		r.EqualValues(iotextypes.ReceiptStatus_ErrWriteAccount, receipt.Status)
+
+		// The write the handler made before it failed is still there: the
+		// bucket the action reports not having touched is gone. Asserted, not
+		// endorsed -- historical blocks have to replay to the same state root,
+		// so this is what a node below the gate height must keep doing.
+		_, err := e.csm(t).NativeBucket(bucketIdx)
+		r.ErrorIs(err, state.ErrStateNotExist)
+
+		// Gas and nonce, the two effects a failure receipt is meant to keep,
+		// land here as well -- they are the baseline the post-gate case has to
+		// reproduce.
+		acc := e.account(t, _staker)
+		gasFee := new(big.Int).Mul(_testGasPrice, new(big.Int).SetUint64(receipt.GasConsumed))
+		r.Equal(new(big.Int).Sub(balanceBefore, gasFee), acc.Balance)
+		r.Equal(nonceBefore+1, acc.PendingNonce())
+	})
+
+	t.Run("post-gate discards the partial write", func(t *testing.T) {
+		r := require.New(t)
+		e := newStakingEnv(t, 1)
+		bucketIdx, withdrawTime := e.setupBucket(t)
+		e.breakBucketPool(t, 2)
+
+		before, err := e.csm(t).NativeBucket(bucketIdx)
+		r.NoError(err)
+		balanceBefore := new(big.Int).Set(e.account(t, _staker).Balance)
+		nonceBefore := e.account(t, _staker).PendingNonce()
+
+		receipt := e.run(t, _staker, 3, envelope(3).SetAction(action.NewWithdrawStake(bucketIdx, nil)).Build(), withdrawTime)
+		r.EqualValues(iotextypes.ReceiptStatus_ErrWriteAccount, receipt.Status)
+
+		// The bucket, its amount and its unstake time are exactly as they were.
+		after, err := e.csm(t).NativeBucket(bucketIdx)
+		r.NoError(err)
+		r.Equal(before.StakedAmount, after.StakedAmount)
+		r.Equal(before.UnstakeStartTime, after.UnstakeStartTime)
+		r.Equal(before.Owner.String(), after.Owner.String())
+		r.Equal(before.Candidate.String(), after.Candidate.String())
+
+		// The staked amount was not handed back either -- only the gas came
+		// out, and the nonce still advanced, so the failure receipt charges
+		// its caller just as it does pre-gate.
+		acc := e.account(t, _staker)
+		gasFee := new(big.Int).Mul(_testGasPrice, new(big.Int).SetUint64(receipt.GasConsumed))
+		r.Equal(new(big.Int).Sub(balanceBefore, gasFee), acc.Balance)
+		r.Equal(nonceBefore+1, acc.PendingNonce())
+	})
+}
+
+// TestWithdrawStakeSuccessUnaffected pins the success path: turning the gate on
+// must not disturb an action that does not fail.
+func TestWithdrawStakeSuccessUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		toBeEnabled uint64
+	}{
+		{"pre-gate", math.MaxUint64},
+		{"post-gate", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := require.New(t)
+			e := newStakingEnv(t, tc.toBeEnabled)
+			bucketIdx, withdrawTime := e.setupBucket(t)
+
+			balanceBefore := new(big.Int).Set(e.account(t, _staker).Balance)
+			receipt := e.run(t, _staker, 3, envelope(3).SetAction(action.NewWithdrawStake(bucketIdx, nil)).Build(), withdrawTime)
+			r.EqualValues(iotextypes.ReceiptStatus_Success, receipt.Status)
+
+			// A successful withdraw does delete the bucket, gate or no gate.
+			_, err := e.csm(t).NativeBucket(bucketIdx)
+			r.ErrorIs(err, state.ErrStateNotExist)
+
+			gasFee := new(big.Int).Mul(_testGasPrice, new(big.Int).SetUint64(receipt.GasConsumed))
+			expected := new(big.Int).Sub(new(big.Int).Add(balanceBefore, _stakeAmount), gasFee)
+			r.Equal(expected, e.account(t, _staker).Balance)
+		})
+	}
+}
+
+// TestSnapshotCoversStakingView pins the assumption the rollback rests on: a
+// state-manager snapshot covers the staking protocol view, not only the
+// key-value store. Candidate records live in the candidate center and reach
+// state only at commit, so a rollback that restored the store but not the view
+// would leave a failed action's candidate changes standing.
+//
+// Both cases matter. A candidate already changed earlier in the same block sits
+// in the center's pending change list; one that has been committed is served
+// from the base. The revert has to put either back.
+func TestSnapshotCoversStakingView(t *testing.T) {
+	r := require.New(t)
+	e := newStakingEnv(t, 1)
+	e.setupBucket(t)
+	commitCtx := e.actionCtx(_staker, 1, 0, time.Unix(e.g.Timestamp, 0))
+
+	zeroOutVotes := func() *big.Int {
+		votes := new(big.Int).Set(e.csm(t).GetByName("cand1").Votes)
+		r.Positive(votes.Sign(), "fixture must leave the candidate with votes to drop")
+
+		si := e.ws.Snapshot()
+		csm := e.csm(t)
+		cand := csm.GetByName("cand1")
+		r.NoError(cand.SubVote(votes))
+		r.NoError(csm.Upsert(cand))
+		r.Zero(e.csm(t).GetByName("cand1").Votes.Sign(), "mutation must be visible before the revert")
+
+		r.NoError(e.ws.Revert(si))
+		return votes
+	}
+
+	// The candidate is still pending from setupBucket.
+	votes := zeroOutVotes()
+	r.Equal(votes, e.csm(t).GetByName("cand1").Votes)
+
+	// And again once it has been committed to the center's base.
+	r.NoError(e.csm(t).Commit(commitCtx))
+	votes = zeroOutVotes()
+	r.Equal(votes, e.csm(t).GetByName("cand1").Votes)
+}

--- a/action/protocol/staking/handlers_blsdup_test.go
+++ b/action/protocol/staking/handlers_blsdup_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/action"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 )
 
 // TestHandleCandidateUpdate_DuplicateBLSKeyIsDeterministic is the receipt-level
@@ -46,6 +47,10 @@ func TestHandleCandidateUpdate_DuplicateBLSKeyIsDeterministic(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			sm, p, candA, candB := initAll(t, ctrl)
+			// Post-fork, a failure receipt rolls the state manager back to the
+			// pre-action snapshot. The mock keeps no undo log, so the call only
+			// needs to be accepted; nothing here asserts on it.
+			testdb.AllowRevert(sm)
 
 			// Put both candidates on the same pubkey, the pre-fork state the
 			// uniqueness rule was never able to prevent.

--- a/action/protocol/staking/handlers_blspop_test.go
+++ b/action/protocol/staking/handlers_blspop_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 )
 
 // blsKeyFromSeed generates a deterministic BLS keypair for tests.
@@ -143,6 +144,10 @@ func TestHandleCandidateRegister_PoPGate(t *testing.T) {
 
 	t.Run("gate on, empty PoP → ErrUnauthorizedOperator", func(t *testing.T) {
 		sm, p, _, _ := initAll(t, ctrl)
+		// Post-fork, a failure receipt rolls the state manager back to the
+		// pre-action snapshot. The mock keeps no undo log, so the call only
+		// needs to be accepted; nothing here asserts on it.
+		testdb.AllowRevert(sm)
 		r := runRegisterWithBLS(t, p, sm, caller, owner, 1, "nopop", pk, nil, true)
 		require.NotNil(r)
 		require.EqualValues(iotextypes.ReceiptStatus_ErrUnauthorizedOperator, r.Status,
@@ -151,6 +156,10 @@ func TestHandleCandidateRegister_PoPGate(t *testing.T) {
 
 	t.Run("gate on, invalid PoP → ErrUnauthorizedOperator", func(t *testing.T) {
 		sm, p, _, _ := initAll(t, ctrl)
+		// Post-fork, a failure receipt rolls the state manager back to the
+		// pre-action snapshot. The mock keeps no undo log, so the call only
+		// needs to be accepted; nothing here asserts on it.
+		testdb.AllowRevert(sm)
 		// PoP shape-correct but signed by a different key — verifier
 		// rejects because Verify(pk, ...) doesn't accept a sig produced
 		// under sk_attacker.
@@ -183,6 +192,10 @@ func TestHandleCandidateRegister_BLSPubKeyUniqueness(t *testing.T) {
 	defer ctrl.Finish()
 
 	sm, p, _, _ := initAll(t, ctrl)
+	// Post-fork, a failure receipt rolls the state manager back to the
+	// pre-action snapshot. The mock keeps no undo log, so the call only
+	// needs to be accepted; nothing here asserts on it.
+	testdb.AllowRevert(sm)
 
 	sk := blsKeyFromSeed(t, "shared")
 	pk := sk.PublicKey().Bytes()
@@ -233,6 +246,10 @@ func TestHandleCandidateUpdate_PoPGate(t *testing.T) {
 	// Set up state with an existing candidate owned by `owner`.
 	setupCand := func() (protocol.StateManager, *Protocol) {
 		sm, p, _, _ := initAll(t, ctrl)
+		// Post-fork, a failure receipt rolls the state manager back to the
+		// pre-action snapshot. The mock keeps no undo log, so the call only
+		// needs to be accepted; nothing here asserts on it.
+		testdb.AllowRevert(sm)
 		sk0 := blsKeyFromSeed(t, "original")
 		pk0 := sk0.PublicKey().Bytes()
 		pop0, err := SignBLSPop(sk0, owner)

--- a/action/protocol/staking/handlers_test.go
+++ b/action/protocol/staking/handlers_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/pkg/util/assertions"
 	"github.com/iotexproject/iotex-core/v2/state"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_chainmanager"
 	"github.com/iotexproject/iotex-core/v2/testutil/testdb"
 )
 
@@ -3415,7 +3416,7 @@ func initCreateStake(t *testing.T, sm protocol.StateManager, callerAddr address.
 	return ctx, cost
 }
 
-func initAll(t *testing.T, ctrl *gomock.Controller) (protocol.StateManager, *Protocol, *Candidate, *Candidate) {
+func initAll(t *testing.T, ctrl *gomock.Controller) (*mock_chainmanager.MockStateManager, *Protocol, *Candidate, *Candidate) {
 	require := require.New(t)
 	sm := testdb.NewMockStateManager(ctrl)
 	csm := newCandidateStateManager(sm)

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -865,6 +865,16 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 		snapshot = -1
 	)
 	if protocol.MustGetFeatureCtx(ctx).RevertStakingStateOnFailedReceipt {
+		// Covers the store and every protocol view, which is everything the
+		// handlers below write through -- with one exception that costs
+		// nothing here. recordOwner writes into candCenter.base rather than
+		// the dirty change set, and viewData.Snapshot records only the center
+		// size, the pending change count, the pool totals and contractsStake,
+		// so a base write would outlive this rollback. Both of its call sites
+		// sit behind needToWriteCandsMap, which requires CandCenterHasAlias,
+		// that is !IsOkhotsk. That window closed long before any height this
+		// gate can be given, so the two are mutually exclusive and no
+		// recordOwner write can happen where this rollback applies.
 		snapshot = csm.SM().Snapshot()
 	}
 	switch act := elp.Action().(type) {

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -913,7 +913,17 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 		}
 	}
 	if err == nil {
-		return p.settleAction(ctx, csm.SM(), elp, uint64(iotextypes.ReceiptStatus_Success), logs, tLogs, gasConsumed, gasToBeDeducted, nonceUpdateOption, isSystemAction)
+		receipt, serr := p.settleAction(ctx, csm.SM(), elp, uint64(iotextypes.ReceiptStatus_Success), logs, tLogs, gasConsumed, gasToBeDeducted, nonceUpdateOption, isSystemAction)
+		if serr != nil && snapshot >= 0 {
+			// settleAction moves the gas fee before it touches the nonce, so a
+			// failure here can land between the two. Put the whole action back,
+			// its successful handler writes included, rather than leave the
+			// caller a half-settled one.
+			if rerr := csm.SM().Revert(snapshot); rerr != nil {
+				return nil, errors.Wrap(rerr, "failed to revert state")
+			}
+		}
+		return receipt, serr
 	}
 
 	if receiptErr, ok := err.(ReceiptError); ok {
@@ -933,6 +943,13 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 				return nil, errors.Wrap(rerr, "failed to revert state")
 			}
 		}
+		// No second rollback around settleAction here. The snapshot above has
+		// been spent -- reverting to the same index twice is rejected, since
+		// the first revert truncates the view snapshot list to it -- so
+		// covering a settleAction failure on this path would mean taking a
+		// fresh snapshot on the restored state and settling against that. That
+		// is the shape that has gone wrong before, and it would be added to a
+		// reachable path to cover a failure that is not reachable at all.
 		return p.settleAction(ctx, csm.SM(), elp, receiptErr.ReceiptStatus(), logs, tLogs, gasConsumed, gasToBeDeducted, nonceUpdateOption, isSystemAction)
 	}
 	// A non-receipt error abandons the block being built or validated, so the

--- a/action/protocol/staking/protocol.go
+++ b/action/protocol/staking/protocol.go
@@ -823,6 +823,19 @@ func (p *Protocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.
 	if err != nil {
 		return nil, err
 	}
+	// The handlers mutate two places: the protocol view (candidate center and
+	// bucket pool) and the state manager itself (buckets, bucket indexes,
+	// endorsements, accounts). A view snapshot rolls back only the first, so an
+	// action that gives up part way through keeps whatever it had already
+	// written through to the state manager.
+	//
+	// Past the gate, handle() takes a state-manager snapshot instead, which
+	// covers both -- a working set snapshots every protocol view alongside its
+	// own store -- and settles its own rollbacks, so no view snapshot is taken
+	// here and the number of view snapshots per action is unchanged.
+	if protocol.MustGetFeatureCtx(ctx).RevertStakingStateOnFailedReceipt {
+		return p.handle(ctx, elp, csm)
+	}
 	snapshot := view.Snapshot()
 	receipt, err = p.handle(ctx, elp, csm)
 	if err != nil {
@@ -846,7 +859,14 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 		gasConsumed       = actionCtx.IntrinsicGas
 		gasToBeDeducted   = gasConsumed
 		isSystemAction    bool
+		// snapshot is the pre-action state-manager snapshot the failure paths
+		// below roll back to; -1 before the gate, where no snapshot is taken
+		// and the old behavior of keeping partial writes is preserved.
+		snapshot = -1
 	)
+	if protocol.MustGetFeatureCtx(ctx).RevertStakingStateOnFailedReceipt {
+		snapshot = csm.SM().Snapshot()
+	}
 	switch act := elp.Action().(type) {
 	case *action.CreateStake:
 		rLog, tLogs, err = p.handleCreateStake(ctx, act, csm)
@@ -900,7 +920,29 @@ func (p *Protocol) handle(ctx context.Context, elp action.Envelope, csm Candidat
 		actionCtx := protocol.MustGetActionCtx(ctx)
 		log.L().With(
 			zap.String("actionHash", hex.EncodeToString(actionCtx.ActionHash[:]))).Debug("Failed to commit staking action", zap.Error(err))
+		// Discard whatever the handler wrote before it reached its verdict, so
+		// that the receipt and the state agree the action did nothing.
+		//
+		// Order matters. The rollback runs first and settleAction deposits the
+		// gas and bumps the nonce afterwards, on top of the restored state, so
+		// both survive exactly as they do today -- a failure receipt still
+		// charges its caller. Settling first and reverting after would take the
+		// gas and the nonce down together with the partial writes.
+		if snapshot >= 0 {
+			if rerr := csm.SM().Revert(snapshot); rerr != nil {
+				return nil, errors.Wrap(rerr, "failed to revert state")
+			}
+		}
 		return p.settleAction(ctx, csm.SM(), elp, receiptErr.ReceiptStatus(), logs, tLogs, gasConsumed, gasToBeDeducted, nonceUpdateOption, isSystemAction)
+	}
+	// A non-receipt error abandons the block being built or validated, so the
+	// rollback is not what makes the caller safe. It is taken anyway to leave
+	// the working set consistent for whoever inspects it next, matching the
+	// view rollback Handle performs before the gate.
+	if snapshot >= 0 {
+		if rerr := csm.SM().Revert(snapshot); rerr != nil {
+			return nil, errors.Wrap(rerr, "failed to revert state")
+		}
 	}
 	return nil, err
 }

--- a/state/factory/workingset.go
+++ b/state/factory/workingset.go
@@ -894,7 +894,13 @@ func (ws *workingSet) pickAndRunActions(
 					}
 					bBlobCnt := blobCnt
 					bReceipts := make([]*action.Receipt, 0, bundle.Len())
-					si := ws.store.Snapshot()
+					// ws.Snapshot() rather than ws.store.Snapshot(): a bundle
+					// that gives up part way through has to put the protocol
+					// views back as well as the store, and only the working
+					// set snapshot records both. Mint is the only caller of
+					// this path, so a proposer that skips a bundle carries on
+					// from the state it held before the bundle ran.
+					si := ws.Snapshot()
 					if err := bundle.ForEach(func(selp *action.SealedEnvelope) error {
 						_, _, receipt, err := ws.validateAndRun(ctxWithBlockContext, reg, selp, bGasLimit, bBlobCnt, uint64(blobLimit), false)
 						if err != nil {
@@ -918,7 +924,7 @@ func (ws *workingSet) pickAndRunActions(
 						return nil
 					}); err != nil {
 						log.L().Warn("failed to process bundle", zap.String("uuid", bids[i]), zap.Uint64("height", ws.height), zap.Error(err))
-						if err := ws.store.RevertSnapshot(si); err != nil {
+						if err := ws.Revert(si); err != nil {
 							return nil, errors.Wrapf(err, "failed to revert snapshot %d for bundle %s at height %d", si, bids[i], ws.height)
 						}
 						continue

--- a/state/factory/workingset_test.go
+++ b/state/factory/workingset_test.go
@@ -8,6 +8,7 @@ package factory
 import (
 	"context"
 	"math/big"
+	"sync"
 	"testing"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/account"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rewarding"
+	"github.com/iotexproject/iotex-core/v2/actpool"
 	"github.com/iotexproject/iotex-core/v2/blockchain"
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
@@ -448,4 +450,208 @@ func makeBlock(t *testing.T, prevHash hash.Hash256, receiptRoot hash.Hash256, di
 		SignAndBuild(identityset.PrivateKey(0))
 	require.NoError(t, err)
 	return &blk
+}
+
+// viewTrace records what a protocol view was asked to do. Forks share it, so a
+// test can watch a view that only ever exists inside Mint.
+type viewTrace struct {
+	mu  sync.Mutex
+	ops []string
+}
+
+func (tr *viewTrace) record(op string) {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	tr.ops = append(tr.ops, op)
+}
+
+func (tr *viewTrace) snapshot() []string {
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	return append([]string(nil), tr.ops...)
+}
+
+// countingView is a minimal protocol view: an integer every handled action
+// bumps, with the snapshot and revert semantics the working set relies on.
+type countingView struct {
+	n         int
+	snapshots []int
+	trace     *viewTrace
+}
+
+func (v *countingView) Fork() protocol.View {
+	// The fork shares the trace on purpose: it is the only handle the test has
+	// on the copy the working set actually mutates.
+	return &countingView{n: v.n, snapshots: append([]int(nil), v.snapshots...), trace: v.trace}
+}
+
+func (v *countingView) Snapshot() int {
+	v.snapshots = append(v.snapshots, v.n)
+	v.trace.record("snapshot")
+	return len(v.snapshots) - 1
+}
+
+func (v *countingView) Revert(i int) error {
+	if i < 0 || i >= len(v.snapshots) {
+		return errors.Errorf("invalid snapshot index %d", i)
+	}
+	v.n = v.snapshots[i]
+	v.snapshots = v.snapshots[:i]
+	v.trace.record("revert")
+	return nil
+}
+
+func (v *countingView) Commit(context.Context, protocol.StateManager) error { return nil }
+
+// viewBumpProtocol mutates its view for every transfer it sees and fails on one
+// designated recipient, which is how the bundle below is made to give up after
+// it has already changed a view.
+type viewBumpProtocol struct {
+	poison string
+	trace  *viewTrace
+}
+
+func (p *viewBumpProtocol) Name() string { return "viewbump" }
+
+func (p *viewBumpProtocol) Start(context.Context, protocol.StateReader) (protocol.View, error) {
+	return &countingView{trace: p.trace}, nil
+}
+
+func (p *viewBumpProtocol) Handle(ctx context.Context, elp action.Envelope, sm protocol.StateManager) (*action.Receipt, error) {
+	tsf, ok := elp.Action().(*action.Transfer)
+	if !ok {
+		return nil, nil
+	}
+	v, err := sm.ReadView(p.Name())
+	if err != nil {
+		return nil, err
+	}
+	cv, ok := v.(*countingView)
+	if !ok {
+		return nil, errors.Errorf("unexpected view type %T", v)
+	}
+	cv.n++
+	cv.trace.record("bump")
+	if tsf.Recipient() == p.poison {
+		return nil, errors.New("injected failure inside bundle")
+	}
+	// Leave the receipt to the account protocol.
+	return nil, nil
+}
+
+func (p *viewBumpProtocol) ReadState(context.Context, protocol.StateReader, []byte, ...[]byte) ([]byte, uint64, error) {
+	return nil, 0, protocol.ErrUnimplemented
+}
+
+func (p *viewBumpProtocol) Register(r *protocol.Registry) error { return r.Register(p.Name(), p) }
+
+func (p *viewBumpProtocol) ForceRegister(r *protocol.Registry) error {
+	return r.ForceRegister(p.Name(), p)
+}
+
+func bundleTransfer(t *testing.T, nonce uint64, recipient string) *action.SealedEnvelope {
+	tsf := action.NewTransfer(big.NewInt(1), recipient, nil)
+	evlp := (&action.EnvelopeBuilder{}).
+		SetAction(tsf).
+		SetGasLimit(testutil.TestGasLimit).
+		SetNonce(nonce).
+		SetChainID(1).
+		SetVersion(1).
+		Build()
+	sevlp, err := action.Sign(evlp, identityset.PrivateKey(28))
+	require.NoError(t, err)
+	return sevlp
+}
+
+// TestWorkingSet_Mint_BundleAbortRevertsView pins the rollback a bundle takes
+// when it gives up part way through. The store snapshot alone leaves protocol
+// views carrying the changes of a bundle that was dropped, and the block the
+// proposer goes on to build then reflects actions it did not include. Reverting
+// through the working set puts both back.
+func TestWorkingSet_Mint_BundleAbortRevertsView(t *testing.T) {
+	require := require.New(t)
+	trace := &viewTrace{}
+	registry := protocol.NewRegistry()
+	// Registered ahead of the account protocol: runAction walks the registry in
+	// registration order and stops at the first handler that returns a receipt,
+	// so this one has to see the action before account settles it.
+	poison := identityset.Address(30).String()
+	require.NoError((&viewBumpProtocol{poison: poison, trace: trace}).Register(registry))
+	require.NoError(account.NewProtocol(rewarding.DepositGas).Register(registry))
+
+	cfg := Config{
+		Chain:   blockchain.DefaultConfig,
+		Genesis: genesis.TestDefault(),
+	}
+	cfg.Genesis.InitBalanceMap[identityset.Address(28).String()] = "100000000000000000000"
+	f, err := NewStateDB(cfg, db.NewMemKVStore(), RegistryStateDBOption(registry))
+	require.NoError(err)
+
+	startCtx := protocol.WithBlockCtx(
+		genesis.WithGenesisContext(context.Background(), cfg.Genesis),
+		protocol.BlockCtx{},
+	)
+	require.NoError(f.Start(startCtx))
+	defer func() { require.NoError(f.Stop(startCtx)) }()
+
+	// A bundle whose second action fails, after the first has already moved the
+	// view. Bundles only accept transfers, executions and tx containers.
+	bundle := action.NewBundle()
+	require.NoError(bundle.Add(
+		bundleTransfer(t, 1, identityset.Address(29).String()),
+		bundleTransfer(t, 2, poison),
+	))
+	bundle.SetTargetBlockHeight(1)
+
+	bp := actpool.NewBundlePool(cfg.Genesis)
+	require.NoError(bp.AddBundle(context.Background(), identityset.Address(28), "bundle-uuid", bundle))
+
+	ctrl := gomock.NewController(t)
+	ap := mock_actpool.NewMockActPool(ctrl)
+	ap.EXPECT().BundlePool().Return(bp).Times(1)
+	ap.EXPECT().PendingActionMap().Return(map[string][]*action.SealedEnvelope{}).Times(1)
+
+	ctx := protocol.WithBlockCtx(context.Background(),
+		protocol.BlockCtx{
+			BlockHeight: uint64(1),
+			Producer:    identityset.Address(27),
+			GasLimit:    testutil.TestGasLimit * 100000,
+		})
+	ctx = protocol.WithBlockchainCtx(
+		genesis.WithGenesisContext(ctx, cfg.Genesis),
+		protocol.BlockchainCtx{},
+	)
+	ctx = protocol.WithFeatureCtx(protocol.WithFeatureWithHeightCtx(ctx))
+
+	blk, err := f.Mint(ctx, ap, identityset.PrivateKey(27))
+	require.NoError(err, "a failed bundle is skipped, it must not fail the mint")
+	for _, selp := range blk.Actions {
+		if tsf, ok := selp.Action().(*action.Transfer); ok {
+			require.NotEqual(poison, tsf.Recipient(), "the dropped bundle must not reach the block")
+		}
+	}
+
+	ops := trace.snapshot()
+	require.Contains(ops, "bump", "the bundle must have reached the protocol")
+	require.Contains(ops, "revert", "the dropped bundle must have rolled its view back")
+	// The revert has to come after the mutations it undoes.
+	require.Greater(indexOfLast(ops, "revert"), indexOfFirst(ops, "bump"))
+}
+
+func indexOfFirst(ops []string, want string) int {
+	for i, op := range ops {
+		if op == want {
+			return i
+		}
+	}
+	return -1
+}
+
+func indexOfLast(ops []string, want string) int {
+	for i := len(ops) - 1; i >= 0; i-- {
+		if ops[i] == want {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## What this changes

`Protocol.Handle` snapshotted only the protocol view. A staking handler that writes to the state manager and then returns a `ReceiptError` settles a **failure receipt**, not an error, so those writes stayed in place under a receipt saying the action did not take effect.

Concrete shape: `handleWithdrawStake` calls `csm.delBucketAndIndex(...)`, a real `DelState`, and only then credits the bucket pool. A rejected credit returns `*handleError{ErrWriteAccount}`, which settles a failure receipt. Nothing undid the delete.

`handle()` now takes `csm.SM().Snapshot()` at its top, past the gate, and reverts to it on the failure paths. A working set snapshots every protocol view alongside its own store, so one snapshot covers both. `Handle` skips its own view snapshot past the gate rather than taking a second one, so the number of view snapshots per action is unchanged. The signature of `handle()` is untouched.

Two rollbacks that were reached only partly are fixed alongside it.

**Bundle abort.** A bundle that gives up part way through is skipped and block building carries on with the same working set, so its rollback is load bearing. The snapshot was taken on the store alone (`ws.store.Snapshot`), so the protocol views kept whatever the dropped bundle had written and the block the proposer went on to build reflected actions it did not include. Such a block computes a state root no validator reproduces, so it is rejected and the slot is lost. The snapshot and the revert now both go through the working set, which covers the store and every view. The pairing matters: view snapshot ids are recorded by `ws.Snapshot()`, so reverting a store-only snapshot through `ws.Revert()` cannot work. Mint is the only caller of `pickAndRunActions` -- validation runs the actions a block already contains -- so this changes what a proposer builds, not what a node accepts, and needs no fork gate.

**settleAction on the success path.** `settleAction` moves the gas fee before it touches the nonce, so a failure inside it can land between the two and leave a half-settled action behind. On the success path the snapshot is still untouched, so the whole action is put back through it. The receipt-failure path deliberately keeps no equivalent: that snapshot has been spent, reverting to the same index twice is rejected (`viewData.Revert` truncates the snapshot list to the index it restores), and covering it would mean taking a fresh snapshot on restored state and settling against that -- the shape that has gone wrong in this codebase before, added to a reachable path for a failure that is not reachable at all. All five of settleAction failure points are internal-failure guards.

## Ordering

The revert runs before `settleAction`, which then deposits gas and bumps the nonce on the restored state, so both survive a failed action. This is asserted in both the pre- and post-gate subtests. Nothing writes state between the handler returning and `settleAction` (only `rLog.Build`, which rides the receipt).

The non-receipt error path reverts too, and that rollback is not merely housekeeping. It abandons the block in the ordinary case, but not inside a bundle: `pickAndRunActions` skips a failed bundle and carries on building with the same working set, so anything left behind there reaches the block the proposer produces. The same commit fixes that path to revert through the working set rather than the store alone (see below).

The nested case was checked: `handleStakeMigrate` reverts to its own inner snapshot and this then reverts to the outer one. `cachedBatch.RevertSnapshot` sets `tag = snapshot+1`, `views.Revert` and `viewData.Revert` both accept a lower index afterwards, and `workingSetStoreWithSecondary.snMap` retains the outer entry.

## Fork gating

What state a failed action leaves behind is part of the state root, so this is gated on a new `FeatureCtx.RevertStakingStateOnFailedReceipt` wired to `IsZanzibarGamma(height)`. It was found after Zanzibar Beta had been scheduled, so folding it into Beta would rewrite the semantics of blocks a chain that activated Beta has already committed -- the same argument that gave Beta a height of its own, one level up. Below the gate the view-only snapshot and revert are kept exactly as they are, so historical blocks replay to identical roots.

## Tests

`handler_failure_revert_test.go` is new, an external `staking_test` package driving a real state factory and working set rather than a mock, which keeps no undo log and so cannot tell a rollback that happens from one that does not.

- **`TestWithdrawStakeFailureLeavesNoPartialState`** -- the reproduction. Pre-gate the withdraw settles a failure receipt and the bucket stays deleted; post-gate the bucket survives untouched while the gas charge and the nonce bump still land.
- **`TestCandidateRegisterPoPFailureLeavesNoBucket`** -- the ordering that makes this matter beyond the withdraw. The register writes the self-stake bucket and its indexes and only then verifies the BLS proof of possession, so a rejected proof would otherwise leave an orphan bucket owned by an address with no candidate record. Enforcement of the proof rides the same height as this rollback, so there is no pre-gate half to compare against and the case is post-gate only.
- **`TestStakeMigrateFailureRevertsNested`** -- the one handler that snapshots on its own. `handleStakeMigrate` reverts to its own inner snapshot when the contract call fails, so the outer snapshot has to compose with it. It runs and passes on both sides of the gate, which is the point: the inner revert already covered this path and adding an outer snapshot must not change that. It is also the plain-error path, so no receipt is settled and neither gas nor nonce moves.
- **`TestWorkingSet_Mint_BundleAbortRevertsView`** (in `state/factory`) covers the bundle rollback, using a protocol view whose snapshot and revert calls are traced through the fork the working set makes, so the test can watch a view that only ever exists inside `Mint`. Without the change the trace shows the two mutations of the dropped bundle and no revert at all.
- **`TestWithdrawStakeSuccessUnaffected`** and **`TestSnapshotCoversStakingView`** pin the success path and the assumption that a state-manager snapshot covers the protocol view, not only the store.

Each case was checked by removing the rollback: the withdraw and register cases then fail, the migrate case is unaffected either way, as described above.

**One gap, deliberately not filled.** There is no isolated test for the plain-error path on a handler that does *not* carry its own inner snapshot. Every plain-error return that sits after a write is an internal-failure guard -- `AddBalance`, `StoreAccount`, ABI packing, a partially deleted bucket index -- and none is reachable through the public action surface. Reproducing one means hand-building internal state keys from an external test package, which would encode the current key layout into a test and rot silently when it changes. The migrate case above exercises the same branch of `handle()`. Happy to add one if a reviewer sees a reachable trigger I missed.

Two small mock adjustments: `initAll` returns the concrete mock type so `testdb.AllowRevert` can be applied to it, and `testdb.AllowRevert(sm)` is added at four sites in the BLS tests that enable the gate and settle failure receipts, since the mock declares no `Revert` expectation by default.

`go build ./...`, `go vet`, and `go test` pass on `action/protocol`, `action/protocol/staking`, `state/factory` and `e2etest`. A full `go test ./...` shows 97 packages ok and 2 failures, both of which reproduce on the clean base tree with the changes stashed (`api.TestEstimateExecutionGasConsumption/FailedToAccountState` and `blockchain/blockdao.TestBlockIndexerChecker_CheckIndexer`); neither touches staking.

## For reviewers

**Scope.** Past the gate this changes what every staking failure receipt leaves behind, not only the one case reproduced above. Seven handlers share the write-then-failure-receipt shape: `handleCreateStake`, `handleUnstake`, `handleWithdrawStake`, `handleChangeCandidate`, `handleDepositToStake`, `handleRestake` and `handleCandidateRegister`. That breadth is the intent, but it is wider than the single reproduction and worth confirming.

Note `handleUnstake` already moved its `updateBucket` from before the self-stake check to after it, gated on `UnstakedButNotClearSelfStakeAmount`. That is the same class of fix applied once, locally, to one handler; this generalizes it.

**Coverage boundary.** The snapshot covers the store and every protocol view. It does not cover writes that bypass both, of which there is one in this package: `recordOwner` writes into `candCenter.base` rather than the dirty change set, and `viewData.Snapshot` records only `size`, `changes`, the pool totals and `contractsStake`. Both call sites sit behind `needToWriteCandsMap`, which requires `CandCenterHasAlias(height)`, i.e. `!IsOkhotsk(height)`. That window closed long ago, and this gate is far above it, so the two are mutually exclusive and no `recordOwner` write can occur where this rollback applies. Worth a source comment so the next reader does not have to re-derive it.

**Activation ordering, and a window that cannot be closed.** `handleCandidateRegister` writes the self-stake bucket and its indexes before it verifies the BLS proof of possession. Once `EnforceBLSPoP` is active, a failed proof leaves that bucket behind, owned by an address with no candidate record but still counted in `totalBucketCount`.

`EnforceBLSPoP` rides Zanzibar and this rollback rides Gamma, so on any chain where Gamma trails Zanzibar the proof is enforced for a while before the rollback covers it. Testnet is already in that position, which means the window is not something scheduling can avoid there -- worth a scan for buckets already left behind. On a chain that has activated none of the family the heights are equal and the window does not exist.

**Fork height.** Gamma is unscheduled and needs maintainer sign-off. Assigning it is also what lets a fork-at-height devnet run attribute behaviour to this batch, rather than to the eight unrelated WIP features that used to share a gate with it.

**Two adjacent issues, not addressed here.** `handler_stake_migrate.go` wraps a `ReceiptError` from `createNFTBucket` in `errors.Wrap`, which destroys the `ReceiptStatus()` method, so a contract failure surfaces as a hard error rather than a failure receipt. And `handleCandidateActivate` returns `SubVote`/`AddVote` errors raw rather than through `csmErrorToHandleError`, making them hard errors too, inconsistent with every sibling handler. Both look like candidates for the same fork.

**Not gated, deliberately.** The bundle rollback is the one change here that carries no feature flag. It only affects what a proposer assembles, and a block built on a polluted view was never acceptable to anyone else, so no historical block can change meaning. Worth a second opinion on that reasoning.

---

Do not merge until the Zanzibar Gamma height is assigned.

Generated with [Claude Code](https://claude.com/claude-code)


