### PR TITLE
fix(consensus): skip a height CommitBlock reports as already committed

### DIFF
--- a/blockchain/blockchain.go
+++ b/blockchain/blockchain.go
@@ -47,8 +47,10 @@ var (
 		},
 		[]string{"type"},
 	)
-	// ErrInvalidTipHeight is the error returned when the block height is not valid
-	ErrInvalidTipHeight = errors.New("invalid tip height")
+	// ErrInvalidTipHeight is the error returned when the block height is not valid.
+	// It aliases filedao.ErrInvalidTipHeight so that a height rejection raised by the
+	// block store on CommitBlock still matches the sentinel callers compare against.
+	ErrInvalidTipHeight = filedao.ErrInvalidTipHeight
 	// ErrInvalidBlock is the error returned when the block is not valid
 	ErrInvalidBlock = errors.New("failed to validate the block")
 	// ErrActionNonce is the error when the nonce of the action is wrong

--- a/blockchain/blockchain_extra_test.go
+++ b/blockchain/blockchain_extra_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/blockchain"
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/filedao"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 	"github.com/iotexproject/iotex-core/v2/test/mock/mock_blockchain"
@@ -83,4 +84,29 @@ func TestBlockchainAccessorsAndSubscriber(t *testing.T) {
 
 	// a nil subscriber is rejected
 	r.Error(bc.AddSubscriber(nil))
+}
+
+// TestCommitBlockInvalidTipHeight asserts that a height rejection raised by the block
+// store surfaces as blockchain.ErrInvalidTipHeight, which is what callers such as
+// rolldpos and the block sync handler match on to skip an already-committed height.
+func TestCommitBlockInvalidTipHeight(t *testing.T) {
+	r := require.New(t)
+	ctrl := gomock.NewController(t)
+	dao := mock_blockdao.NewMockBlockDAO(ctrl)
+
+	blk, err := block.NewTestingBuilder().
+		SetHeight(51).
+		SetVersion(1).
+		SignAndBuild(identityset.PrivateKey(0))
+	r.NoError(err)
+	tipHeader := blk.Header
+
+	dao.EXPECT().Height().Return(uint64(51), nil).Times(1)
+	dao.EXPECT().HeaderByHeight(uint64(51)).Return(&tipHeader, nil).Times(1)
+	dao.EXPECT().PutBlock(gomock.Any(), gomock.Any()).Return(filedao.ErrInvalidTipHeight).Times(1)
+
+	bc := blockchain.NewBlockchain(blockchain.DefaultConfig, genesis.TestDefault(), dao, nil)
+	err = bc.CommitBlock(&blk)
+	r.ErrorIs(err, blockchain.ErrInvalidTipHeight)
+	r.ErrorIs(err, filedao.ErrInvalidTipHeight)
 }

--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -627,6 +627,42 @@ func (builder *Builder) buildNodeInfoManager() error {
 	return nil
 }
 
