### PR TITLE
fix(chainservice): propagate block store construction error

### DIFF
--- a/chainservice/builder.go
+++ b/chainservice/builder.go
@@ -344,7 +344,11 @@ func (builder *Builder) buildBlockDAO(forTest bool) error {
 		store, err = filedao.NewFileDAOInMemForTest()
 	} else {
 		path := builder.cfg.Chain.ChainDBPath
-		uri, err := url.Parse(path)
+		// NOTE: assign to the err declared above rather than declaring a new one.
+		// A ":=" here shadows it for the whole block, and the store-construction
+		// error below would then never reach the "if err != nil" after the block.
+		var uri *url.URL
+		uri, err = url.Parse(path)
 		if err != nil {
 			return errors.Wrapf(err, "failed to parse chain db path %s", path)
 		}

--- a/chainservice/builder_test.go
+++ b/chainservice/builder_test.go
@@ -1,6 +1,8 @@
 package chainservice
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -8,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/iotexproject/iotex-core/v2/blockchain/block"
+	"github.com/iotexproject/iotex-core/v2/blockchain/filedao"
 	"github.com/iotexproject/iotex-core/v2/config"
 	"github.com/iotexproject/iotex-core/v2/test/identityset"
 )
@@ -103,4 +106,35 @@ func TestBlockDistanceAt(t *testing.T) {
 			r.Equal(tt.want, got, "test %d: %s", i, tt.name)
 		})
 	}
+}
+
+// TestBuildBlockDAOPropagatesStoreError guards against the block store
+// construction error being swallowed. The "else" branch of buildBlockDAO used
+// to redeclare err with ":=", shadowing the one the check after the block
+// reads, so a chain DB that could not be opened produced no error and left
+// cs.blockdao nil -- NewBlockDAOWithIndexersAndCache returns nil for a nil
+// store. The node then continued building over that nil.
+//
+// The forTest branch was unaffected, which is why no existing test caught it.
+func TestBuildBlockDAOPropagatesStoreError(t *testing.T) {
+	r := require.New(t)
+
+	// A directory where a bolt file is expected, so the store cannot be opened.
+	badPath := filepath.Join(t.TempDir(), "chain.db")
+	r.NoError(os.Mkdir(badPath, 0o755))
+
+	cfg := deepcopy.Copy(config.Default).(config.Config)
+	cfg.Chain.ChainDBPath = badPath
+	cfg.Chain.BlobStoreDBPath = ""
+	cfg.Chain.PatchReceiptIndexPath = ""
+	cfg.Chain.PatchTransactionLogPath = ""
+
+	// Without this the test could pass while proving nothing.
+	dbCfg := cfg.DB
+	dbCfg.DbPath = badPath
+	_, ferr := filedao.NewFileDAO(dbCfg, block.NewDeserializer(cfg.Chain.EVMNetworkID))
+	r.Error(ferr, "precondition: NewFileDAO must fail for this config")
+
+	builder := NewBuilder(cfg)
+	r.Error(builder.buildBlockDAO(false), "block store failure must be propagated, not swallowed")
 }


### PR DESCRIPTION
## Problem

`buildBlockDAO` declares `err` in a `var` block, then the non-test branch redeclares it:

```go
var ( err error; store blockdao.BlockStore; ... )    // outer err
if forTest {
    store, err = filedao.NewFileDAOInMemForTest()    // assigns outer err
} else {
    uri, err := url.Parse(path)                      // ":=" shadows err for the whole block
    ...
    store, err = filedao.NewFileDAO(dbConfig, ser)   // assigns the shadowed err
}
if err != nil { return err }                         // reads the outer err — never assigned here
```

`uri` is new, so `:=` declares a fresh `err` scoped to the `else` block. Every later assignment
in that block targets it, while the check after the block reads the outer one.

`store` is *not* shadowed, so on failure it leaves the block as `nil`.

## Impact

A chain DB that cannot be opened — corrupt file, wrong permissions, path occupied by a
directory — produces no error:

1. `filedao.NewFileDAO` fails; the error lands on the shadowed variable and is never read
2. `store` is `nil`
3. `NewBlockDAOWithIndexersAndCache` returns `nil` for a `nil` store
4. `cs.blockdao` is `nil` and `buildBlockDAO` returns `nil`
5. `Build` continues, passing the `nil` into `buildBlockchain` and `staking.WithBlockStore`

The node reports a successful start and fails later as a nil dereference, far from the cause.
A clear startup error becomes an obscure crash.

The `forTest` branch assigns the outer `err` and behaves correctly — which is why no existing
test covers this path.

## Fix

Assign to the outer `err` rather than declaring a new one, restoring the intent of the
existing `if err != nil` check after the block. A comment records why `:=` cannot be used here.

## Test plan

`TestBuildBlockDAOPropagatesStoreError` points `ChainDBPath` at a directory, so the store
cannot be opened, and asserts the error is propagated. It carries a precondition check that
fails loudly if `filedao.NewFileDAO` unexpectedly succeeds, so it cannot pass while proving
nothing.

| Check | Result |
|---|---|
| `go test ./chainservice/ -run TestBuildBlockDAOPropagatesStoreError` | pass |
| **same test with the `builder.go` change reverted** | **fail** — `An error is expected but got nil` |
| `make lint` (`go vet` repo-wide) | clean |
| `go test -short -race ./chainservice/` | ok |
| `go test -short -race ./server/itx/` | ok (dependent package) |
| `go test -short ./e2etest/` | ok (dependent package) |

The second row is the one that matters: the test distinguishes the defect from the fix rather
than passing either way.

### Note on `e2etest` flakiness

`./e2etest/` failed once during this work, at `TestLocalCommit` (`local_test.go`, expected
height `101`, got `100`). It reproduces on unmodified `master` — two runs on a clean checkout
gave one pass and one failure with the same assertion — so it is pre-existing and unrelated to
this change. Flagging it because a flaky suite masks real regressions.

## Not addressed here

`NewBlockDAOWithIndexersAndCache` returns `nil` for a `nil` store, which makes "construction
failed" and "construction succeeded" indistinguishable to its caller. This PR closes the one
entry point; the same shape will silently swallow the next comparable error. Worth its own
change, since it touches the constructor's contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)