### PR TITLE
genesis: introduce the Zanzibar Gamma hardfork height

### DIFF
--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -84,6 +84,7 @@ func defaultConfig() Genesis {
 			YapBetaBlockHeight:        48985561,
 			ZanzibarBlockHeight:       math.MaxUint64,
 			ZanzibarBetaBlockHeight:   math.MaxUint64,
+			ZanzibarGammaBlockHeight:  math.MaxUint64,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 			PersistStakingPatchBlock:  19778037,
 			FixAliasForNonStopHeight:  19778036,
@@ -422,6 +423,22 @@ type (
 		// reads false there, the migration runs unguarded, and no later height
 		// brings it back. On such a chain the flag is permanently inert.
 		ZanzibarBetaBlockHeight uint64 `yaml:"zanzibarBetaHeight"`
+		// ZanzibarGammaBlockHeight is the start height of the corrections found
+		// after Zanzibar Beta was scheduled. It exists for the same reason Beta
+		// does, one level up: a chain that has already activated Beta is running
+		// the pre-correction behaviour, and folding these into Beta would
+		// rewrite the semantics of blocks that chain has committed.
+		//
+		// Set this EQUAL to ZanzibarBetaBlockHeight on any chain that has not
+		// activated Beta yet. A later height is only for a chain that has, and
+		// it carries the same cost: a window in which the chain knowingly runs
+		// behaviour already found to be wrong.
+		//
+		// One such window is not avoidable. EnforceBLSPoP rides Zanzibar, and
+		// candidate register writes its self-stake bucket before it verifies the
+		// proof, so on a chain where Gamma trails Zanzibar a rejected proof
+		// leaves that bucket behind until Gamma activates.
+		ZanzibarGammaBlockHeight uint64 `yaml:"zanzibarGammaHeight"`
 		// ToBeEnabledBlockHeight is a fake height that acts as a gating factor for WIP features
 		// upon next release, change IsToBeEnabled() to IsNextHeight() for features to be released
 		ToBeEnabledBlockHeight uint64 `yaml:"toBeEnabledHeight"`
@@ -634,6 +651,14 @@ func (g *Genesis) validate() error {
 		return errors.Errorf(
 			"genesis: zanzibarBetaHeight %d must not precede zanzibarHeight %d",
 			g.ZanzibarBetaBlockHeight, g.ZanzibarBlockHeight,
+		)
+	}
+	// Zanzibar Gamma only corrects behaviour Zanzibar Beta already turned on,
+	// so it cannot precede it.
+	if g.ZanzibarGammaBlockHeight < g.ZanzibarBetaBlockHeight {
+		return errors.Errorf(
+			"genesis: zanzibarGammaHeight %d must not precede zanzibarBetaHeight %d",
+			g.ZanzibarGammaBlockHeight, g.ZanzibarBetaBlockHeight,
 		)
 	}
 	// IIP-59 enumerates pending reward pools by their unhashed V2 state-key
@@ -944,6 +969,11 @@ func (g *Blockchain) IsZanzibar(height uint64) bool {
 // IsZanzibarBeta checks whether height is equal to or larger than zanzibar beta height
 func (g *Blockchain) IsZanzibarBeta(height uint64) bool {
 	return g.isPost(g.ZanzibarBetaBlockHeight, height)
+}
+
+// IsZanzibarGamma checks whether height is equal to or larger than zanzibar gamma height
+func (g *Blockchain) IsZanzibarGamma(height uint64) bool {
+	return g.isPost(g.ZanzibarGammaBlockHeight, height)
 }
 
 // IsToBeEnabled checks whether height is equal to or larger than toBeEnabled height

--- a/blockchain/genesis/genesis_test.go
+++ b/blockchain/genesis/genesis_test.go
@@ -7,6 +7,7 @@ package genesis
 
 import (
 	"encoding/hex"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -141,4 +142,50 @@ func TestIIP59EraDefaults(t *testing.T) {
 		"io19604a05s2p3mecam2zz7d27hcr6ndyw80wvkmh",
 		"io12mgttmfa2ffn9uqvn0yn37f4nz43d248l2ga85",
 	}, cfg.Rewarding.HermesRewardVaultAddresses)
+}
+
+// TestZanzibarHeightOrdering covers the two ordering rules in the Zanzibar
+// family. Both are checked before the Greenland, Xingu and contract-address
+// requirements, so a case that trips one of them needs nothing else set up.
+func TestZanzibarHeightOrdering(t *testing.T) {
+	r := require.New(t)
+	withHeights := func(zanzibar, beta, gamma uint64) *Genesis {
+		g := TestDefault()
+		g.ZanzibarBlockHeight = zanzibar
+		g.ZanzibarBetaBlockHeight = beta
+		g.ZanzibarGammaBlockHeight = gamma
+		return &g
+	}
+
+	t.Run("gamma may not precede beta", func(t *testing.T) {
+		err := withHeights(100, 200, 150).validate()
+		r.ErrorContains(err, "zanzibarGammaHeight 150 must not precede zanzibarBetaHeight 200")
+	})
+
+	t.Run("beta may not precede zanzibar", func(t *testing.T) {
+		err := withHeights(200, 100, 300).validate()
+		r.ErrorContains(err, "zanzibarBetaHeight 100 must not precede zanzibarHeight 200")
+	})
+
+	t.Run("equal heights clear both rules", func(t *testing.T) {
+		// A chain that has activated none of them carries all three at one
+		// height. validate goes on to the requirements this fixture does not
+		// meet, so the assertion is that it got past the ordering rules.
+		err := withHeights(100, 100, 100).validate()
+		r.Error(err)
+		r.NotContains(err.Error(), "zanzibarGammaHeight")
+		r.NotContains(err.Error(), "zanzibarBetaHeight")
+	})
+
+	t.Run("unscheduled zanzibar skips the family", func(t *testing.T) {
+		// Nothing below the gate is read, so any value has to be acceptable and
+		// a node still has to start.
+		g := TestDefault()
+		r.EqualValues(uint64(math.MaxUint64), g.ZanzibarBlockHeight)
+		r.EqualValues(uint64(math.MaxUint64), g.ZanzibarBetaBlockHeight)
+		r.EqualValues(uint64(math.MaxUint64), g.ZanzibarGammaBlockHeight)
+		r.NoError(g.validate())
+		g.ZanzibarGammaBlockHeight = 1
+		r.NoError(g.validate())
+	})
 }

--- a/testutil/genesis.go
+++ b/testutil/genesis.go
@@ -38,6 +38,7 @@ func NormalizeGenesisHeights(g *genesis.Blockchain) {
 		&g.YapBetaBlockHeight,
 		&g.ZanzibarBlockHeight,
 		&g.ZanzibarBetaBlockHeight,
+		&g.ZanzibarGammaBlockHeight,
 		&g.ToBeEnabledBlockHeight,
 	}
 	for i := len(heights) - 2; i >= 0; i-- {


### PR DESCRIPTION
## Why

`ZanzibarBetaBlockHeight` exists because a chain that has already activated Zanzibar is running the pre-correction behaviour, so folding corrections into Zanzibar would rewrite the semantics of blocks that chain has committed. The field says so itself.

Once Beta is activated somewhere, the same argument applies to Beta, and a correction found afterwards needs a height of its own. This adds it.

## What

`ZanzibarGammaBlockHeight`, defaulting to `math.MaxUint64`, with `IsZanzibarGamma`, an ordering rule (Gamma must not precede Beta) alongside the one the family already carries, and a slot in `testutil.NormalizeGenesisHeights`.

A chain that has activated none of them sets all three equal. A later Gamma is only for a chain that has, and it buys the same thing Beta buys at the same price: a window in which the chain knowingly runs behaviour already found to be wrong.

## One window that cannot be closed

Recorded on the field itself, because it is the kind of thing that is expensive to rediscover:

`EnforceBLSPoP` rides Zanzibar, and `handleCandidateRegister` writes its self-stake bucket before it verifies the proof. Wherever Gamma trails Zanzibar, a rejected proof leaves that bucket behind -- owned by an address with no candidate record, still counted in the bucket total -- until Gamma activates. On a chain carrying the heights equal the window does not exist.

## Tests

Neither ordering rule had a test. Both do now, plus the default and the unscheduled case. They sit above the Greenland, Xingu and contract-address requirements in `validate`, so a case that trips one needs nothing else set up.

`go build ./...`, `go vet` and `go test -count=1` pass on `blockchain/genesis`, `action/protocol` and `blockchain/integrity`.

## For reviewers

The name is the open question. Gamma follows Beta, but if the family is meant to stop at two and this batch should carry a name of its own, that is a governance call and the field is trivial to rename while it is unscheduled.

Generated with [Claude Code](https://claude.com/claude-code)