+// commitSyncedBlock validates and commits a block received from block sync, retrying
+// the failures that are expected to clear on their own. committed reports whether the
+// block was actually appended: it is false, with a nil error, when the block store has
+// already moved past the block's height, so there is nothing left to do for it.
+func commitSyncedBlock(
+	chain blockchain.Blockchain,
+	blk *block.Block,
+	retries int,
+	opts ...blockchain.BlockValidationOption,
+) (committed bool, err error) {
+	for i := 0; i < retries; i++ {
+		if err = chain.ValidateBlock(blk, opts...); err == nil {
+			if err = chain.CommitBlock(blk); err == nil {
+				return true, nil
+			}
+		}
+		switch errors.Cause(err) {
+		case blockchain.ErrInvalidTipHeight:
+			log.L().Debug("Skip block.", zap.Error(err), zap.Uint64("height", blk.Height()))
+			return false, nil
+		case block.ErrDeltaStateMismatch:
+			log.L().Debug("Delta state mismatched.", zap.Uint64("height", blk.Height()))
+		case blockdao.ErrRemoteHeightTooLow:
+			if retries == 1 {
+				retries = 4
+			}
+			log.L().Debug("Remote height too low.", zap.Uint64("height", blk.Height()))
+			time.Sleep(100 * time.Millisecond)
+		default:
+			log.L().Debug("Failed to commit the block.", zap.Error(err), zap.Uint64("height", blk.Height()))
+			return false, err
+		}
+	}
+	return false, err
+}
+
 func (builder *Builder) buildBlockSyncer() error {
 	if builder.cs.blocksync != nil {
 		return nil
@@ -674,38 +710,18 @@ func (builder *Builder) buildBlockSyncer() error {
 			if !builder.cfg.Genesis.IsHawaii(blk.Height()) {
 				retries = 4
 			}
-			var err error
 			opts := []blockchain.BlockValidationOption{}
 			if now := time.Now(); now.After(blk.Timestamp()) &&
 				blk.Height()+cfg.Genesis.MinBlocksForBlobRetention <= estimateTipHeight(&cfg, blk, now.Sub(blk.Timestamp())) {
 				opts = append(opts, blockchain.SkipSidecarValidationOption())
 			}
-			for i := 0; i < retries; i++ {
-				if err = chain.ValidateBlock(blk, opts...); err == nil {
-					if err = chain.CommitBlock(blk); err == nil {
-						break
-					}
-				}
-				switch errors.Cause(err) {
-				case blockchain.ErrInvalidTipHeight:
-					log.L().Debug("Skip block.", zap.Error(err), zap.Uint64("height", blk.Height()))
-					return nil
-				case block.ErrDeltaStateMismatch:
-					log.L().Debug("Delta state mismatched.", zap.Uint64("height", blk.Height()))
-				case blockdao.ErrRemoteHeightTooLow:
-					if retries == 1 {
-						retries = 4
-					}
-					log.L().Debug("Remote height too low.", zap.Uint64("height", blk.Height()))
-					time.Sleep(100 * time.Millisecond)
-				default:
-					log.L().Debug("Failed to commit the block.", zap.Error(err), zap.Uint64("height", blk.Height()))
-					return err
-				}
-			}
+			committed, err := commitSyncedBlock(chain, blk, retries, opts...)
 			if err != nil {
 				log.L().Debug("Failed to commit block.", zap.Error(err), zap.Uint64("height", blk.Height()))
 				return err
+			}
+			if !committed {
+				return nil
 			}
 			log.L().Info("Successfully committed block.", zap.Uint64("height", blk.Height()))
 			consens.Calibrate(blk.Height())

--- a/chainservice/builder_test.go
+++ b/chainservice/builder_test.go
@@ -5,11 +5,17 @@ import (
 	"time"
 
 	"github.com/mohae/deepcopy"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	"github.com/iotexproject/iotex-core/v2/blockchain"
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/blockdao"
+	"github.com/iotexproject/iotex-core/v2/blockchain/filedao"
 	"github.com/iotexproject/iotex-core/v2/config"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
+	"github.com/iotexproject/iotex-core/v2/test/mock/mock_blockchain"
 )
 
 func TestEstimateTipHeight(t *testing.T) {
@@ -103,4 +109,65 @@ func TestBlockDistanceAt(t *testing.T) {
 			r.Equal(tt.want, got, "test %d: %s", i, tt.name)
 		})
 	}
+}
+
+// TestCommitSyncedBlock covers how the block sync callback classifies a commit failure.
+// A height the block store has already moved past is a skip, not a failure: the block
+// store raises filedao.ErrInvalidTipHeight, which reaches the caller as
+// blockchain.ErrInvalidTipHeight.
+func TestCommitSyncedBlock(t *testing.T) {
+	r := require.New(t)
+	blk, err := block.NewBuilder(block.RunnableActions{}).
+		SetHeight(51).
+		SignAndBuild(identityset.PrivateKey(1))
+	r.NoError(err)
+
+	t.Run("committed", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		bc.EXPECT().ValidateBlock(gomock.Any()).Return(nil).Times(1)
+		bc.EXPECT().CommitBlock(gomock.Any()).Return(nil).Times(1)
+		committed, err := commitSyncedBlock(bc, &blk, 4)
+		r.NoError(err)
+		r.True(committed)
+	})
+	t.Run("height already committed by the block store", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		bc.EXPECT().ValidateBlock(gomock.Any()).Return(nil).Times(1)
+		bc.EXPECT().CommitBlock(gomock.Any()).Return(filedao.ErrInvalidTipHeight).Times(1)
+		committed, err := commitSyncedBlock(bc, &blk, 4)
+		r.NoError(err)
+		r.False(committed)
+	})
+	t.Run("height already committed on validation", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		bc.EXPECT().ValidateBlock(gomock.Any()).
+			Return(errors.Wrap(blockchain.ErrInvalidTipHeight, "wrong block height")).Times(1)
+		committed, err := commitSyncedBlock(bc, &blk, 4)
+		r.NoError(err)
+		r.False(committed)
+	})
+	t.Run("retry on delta state mismatch", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		bc.EXPECT().ValidateBlock(gomock.Any()).Return(nil).Times(4)
+		bc.EXPECT().CommitBlock(gomock.Any()).Return(block.ErrDeltaStateMismatch).Times(4)
+		committed, err := commitSyncedBlock(bc, &blk, 4)
+		r.ErrorIs(err, block.ErrDeltaStateMismatch)
+		r.False(committed)
+	})
+	t.Run("retry on remote height too low", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		// a single attempt is extended to 4 when the remote height is behind
+		bc.EXPECT().ValidateBlock(gomock.Any()).Return(blockdao.ErrRemoteHeightTooLow).Times(4)
+		committed, err := commitSyncedBlock(bc, &blk, 1)
+		r.ErrorIs(err, blockdao.ErrRemoteHeightTooLow)
+		r.False(committed)
+	})
+	t.Run("any other failure is reported", func(t *testing.T) {
+		bc := mock_blockchain.NewMockBlockchain(gomock.NewController(t))
+		bc.EXPECT().ValidateBlock(gomock.Any()).Return(nil).Times(1)
+		bc.EXPECT().CommitBlock(gomock.Any()).Return(errors.New("commit failed")).Times(1)
+		committed, err := commitSyncedBlock(bc, &blk, 4)
+		r.ErrorContains(err, "commit failed")
+		r.False(committed)
+	})
 }

