### PR TITLE
genesis: schedule Zanzibar on MainNet at 53155801

### DIFF
--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -97,9 +97,9 @@ func defaultConfig() Genesis {
 			XinguBetaBlockHeight:      41648761,
 			YapBlockHeight:            48985561,
 			YapBetaBlockHeight:        48985561,
-			ZanzibarBlockHeight:       math.MaxUint64,
-			ZanzibarBetaBlockHeight:   math.MaxUint64,
-			ZanzibarGammaBlockHeight:  math.MaxUint64,
+			ZanzibarBlockHeight:       52813081,
+			ZanzibarBetaBlockHeight:   52813081,
+			ZanzibarGammaBlockHeight:  52813081,
 			ToBeEnabledBlockHeight:    math.MaxUint64,
 			PersistStakingPatchBlock:  19778037,
 			FixAliasForNonStopHeight:  19778036,
@@ -124,15 +124,21 @@ func defaultConfig() Genesis {
 			SystemStakingContractV2Height:    30934838,
 			SystemStakingContractV3Address:   "io1vkcvq4ywarvfj4u9zwlqedfsttalq55jmtmqcu", // https://iotexscan.io/tx/0261599524be26cd0a5bdfffc4df1316b244306b4d31488bf60d3f6cbfa6722e
 			SystemStakingContractV3Height:    36726575,
-			NativeStakingContractAddress:     "io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza",
-			VoteThreshold:                    "100000000000000000000",
-			StakingContractAddress:           "0x87c9dbff0016af23f5b1ab9b8e072124ab729193",
-			SelfStakingThreshold:             "1200000000000000000000000",
-			ScoreThreshold:                   "2000000000000000000000000",
-			RegisterContractAddress:          "0x95724986563028deb58f15c5fac19fa09304f32d",
-			GravityChainStartHeight:          7614500,
-			GravityChainHeightInterval:       100,
-			Delegates:                        []Delegate{},
+			// Deployed on MainNet well before Zanzibar; IIP-59 reads each delegate's
+			// voter-take portions from it at the era freeze. Scheduling zanzibarHeight
+			// without this address is rejected by validate(), because an empty address
+			// does not switch commission routing off -- it pins every opted-in delegate
+			// at 100% commission, paying no voter and logging nothing.
+			DelegateProfileContractAddress: "io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u",
+			NativeStakingContractAddress:   "io1xpq62aw85uqzrccg9y5hnryv8ld2nkpycc3gza",
+			VoteThreshold:                  "100000000000000000000",
+			StakingContractAddress:         "0x87c9dbff0016af23f5b1ab9b8e072124ab729193",
+			SelfStakingThreshold:           "1200000000000000000000000",
+			ScoreThreshold:                 "2000000000000000000000000",
+			RegisterContractAddress:        "0x95724986563028deb58f15c5fac19fa09304f32d",
+			GravityChainStartHeight:        7614500,
+			GravityChainHeightInterval:     100,
+			Delegates:                      []Delegate{},
 		},
 		Rewarding: Rewarding{
 			InitBalanceStr:             unit.ConvertIotxToRau(200000000).String(),
@@ -257,6 +263,13 @@ func TestDefault() Genesis {
 	cfg.PacificBlockHeight = 0
 	cfg.NumSubEpochs = 2
 	cfg.EnableGravityChainVoting = false
+	// A test chain does not inherit MainNet's Zanzibar schedule. It never reaches
+	// that height, and carrying it would make validate() enforce the IIP-59
+	// contract requirements on every genesis a unit test builds.
+	cfg.ZanzibarBlockHeight = math.MaxUint64
+	cfg.ZanzibarBetaBlockHeight = math.MaxUint64
+	cfg.ZanzibarGammaBlockHeight = math.MaxUint64
+	cfg.DelegateProfileContractAddress = ""
 	for i := 0; i < identityset.Size(); i++ {
 		addr := identityset.Address(i).String()
 		value := unit.ConvertIotxToRau(100000000).String()

--- a/blockchain/genesis/genesis.go
+++ b/blockchain/genesis/genesis.go
@@ -100,9 +100,16 @@ func defaultConfig() Genesis {
 			ZanzibarBlockHeight:       52813081,
 			ZanzibarBetaBlockHeight:   52813081,
 			ZanzibarGammaBlockHeight:  52813081,
-			ToBeEnabledBlockHeight:    math.MaxUint64,
-			PersistStakingPatchBlock:  19778037,
-			FixAliasForNonStopHeight:  19778036,
+			// The AutoDepositRegister iotex-hub writes compound registrations to, so
+			// a preference set through the hub is the one the protocol acts on. Its
+			// runtime is byte-identical to e2etest/autodeposit_bytecode, which is what
+			// the slot constants in action/protocol/rewarding/autodeposit were derived
+			// against -- IIP-59 reads those slots directly rather than calling
+			// bucket(), so the address and that layout travel together.
+			AutoDepositContractAddress: "io108ckwzlzpkhva7cnfceajlu7wu6ql5kq95uat9",
+			ToBeEnabledBlockHeight:     math.MaxUint64,
+			PersistStakingPatchBlock:   19778037,
+			FixAliasForNonStopHeight:   19778036,
 		},
 		Account: Account{
 			InitBalanceMap:          map[string]string{},
@@ -270,6 +277,7 @@ func TestDefault() Genesis {
 	cfg.ZanzibarBetaBlockHeight = math.MaxUint64
 	cfg.ZanzibarGammaBlockHeight = math.MaxUint64
 	cfg.DelegateProfileContractAddress = ""
+	cfg.AutoDepositContractAddress = ""
 	for i := 0; i < identityset.Size(); i++ {
 		addr := identityset.Address(i).String()
 		value := unit.ConvertIotxToRau(100000000).String()

--- a/blockchain/genesis/genesis_validate_test.go
+++ b/blockchain/genesis/genesis_validate_test.go
@@ -64,6 +64,8 @@ blockchain:
   xinguHeight: 999
   zanzibarHeight: 1000
   zanzibarBetaHeight: 1000
+poll:
+  delegateProfileContractAddress: ""
 rewarding:
   epochsPerRewardEra: 2
 `)
@@ -133,7 +135,9 @@ rewarding:
 	t.Run("unscheduled tolerates both unset", func(t *testing.T) {
 		// The addresses are read only once IIP-59 is live. Requiring them on an
 		// unscheduled chain would stop every existing network from starting.
-		g, err := New(writeGenesisYAML(t, "rewarding:\n  epochsPerRewardEra: 24\n"))
+		g, err := New(writeGenesisYAML(t, "blockchain:\n  zanzibarHeight: 18446744073709551615\n  zanzibarBetaHeight: 18446744073709551615\n  zanzibarGammaHeight: 18446744073709551615\n"+
+			"poll:\n  delegateProfileContractAddress: \"\"\n"+
+			"rewarding:\n  epochsPerRewardEra: 24\n"))
 		r.NoError(err)
 		r.Empty(g.DelegateProfileContractAddress)
 	})
@@ -192,6 +196,10 @@ rewarding:
 		// EpochsPerRewardEra is never read and must not block a node from
 		// starting. Existing networks rely on this.
 		path := writeGenesisYAML(t, `
+blockchain:
+  zanzibarHeight: 18446744073709551615
+  zanzibarBetaHeight: 18446744073709551615
+  zanzibarGammaHeight: 18446744073709551615
 rewarding:
   epochsPerRewardEra: 0
 `)

--- a/blockchain/genesis/genesis_validate_test.go
+++ b/blockchain/genesis/genesis_validate_test.go
@@ -122,6 +122,7 @@ blockchain:
   xinguHeight: 999
   zanzibarHeight: 1000
   zanzibarBetaHeight: 1000
+  autoDepositContractAddress: ""
 poll:
   delegateProfileContractAddress: %q
 rewarding:


### PR DESCRIPTION
Schedules Zanzibar on MainNet at **block 53155801** — around **2026-10-08 10:00 CST (02:00 UTC)**.

## The heights

| | height |
|---|---|
| `zanzibarHeight` | 53155801 |
| `zanzibarBetaHeight` | 53155801 |
| `zanzibarGammaHeight` | 53155801 |

**All three go to one block because MainNet has activated none of them.** Beta and Gamma exist to carry corrections to behaviour their predecessor turned on; splitting them is only forced on a chain that has already committed blocks under the pre-correction behaviour — as TestNet had to, which is why it runs Zanzibar at 46880641 and Beta at 47141281.

Activating them together is not just cheaper, it is the only way Gamma's corrections apply from the first block IIP-59 is live. One of them, `RequireProfileForHermesMigration`, guards a migration that runs in **exactly the block Zanzibar activates at and never again** — on TestNet, where Beta trails Zanzibar, that guard is permanently inert. The field comments state this rule directly ("Set this EQUAL to … on any chain that has not activated … yet"), and `validate()` enforces `gamma >= beta >= zanzibar`.

## Why the height

**Epoch-aligned.** Not by `(h-1) % 1440 == 0` — epoch length changed at dardanelles and again at wake, so the grid is offset from height 1. Verified instead against heights this chain already forked at:

| | height | `(h − 51918841) mod 1440` |
|---|---|---|
| wake | 36893881 | 0 |
| xingu | 41648761 | 0 |
| yap | 48985561 | 0 |
| **this** | **53155801** | **0** |

(51918841 is an epoch start read off the chain; all four also share residue 1080 mod 1440 measured from height 1.)

**Far enough out.** Tip was 52,389,026 at 2026-09-15 18:39 UTC — 766,775 blocks, about 22 days. Using the measured ~2.515 s/block rate projects activation to 2026-10-08 around 02:00 UTC (10:00 CST).

**Ordering holds.** `zanzibar >= xingu (41648761)` and `>= greenland (6544441)`.

## `delegateProfileContractAddress` had to come with it

`validate()` refuses a scheduled `zanzibarHeight` without one, and the reason is worth restating: an empty address **does not switch commission routing off — it pins every opted-in delegate at 100% commission**. No voter is paid on chain, the payout stops arriving at the reward address an off-chain distributor watches, and nothing is logged and no error raised.

Set to the DelegateProfile contract already live on MainNet: `io1lfl4ppn2c3wcft04f0rk0jy9lyn4pcjcm7638u` / `0xfa7f50866ac45d84adf54bc767c885f92750e258` — verified to carry code (11,347 bytes) via `eth_getCode` on MainNet.

## `autoDepositContractAddress` — resolved

`io108ckwzlzpkhva7cnfceajlu7wu6ql5kq95uat9` / `0x79f1670BE20daecEfB134E33D97f9E77340fd2C0`, the AutoDepositRegister iotex-hub writes compound registrations to.

**Verified by byte comparison, not assumed.** IIP-59 reads this contract's storage slots directly rather than calling `bucket()`, so the address is only usable if its runtime matches the layout those constants were derived against. The runtime at this address is byte-identical to `e2etest/autodeposit_bytecode` — 2040 bytes, keccak `e5de3565a42bd78a` — the fixture `action/protocol/rewarding/autodeposit` was written to.

That comparison mattered. The `AutoDepositRegister` in iotex-hermes builds to a **different** runtime (2783 bytes, keccak `bb00f77eadfe1167`), and that is what TestNet deployed for this release. The MainNet deployment predates it and installs runtime bytecode directly without running the constructor — which is also why `slot_reader.go` notes `Ownable.owner` is never allocated there. Checking against the hermes artifact would have rejected the correct address.

Leaving it empty was not neutral: compound routing switches off and voters who registered for compounding are paid into their unclaimed balance instead.

## Hermes migration impact on MainNet

At this height `migrateHermesRewardOptIn` runs once and auto-opts-in every candidate whose reward address is one of the two Hermes vaults. Measured against the live candidate set at block 52,004,121:

| | count | behaviour at activation |
|---|---|---|
| vault + complete DelegateProfile portions | **88** | migrated onto on-chain distribution |
| vault + incomplete portions | **9** | **skipped**, stay on the Hermes path |
| not a vault reward address | 26 (10 already configured) | unaffected; opt in themselves |

97 of 123 candidates use a Hermes vault, so unlike TestNet — which inherited these MainNet vault addresses and therefore matched nobody — this migration is real and large. The two configured `hermesRewardVaultAddresses` were confirmed against the deployed vaults.

**This is the concrete reason Gamma goes to the same height as Zanzibar.** With Gamma active, `RequireProfileForHermesMigration` skips those 9 and their voters keep being paid through Hermes. With Gamma trailing, the guard reads false, all 9 are migrated and frozen at 100% commission — their voters are paid nothing — and because the migration runs in exactly one block and never again, there is no way to repair it afterwards.

The 9 are `goodwill`, `xangle`, `01node`, `hsiotx`, `elitex`, `iotxplorerio` and three that look like test accounts (`uuztest123`, `optest123`, `uuztest`). All are in the consensus set. They can be told to configure their DelegateProfile before activation to be migrated with the rest; not doing so costs them the feature but breaks nothing.

## Test changes

`TestDefault` keeps the Zanzibar family unscheduled and the contract address empty. A test chain never reaches 53155801, and inheriting the schedule would make `validate()` enforce the IIP-59 contract requirements on every genesis a unit test builds.

Three `validate` tests had been reaching "unscheduled" by inheriting the default rather than saying so. They now set the heights to `MaxUint64` explicitly, which is what they meant to test — the assertions themselves are unchanged.

## Verification

- `go build ./...` clean; `./blockchain/genesis/...` and `./action/protocol/` pass.
- Sanity test asserting all three heights, the ordering constraints, and same-grid epoch alignment against `yapHeight`.
- The rest of the genesis.go diff is `gofmt` realigning the struct block: the new field name is longer than the previous widest, so the whole literal reflows.

## Follow-up, not in this PR

**TestNet will need a `zanzibarGammaHeight`.** Gamma did not exist in `rc1_2.5.0` — it arrived with #4996's master version. TestNet has already activated Zanzibar and Beta, so when it moves to a build containing Gamma it inherits `MaxUint64` and those four corrections stay off until a height is scheduled. Per the field comment, a chain where Gamma trails Zanzibar also carries a window where a rejected BLS proof leaves an orphan self-stake bucket behind.