--- a/consensus/scheme/rolldpos/rolldposctx.go
+++ b/consensus/scheme/rolldpos/rolldposctx.go
@@ -615,17 +615,18 @@ func (ctx *rollDPoSCtx) Commit(msg interface{}) (bool, error) {
 	}
 
 	// Commit and broadcast the pending block
-	switch err := ctx.chain.CommitBlock(pendingBlock); errors.Cause(err) {
-	case blockchain.ErrInvalidTipHeight:
-		return true, nil
-	case blockchain.ErrPaused:
-		ctx.logger().Info("chain is paused, block will not be committed")
-		return false, nil
-	case nil:
-		break
-	default:
-		log.L().Error("error when committing the block", zap.Error(err))
-		return false, errors.Wrap(err, "error when committing a block")
+	if err := ctx.chain.CommitBlock(pendingBlock); err != nil {
+		switch {
+		case errors.Is(err, blockchain.ErrInvalidTipHeight):
+			// the height is already committed, e.g. by block sync, so the round is done
+			return true, nil
+		case errors.Is(err, blockchain.ErrPaused):
+			ctx.logger().Info("chain is paused, block will not be committed")
+			return false, nil
+		default:
+			log.L().Error("error when committing the block", zap.Error(err))
+			return false, errors.Wrap(err, "error when committing a block")
+		}
 	}
 	// Broadcast the committed block to the network
 	if blkProto := pendingBlock.ConvertToBlockPb(); blkProto != nil {

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/iotexproject/iotex-core/v2/action/protocol"
 	"github.com/iotexproject/iotex-core/v2/action/protocol/rolldpos"
+	"github.com/iotexproject/iotex-core/v2/blockchain"
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
 	"github.com/iotexproject/iotex-core/v2/blockchain/genesis"
 	"github.com/iotexproject/iotex-core/v2/consensus/consensusfsm"
@@ -438,30 +439,42 @@ func getBlockforctx(t *testing.T, i int, sign bool, prevHash hash.Hash256) block
 	return b
 }
 
-// TestCommitAlreadyCommittedHeight covers the case where block sync commits a block at
-// the round's height while the round is still collecting endorsements. Committing the
-// round's own block is then refused by the block store, and the consensus context must
-// report the round as done instead of surfacing an error.
-func TestCommitAlreadyCommittedHeight(t *testing.T) {
+// commitTestEnv is a rollDPoSCtx whose round sits at the chain tip + 1 with a pending
+// block registered, ready to be driven to consensus by reachConsensus.
+type commitTestEnv struct {
+	rctx    *rollDPoSCtx
+	chain   blockchain.Blockchain
+	pending *block.Block
+	keys    map[string]crypto.PrivateKey
+	ts      time.Time
+}
+
+// newCommitTestEnv builds the environment above. wrap, when not nil, may replace the
+// chain manager that the consensus context commits through.
+func newCommitTestEnv(t *testing.T, wrap func(ChainManager) ChainManager) *commitTestEnv {
 	require := require.New(t)
 	b, sf, _, rp, _ := makeChain(t)
 	g := genesis.TestDefault()
 	g.Blockchain.BlockInterval = time.Second * 20
 	delegates := make([]string, 0, rp.NumDelegates())
-	keyOfDelegate := make(map[string]crypto.PrivateKey, rp.NumDelegates())
+	keys := make(map[string]crypto.PrivateKey, rp.NumDelegates())
 	for i := 0; i < int(rp.NumDelegates()); i++ {
 		addr := identityset.Address(i).String()
 		delegates = append(delegates, addr)
-		keyOfDelegate[addr] = identityset.PrivateKey(i)
+		keys[addr] = identityset.PrivateKey(i)
 	}
 	delegatesByEpoch := func(uint64, []byte) ([]string, error) { return delegates, nil }
+	var cm ChainManager = NewChainManager(b, sf, &dummyBlockBuildFactory{})
+	if wrap != nil {
+		cm = wrap(cm)
+	}
 	rdctx, err := NewRollDPoSCtx(
 		consensusfsm.NewConsensusConfig(DefaultConfig.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, DefaultConfig.Delay),
 		db.DefaultConfig,
 		true,
 		time.Second,
 		true,
-		NewChainManager(b, sf, &dummyBlockBuildFactory{}),
+		cm,
 		block.NewDeserializer(0),
 		rp,
 		nil,
@@ -475,40 +488,91 @@ func TestCommitAlreadyCommittedHeight(t *testing.T) {
 	rctx, ok := rdctx.(*rollDPoSCtx)
 	require.True(ok)
 	require.NoError(rctx.Start(context.Background()))
-	defer rctx.Stop(context.Background())
+	t.Cleanup(func() { rctx.Stop(context.Background()) })
 	require.NoError(rctx.Prepare())
 	require.Equal(b.TipHeight()+1, rctx.round.Height())
 
-	// the round is working on its own block
 	ts := time.Unix(1562382372+100, 0)
 	pending, err := b.MintNewBlock(ts)
 	require.NoError(err)
 	require.Equal(rctx.round.Height(), pending.Height())
 	require.NoError(rctx.round.AddBlock(pending))
-	blkHash := pending.HashBlock()
+	return &commitTestEnv{rctx: rctx, chain: b, pending: pending, keys: keys, ts: ts}
+}
 
-	// meanwhile block sync commits a different block at the same height
-	synced, err := b.MintNewBlock(ts.Add(time.Second))
-	require.NoError(err)
-	require.NoError(synced.Finalize(nil, ts.Add(time.Second)))
-	require.NotEqual(blkHash, synced.HashBlock())
-	require.NoError(b.CommitBlock(synced))
-	require.Equal(pending.Height(), b.TipHeight())
-
-	// the round then reaches consensus on its own block: the block store refuses it,
-	// which must be reported as the height being done rather than as an error
+// reachConsensus feeds COMMIT endorsements from the round's delegates and returns the
+// outcome of the Commit call that crosses the majority, i.e. the one that commits.
+func (env *commitTestEnv) reachConsensus(t *testing.T) (bool, error) {
+	require := require.New(t)
+	blkHash := env.pending.HashBlock()
 	vote := NewConsensusVote(blkHash[:], COMMIT)
-	var done bool
-	for _, delegate := range rctx.round.Delegates() {
-		ens, err := endorsement.Endorse(vote, ts, keyOfDelegate[delegate])
+	for _, delegate := range env.rctx.round.Delegates() {
+		ens, err := endorsement.Endorse(vote, env.ts, env.keys[delegate])
 		require.NoError(err)
-		done, err = rctx.Commit(NewEndorsedConsensusMessage(pending.Height(), vote, ens[0]))
-		require.NoError(err)
-		if done {
-			break
+		done, err := env.rctx.Commit(NewEndorsedConsensusMessage(env.pending.Height(), vote, ens[0]))
+		if err != nil || env.rctx.round.EndorsedByMajority(blkHash[:], []ConsensusVoteTopic{COMMIT}) {
+			return done, err
 		}
 	}
+	require.FailNow("the round never reached a majority of COMMIT endorsements")
+	return false, nil
+}
+
+// TestCommitAlreadyCommittedHeight covers the case where block sync commits a block at
+// the round's height while the round is still collecting endorsements. Committing the
+// round's own block is then refused by the block store, and the consensus context must
+// report the round as done instead of surfacing an error.
+func TestCommitAlreadyCommittedHeight(t *testing.T) {
+	require := require.New(t)
+	env := newCommitTestEnv(t, nil)
+
+	// block sync commits a different block at the height the round is working on
+	synced, err := env.chain.MintNewBlock(env.ts.Add(time.Second))
+	require.NoError(err)
+	require.NoError(synced.Finalize(nil, env.ts.Add(time.Second)))
+	require.NotEqual(env.pending.HashBlock(), synced.HashBlock())
+	require.NoError(env.chain.CommitBlock(synced))
+	require.Equal(env.pending.Height(), env.chain.TipHeight())
+
+	// the block store refuses the round's block, which must be reported as the height
+	// being done rather than as an error
+	done, err := env.reachConsensus(t)
+	require.NoError(err)
 	require.True(done)
 	// the block committed by block sync is still the tip
-	require.Equal(synced.HashBlock(), b.TipHash())
+	require.Equal(synced.HashBlock(), env.chain.TipHash())
 }
+
+// TestCommitPausedChain asserts that a paused chain leaves the round unfinished without
+// reporting an error, so that the FSM retries rather than failing the round.
+func TestCommitPausedChain(t *testing.T) {
+	require := require.New(t)
+	env := newCommitTestEnv(t, nil)
+	env.chain.Pause(true)
+
+	done, err := env.reachConsensus(t)
+	require.NoError(err)
+	require.False(done)
+	require.Less(env.chain.TipHeight(), env.pending.Height())
+}
+
+// TestCommitBlockError asserts that any other commit failure is still reported as an
+// error and does not finish the round.
+func TestCommitBlockError(t *testing.T) {
+	require := require.New(t)
+	env := newCommitTestEnv(t, func(cm ChainManager) ChainManager {
+		return &commitErrChainManager{ChainManager: cm, err: errors.New("commit failed")}
+	})
+
+	done, err := env.reachConsensus(t)
+	require.ErrorContains(err, "commit failed")
+	require.False(done)
+}
+
+// commitErrChainManager fails every CommitBlock with a fixed error.
+type commitErrChainManager struct {
+	ChainManager
+	err error
+}
+
+func (cm *commitErrChainManager) CommitBlock(*block.Block) error { return cm.err }

--- a/consensus/scheme/rolldpos/rolldposctx_test.go
+++ b/consensus/scheme/rolldpos/rolldposctx_test.go
@@ -437,3 +437,78 @@ func getBlockforctx(t *testing.T, i int, sign bool, prevHash hash.Hash256) block
 	b := block.Block{Header: header}
 	return b
 }
+
+// TestCommitAlreadyCommittedHeight covers the case where block sync commits a block at
+// the round's height while the round is still collecting endorsements. Committing the
+// round's own block is then refused by the block store, and the consensus context must
+// report the round as done instead of surfacing an error.
+func TestCommitAlreadyCommittedHeight(t *testing.T) {
+	require := require.New(t)
+	b, sf, _, rp, _ := makeChain(t)
+	g := genesis.TestDefault()
+	g.Blockchain.BlockInterval = time.Second * 20
+	delegates := make([]string, 0, rp.NumDelegates())
+	keyOfDelegate := make(map[string]crypto.PrivateKey, rp.NumDelegates())
+	for i := 0; i < int(rp.NumDelegates()); i++ {
+		addr := identityset.Address(i).String()
+		delegates = append(delegates, addr)
+		keyOfDelegate[addr] = identityset.PrivateKey(i)
+	}
+	delegatesByEpoch := func(uint64, []byte) ([]string, error) { return delegates, nil }
+	rdctx, err := NewRollDPoSCtx(
+		consensusfsm.NewConsensusConfig(DefaultConfig.FSM, consensusfsm.DefaultDardanellesUpgradeConfig, consensusfsm.DefaultWakeUpgradeConfig, g, DefaultConfig.Delay),
+		db.DefaultConfig,
+		true,
+		time.Second,
+		true,
+		NewChainManager(b, sf, &dummyBlockBuildFactory{}),
+		block.NewDeserializer(0),
+		rp,
+		nil,
+		delegatesByEpoch,
+		delegatesByEpoch,
+		[]crypto.PrivateKey{identityset.PrivateKey(10)},
+		clock.New(),
+		g.BeringBlockHeight,
+	)
+	require.NoError(err)
+	rctx, ok := rdctx.(*rollDPoSCtx)
+	require.True(ok)
+	require.NoError(rctx.Start(context.Background()))
+	defer rctx.Stop(context.Background())
+	require.NoError(rctx.Prepare())
+	require.Equal(b.TipHeight()+1, rctx.round.Height())
+
+	// the round is working on its own block
+	ts := time.Unix(1562382372+100, 0)
+	pending, err := b.MintNewBlock(ts)
+	require.NoError(err)
+	require.Equal(rctx.round.Height(), pending.Height())
+	require.NoError(rctx.round.AddBlock(pending))
+	blkHash := pending.HashBlock()
+
+	// meanwhile block sync commits a different block at the same height
+	synced, err := b.MintNewBlock(ts.Add(time.Second))
+	require.NoError(err)
+	require.NoError(synced.Finalize(nil, ts.Add(time.Second)))
+	require.NotEqual(blkHash, synced.HashBlock())
+	require.NoError(b.CommitBlock(synced))
+	require.Equal(pending.Height(), b.TipHeight())
+
+	// the round then reaches consensus on its own block: the block store refuses it,
+	// which must be reported as the height being done rather than as an error
+	vote := NewConsensusVote(blkHash[:], COMMIT)
+	var done bool
+	for _, delegate := range rctx.round.Delegates() {
+		ens, err := endorsement.Endorse(vote, ts, keyOfDelegate[delegate])
+		require.NoError(err)
+		done, err = rctx.Commit(NewEndorsedConsensusMessage(pending.Height(), vote, ens[0]))
+		require.NoError(err)
+		if done {
+			break
+		}
+	}
+	require.True(done)
+	// the block committed by block sync is still the tip
+	require.Equal(synced.HashBlock(), b.TipHash())
+}


### PR DESCRIPTION
## Description

`blockchain/filedao/filedao.go` and `blockchain/blockchain.go` each declared their own `ErrInvalidTipHeight` sentinel with the same message. The block store raises the `filedao` one when it refuses a block whose height is not `tip + 1`, and `blockchain.CommitBlock` propagates it verbatim — but callers compare against the `blockchain` one, so the comparison never matches.

In `rolldposCtx.Commit` that turns an expected outcome into an error path: if block sync has already committed height H and the consensus round then calls `CommitBlock` for its own block at H, the switch misses `blockchain.ErrInvalidTipHeight` (which returns `true, nil`), falls through to `default`, logs `error when committing the block`, and returns an error. The FSM then stays in its pre-commit state until the round TTL expires instead of recognising the height as done.

`chainservice/builder.go:690` has the same comparison, but it is masked there because the preceding `ValidateBlock` returns the `blockchain` variable first.

There is no finality or state impact — the block store guard still refuses the second block. This is a robustness fix.

Fixes #5010

## Changes

- `blockchain.ErrInvalidTipHeight` now aliases `filedao.ErrInvalidTipHeight`, so both names refer to a single sentinel and a height rejection from the block store matches what callers switch on. (`blockchain` already imports `filedao`; the reverse direction would be an import cycle.)
- `rolldposCtx.Commit` matches with `errors.Is` instead of `errors.Cause` equality, so the skip branch keeps working if the storage error is ever wrapped, and the skip intent is documented in a comment.

## Tests

- `TestCommitAlreadyCommittedHeight` (`consensus/scheme/rolldpos`): drives the reported scenario end to end on a real chain — the round registers its own block at H, block sync commits a *different* block at H, then the round collects a majority of COMMIT endorsements and calls `Commit`. Asserts `(true, nil)` and that the block-sync block is still the tip. Fails on `master` with `error when committing a block` / `invalid tip height`.
- `TestCommitBlockInvalidTipHeight` (`blockchain`): pins the contract at the layer where it broke — a height rejection from the block store must satisfy `errors.Is(err, blockchain.ErrInvalidTipHeight)`. Fails on `master`.

Full `./blockchain/... ./consensus/... ./chainservice/...` run is green apart from `TestBlockIndexerChecker_CheckIndexer`, which fails identically on unmodified `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)